### PR TITLE
Fix fatal error when other plugin runs exit() on plugins_loaded hook.

### DIFF
--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -605,7 +605,7 @@ class Yoast_Notification_Center {
 		 * This prevents the pluggable.php file from loading, as it's loaded after the plugins_loaded hook.
 		 * As we need functions defined in pluggable.php, make sure it's loaded.
    		 */
-		require ABSPATH . WPINC . '/pluggable.php';
+		require_once ABSPATH . WPINC . '/pluggable.php';
 
 		$notifications = $this->notifications;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid triggering a fatal error if `exit` is called early in a WordPress request lifecycle.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where another plugin running the `exit()` function inside the `plugin_loaded` hook would result in a fatal error. Props to @menno-ll.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `wp-content/plugins` create a new folder named `zzzz` 
  * inside the folder create the file `zzzz.php` and copy-paste the following in it:
```php
<?php
/**
 * Plugin Name: ZZZZ
 * Version:     1.0.0
 * Plugin URI:  https://level-level.com
 * Description: Test plugin calling exit
 * Author:      Level Level
 * Author URI:  https://level-level.com
 * Text Domain: zzzz
 * Domain Path: /languages/
 * License:     GPL v3
 */
 add_action(
         'plugin_loaded', function(): void {
         exit("TEST");
         }
 );
```
* Visit the backend of your site
  * you should get a blank page with `TEST` written in it
  * open your site `debug.log` and:
    * without this PR you'll have an error as follows: `PHP Fatal error:  Uncaught Error: Call to undefined function get_userdata() in /Users/pls/Local Sites/hackaton/app/public/wp-includes/user.php:692`
    * with this PR the error is not present in the log file 

* Note for testers: if you are not able to trigger the error with the above strategy, do the following:
    * copy-paste the following in `zzzz.php`:
```php
<?php
/**
 * Plugin Name: ZZZZ
 * Version:     1.0.0
 * Plugin URI:  https://level-level.com
 * Description: Test plugin calling exit
 * Author:      Level Level
 * Author URI:  https://level-level.com
 * Text Domain: zzzz
 * Domain Path: /languages/
 * License:     GPL v3
 */
if ( wp_doing_ajax() ) {
    exit('TEST');
}
```
* Visit the page `wp-admin/admin-ajax.php` of your site: this should trigger the error

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

Please use the network tab to see the status code is 500.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21061
