### PR TITLE
Links `Person or Organization` node to the `ProfilePage` Node.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2624",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2625",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=294",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2665",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2653",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=297",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -43,7 +43,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  * @property int             $site_user_id
  * @property string          $site_represents
  * @property array|false     $site_represents_reference
- * @property string          $schema_page_type
+ * @property string|string[] $schema_page_type
  * @property string|string[] $schema_article_type      Represents the type of article.
  * @property string          $main_schema_id
  * @property string|array    $main_entity_of_page

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -149,7 +149,7 @@ class Person extends Abstract_Schema_Piece {
 			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $user_data->description );
 		}
 
-		if ( \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
+		if ( ! \is_null( $this->context->schema_page_type ) && \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
 			$data['mainEntityOfPage'] = [
 				'@id' => $this->context->main_schema_id,
 			];

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -149,7 +149,7 @@ class Person extends Abstract_Schema_Piece {
 			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $user_data->description );
 		}
 
-		if ( ! \is_null( $this->context->schema_page_type ) && \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
+		if ( \is_array( $this->context->schema_page_type ) && \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
 			$data['mainEntityOfPage'] = [
 				'@id' => $this->context->main_schema_id,
 			];

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -52,7 +52,7 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Returns Person Schema data.
 	 *
-	 * @return bool|array Person data on success, false on failure.
+	 * @return bool|array<string|string[]> Person data on success, false on failure.
 	 */
 	public function generate() {
 		$user_id = $this->determine_user_id();
@@ -87,8 +87,8 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Retrieve a list of social profile URLs for Person.
 	 *
-	 * @param array $same_as_urls Array of SameAs URLs.
-	 * @param int   $user_id      User ID.
+	 * @param string[] $same_as_urls Array of SameAs URLs.
+	 * @param int      $user_id      User ID.
 	 *
 	 * @return string[] A list of SameAs URLs.
 	 */
@@ -128,7 +128,7 @@ class Person extends Abstract_Schema_Piece {
 	 * @param int  $user_id  The user ID to use.
 	 * @param bool $add_hash Wether or not the person's image url hash should be added to the image id.
 	 *
-	 * @return array An array of Schema Person data.
+	 * @return array<string|string[]> An array of Schema Person data.
 	 */
 	protected function build_person_data( $user_id, $add_hash = false ) {
 		$user_data = \get_userdata( $user_id );
@@ -149,6 +149,11 @@ class Person extends Abstract_Schema_Piece {
 			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $user_data->description );
 		}
 
+		if ( \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
+			$data['mainEntityOfPage'] = [
+				'@id' => $this->context->main_schema_id,
+			];
+		}
 		$data = $this->add_same_as_urls( $data, $user_data, $user_id );
 
 		/**
@@ -165,11 +170,11 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Returns an ImageObject for the persons avatar.
 	 *
-	 * @param array   $data      The Person schema.
-	 * @param WP_User $user_data User data.
-	 * @param bool    $add_hash  Wether or not the person's image url hash should be added to the image id.
+	 * @param array<string|string[]> $data      The Person schema.
+	 * @param WP_User                $user_data User data.
+	 * @param bool                   $add_hash  Wether or not the person's image url hash should be added to the image id.
 	 *
-	 * @return array The Person schema.
+	 * @return array<string|string[]> The Person schema.
 	 */
 	protected function add_image( $data, $user_data, $add_hash = false ) {
 		$schema_id = $this->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
@@ -190,12 +195,12 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Generate the person image from our settings.
 	 *
-	 * @param array   $data      The Person schema.
-	 * @param string  $schema_id The string used in the `@id` for the schema.
-	 * @param bool    $add_hash  Whether or not the person's image url hash should be added to the image id.
-	 * @param WP_User $user_data User data.
+	 * @param array<string|string[]> $data      The Person schema.
+	 * @param string                 $schema_id The string used in the `@id` for the schema.
+	 * @param bool                   $add_hash  Whether or not the person's image url hash should be added to the image id.
+	 * @param WP_User                $user_data User data.
 	 *
-	 * @return array The Person schema.
+	 * @return array<string|string[]> The Person schema.
 	 */
 	protected function set_image_from_options( $data, $schema_id, $add_hash = false, $user_data = null ) {
 		if ( $this->context->site_represents !== 'person' ) {
@@ -211,12 +216,12 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Generate the person logo from gravatar.
 	 *
-	 * @param array   $data      The Person schema.
-	 * @param WP_User $user_data User data.
-	 * @param string  $schema_id The string used in the `@id` for the schema.
-	 * @param bool    $add_hash  Wether or not the person's image url hash should be added to the image id.
+	 * @param array<string|string[]> $data      The Person schema.
+	 * @param WP_User                $user_data User data.
+	 * @param string                 $schema_id The string used in the `@id` for the schema.
+	 * @param bool                   $add_hash  Wether or not the person's image url hash should be added to the image id.
 	 *
-	 * @return array The Person schema.
+	 * @return array<string|string[]> The Person schema.
 	 */
 	protected function set_image_from_avatar( $data, $user_data, $schema_id, $add_hash = false ) {
 		// If we don't have an image in our settings, fall back to an avatar, if we're allowed to.
@@ -238,8 +243,8 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Returns an author's social site URL.
 	 *
-	 * @param string $social_site The social site to retrieve the URL for.
-	 * @param mixed  $user_id     The user ID to use function outside of the loop.
+	 * @param string    $social_site The social site to retrieve the URL for.
+	 * @param int|false $user_id     The user ID to use function outside of the loop.
 	 *
 	 * @return string
 	 */
@@ -284,11 +289,11 @@ class Person extends Abstract_Schema_Piece {
 	/**
 	 * Builds our SameAs array.
 	 *
-	 * @param array   $data      The Person schema data.
-	 * @param WP_User $user_data The user data object.
-	 * @param int     $user_id   The user ID to use.
+	 * @param array<string|string[]> $data      The Person schema data.
+	 * @param WP_User                $user_data The user data object.
+	 * @param int                    $user_id   The user ID to use.
 	 *
-	 * @return array The Person schema data.
+	 * @return array<string|string[]> The Person schema data.
 	 */
 	protected function add_same_as_urls( $data, $user_data, $user_id ) {
 		$same_as_urls = [];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -83,7 +83,7 @@ class WebPage extends Abstract_Schema_Piece {
 	 * Adds an author property to the $data if the WebPage is not represented.
 	 *
 	 * @param array<string|array<string>> $data The WebPage schema.
-	 * @param WP_Post                                   $post The post the context is representing.
+	 * @param WP_Post                     $post The post the context is representing.
 	 *
 	 * @return array<string|array<string>> The WebPage schema.
 	 */

--- a/tests/WP/Generators/Schema/Person_Test.php
+++ b/tests/WP/Generators/Schema/Person_Test.php
@@ -76,7 +76,7 @@ final class Person_Test extends TestCase {
 
 		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 
-		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
+		$this->context = clone $meta_tags_context_memoizer->get( $built_indexable, 'page' );
 	}
 
 	/**

--- a/tests/WP/Generators/Schema/Person_Test.php
+++ b/tests/WP/Generators/Schema/Person_Test.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Generators\Schema;
+
+use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
+use Yoast\WP\SEO\Generators\Schema\Person;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
+
+/**
+ * Integration Test Class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Generators\Schema\Person
+ */
+final class Person_Test extends TestCase {
+
+	/**
+	 * The generator to test.
+	 *
+	 * @var Person
+	 */
+	private $instance;
+
+	/**
+	 * The meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $context;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$indexable_post_builder = new Indexable_Post_Builder(
+			\YoastSEO()->helpers->post,
+			\YoastSEO()->helpers->post_type,
+			\YoastSEO()->classes->get( Indexable_Builder_Versions::class ),
+			\YoastSEO()->helpers->meta
+		);
+
+		$indexable_post_builder->set_social_image_helpers(
+			\YoastSEO()->helpers->image,
+			\YoastSEO()->helpers->open_graph->image,
+			\YoastSEO()->helpers->twitter->image
+		);
+
+		$post_type = 'my-custom-post-type';
+		\register_post_type(
+			$post_type,
+			[
+				'public'      => true,
+				'has_archive' => true,
+				'description' => 'a cool post type',
+				'label'       => $post_type,
+			]
+		);
+
+		$post = [
+			'post_date'   => '1978-09-13 08:50:00',
+			'post_status' => 'publish',
+			'post_type'   => $post_type,
+		];
+
+		$post_id         = self::factory()->post->create( $post );
+		$indexable       = new Indexable();
+		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
+		$built_indexable = $indexable_post_builder->build( $post_id, $indexable );
+
+		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+
+		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
+	}
+
+	/**
+	 * Tests that the type is properly set if everything is in the default setting.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_create_person_schema() {
+		$this->context->site_user_id = 1;
+
+		$this->instance          = \YoastSEO()->classes->get( Person::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = [ 'Person', 'Organization' ];
+
+		$this->assertEquals( $expected, $webpage_schema_piece['@type'] );
+	}
+
+	/**
+	 * Tests that mainEntityOfPage gets set for Profile pages.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_create_person_schema_for_profile_page() {
+		$this->context->site_user_id     = 1;
+		$this->context->schema_page_type = [ 'ProfilePage' ];
+
+		$this->instance          = \YoastSEO()->classes->get( Person::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = $this->context->main_schema_id;
+
+		$this->assertEquals( $expected, $webpage_schema_piece['mainEntityOfPage']['@id'] );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure our ProfilePage schema is valid whenever it's used.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the ProfilePage schema node was not valid when it was manually chosen for a page.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your site to `person` in the site representation: /wp-admin/admin.php?page=wpseo_page_settings#/site-representation. 
* Select an author on your page.
* Create a new page and set the `Page type` In our Schema settings to `Profile Page`.
* Make sure the following code is visible in your schema and there are no error in the google rich result test (RRT) and schema validator.
NOTE: You will not see ProfilePage in the RRT, but this will work in GSC. See this [thread](https://yoast.slack.com/archives/C03KU0EHCNQ/p1706521515517499) for some more context.

In the first schema node:
```
"@type": [
 "WebPage", "ProfilePage"
],
```
In the node with `Person and Organization`
```

"mainEntityOfPage": {
   "@id": "{link of your current page}"
  |},

```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
