### PR TITLE
Add id attribute to SidebarCollapsible inner button

### DIFF
--- a/packages/js/src/components/SidebarCollapsible.js
+++ b/packages/js/src/components/SidebarCollapsible.js
@@ -32,6 +32,7 @@ const SidebarCollapsible = ( props ) => {
 				onClick={ handleClick }
 				className="components-button components-panel__body-toggle"
 				type="button"
+				id={ props.buttonId }
 			>
 				<span
 					className="yoast-icon-span"
@@ -69,10 +70,12 @@ SidebarCollapsible.propTypes = {
 	prefixIcon: PropTypes.object,
 	subTitle: PropTypes.string,
 	hasBetaBadgeLabel: PropTypes.bool,
+	buttonId: PropTypes.string,
 };
 
 SidebarCollapsible.defaultProps = {
 	prefixIcon: null,
 	subTitle: "",
 	hasBetaBadgeLabel: false,
+	buttonId: null,
 };

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -117,6 +117,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 29 }>
 					<SidebarCollapsible
 						title={ __( "Advanced", "wordpress-seo" ) }
+						buttonId="yoast-seo-elementor-advanced-button"
 					>
 						<AdvancedSettings location="sidebar" />
 					</SidebarCollapsible>

--- a/packages/js/tests/components/SidebarCollapsibleTest.js
+++ b/packages/js/tests/components/SidebarCollapsibleTest.js
@@ -36,4 +36,10 @@ describe( "SidebarCollapsible", () => {
 
 		expect( icon ).toBeInTheDocument();
 	} );
+
+	it( "has id associated to inner button", async() => {
+		const { container } = render( <SidebarCollapsible buttonId="test-button-id" { ...defaultArgs } /> );
+		const button = container.querySelector( "#test-button-id" );
+		expect( button ).toBeInTheDocument();
+	} );
 } );

--- a/packages/js/tests/components/SidebarCollapsibleTest.js
+++ b/packages/js/tests/components/SidebarCollapsibleTest.js
@@ -1,0 +1,39 @@
+import React from "react";
+import SidebarCollapsible from "../../src/components/SidebarCollapsible";
+import { fireEvent, render, screen } from "../test-utils";
+
+const defaultArgs = {
+	title: "Test title",
+	children: <div id="inner-div">Test children</div>,
+};
+
+describe( "SidebarCollapsible", () => {
+	it( "is opened", async() => {
+		const { container } = render( <SidebarCollapsible { ...defaultArgs } /> );
+		const button = screen.getByRole( "button" );
+		fireEvent.click( button );
+		const innerDiv = container.querySelector( "#inner-div" );
+		expect( innerDiv ).toBeInTheDocument();
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( "is closed", async() => {
+		const { container } = render( <SidebarCollapsible { ...defaultArgs } /> );
+		const innerDiv = container.querySelector( "#inner-div" );
+		expect( innerDiv ).not.toBeInTheDocument();
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( "has beta badge", async() => {
+		const { container } = render( <SidebarCollapsible hasBetaBadgeLabel={ true } { ...defaultArgs } /> );
+		const badge = container.querySelector( ".yoast-beta-badge" );
+		expect( badge ).toBeInTheDocument();
+	} );
+
+	it( "has svg prefix icon", async() => {
+		const { container } = render( <SidebarCollapsible prefixIcon={ { icon: "gear", color: "green" } } { ...defaultArgs } /> );
+		const icon = container.querySelector( "svg" );
+
+		expect( icon ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/tests/components/__snapshots__/SidebarCollapsibleTest.js.snap
+++ b/packages/js/tests/components/__snapshots__/SidebarCollapsibleTest.js.snap
@@ -1,0 +1,80 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SidebarCollapsible is closed 1`] = `
+<div>
+  <div
+    class="yoast components-panel__body "
+  >
+    <h2
+      class="components-panel__body-title"
+    >
+      <button
+        class="components-button components-panel__body-toggle"
+        type="button"
+      >
+        <span
+          class="yoast-icon-span"
+        />
+        <span
+          class="yoast-title-container"
+        >
+          <div
+            class="yoast-title"
+          >
+            Test title
+          </div>
+          <div
+            class="yoast-subtitle"
+          />
+        </span>
+        <span
+          aria-hidden="true"
+          class="yoast-chevron"
+        />
+      </button>
+    </h2>
+  </div>
+</div>
+`;
+
+exports[`SidebarCollapsible is opened 1`] = `
+<div>
+  <div
+    class="yoast components-panel__body is-opened"
+  >
+    <h2
+      class="components-panel__body-title"
+    >
+      <button
+        class="components-button components-panel__body-toggle"
+        type="button"
+      >
+        <span
+          class="yoast-icon-span"
+        />
+        <span
+          class="yoast-title-container"
+        >
+          <div
+            class="yoast-title"
+          >
+            Test title
+          </div>
+          <div
+            class="yoast-subtitle"
+          />
+        </span>
+        <span
+          aria-hidden="true"
+          class="yoast-chevron"
+        />
+      </button>
+    </h2>
+    <div
+      id="inner-div"
+    >
+      Test children
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add an `id` to the `SidebarCollapsible` button in the Elementor sidebar in order to make automated testing simpler.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the possibility to add an `id` to a `SidebarCollapsible` button.
* Adds an `id` to the `Advanced` `SidebarCollapsible` button in the Elementor sidebar. 

## Relevant technical choices:

* The `id` attribute is added to the button only if the `buttonId` prop of `SidebarCollapsible` is not null. This allows us to incrementally introduce ids when needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with Elementor
* Open the `Yoast` sidebar menu
* [ ] Verify the button inside the `Advanced` collapsible has the id `yoast-seo-elementor-advanced-button`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21035
