### PR TITLE
Prevent parsing  with full url

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -322,24 +322,14 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		if ( $rel === 'next' || $rel === 'prev' ) {
-
-			// WP_HTML_Tag_Processor was introduced in WordPress 6.2.
+			// Reconstruct url if it's relative.
 			if ( \class_exists( WP_HTML_Tag_Processor::class ) ) {
 				$processor = new WP_HTML_Tag_Processor( $this->$rel );
 				while ( $processor->next_tag( [ 'tag_name' => 'a' ] ) ) {
 					$href = $processor->get_attribute( 'href' );
-					if ( $href ) {
+					if ( $href && \strpos( $href, '/' ) === 0 ) {
 						return $presentation->permalink . \substr( $href, 1 );
 					}
-				}
-			}
-			// Remove else when dropping support for WordPress 6.1 and lower.
-			else {
-				$pattern = '/"(.*?)"/';
-				// Find all matches of the pattern in the HTML string.
-				\preg_match_all( $pattern, $this->$rel, $matches );
-				if ( isset( $matches[1] ) && isset( $matches[1][0] ) && $matches[1][0] ) {
-					return $presentation->permalink . \substr( $matches[1][0], 1 );
 				}
 			}
 		}

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -308,7 +308,7 @@ class Front_End_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Returns correct adjacent pages when QUery loop block does not inherit query from template.
+	 * Returns correct adjacent pages when Query loop block does not inherit query from template.
 	 *
 	 * @param string                      $link         The current link.
 	 * @param string                      $rel          Link relationship, prev or next.

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -160,7 +160,7 @@ final class Front_End_Integration_Test extends TestCase {
 				'rel'      => 'prev',
 				'prev'     => '<a href="https://example.org/?query-1-page=2">Prev</a>',
 				'next'     => '<a href="https://example.org/?query-1-page=4">Next</a>',
-				'expected' => 'https://example.org/?query-1-page=2',
+				'expected' => 'https://example.org/?query-1-page=3',
 			],
 		];
 	}

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -155,6 +155,13 @@ final class Front_End_Integration_Test extends TestCase {
 				'next'     => '<a href="/?query-1-page=4">Next</a>',
 				'expected' => 'https://example.org/?query-1-page=2',
 			],
+			'full url' => [
+				'link'     => 'https://example.org/?query-1-page=3',
+				'rel'      => 'prev',
+				'prev'     => '<a href="https://example.org/?query-1-page=2">Prev</a>',
+				'next'     => '<a href="https://example.org/?query-1-page=4">Next</a>',
+				'expected' => 'https://example.org/?query-1-page=2',
+			],
 		];
 	}
 }

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -156,11 +156,11 @@ final class Front_End_Integration_Test extends TestCase {
 				'expected' => 'https://example.org/?query-1-page=2',
 			],
 			'full url' => [
-				'link'     => 'https://example.org/?query-1-page=3',
+				'link'     => 'https://example.org/?query-1-page=2',
 				'rel'      => 'prev',
 				'prev'     => '<a href="https://example.org/?query-1-page=2">Prev</a>',
 				'next'     => '<a href="https://example.org/?query-1-page=4">Next</a>',
-				'expected' => 'https://example.org/?query-1-page=3',
+				'expected' => 'https://example.org/?query-1-page=2',
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to avoid parsing prev and next link if we have a full url.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where next and prev links in query loop would be wrong when disabling `Inherit query from template`.

## Relevant technical choices:

* Removed code that is no longer supported, for WordPress version 6.1.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate FSE theme, like FSE BlogStory.
* Make sure you have around 10 posts
* In `Settings`->`Reading`->`Blog pages show at most` and change it to 2 so that you would have pagination.
* Edit site through the Site Editor. Appearance->Editor
* Go to Templates ->Blog Home
* Duplicate the Query Loop Block and delete the pagination from the duplication.
* In the block configuration uncheck `Inherit query from template`.
* Go to the home page and go to the next page of posts in the original query loop.
* Inspect page and check canonical link, next link, and prev link are correct.
![image](https://github.com/Yoast/wordpress-seo/assets/6975345/85ae4a4c-825e-40a4-8810-6da12fda5c80)

* Repeat tests in https://github.com/Yoast/wordpress-seo/pull/20542

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Block/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Links rel="next" and rel="prev" are broken when blog archive has query loop which is not 'Inherited query'](https://github.com/Yoast/wordpress-seo/issues/20733)
