### PR TITLE
Add discount on all plugins subscription card

### DIFF
--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -316,6 +316,8 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 					<h3>
 						<img alt="" width="100" height="100" src="<?php echo esc_url( $extension['image'] ); ?>"/>
 						<?php echo esc_html( $extension['display_title'] ); ?>
+						<?php
+						?>
 					</h3>
 					<ul class="yoast-list--usp">
 						<?php foreach ( $extension['benefits'] as $benefit ) : ?>
@@ -373,7 +375,11 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 								echo '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
 								?>
 							</a>
-
+							<?php if ( $slug === 'yoast-seo-plugin-subscription' ) : ?>
+								<p class="yoast-subscription-discount">
+									<?php esc_html_e( 'Only €229 EUR / year (ex VAT). Save over 40% with this subscription!', 'wordpress-seo' ); ?>
+								</p>
+							<?php endif; ?>
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension['infoUrl'] ); ?>">
 								<?php
 								esc_html_e( 'Explore now', 'wordpress-seo' );

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -316,8 +316,6 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 					<h3>
 						<img alt="" width="100" height="100" src="<?php echo esc_url( $extension['image'] ); ?>"/>
 						<?php echo esc_html( $extension['display_title'] ); ?>
-						<?php
-						?>
 					</h3>
 					<ul class="yoast-list--usp">
 						<?php foreach ( $extension['benefits'] as $benefit ) : ?>
@@ -377,7 +375,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 							</a>
 							<?php if ( $slug === 'yoast-seo-plugin-subscription' ) : ?>
 								<p class="yoast-subscription-discount">
-									<?php esc_html_e( 'Only €229 EUR / year (ex VAT). Save over 40% with this subscription!', 'wordpress-seo' ); ?>
+									<?php esc_html_e( 'Only €229 EUR per year (ex VAT). Save over 40% with this subscription!', 'wordpress-seo' ); ?>
 								</p>
 							<?php endif; ?>
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension['infoUrl'] ); ?>">

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -375,7 +375,7 @@ if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-202
 							</a>
 							<?php if ( $slug === 'yoast-seo-plugin-subscription' ) : ?>
 								<p class="yoast-subscription-discount">
-									<?php esc_html_e( 'Only €229 EUR per year (ex VAT). Save over 40% with this subscription!', 'wordpress-seo' ); ?>
+									<?php esc_html_e( 'Only $/€/£229 per year (ex VAT). Save over 40% with this subscription!', 'wordpress-seo' ); ?>
 								</p>
 							<?php endif; ?>
 							<a target="_blank" class="yoast-link--more-info" href="<?php echo esc_url( $extension['infoUrl'] ); ?>">

--- a/css/src/yoast-extensions.css
+++ b/css/src/yoast-extensions.css
@@ -776,4 +776,11 @@ a.promoblock:hover {
   background: #dc3232;
 }
 
+.yoast-promoblock.secondary.yoast-promo-extension .yoast-button-container .yoast-subscription-discount {
+  font-size: 12px;
+  color: #617993;
+  margin-top: -8px;
+  margin-bottom: 8px;
+  text-align: center;
+}
 /*# sourceMappingURL=yoast-extensions.css.map */

--- a/css/src/yoast-extensions.css
+++ b/css/src/yoast-extensions.css
@@ -778,7 +778,7 @@ a.promoblock:hover {
 
 .yoast-promoblock.secondary.yoast-promo-extension .yoast-button-container .yoast-subscription-discount {
   font-size: 12px;
-  color: #617993;
+  color: #64748b;
   margin-top: -8px;
   margin-bottom: 8px;
   text-align: center;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the `Cover all your SEO bases` card in the `Premium` page.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds price and saving information to the `Cover all your SEO bases` card in the `Premium` page.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `Premium`
* [ ] Verify the `Cover all your SEO bases` card looks as follows
 <img width="361" alt="Screenshot 2024-01-30 at 11 30 23" src="https://github.com/Yoast/wordpress-seo/assets/68744851/4753e027-6834-47e5-8f5f-964f788a866b">


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Plugin ad copy: Add discount on “all plugin subscription” card
#106](https://github.com/Yoast/growth/issues/106)
