### PR TITLE
Sync JS dependencies (to WP versions)

### DIFF
--- a/config/scripts/sync-wp-dependencies.js
+++ b/config/scripts/sync-wp-dependencies.js
@@ -1,0 +1,89 @@
+/**
+ * This script is used to sync the WordPress dependencies in our package.json files with the versions in their package.json.
+ *
+ * Steps:
+ * 1. Get the lowest supported WordPress version from the PHP file.
+ * 2. Get the package.json from the WordPress repository, using the WP version found in step 1 as tag.
+ * 3. Extract the versions of the dependencies (that we care about) from the package.json from the WordPress repository.
+ * 4. Update our packages with the versions from the WordPress package.json.
+ * 5. Optionally, we could try and fix some obvious dependency errors we know about.
+ */
+const fs = require( "fs" );
+const https = require( "https" );
+
+const wpPackagesToSync = [
+	"@wordpress/a11y",
+	"@wordpress/api-fetch",
+	"@wordpress/block-editor",
+	"@wordpress/blocks",
+	"@wordpress/components",
+	"@wordpress/compose",
+	"@wordpress/data",
+	"@wordpress/dom-ready",
+	"@wordpress/element",
+	"@wordpress/hooks",
+	"@wordpress/html-entities",
+	"@wordpress/i18n",
+	"@wordpress/is-shallow-equal",
+	"@wordpress/plugins",
+	"@wordpress/rich-text",
+	"@wordpress/server-side-render",
+	"@wordpress/url",
+];
+
+const getLowestSupportedWordPressVersion = () => {
+	const data = fs.readFileSync( "./wp-seo.php", "utf8" );
+
+	// Get the latest version number from the PHP file.
+	const match = data.match( /Requires at least: (\d+\.\d+)/ );
+	if ( match ) {
+		return match[ 1 ];
+	}
+
+	console.log( "No match found" );
+	return null;
+};
+
+const getWordPressPackageJsonDependencies = ( wpVersion ) => {
+	const url = `https://raw.githubusercontent.com/WordPress/wordpress-develop/${ wpVersion }/package.json`;
+
+	const processData = ( data ) => {
+		try {
+			const json = JSON.parse( data );
+			return json.dependencies;
+		} catch ( e ) {
+			console.error( "Error parsing JSON", data, e );
+			return null;
+		}
+	};
+
+	return new Promise( ( resolve ) => {
+		// Get the package.json from the WordPress repository.
+		https.get( url, ( res ) => {
+			let data = "";
+
+			res.on( "data", ( chunk ) => {
+				data += chunk;
+			} );
+			res.on( "end", () => resolve( processData( data ) ) );
+		} ).on( "error", ( err ) => {
+			console.error( `Error: ${ err.message }` );
+			resolve( null );
+		} );
+	} );
+};
+
+const getYarnUpdateCommandParameter = ( wantedDependencies, listedVersions ) => {
+	return wantedDependencies.map( ( dependency ) => ( `${ dependency }@${ listedVersions[ dependency ] }` ) );
+};
+
+const syncPackageDependencies = async() => {
+	const lowestSupportedWordPressVersion = getLowestSupportedWordPressVersion();
+	console.log( `WP version: ${ lowestSupportedWordPressVersion }` );
+	const wpDependencies = await getWordPressPackageJsonDependencies( lowestSupportedWordPressVersion );
+	const yarnUpdateCommandParameter = getYarnUpdateCommandParameter( wpPackagesToSync, wpDependencies );
+
+	console.log( `yarn add ${ yarnUpdateCommandParameter.join( " " ) }` );
+};
+
+syncPackageDependencies();

--- a/config/scripts/sync-wp-dependencies.js
+++ b/config/scripts/sync-wp-dependencies.js
@@ -11,7 +11,7 @@
 const fs = require( "fs" );
 const https = require( "https" );
 
