### PR TITLE
Ensure disabled and read-only textareas apply this state

### DIFF
--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -46,6 +46,8 @@ const TextareaField = forwardRef( ( {
 				className="yst-textarea-field__input"
 				aria-describedby={ describedBy }
 				validation={ validation }
+				disabled={ disabled }
+				readOnly={ readOnly }
 				{ ...props }
 			/>
 			{ validation?.message && (

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -13,6 +13,8 @@ import { useDescribedBy } from "../../hooks";
  * @param {string} [className] The HTML class.
  * @param {JSX.node} [description] A description.
  * @param {Object} [error] The validation state.
+ * @param {boolean} disabled Whether the input is disabled.
+ * @param {boolean} readOnly Whether the input is read-only.
  * @param {Object} [props] Any extra properties for the Textarea.
  * @returns {JSX.Element} The textarea field.
  */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The `TextareaField` used to support properties to disable / mark as read-only, through the rest property in the argument destructuring. When pulled out of the rest property into separate properties, these properties were no longer passed on to the `Textarea` component as part of the expanded props object.

This resulted in the `TextareaField` only being styled as disabled or read-only, while the underlying `<textarea>` actually wasn't in that state and could still be edited.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "organization description" field would still be focusable via tabbing.
* [@yoast/ui-library 0.0.1] Fixed an unreleased bug where the readonly & disabled props of the `TextareaField` component would not be passed on to the underlying `Textarea` element.

## Relevant technical choices:

* Whenever there's a rest property in a component, we need to make sure that introducing new destructured arguments continues to be applied where the rest property is applied.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

** Verify fix in Yoast SEO **

* Only have Yoast SEO enabled (not Premium)
* Go to the Settings admin page
* Go to the Site representation screen
* Verify the "Organization description" looks disabled
* Focus one of the active fields before it (e.g. the Twitter profile input)
* Hit the TAB button on your keyboard a few times to cycle over focused elements
* Verify the "Organization description" field never gets focus

** Verify unchanged functionality in Premium **

- Enable Yoast SEO Premium
- Go to the same page
- Verify the "Organization description" looks enabled
- Verify data can still be filled in the field
- Verify data can still be persisted

** Verify non-disabled TextareaField in Free **

* Visit the advanced "RSS" settings page in the admin
* Make sure both textarea's work as before

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
    * No new errors/warnings should appear.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The TextareaField from the UI library, used in the RSS page and this Organization description field.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
