### PR TITLE
Deprecate search engine pings.

### DIFF
--- a/inc/sitemaps/class-sitemaps-admin.php
+++ b/inc/sitemaps/class-sitemaps-admin.php
@@ -53,52 +53,18 @@ class WPSEO_Sitemaps_Admin {
 		$post_type = get_post_type( $post );
 
 		wp_cache_delete( 'lastpostmodified:gmt:' . $post_type, 'timeinfo' ); // #17455.
-
-		// Not something we're interested in.
-		if ( $post_type === 'nav_menu_item' ) {
-			return;
-		}
-
-		// If the post type is excluded in options, we can stop.
-		if ( WPSEO_Options::get( 'noindex-' . $post_type, false ) ) {
-			return;
-		}
-
-		if ( ! YoastSEO()->helpers->environment->is_production_mode() ) {
-			return;
-		}
-
-		$this->ping_search_engines();
 	}
 
 	/**
 	 * Notify Google of the updated sitemap.
 	 *
+	 * @deprecated 22.0
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function ping_search_engines() {
-
-		if ( get_option( 'blog_public' ) === '0' ) { // Don't ping if blog is not public.
-			return;
-		}
-
-		/**
-		 * Filter: 'wpseo_allow_xml_sitemap_ping' - Check if pinging is not allowed (allowed by default).
-		 *
-		 * @param bool $allow_ping The boolean that is set to true by default.
-		 */
-		if ( apply_filters( 'wpseo_allow_xml_sitemap_ping', true ) === false ) {
-			return;
-		}
-
-		$url = rawurlencode( WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' ) );
-
-		// Ping Google about our sitemap change.
-		wp_remote_get( 'https://www.google.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
-
-		if ( ! defined( 'WPSEO_PREMIUM_FILE' ) || WPSEO_Options::get( 'enable_index_now' ) === false ) {
-			wp_remote_get( 'https://www.bing.com/ping?sitemap=' . $url, [ 'blocking' => false ] );
-		}
+		_deprecated_function( __METHOD__, 'Yoast SEO 22.0' );
 	}
 
 	/**
@@ -155,7 +121,5 @@ class WPSEO_Sitemaps_Admin {
 		if ( WP_CACHE ) {
 			do_action( 'wpseo_hit_sitemap_index' );
 		}
-
-		$this->ping_search_engines();
 	}
 }

--- a/phpunit-wp.xml.dist
+++ b/phpunit-wp.xml.dist
@@ -42,5 +42,8 @@
 		<log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
 		<log type="coverage-clover" target="build/logs/clover-wp.xml"/>
 	</logging>
+<php>
+   		<env name="WP_DEVELOP_DIR" value="/Users/thijsvanderheijden/Projects/yoast/wordpress-develop"/>
+ 	</php>
 
 </phpunit>

--- a/phpunit-wp.xml.dist
+++ b/phpunit-wp.xml.dist
@@ -42,8 +42,5 @@
 		<log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
 		<log type="coverage-clover" target="build/logs/clover-wp.xml"/>
 	</logging>
-<php>
-   		<env name="WP_DEVELOP_DIR" value="/Users/thijsvanderheijden/Projects/yoast/wordpress-develop"/>
- 	</php>
 
 </phpunit>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to deprecate the usages of search engine sitemap pings, since both Google and Bing don't support this anymore.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deprecates pings to Google and Bing since they are not supported anymore.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Smoke test creating a post and making sure it still appears in your sitemap.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
