### PR TITLE
Encode spaces in webpage id and url

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -238,7 +238,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			return $this->presentation->permalink;
 		}
 
-		return \add_query_arg( 's', \get_search_query(), \trailingslashit( $this->site_url ) );
+		return \add_query_arg( 's', \rawurlencode( \get_search_query() ), \trailingslashit( $this->site_url ) );
 	}
 
 	/**
@@ -349,7 +349,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Retrieve the person logo meta.
 	 *
-	 * @return array|bool
+	 * @return array<string|array<int>>|bool
 	 */
 	public function generate_person_logo_meta() {
 		$person_logo_meta = $this->image->get_attachment_meta_from_settings( 'person_logo' );
@@ -390,7 +390,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Retrieve the company logo meta.
 	 *
-	 * @return array|bool
+	 * @return array<string|array<int>>|bool
 	 */
 	public function generate_company_logo_meta() {
 		$company_logo_meta = $this->image->get_attachment_meta_from_settings( 'company_logo' );
@@ -449,7 +449,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Returns the site represents reference.
 	 *
-	 * @return array|bool The site represents reference. False if none.
+	 * @return array<string>|bool The site represents reference. False if none.
 	 */
 	public function generate_site_represents_reference() {
 		if ( $this->site_represents === 'person' ) {
@@ -499,7 +499,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Returns the schema page type.
 	 *
-	 * @return string|array The schema page type.
+	 * @return string|array<string> The schema page type.
 	 */
 	public function generate_schema_page_type() {
 		switch ( $this->indexable->object_type ) {
@@ -549,7 +549,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Returns the schema article type.
 	 *
-	 * @return string|array The schema article type.
+	 * @return string|array<string> The schema article type.
 	 */
 	public function generate_schema_article_type() {
 		$additional_type = $this->indexable->schema_article_type;
@@ -667,7 +667,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	/**
 	 * Strips all nested dependencies from the debug info.
 	 *
-	 * @return array
+	 * @return array<Indexable,Indexable_Presentation>
 	 */
 	public function __debugInfo() {
 		return [

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -25,7 +25,7 @@ class WebPage extends Abstract_Schema_Piece {
 	/**
 	 * Returns WebPage schema data.
 	 *
-	 * @return array WebPage schema data.
+	 * @return array<string|array<string>> WebPage schema data.
 	 */
 	public function generate() {
 		$data = [
@@ -82,10 +82,10 @@ class WebPage extends Abstract_Schema_Piece {
 	/**
 	 * Adds an author property to the $data if the WebPage is not represented.
 	 *
-	 * @param array   $data The WebPage schema.
-	 * @param WP_Post $post The post the context is representing.
+	 * @param array<string|array<string>> $data The WebPage schema.
+	 * @param WP_Post                                   $post The post the context is representing.
 	 *
-	 * @return array The WebPage schema.
+	 * @return array<string|array<string>> The WebPage schema.
 	 */
 	public function add_author( $data, $post ) {
 		if ( $this->context->site_represents === false ) {
@@ -98,9 +98,9 @@ class WebPage extends Abstract_Schema_Piece {
 	/**
 	 * If we have an image, make it the primary image of the page.
 	 *
-	 * @param array $data WebPage schema data.
+	 * @param array<string|array<string>> $data WebPage schema data.
 	 *
-	 * @return array
+	 * @return array<string|array<string>>
 	 */
 	public function add_image( $data ) {
 		if ( $this->context->has_image ) {
@@ -127,9 +127,9 @@ class WebPage extends Abstract_Schema_Piece {
 	/**
 	 * Adds the potential action property to the WebPage Schema piece.
 	 *
-	 * @param array $data The WebPage data.
+	 * @param array<string|array<string>> $data The WebPage data.
 	 *
-	 * @return array The WebPage data with the potential action added.
+	 * @return array<string|array<string>> The WebPage data with the potential action added.
 	 */
 	private function add_potential_action( $data ) {
 		$url = $this->context->canonical;
@@ -140,7 +140,7 @@ class WebPage extends Abstract_Schema_Piece {
 		/**
 		 * Filter: 'wpseo_schema_webpage_potential_action_target' - Allows filtering of the schema WebPage potentialAction target.
 		 *
-		 * @param array $targets The URLs for the WebPage potentialAction target.
+		 * @param array<string> $targets The URLs for the WebPage potentialAction target.
 		 */
 		$targets = \apply_filters( 'wpseo_schema_webpage_potential_action_target', [ $url ] );
 
@@ -158,6 +158,6 @@ class WebPage extends Abstract_Schema_Piece {
 	 * @return string Search URL.
 	 */
 	private function build_search_url() {
-		return $this->context->site_url . '?s=' . \get_search_query();
+		return $this->context->site_url . '?s=' . \rawurlencode( \get_search_query() );
 	}
 }

--- a/tests/WP/Generators/Schema/WebPage_Test.php
+++ b/tests/WP/Generators/Schema/WebPage_Test.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Generators\Schema;
+
+use WP_Query;
+use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Builders\Indexable_System_Page_Builder;
+use Yoast\WP\SEO\Generators\Schema\WebPage;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
+
+/**
+ * Integration Test Class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Generators\Schema\WebPage
+ */
+final class WebPage_Test extends TestCase {
+
+	/**
+	 * The generator to test.
+	 *
+	 * @var WebPage
+	 */
+	private $instance;
+
+	/**
+	 * The meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $context;
+
+	/**
+	 * The indexable system page builder.
+	 *
+	 * @var Indexable_System_Page_Builder
+	 */
+	private $indexable_system_page_builder;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->indexable_system_page_builder = new Indexable_System_Page_Builder(
+			\YoastSEO()->helpers->options,
+			\YoastSEO()->classes->get( Indexable_Builder_Versions::class )
+		);
+	}
+
+	/**
+	 * Tests that @id and url properties of the WebPage schema piece are correctly encoded.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_search_url_with_multiple_keywords() {
+		global $wp_query, $wp_the_query;
+
+		$wp_query     = new WP_Query( [ 's' => 'test search' ] );
+		$wp_the_query = $wp_query;
+
+		$indexable       = new Indexable();
+		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
+		$built_indexable = $this->indexable_system_page_builder->build( 'search-result', $indexable );
+
+		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+
+		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
+
+		$this->instance          = \YoastSEO()->classes->get( WebPage::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = \trailingslashit( \home_url() ) . '?s=test%20search';
+
+		$this->assertEquals( $expected, $webpage_schema_piece['@id'] );
+		$this->assertEquals( $expected, $webpage_schema_piece['url'] );
+	}
+
+	/**
+	 * Tests that @id and url properties of the WebPage schema piece are correctly encoded when no canonical is set.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_search_url_with_multiple_keywords_no_canonical_set() {
+		global $wp_query, $wp_the_query;
+
+		$wp_query     = new WP_Query( [ 's' => 'test search' ] );
+		$wp_the_query = $wp_query;
+
+		$indexable       = new Indexable();
+		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
+		$built_indexable = $this->indexable_system_page_builder->build( 'search-result', $indexable );
+
+		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+
+		$this->context            = $meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
+		$this->context->canonical = '';
+
+		$this->instance          = \YoastSEO()->classes->get( WebPage::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = \trailingslashit( \home_url() ) . '?s=test%20search';
+
+		$this->assertEquals( $expected, $webpage_schema_piece['@id'] );
+		$this->assertEquals( $expected, $webpage_schema_piece['url'] );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to encode spaces in URLs which can be present in our schema WebPage properties in case of a multiple keyword search page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Encodes possible spaces in URLs used in `@id` and `url` `WebPage` schema piece properties when the schema represents a search results page.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Perform a search with multiple keywords in your website frontend
* Inspect the schema and verify the `@id` and `url` of the `WebPage` schema piece contains `%20` instead of spaces

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added ~unit~ integration tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#21066](https://github.com/Yoast/wordpress-seo/issues/21066)
