### PR TITLE
Update tests to not rely on the DI instance of the `Meta_Tags_Context_Memoizer`

### DIFF
--- a/tests/WP/Generators/Schema/Person_Test.php
+++ b/tests/WP/Generators/Schema/Person_Test.php
@@ -4,9 +4,12 @@ namespace Yoast\WP\SEO\Tests\WP\Generators\Schema;
 
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Presentation_Memoizer;
 use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\WP\TestCase;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 
@@ -74,9 +77,15 @@ final class Person_Test extends TestCase {
 		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
 		$built_indexable = $indexable_post_builder->build( $post_id, $indexable );
 
-		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
-
-		$this->context = clone $meta_tags_context_memoizer->get( $built_indexable, 'page' );
+		$meta_tags_context_memoizer = new Meta_Tags_Context_Memoizer(
+			\YoastSEO()->helpers->blocks,
+			\YoastSEO()->helpers->current_page,
+			\YoastSEO()->classes->get( Indexable_Repository::class ),
+			\YoastSEO()->classes->get( Meta_Tags_Context::class ),
+			\YoastSEO()->classes->get( Presentation_Memoizer::class )
+		);
+		\YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
+		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
 	}
 
 	/**

--- a/tests/WP/Generators/Schema/Person_Test.php
+++ b/tests/WP/Generators/Schema/Person_Test.php
@@ -84,7 +84,7 @@ final class Person_Test extends TestCase {
 			\YoastSEO()->classes->get( Meta_Tags_Context::class ),
 			\YoastSEO()->classes->get( Presentation_Memoizer::class )
 		);
-		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
+		$this->context              = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
 	}
 
 	/**

--- a/tests/WP/Generators/Schema/Person_Test.php
+++ b/tests/WP/Generators/Schema/Person_Test.php
@@ -84,7 +84,6 @@ final class Person_Test extends TestCase {
 			\YoastSEO()->classes->get( Meta_Tags_Context::class ),
 			\YoastSEO()->classes->get( Presentation_Memoizer::class )
 		);
-		\YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
 		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
 	}
 

--- a/tests/WP/Generators/Schema/WebPage_Test.php
+++ b/tests/WP/Generators/Schema/WebPage_Test.php
@@ -5,9 +5,12 @@ namespace Yoast\WP\SEO\Tests\WP\Generators\Schema;
 use WP_Query;
 use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_System_Page_Builder;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Generators\Schema\WebPage;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Presentation_Memoizer;
 use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\WP\TestCase;
 use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
 
@@ -17,6 +20,13 @@ use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
  * @coversDefaultClass Yoast\WP\SEO\Generators\Schema\WebPage
  */
 final class WebPage_Test extends TestCase {
+
+	/**
+	 * The Meta tags context memoizer.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	protected $meta_tags_context_memoizer;
 
 	/**
 	 * The generator to test.
@@ -51,6 +61,13 @@ final class WebPage_Test extends TestCase {
 			\YoastSEO()->helpers->options,
 			\YoastSEO()->classes->get( Indexable_Builder_Versions::class )
 		);
+		$this->meta_tags_context_memoizer    = new Meta_Tags_Context_Memoizer(
+			\YoastSEO()->helpers->blocks,
+			\YoastSEO()->helpers->current_page,
+			\YoastSEO()->classes->get( Indexable_Repository::class ),
+			\YoastSEO()->classes->get( Meta_Tags_Context::class ),
+			\YoastSEO()->classes->get( Presentation_Memoizer::class )
+		);
 	}
 
 	/**
@@ -70,9 +87,7 @@ final class WebPage_Test extends TestCase {
 		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
 		$built_indexable = $this->indexable_system_page_builder->build( 'search-result', $indexable );
 
-		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
-
-		$this->context = $meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
+		$this->context = $this->meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
 
 		$this->instance          = \YoastSEO()->classes->get( WebPage::class );
 		$this->instance->context = $this->context;
@@ -102,9 +117,7 @@ final class WebPage_Test extends TestCase {
 		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
 		$built_indexable = $this->indexable_system_page_builder->build( 'search-result', $indexable );
 
-		$meta_tags_context_memoizer = \YoastSEO()->classes->get( Meta_Tags_Context_Memoizer::class );
-
-		$this->context            = $meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
+		$this->context            = $this->meta_tags_context_memoizer->get( $built_indexable, 'system-page' );
 		$this->context->canonical = '';
 
 		$this->instance          = \YoastSEO()->classes->get( WebPage::class );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update some integration tests so that they don't rely on a DI version that can conflict with other tests.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates integration tests to make them more future proof.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* N/A

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
