### PR TITLE
Set default values to empty string when no primary location is set

### DIFF
--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -668,7 +668,7 @@ class Settings_Integration implements Integration_Interface {
 				foreach ( $location_keys as $key => $meta_keys ) {
 					$is_overridden = \get_post_meta( $primary_location, $meta_keys['is_overridden'], true );
 					if ( ( $shared_info === 'on' && $is_overridden && $is_overridden === 'on' ) || $shared_info !== 'on' ) {
-						$defaults['wpseo_titles'][ $key ] = \get_post_meta( $primary_location, $meta_keys['value'], true );
+						$defaults['wpseo_titles'][ $key ] = $primary_location === '' ? '' : \get_post_meta( $primary_location, $meta_keys['value'], true );
 					}
 				}
 			}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When Yoast SEO Local is set to have locations as part of the same business but a primary location is not set, the organization information in the Settings page wrongly shows `false` as default value.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where organization information in the Settings page would show `false` as Yoast SEO Local organization default values.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate the latest RCs of both Yoast SEO Local and Yoast SEO Premium
* Go to `Yoast SEO` -> `Local SEO`
* Set both `My business has multiple locations` and `All locations are part of the same business` to `Yes`
* Do not select any location from the `Primary location` dropdown
* Save the changes
* Go to `Yoast SEO` -> `Settings` -> `Site representation` -> `Additional organization info` section
  * [ ] Verify the following fields are deactivated and empty:
    * Organization email address
    * Organization phone number
    * VAT ID
    * Tax ID 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1328
