### PR TITLE
Adds defensive programming for FAQ and How-To blocks

### DIFF
--- a/packages/js/src/structured-data-blocks/how-to/legacy/11.4.js
+++ b/packages/js/src/structured-data-blocks/how-to/legacy/11.4.js
@@ -42,13 +42,13 @@ function LegacyHowToStep( step ) {
 
 /**
  * Returns the component to be used to render
- * the How-to block on Wordpress (e.g. not in the editor).
+ * the How-to block on WordPress (e.g. not in the editor).
  *
  * @param {Object} props the attributes of the How-to block.
  *
  * @returns {wp.Element} The component representing a How-to block.
  */
-export default function LegacyHowTo( props ) {
+export default function LegacyHowTo( props ) { // eslint-disable-line complexity
 	const {
 		steps,
 		hasDuration,
@@ -68,9 +68,12 @@ export default function LegacyHowTo( props ) {
 
 	const timeString = buildDurationString( { days, hours, minutes } );
 
-	const stepElements = steps.map( step => {
-		return <LegacyHowToStep { ...step } key={ step.id } />;
-	} );
+	let stepElements = [];
+	if ( steps ) {
+		stepElements = steps.map( step => {
+			return <LegacyHowToStep { ...step } key={ step.id } />;
+		} );
+	}
 
 	return (
 		<div className={ classNames }>

--- a/src/generators/schema/faq.php
+++ b/src/generators/schema/faq.php
@@ -8,7 +8,7 @@ namespace Yoast\WP\SEO\Generators\Schema;
 class FAQ extends Abstract_Schema_Piece {
 
 	/**
-	 * Determines whether or not a piece should be added to the graph.
+	 * Determines whether a piece should be added to the graph.
 	 *
 	 * @return bool
 	 */
@@ -34,11 +34,13 @@ class FAQ extends Abstract_Schema_Piece {
 	private function generate_ids() {
 		$ids = [];
 		foreach ( $this->context->blocks['yoast/faq-block'] as $block ) {
-			foreach ( $block['attrs']['questions'] as $question ) {
-				if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
-					continue;
+			if ( isset( $block['attrs']['questions'] ) ) {
+				foreach ( $block['attrs']['questions'] as $question ) {
+					if ( empty( $question['jsonAnswer'] ) ) {
+						continue;
+					}
+					$ids[] = [ '@id' => $this->context->canonical . '#' . \esc_attr( $question['id'] ) ];
 				}
-				$ids[] = [ '@id' => $this->context->canonical . '#' . \esc_attr( $question['id'] ) ];
 			}
 		}
 
@@ -54,8 +56,10 @@ class FAQ extends Abstract_Schema_Piece {
 		$graph = [];
 
 		$questions = [];
-		foreach ( $this->context->blocks['yoast/faq-block'] as $index => $block ) {
-			$questions = \array_merge( $questions, $block['attrs']['questions'] );
+		foreach ( $this->context->blocks['yoast/faq-block'] as $block ) {
+			if ( isset( $block['attrs']['questions'] ) ) {
+				$questions = \array_merge( $questions, $block['attrs']['questions'] );
+			}
 		}
 		foreach ( $questions as $index => $question ) {
 			if ( ! isset( $question['jsonAnswer'] ) || empty( $question['jsonAnswer'] ) ) {
@@ -88,9 +92,7 @@ class FAQ extends Abstract_Schema_Piece {
 			'acceptedAnswer' => $this->add_accepted_answer_property( $question ),
 		];
 
-		$data = $this->helpers->schema->language->add_piece_language( $data );
-
-		return $data;
+		return $this->helpers->schema->language->add_piece_language( $data );
 	}
 
 	/**
@@ -106,8 +108,6 @@ class FAQ extends Abstract_Schema_Piece {
 			'text'  => $this->helpers->schema->html->sanitize( $question['jsonAnswer'] ),
 		];
 
-		$data = $this->helpers->schema->language->add_piece_language( $data );
-
-		return $data;
+		return $this->helpers->schema->language->add_piece_language( $data );
 	}
 }

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -174,7 +174,10 @@ class HowTo extends Abstract_Schema_Piece {
 		}
 
 		$this->add_duration( $data, $block['attrs'] );
-		$this->add_steps( $data, $block['attrs']['steps'] );
+
+		if ( isset( $block['attrs']['steps'] ) ) {
+			$this->add_steps( $data, $block['attrs']['steps'] );
+		}
 
 		$data = $this->helpers->schema->language->add_piece_language( $data );
 

--- a/tests/Unit/Generators/Schema/FAQ_Test.php
+++ b/tests/Unit/Generators/Schema/FAQ_Test.php
@@ -229,6 +229,38 @@ final class FAQ_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that an empty attrs block does not block the schema generation.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_generate_empty_attrs() {
+		$this->stubEscapeFunctions();
+
+		$blocks = [
+			'yoast/faq-block' => [
+				[
+					'attrs' => [],
+				],
+			],
+		];
+
+		$meta_tags_context                 = new Meta_Tags_Context_Mock();
+		$meta_tags_context->blocks         = $blocks;
+		$meta_tags_context->main_schema_id = 'https://example.org/page/';
+		$meta_tags_context->canonical      = 'https://example.org/page/';
+
+		$this->instance->context = $meta_tags_context;
+
+		$expected = [];
+
+		$actual = $this->instance->generate();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
 	 * Tests that no FAQ Schema pieces are needed when no
 	 * FAQ blocks are on the page.
 	 *

--- a/tests/Unit/Generators/Schema/HowTo_Test.php
+++ b/tests/Unit/Generators/Schema/HowTo_Test.php
@@ -280,6 +280,28 @@ final class HowTo_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that no Schema step is output when no steps are set.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_empty_steps() {
+		$blocks = $this->base_blocks;
+		// Remove the steps attribute.
+		unset(
+			$blocks['yoast/how-to-block'][0]['attrs']['steps']
+		);
+
+		$schema = $this->base_schema;
+		unset( $schema[0]['step'] );
+
+		$this->meta_tags_context->blocks = $blocks;
+		$actual_schema                   = $this->instance->generate();
+		$this->assertEquals( $schema, $actual_schema );
+	}
+
+	/**
 	 * Tests that an image Schema piece is output when a step has an image.
 	 *
 	 * @covers ::generate


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* TBA

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where ending a How-To or FAQ block element with a backslash would error when re-opening the post. 

## Relevant technical choices:

* We also added defensive programming around the schema generation so that will not break that easily if there would be other characters that would interfere with these blocks.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* TBA

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The How-To and FAQ blocks.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20592 
