### PR TITLE
fix bug in map_meta_cap_for_seo_manager

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -21,11 +21,11 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		if ( is_multisite() ) {
 			add_action( 'user_has_cap', [ $this, 'filter_user_has_wpseo_manage_options_cap' ], 10, 4 );
 		}
-
+ 
 		/**
 		 * Maybe add manage_privacy_options capability for wpseo_manager user role.
 		 */
-		add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 2 );
+		add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 3 );
 	}
 
 	/**
@@ -85,17 +85,22 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	 *
 	 * @param string[] $caps Primitive capabilities required of the user.
 	 * @param string[] $cap  Capability being checked.
+     * @param int $user_id The user ID of the checked user.
 	 *
 	 * @return string[] Filtered primitive capabilities required of the user.
 	 */
-	public function map_meta_cap_for_seo_manager( $caps, $cap ) {
-		$user = wp_get_current_user();
-
+	public function map_meta_cap_for_seo_manager( $caps, $cap, $user_id ) {
 		// No multisite support.
 		if ( is_multisite() ) {
 			return $caps;
 		}
-
+        
+        $user = get_user_by('id', $user_id);
+        
+		if(!$user){
+        	return $user;
+		}
+          
 		// User must be of role wpseo_manager.
 		if ( ! in_array( 'wpseo_manager', $user->roles, true ) ) {
 			return $caps;


### PR DESCRIPTION
## Context

 Yoast adds the {@see WPSEO_Register_Capabilities::map_meta_cap_for_seo_manager()} filter
 before the current user has determined, however, that callback relies on a call to {@see wp_get_current_user}
 which will cause an infinite loop if any plugin/theme/custom-code uses {@see user_can()} during the creation of the
 user session to determine per-user configurations of sessions.
 
 The correct hook to add the callback would probably be the {@see set_current_user} hook, otherwise
 the callback to {@see WPSEO_Register_Capabilities::map_meta_cap_for_seo_manager()} also always receives the user id
 which means it would actually also work if {@see user_can()} is called on a user that's not the currently logged in
 one, which is pretty common as well.
*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix bug in capability mapping if current user is no set yet

## Relevant technical choices:

* No performance issues, get_user_by_id will always come from the cache for the current logged-in user. 
* Also supports non-logged in users now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