-const wpPackagesToSync = [
+const packageAllowList = [
 	"@wordpress/a11y",
 	"@wordpress/api-fetch",
 	"@wordpress/block-editor",
@@ -31,59 +31,128 @@ const wpPackagesToSync = [
 	"@wordpress/url",
 ];
 
+/**
+ * Gets the lowest supported WordPress version.
+ * @returns {null|string} The lowest supported WordPress version or null.
+ */
 const getLowestSupportedWordPressVersion = () => {
 	const data = fs.readFileSync( "./wp-seo.php", "utf8" );
 
 	// Get the latest version number from the PHP file.
 	const match = data.match( /Requires at least: (\d+\.\d+)/ );
-	if ( match ) {
+	if ( match && match.length > 0 ) {
 		return match[ 1 ];
 	}
 
-	console.log( "No match found" );
+	console.error( "Lowest supported WordPress version not found" );
 	return null;
 };
 
-const getWordPressPackageJsonDependencies = ( wpVersion ) => {
+/**
+ * Fetches the data from the specified URL.
+ * @param {string} url The URL to fetch the data from.
+ * @returns {Promise<any|e>} A promise of the data or a reject with the error.
+ */
+const fetchData = ( url ) => new Promise( ( resolve, reject ) => {
+	// Get the package.json from the WordPress repository.
+	https.get( url, ( res ) => {
+		let data = "";
+
+		res.on( "data", ( chunk ) => {
+			data += chunk;
+		} );
+		res.on( "end", () => resolve( data ) );
+	} ).on( "error", ( e ) => reject( e ) );
+} );
+
+/**
+ * Tries to parse the JSON string.
+ * @param {string} json The JSON string to parse.
+ * @returns {any|null} The parse result or null.
+ */
+const tryJsonParse = ( json ) => {
+	try {
+		return JSON.parse( json );
+	} catch ( e ) {
+		return null;
+	}
+};
+
+/**
+ * Gets the parsed WordPress package.json.
+ * @param {string} wpVersion The WordPress version to get the dependencies for.
+ * @returns {Promise<Object<string, string>|null>} A promise of the dependencies or null.
+ */
+const getWordPressPackageJson = ( wpVersion ) => {
 	const url = `https://raw.githubusercontent.com/WordPress/wordpress-develop/${ wpVersion }/package.json`;
 
-	const processData = ( data ) => {
-		try {
-			const json = JSON.parse( data );
-			return json.dependencies;
-		} catch ( e ) {
-			console.error( "Error parsing JSON", data, e );
-			return null;
-		}
-	};
-
+	// Perform the request and process the data.
 	return new Promise( ( resolve ) => {
-		// Get the package.json from the WordPress repository.
-		https.get( url, ( res ) => {
-			let data = "";
-
-			res.on( "data", ( chunk ) => {
-				data += chunk;
+		fetchData( url )
+			.then( ( data ) => resolve( tryJsonParse( data ) ) )
+			.catch( ( e ) => {
+				console.error( "Error fetching URL", url, e );
+				resolve( null );
 			} );
-			res.on( "end", () => resolve( processData( data ) ) );
-		} ).on( "error", ( err ) => {
-			console.error( `Error: ${ err.message }` );
-			resolve( null );
-		} );
 	} );
 };
 
+/**
+ * Gets the dependencies from the package.json of the specified package.
+ * @param {string} packageName The package to get the dependencies for.
+ * @returns {Object<string,string>|null} The dependencies or null.
+ */
+const getPackageJsonForPackage = ( packageName ) => {
+	const data = fs.readFileSync( `./packages/${ packageName }/package.json`, "utf8" );
+	return tryJsonParse( data );
+};
+
+/**
+ * Gets the dependencies from the specified package.json.
+ * Doing this instead of optional chaining, because ESLint doesn't seem to like it.
+ * @param {Object} packageJson The package.json to get the dependencies from.
+ * @returns {{}|Object<string,string>} The dependencies or an empty object.
+ */
+const getDependenciesFromPackageJson = ( packageJson ) => {
+	if ( ! packageJson || ! packageJson.dependencies ) {
+		return {};
+	}
+	return packageJson.dependencies;
+};
+
+/**
+ * Filters the dependencies, based on the allowList.
+ * @param {Object|Object<string,string>} dependencies The dependencies to filter.
+ * @param {string[]} allowList The allowList to filter with.
+ * @returns {string[]} The filtered dependencies.
+ */
+const filterDependenciesFromPackageJson = ( dependencies, allowList ) => {
+	return Object.keys( dependencies ).filter( ( dependency ) => allowList.includes( dependency ) );
+};
+
+/**
+ * Gets the yarn update command parameter.
+ * @param {string[]} wantedDependencies The dependencies we want to update.
+ * @param {Object|Object<string,string>} listedVersions The versions of the dependencies we want to update.
+ * @returns {string} The yarn update command parameter.
+ */
 const getYarnUpdateCommandParameter = ( wantedDependencies, listedVersions ) => {
-	return wantedDependencies.map( ( dependency ) => ( `${ dependency }@${ listedVersions[ dependency ] }` ) );
+	return wantedDependencies.map( ( dependency ) => ( `${ dependency }@${ listedVersions[ dependency ] }` ) ).join( " " );
 };
 
-const syncPackageDependencies = async() => {
+const syncPackageDependenciesFor = async( packageFolder ) => {
+	console.log( `Syncing dependencies for: packages/${ packageFolder }` );
+
 	const lowestSupportedWordPressVersion = getLowestSupportedWordPressVersion();
-	console.log( `WP version: ${ lowestSupportedWordPressVersion }` );
-	const wpDependencies = await getWordPressPackageJsonDependencies( lowestSupportedWordPressVersion );
-	const yarnUpdateCommandParameter = getYarnUpdateCommandParameter( wpPackagesToSync, wpDependencies );
+	console.log( `Lowest supported WordPress version: ${ lowestSupportedWordPressVersion }` );
 
-	console.log( `yarn add ${ yarnUpdateCommandParameter.join( " " ) }` );
+	const wpDependencies = getDependenciesFromPackageJson( await getWordPressPackageJson( lowestSupportedWordPressVersion ) );
+	const packageJson = getPackageJsonForPackage( packageFolder );
+	const dependenciesToUpdate = filterDependenciesFromPackageJson( getDependenciesFromPackageJson( packageJson ), packageAllowList );
+	const yarnUpdateCommandParameter = getYarnUpdateCommandParameter( dependenciesToUpdate, wpDependencies );
+
+	console.log( "\nRun the command:" );
+	console.log( `yarn workspace ${ packageJson.name } add ${ yarnUpdateCommandParameter }` );
 };
 
-syncPackageDependencies();
+syncPackageDependenciesFor( process.argv[ 2 ] || "js" );

--- a/config/scripts/sync-wp-dependencies.js
+++ b/config/scripts/sync-wp-dependencies.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * This script is used to sync the WordPress dependencies in our package.json files with the versions in their package.json.
  *
@@ -188,6 +189,10 @@ const getPackageFoldersFromArguments = () => {
 	return packages.filter( ( packageFolder ) => existsSync( `./packages/${ packageFolder }/package.json` ) );
 };
 
+/**
+ * Syncs the WordPress dependencies for the specified packages (in command).
+ * @returns {Promise<void>} A promise that resolves when the dependencies are synced.
+ */
 const syncPackageDependencies = async() => {
 	const packageFolders = getPackageFoldersFromArguments();
 	if ( packageFolders.length === 0 ) {

--- a/config/scripts/sync-wp-dependencies.js
+++ b/config/scripts/sync-wp-dependencies.js
@@ -1,6 +1,11 @@
 /**
  * This script is used to sync the WordPress dependencies in our package.json files with the versions in their package.json.
  *
+ * Usage:
+ * $ node config/scripts/sync-wp-dependencies.js [packageFolder1] [packageFolder2] ...
+ * If no packageFolders are specified, all packages will be updated.
+ *
+ * What does it do?
  * Steps:
  * 1. Get the lowest supported WordPress version from the PHP file.
  * 2. Get the package.json from the WordPress repository, using the WP version found in step 1 as tag.
@@ -153,7 +158,7 @@ const syncPackageDependenciesFor = async( packageFolder, wpDependencies ) => {
 	const dependenciesWithWantedVersions = getDependenciesWithWantedVersions( dependenciesToUpdate, wpDependencies );
 
 	if ( dependenciesWithWantedVersions.length === 0 ) {
-		console.info( "No dependencies to update for:", packageJson.name );
+		console.info( "No WordPress dependencies found in:", packageJson.name );
 		return;
 	}
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "build:css:dev": "cross-env NODE_ENV=development postcss css/dist/*.css --verbose --replace",
     "webpack-analyze-bundle": "wp-scripts build --config config/webpack/webpack.config.js --webpack-bundle-analyzer",
     "prestart": "grunt build:css && grunt copy:js-dependencies",
-    "start": "wp-scripts start --config config/webpack/webpack.config.js"
+    "start": "wp-scripts start --config config/webpack/webpack.config.js",
+    "sync:wp-deps": "node config/scripts/sync-wp-dependencies.js"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

We want to sync our JS dependencies to the versions that WordPress provides.
Why? This will make our JS testing and IDE autocompletion actually work with the correct versions. Granted, we actually support multiple versions of WP, this script picks the lowest supported version currently.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a script to sync the JS dependencies of our packages to the versions used by our lowest supported WordPress version.

## Relevant technical choices:

* Used a node script, because JS
* Using an allow dependencies list to prevent any extra packages WP uses (that we might also use)
* Using an disallow package list to prevent some of our packages to be included here, because not all of our packages are running inside the WP environment. E.g. our tooling packages
* Huge thanks to @noud-github for coming up with this idea, and helping with the implementation (we shifted to this from the idea of a packages test matrix in the CI)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run `yarn sync:wp-deps`
* Get a lot of output, check the output and result
* `Lowest supported WordPress version` should be as read from `./wp-seo.php`
* Versions synced to should be read from the WP develop tag on Github, e.g. for [WP 6.3](https://github.com/WordPress/wordpress-develop/blob/6.3/package.json)
* The packages synced should be all but our tooling packages ([listed here](https://github.com/Yoast/wordpress-seo/blob/6ccc0f307b97fe0ff8db37ccbd93de19fa4f154b/config/scripts/sync-wp-dependencies.js#L98-L104))
* Note: don't actually commit these changes, actually upgrading the deps is for later

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need to test, this concerns a stand-alone script to help devs' tech debt.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
