### PR TITLE
Fix filter params for images in sitemap

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -388,7 +388,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			 * @return array $image_list Array of image items.
 			 */
 			$image_list = apply_filters( 'wpseo_sitemap_urlimages_front_page', $images );
-			if ( isset( $image_list ) && is_array( $image_list ) ) {
+			if ( is_array( $image_list ) ) {
 				$front_page['images'] = $image_list;
 			}
 

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -379,7 +379,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$front_page['chf'] = 'daily';
 			$front_page['pri'] = 1;
 
-			$images = $front_page['images'] ?? [];
+			$images = ( $front_page['images'] ?? [] );
 
 			/**
 			 * Filter images to be included for the term in XML sitemap.

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -379,18 +379,13 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$front_page['chf'] = 'daily';
 			$front_page['pri'] = 1;
 
-			$images = [];
-
 			/**
 			 * Filter images to be included for the term in XML sitemap.
 			 *
-			 * @param array  $images Array of image items.
-			 * @return array $image_list Array of image items.
+			 * @param array<string> Array of image items.
+			 * @return array<string> Array of new image items.
 			 */
-			$image_list = apply_filters( 'wpseo_sitemap_urlimages_front_page', $images );
-			if ( isset( $image_list ) && is_array( $image_list ) ) {
-				$front_page['images'] = $image_list;
-			}
+			$front_page['images'] = apply_filters( 'wpseo_sitemap_urlimages_front_page', $front_page['images'] );
 
 			$links[] = $front_page;
 		}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -379,13 +379,18 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$front_page['chf'] = 'daily';
 			$front_page['pri'] = 1;
 
+			$images = [];
+
 			/**
 			 * Filter images to be included for the term in XML sitemap.
 			 *
-			 * @param array<string> Array of image items.
-			 * @return array<string> Array of new image items.
+			 * @param array  $images Array of image items.
+			 * @return array $image_list Array of image items.
 			 */
-			$front_page['images'] = apply_filters( 'wpseo_sitemap_urlimages_front_page', $front_page['images'] );
+			$image_list = apply_filters( 'wpseo_sitemap_urlimages_front_page', $images );
+			if ( isset( $image_list ) && is_array( $image_list ) ) {
+				$front_page['images'] = $image_list;
+			}
 
 			$links[] = $front_page;
 		}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -379,7 +379,7 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$front_page['chf'] = 'daily';
 			$front_page['pri'] = 1;
 
-			$images = [];
+			$images = $front_page['images'] ?? [];
 
 			/**
 			 * Filter images to be included for the term in XML sitemap.

--- a/tests/WP/Doubles/Inc/Post_Type_Sitemap_Provider_Double.php
+++ b/tests/WP/Doubles/Inc/Post_Type_Sitemap_Provider_Double.php
@@ -30,4 +30,15 @@ final class Post_Type_Sitemap_Provider_Double extends WPSEO_Post_Type_Sitemap_Pr
 	public function get_excluded_posts( $post_type ) {
 		return parent::get_excluded_posts( $post_type );
 	}
+
+	/**
+	 * Produces set of links to prepend at start of first sitemap page.
+	 *
+	 * @param string $post_type Post type to produce links for.
+	 *
+	 * @return array<array<string>> Array of link data.
+	 */
+	public function get_first_links( $post_type ) {
+		return parent::get_first_links( $post_type );
+	}
 }

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -458,7 +458,7 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 
 		$expected = [
 			[
-				'loc'    => 'http://example.org/?page_id=5',
+				'loc'    => 'http://example.org/?page_id='.$post_id,
 				'chf'    => 'daily',
 				'pri'    => 1,
 				'images' => [ [ 'src' => 'http://example.org/wp-content/uploads/test.test/path/to/image.jpg' ] ],

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -458,7 +458,7 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 
 		$expected = [
 			[
-				'loc'    => 'http://example.org/?page_id=' . $post_id,
+				'loc'    => \get_permalink( $post_id ),
 				'chf'    => 'daily',
 				'pri'    => 1,
 				'images' => [ [ 'src' => 'http://example.org/wp-content/uploads/test.test/path/to/image.jpg' ] ],

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -458,7 +458,7 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 
 		$expected = [
 			[
-				'loc'    => 'http://example.org/?page_id='.$post_id,
+				'loc'    => 'http://example.org/?page_id=' . $post_id,
 				'chf'    => 'daily',
 				'pri'    => 1,
 				'images' => [ [ 'src' => 'http://example.org/wp-content/uploads/test.test/path/to/image.jpg' ] ],

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -456,8 +456,6 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 
 		$sitemap_provider = new Post_Type_Sitemap_Provider_Double();
 
-		$index_links = $sitemap_provider->get_index_links( 1 );
-
 		$expected = [
 			[
 				'loc'    => 'http://example.org/?page_id=5',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the image tag would be missing in the home page entry of the XML sitemap when using a static front page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WP + WP SEO
* Create a new page with importing an image.
* Set this page as static home page.
* Visit the `wordpress.test/page-sitemap.xml` and view page source.
* Check the home page code has image tags:
```xml
<url>
    <loc>http://wordpress.test/</loc>
    <lastmod>2024-01-24T13:19:20+00:00</lastmod>
    <image:image>
        <image:loc>http://wordpress.test/wp-content/uploads/woocommerce-placeholder.png</image:loc>
    </image:image>
</url>
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
