### PR TITLE
21105 sitemapxml not redirecting when  serverhttps returns on instead of on

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2623",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2620",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=294",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2625",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2623",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=294",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -108,7 +108,8 @@ class WPSEO_Sitemaps_Router {
 		global $wp_query;
 
 		$protocol = 'http://';
-		if ( ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( ! empty( $_SERVER['HTTPS'] ) && strtolower( $_SERVER['HTTPS'] ) === 'on' ) {
 			$protocol = 'https://';
 		}
 

--- a/inc/sitemaps/class-sitemaps-router.php
+++ b/inc/sitemaps/class-sitemaps-router.php
@@ -44,9 +44,9 @@ class WPSEO_Sitemaps_Router {
 	/**
 	 * Adds query variables for sitemaps.
 	 *
-	 * @param array $query_vars List of query variables to filter.
+	 * @param  array<string> $query_vars List of query variables to filter.
 	 *
-	 * @return array Filtered query variables.
+	 * @return array<string> Filtered query variables.
 	 */
 	public function add_query_vars( $query_vars ) {
 		$query_vars[] = 'sitemap';

--- a/tests/WP/Sitemaps/Router_Test.php
+++ b/tests/WP/Sitemaps/Router_Test.php
@@ -79,7 +79,7 @@ final class Router_Test extends TestCase {
 	/**
 	 * Provides data for the get base url test.
 	 *
-	 * @return array Test data to use.
+	 * @return array<array<string>> Test data to use.
 	 */
 	public static function data_get_base_url() {
 		return [
@@ -104,10 +104,10 @@ final class Router_Test extends TestCase {
 	 * @covers       WPSEO_Sitemaps_Router::needs_sitemap_index_redirect
 	 * @dataProvider data_needs_sitemap_index_redirect
 	 *
-	 * @param array    $server_vars Associative array of `$_SERVER` vars to set.
-	 * @param string   $home_url    The home URL to set.
-	 * @param WP_Query $wp_query    WP_Query instance to set.
-	 * @param bool     $expected    The expected test result.
+	 * @param array<string> $server_vars Associative array of `$_SERVER` vars to set.
+	 * @param string        $home_url    The home URL to set.
+	 * @param WP_Query      $wp_query    WP_Query instance to set.
+	 * @param bool          $expected    The expected test result.
 	 *
 	 * @return void
 	 */
@@ -158,7 +158,7 @@ final class Router_Test extends TestCase {
 	 * [2] WP_Query: WP_Query instance to set.
 	 * [3] bool:     The expected test result.
 	 *
-	 * @return array The test data.
+	 * @return array<array<array<string>,string,WP_Query,bool>> The test data.
 	 */
 	public static function data_needs_sitemap_index_redirect() {
 		$server_vars_sets = [

--- a/tests/WP/Sitemaps/Router_Test.php
+++ b/tests/WP/Sitemaps/Router_Test.php
@@ -218,6 +218,12 @@ final class Router_Test extends TestCase {
 			}
 		}
 
+		$testdata["Should correctly interpret SERVER['HTTPS'] as true when set to 'On'"] = [
+			\array_merge( $testdata[1][0], [ 'HTTPS' => 'On' ] ),
+			$testdata[3][1],
+			$testdata[3][2],
+			$testdata[3][3],
+		];
 		return $testdata;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where sitemap.xml would redirect to 404 when response from server of  HTTPS property value would be "On".

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Make sure the $_SERVER['HTTPS'] variable returns 'On' ( you can set it with xdebug ).
- Go to: https://www.yourwebsite.com/sitemap.xml
- [ ] Check redirecting properly to sitemap_index.xml

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Sitemap.xml not redirecting when $_SERVER['HTTPS'] returns 'On' instead of 'on'](https://github.com/Yoast/wordpress-seo/issues/21105)
