### PR TITLE
Update the sidebar Ad.

### DIFF
--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -595,6 +595,12 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-size: 1rem;
 }
 
+.yoast-sidebar__product .price-micro-copy {
+	font-size: 11px;
+	text-align: center;
+	line-height: 19px;
+}
+
 .yoast-sidebar__product .plugin-buy-button .yoast-button-upsell {
 	width: 100%;
 }

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -596,9 +596,10 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 .yoast-sidebar__product .yoast-price-micro-copy {
-	font-size: 11px;
+	font-weight: 300;
+	font-size: 12px;
 	text-align: center;
-	line-height: 19px;
+	line-height: 20px;
 	margin-bottom: 16px;
 }
 

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -595,10 +595,17 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-size: 1rem;
 }
 
-.yoast-sidebar__product .price-micro-copy {
+.yoast-sidebar__product .yoast-price-micro-copy {
 	font-size: 11px;
 	text-align: center;
 	line-height: 19px;
+	margin-bottom: 16px;
+}
+
+.yoast-sidebar__product .yoast-upsell-hr {
+	border-color: #CD82AB;
+	border-top: 1px;
+	margin-bottom: 16px;
 }
 
 .yoast-sidebar__product .plugin-buy-button .yoast-button-upsell {

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -82,7 +82,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			<p className="yst-text-center yst-text-[11px] yst-leading[19px] yst-mt-2">
 				{ __( "Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.", "wordpress-seo" ) }
 			</p>
-			<hr className="yst-border-t-[1px] yst-border-purple-300 yst-my-4" />
+			<hr className="yst-border-t yst-border-primary-300 yst-my-4" />
 			<a
 				className="yst-block yst-mt-4 yst-no-underline"
 				href="https://www.g2.com/products/yoast-yoast/reviews"

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -29,10 +29,6 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			nowrap: <span className="yst-whitespace-nowrap" />,
 		}
 	);
-	const explorePremium = sprintf(
-		/* translators: %1$s expands to "Yoast SEO Premium". */
-		__( "Explore %1$s", "wordpress-seo" ), "Yoast SEO Premium"
-	);
 	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
 	const saveMoneyText = createInterpolateElement(
 		sprintf(
@@ -76,10 +72,10 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...linkProps }
 			>
-				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : explorePremium }</span>
+				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : getPremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
-			<p className="yst-text-center yst-text-[11px] yst-leading-[19px] yst-mt-2">
+			<p className="yst-text-center yst-text-xs yst-font-light yst-leading-5 yst-mt-2">
 				{ __( "Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.", "wordpress-seo" ) }
 			</p>
 			<hr className="yst-border-t yst-border-primary-300 yst-my-4" />

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -79,7 +79,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : explorePremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
-			<p className="yst-text-center yst-text-[11px] yst-leading[19px] yst-mt-2">
+			<p className="yst-text-center yst-text-[11px] yst-leading-[19px] yst-mt-2">
 				{ __( "Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.", "wordpress-seo" ) }
 			</p>
 			<hr className="yst-border-t yst-border-primary-300 yst-my-4" />

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -29,6 +29,10 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			nowrap: <span className="yst-whitespace-nowrap" />,
 		}
 	);
+	const explorePremium = sprintf(
+		/* translators: %1$s expands to "Yoast SEO Premium". */
+		__( "Explore %1$s", "wordpress-seo" ), "Yoast SEO Premium"
+	);
 	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
 	const saveMoneyText = createInterpolateElement(
 		sprintf(
@@ -72,9 +76,13 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...linkProps }
 			>
-				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : getPremium }</span>
+				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : explorePremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
+			<p className="yst-text-center yst-text-[11px] yst-leading[19px] yst-mt-2">
+				{ __( "Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.", "wordpress-seo" ) }
+			</p>
+			<hr className="yst-border-t-[1px] yst-border-purple-300 yst-my-4" />
 			<a
 				className="yst-block yst-mt-4 yst-no-underline"
 				href="https://www.g2.com/products/yoast-yoast/reviews"

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -20,7 +20,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 		$title = \__( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( \WPSEO_FILE ) );
-		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
+		$buy_yoast_seo_shortlink = 'https://yoast.com/checkout/?yst-add-to-cart=2811749';
 		\ob_start();
 		?>
 			<div class="wpseo_content_cell" id="sidebar-container">
@@ -81,11 +81,16 @@ class Sidebar_Presenter extends Abstract_Presenter {
 								}
 								else {
 									/* translators: %s expands to Yoast SEO Premium */
-									\printf( \esc_html__( 'Get %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+									\printf( \esc_html__( 'Explore %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 								}
 								?>
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>
 							</a>
+						</p>
+						<p class="price-micro-copy">
+							<?php
+								echo \esc_html__( 'Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.', 'wordpress-seo' );
+							?>
 						</p>
 						<div class="review-container">
 							<a href="https://www.g2.com/products/yoast-yoast/reviews" target="_blank" rel="noopener">

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -81,7 +81,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 								}
 								else {
 									/* translators: %s expands to Yoast SEO Premium */
-									\printf( \esc_html__( 'Explore %s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+									\printf( \esc_html__( 'Explore %1$s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 								}
 								?>
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -20,7 +20,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 		$title = \__( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( \WPSEO_FILE ) );
-		$buy_yoast_seo_shortlink = 'https://yoast.com/checkout/?yst-add-to-cart=2811749';
+		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
 		\ob_start();
 		?>
 			<div class="wpseo_content_cell" id="sidebar-container">

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -81,7 +81,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 								}
 								else {
 									/* translators: %s expands to Yoast SEO Premium */
-									\printf( \esc_html__( 'Explore %1$s', 'wordpress-seo' ), 'Yoast SEO Premium' );
+									\printf( \esc_html__( 'Get %1$s', 'wordpress-seo' ), 'Yoast SEO Premium' );
 								}
 								?>
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -87,11 +87,12 @@ class Sidebar_Presenter extends Abstract_Presenter {
 								<span aria-hidden="true" class="yoast-button-upsell__caret"></span>
 							</a>
 						</p>
-						<p class="price-micro-copy">
+						<p class="yoast-price-micro-copy">
 							<?php
 								echo \esc_html__( 'Only $/€/£99 per year (ex VAT) 30-day money back guarantee - No questions asked.', 'wordpress-seo' );
 							?>
 						</p>
+						<hr class="yoast-upsell-hr" aria-hidden="true">
 						<div class="review-container">
 							<a href="https://www.g2.com/products/yoast-yoast/reviews" target="_blank" rel="noopener">
 								<span class="claim">


### PR DESCRIPTION
* Adds price and copy
* changed the CTA link to redirect to the checkout page

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the Yoast SEO sidebar ad.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds more information about Yoast SEO Premium price to the sidebar ad.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `General` tab
  * [ ] Verify the sidebar ad looks like the one in the [sketch](https://www.sketch.com/s/b8c606ca-cb0b-48bc-9e0c-a16fd77e70ff/prototype/65A9711A-6B16-46BB-8E43-E6A894D809E4/a/65A9711A-6B16-46BB-8E43-E6A894D809E4)
 * [ ] Perform the same check for the sidebar in `Yoast SEO` -> `Settings`
 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Plugin ad copy: add price & microcopy
#103](https://github.com/Yoast/growth/issues/103)
