### PR TITLE
Remove parameter type declaration on method hooked to a WP filter

### DIFF
--- a/admin/filters/class-abstract-post-filter.php
+++ b/admin/filters/class-abstract-post-filter.php
@@ -96,11 +96,11 @@ abstract class WPSEO_Abstract_Post_Filter implements WPSEO_WordPress_Integration
 	/**
 	 * Adds a filter link to the views.
 	 *
-	 * @param array $views Array with the views.
+	 * @param array<string, string> $views Array with the views.
 	 *
-	 * @return array Array of views including the added view.
+	 * @return array<string, string> Array of views including the added view.
 	 */
-	public function add_filter_link( array $views ) {
+	public function add_filter_link( $views ) {
 		$views[ 'yoast_' . $this->get_query_val() ] = sprintf(
 			'<a href="%1$s"%2$s>%3$s</a> (%4$s)',
 			esc_url( $this->get_filter_url() ),

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2677",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2665",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=297",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2679",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2677",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=297",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents fatal errors when used together with a plugin which hooks into `views_edit-{$post_type}` but doesn't return an array as expected.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install https://wordpress.org/plugins/woocommerce-product-tabs/ v2.1.0 or [2.1.0.1](https://downloads.wordpress.org/plugin/woocommerce-product-tabs.2.1.0.1.zip)
  * v2.1.1 fixes the issue on their side
* see that you don't get a fatal error when visiting the post list
  * without this patch you would see:
```
Fatal error: Uncaught Error: WPSEO_Abstract_Post_Filter::add_filter_link(): Argument #1 ($views) must be of type array, null given, called in /home/lopo/Local Sites/development-symlink/app/public/wp-includes/class-wp-hook.php on line 324
in /home/lopo/src/Yoast/plugin-development-docker/plugins/wordpress-seo/admin/filters/class-abstract-post-filter.php on line 103
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
