### PR TITLE
Improves some translator comments

### DIFF
--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -55,7 +55,7 @@ const WincherSEOPerformanceTableBlurredCell = styled.div`
 const ConnectToWincherWrapper = styled.p`
 	top: 47%;
 	left: 50%;
-	position: absolute; 
+	position: absolute;
 `;
 
 /**
@@ -328,14 +328,12 @@ GetUserMessage.propTypes = {
 const TableExplanation = ( { isLoggedIn } ) => {
 	const loggedInMessage = sprintf(
 		/* translators: %s expands to a link to Wincher login */
-		// eslint-disable-next-line max-len
 		__( "This overview only shows you keyphrases added to Yoast SEO. There may be other keyphrases added to your %s.", "wordpress-seo" ),
 		"{{wincherAccountLink/}}"
 	);
 
 	const notLoggedInMessage = sprintf(
 		/* translators: %s expands to a link to Wincher login */
-		// eslint-disable-next-line max-len
 		__( "This overview will show you your top performing keyphrases in Google. Connect with %s to get started.", "wordpress-seo" ),
 		"{{wincherLink/}}"
 	);

--- a/packages/js/src/components/modals/WordProofWebhookFailed.js
+++ b/packages/js/src/components/modals/WordProofWebhookFailed.js
@@ -44,6 +44,7 @@ const WordProofWebhookFailed = ( props ) => {
 				{
 					addLinkToString(
 						sprintf(
+							// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 							__(
 								"Find possible solutions in this %1$sArticle%2$s.",
 								"wordpress-seo"

--- a/packages/js/src/first-time-configuration/tailwind-components/stepper.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/stepper.js
@@ -166,8 +166,8 @@ export function StepError( { id, message, className } ) {
 		className={ className }
 	>
 		{
-			/* translators: %1$s expands to the error message returned by the server */
 			sprintf(
+				/* translators: %1$s expands to the error message returned by the server */
 				__(
 					"An error has occurred: %1$s",
 					"wordpress-seo"

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -64,6 +64,7 @@ function registerFormats() {
 			__( "Marking links with nofollow/sponsored has been disabled for WordPress installs < 5.4.", "wordpress-seo" ) +
 			" " +
 			sprintf(
+				// translators: %1$s expands to Yoast SEO.
 				__( "Please upgrade your WordPress version or install the Gutenberg plugin to get this %1$s feature.", "wordpress-seo" ),
 				"Yoast SEO"
 			)

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -25,6 +25,7 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 		const link = get( window, "wpseoAdminL10n.shortlinks-insights-keyword_research_link", "" );
 		return createInterpolateElement(
 			sprintf(
+				// translators: %1$s and %2$s are replaced by opening and closing <a> tags.
 				__( "Read our %1$sultimate guide to keyword research%2$s to learn more about keyword research and keyword strategy.", "wordpress-seo" ),
 				"<a>",
 				"</a>"

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -1265,7 +1265,7 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 				route: "/site-representation",
 				routeLabel: __( "Site representation", "wordpress-seo" ),
 				fieldId: `input-wpseo_social-other_social_urls-${ index }`,
-				// translators: %1$s exapnds to array index + 1.
+				// translators: %1$s expands to array index + 1.
 				fieldLabel: sprintf( __( "Other profile %1$s", "wordpress-seo" ), index + 1 ),
 			} ) ),
 		},

--- a/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SubheadingDistributionTooLongAssessment.js
@@ -314,11 +314,9 @@ class SubheadingsDistributionTooLong extends Assessment {
 						score: this._config.scores.okSubheadings,
 						hasMarks: true,
 						resultText: sprintf(
-							/*
-							 * translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
-							 * not separated by subheadings, %4$d expands to the recommended number of words following a
-							 * subheading, %6$s expands to the word 'words' or 'characters', %2$s expands to the link closing tag.
-							 */
+							/* translators: %1$s and %5$s expand to a link on yoast.com, %3$d to the number of text sections
+							not separated by subheadings, %4$d expands to the recommended number of words or characters following a
+							subheading, %6$s expands to the word 'words' or 'characters', %2$s expands to the link closing tag. */
 							_n(
 								// eslint-disable-next-line max-len
 								"%1$sSubheading distribution%2$s: %3$d section of your text is longer than %4$d %6$s and is not separated by any subheadings. %5$sAdd subheadings to improve readability%2$s.",

--- a/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/PageTitleWidthAssessment.js
@@ -109,7 +109,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 		if ( inRange( pageTitleWidth, 1, 400 ) ) {
 			if ( this._allowShortTitle ) {
 				return sprintf(
-					/* translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					/* translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 					__(
 						"%1$sSEO title width%2$s: Good job!",
 						"wordpress-seo"
@@ -133,7 +133,7 @@ export default class PageTitleWidthAssessment extends Assessment {
 
 		if ( inRange( pageTitleWidth, this._config.minLength, this._config.maxLength ) ) {
 			return sprintf(
-				/* translators:  %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
+				/* translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				__(
 					"%1$sSEO title width%2$s: Good job!",
 					"wordpress-seo"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to ensure that translators can properly translate our plugin. This PR adds some translator comments (and improves others) in the JavaScript packages after a run of `wp i18n make-pot . --include="packages/*/src"`. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the translator comments for JavaScript translation strings.

## Relevant technical choices:

* None.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* No tests needed, these are comments and will not change any functionality.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
