### PR TITLE
UI-Library / Align button heights with input fields

### DIFF
--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -16,6 +16,7 @@ export const classNameMap = {
 		"default": "",
 		small: "yst-button--small",
 		large: "yst-button--large",
+		"extra-large": "yst-button--extra-large",
 	},
 };
 

--- a/packages/ui-library/src/elements/button/stories.js
+++ b/packages/ui-library/src/elements/button/stories.js
@@ -47,6 +47,7 @@ Variants.parameters = { docs: { description: { story: variants } } };
 
 export const Sizes = ( args ) => (
 	<div className="yst-flex yst-items-end yst-gap-2">
+		<StoryComponent size="extra-large">Extra Large</StoryComponent>
 		<StoryComponent size="large">Large</StoryComponent>
 		<StoryComponent size="default">Default</StoryComponent>
 		<StoryComponent size="small">Small</StoryComponent>

--- a/packages/ui-library/src/elements/button/style.css
+++ b/packages/ui-library/src/elements/button/style.css
@@ -7,7 +7,7 @@
 			yst-justify-center
 			yst-py-2
 			yst-px-3
-			yst-border
+			yst-ring-inset
 			yst-shadow-sm
 			yst-no-underline
 			yst-cursor-pointer
@@ -38,7 +38,7 @@
 			@apply
 			yst-text-white
 			yst-bg-primary-500
-			yst-border-transparent
+			yst-ring-transparent
 
 			hover:yst-text-white
 			hover:yst-bg-primary-700
@@ -52,7 +52,7 @@
 			@apply
 			yst-text-slate-800
 			yst-bg-white
-			yst-border-slate-300
+			yst-ring-slate-300
 
 			hover:yst-text-slate-800
 			hover:yst-bg-slate-50
@@ -64,7 +64,7 @@
 
 		.yst-button--tertiary {
 			@apply
-			yst-border-none
+			yst-ring-0
 			yst-shadow-none
 			yst-text-primary-500
 			yst-bg-transparent
@@ -110,6 +110,14 @@
 		/* Sizes */
 
 		.yst-button--large {
+			@apply
+			yst-py-2
+			yst-px-3
+			yst-text-base
+			yst-leading-5;
+		}
+
+		.yst-button--extra-large {
 			@apply
 			yst-py-3
 			yst-px-6

--- a/packages/ui-library/src/elements/button/style.css
+++ b/packages/ui-library/src/elements/button/style.css
@@ -14,7 +14,7 @@
 			yst-rounded-md
 			yst-text-sm
 			yst-font-medium
-			yst-leading-4
+			yst-leading-5
 			yst-text-center
 
 			focus:yst-outline-none
@@ -111,25 +111,26 @@
 
 		.yst-button--large {
 			@apply
-			yst-py-2
+			yst-text-tiny
+			yst-leading-6
 			yst-px-3
-			yst-text-base
-			yst-leading-5;
+			yst-py-2;
 		}
 
 		.yst-button--extra-large {
 			@apply
-			yst-py-3
-			yst-px-6
 			yst-text-base
-			yst-leading-5;
+			yst-px-3.5
+			yst-py-2.5
+			yst-leading-6;
 		}
 
 		.yst-button--small {
 			@apply
 			yst-text-xs
-			yst-py-1.5
-			yst-px-2.5;
+			yst-leading-4
+			yst-px-2.5
+			yst-py-1.5;
 		}
 
 		/* States */

--- a/packages/ui-library/src/elements/select/style.css
+++ b/packages/ui-library/src/elements/select/style.css
@@ -21,8 +21,9 @@
 			yst-text-left
 			yst-text-slate-800
 			yst-bg-white
-			yst-border
-			yst-border-slate-300
+			yst-ring-1
+			yst-ring-inset
+			yst-ring-slate-300
 			yst-rounded-md
 			yst-shadow-sm
 			yst-cursor-default

--- a/packages/ui-library/src/elements/tag-input/style.css
+++ b/packages/ui-library/src/elements/tag-input/style.css
@@ -8,8 +8,9 @@
 			yst-py-2
 			yst-px-3
 			yst-gap-1.5
-			yst-border
-			yst-border-slate-300
+			yst-ring-1
+			yst-ring-inset
+			yst-ring-slate-300
 			yst-rounded-md
 			yst-shadow-sm
 			yst-bg-white

--- a/packages/ui-library/src/elements/text-input/style.css
+++ b/packages/ui-library/src/elements/text-input/style.css
@@ -5,12 +5,13 @@
 			yst-w-full
 			yst-py-2
 			yst-px-3
-			yst-border
-			yst-border-slate-300
+			yst-ring-1
+			yst-ring-inset
+			yst-ring-slate-300
 			yst-rounded-md
 			yst-shadow-sm
 			yst-text-sm
-			yst-text-slate-800		
+			yst-text-slate-800
 			yst-bg-white
 			focus:yst-outline-none
 			focus:yst-ring-primary-500

--- a/packages/ui-library/src/elements/textarea/style.css
+++ b/packages/ui-library/src/elements/textarea/style.css
@@ -5,13 +5,14 @@
 			yst-w-full
 			yst-py-2
 			yst-px-3
-			yst-border
-			yst-border-slate-300
+			yst-ring-1
+			yst-ring-inset
+			yst-ring-slate-300
 			yst-rounded-md
 			yst-shadow-sm
 			yst-bg-white
 			yst-text-sm
-			yst-text-slate-800	
+			yst-text-slate-800
 			focus:yst-outline-none
 			focus:yst-ring-primary-500
 			focus:yst-border-primary-500;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to adjust button heights to make it same height with inputs inlined.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates styling of buttons height, introduces new button size (extra-large), and changes border styling for text input, select, textarea, tag-input.

## Relevant technical choices:

* Updated styling of inputs: text input, select, textarea, tag-input
* Adjusted existing sizing of buttons
* Added new sizing for button - extra-large

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* pull this PR
* verify if button sizes reflects expected sizes and design:
<img width="483" alt="Zrzut ekranu 2024-02-7 o 14 39 57" src="https://github.com/Yoast/wordpress-seo/assets/86713657/5ef7bbb6-a99d-4f2e-a3c2-f67b84c4d822">
<img width="785" alt="Zrzut ekranu 2024-02-7 o 14 43 46" src="https://github.com/Yoast/wordpress-seo/assets/86713657/d1c1ce5e-779b-4b94-9b78-96b6dab1860c">
<img width="1133" alt="Zrzut ekranu 2024-02-7 o 14 43 50" src="https://github.com/Yoast/wordpress-seo/assets/86713657/724c044e-3427-4c72-99cc-484fa4c0ee97">
<img width="1147" alt="Zrzut ekranu 2024-02-7 o 14 43 53" src="https://github.com/Yoast/wordpress-seo/assets/86713657/ccb7b1a3-b055-492d-881e-9d18093649b2">
* check if input border styling still works well for: select, text input, tag input, and textarea

### Test instructions for Shopify
* update UI LIBRARY package version
* run application
* go to Optimize module, open any content type optimizing editor
* use Semrush Related keyphrases function
* check if "Change country" button height is adjusted with country selection dropdown height

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
