### PR TITLE
Revert #20921 - Invalidate the Yoast SEO PHP files and directories instead of...

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -346,7 +346,6 @@ function wpseo_init() {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 		WP_Filesystem();
-
 		/*
 		 * We invalidate each subdir and the main files instead of the whole `wordpress-seo` dir
 		 * to avoid any timeout or resource exhaustion when building from source.

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -342,27 +342,9 @@ function wpseo_init() {
 	WPSEO_Meta::init();
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
-		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-		/*
-		 * We invalidate each subdir and the main files instead of the whole `wordpress-seo` dir
-		 * to avoid any timeout or resource exhaustion when building from source.
-		 */
-		if ( function_exists( 'wp_opcache_invalidate' ) ) {
-			// Since WP 5.5.
-			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo-main.php' );
-			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo.php' );
-		}
-		if ( function_exists( 'wp_opcache_invalidate_directory' ) ) {
-			// Since WP 6.2.
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'admin' );
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'inc' );
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'lib' );
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'src' );
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'vendor' );
-			wp_opcache_invalidate_directory( WPSEO_PATH . 'vendor_prefixed' );
+		if ( function_exists( 'opcache_reset' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
+			@opcache_reset();
 		}
 
 		new WPSEO_Upgrade();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Revert #20921

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal error would occur when upgrading Yoast SEO on certain setups.

## Relevant technical choices:

* Unfortunately we have to restore the `opcache_reset()` call that we wanted to avoid. We'll dive deeper into how to reintroduce the improvement.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install `Yoast test helper`
* Clone [op-cache gui](https://github.com/amnuts/opcache-gui) to the `public` folder of your WordPress environment.
* Go to `http://wordpress.test/opcache-gui/` (with your site).
* Enable real time update
* Check the cache is full of files.
* edit `wp-config.php` and add this line: `define( 'FS_METHOD', 'ftpext');`
* Go to `Tools`->`Yoast Test`
* In section `Plugin options & database versions` change `YoastSEO` DB version to an older version
* Save
* See that you don't get any fatal error.
* Go to `http://wordpress.test/opcache-gui/` (with your site).
* Go to the `Cached` tab and see that the cache is empty

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
