### PR TITLE
Try to invalidate opcache selectively, resetting it only as a last resort

### DIFF
--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -350,7 +350,7 @@ function wpseo_init() {
 		 *
 		 * @param bool $skip_opcache_reset Whether the opcache reset should be skipped.
 		 */
-		if ( ! apply_filters( 'wpseo_skip_opcache_reset', $skip_opcache_reset ) ) {
+		if ( ! apply_filters( 'wpseo_skip_opcache_reset', $skip_opcache_reset ) && function_exists( 'opcache_reset' ) ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
 			@opcache_reset();
 		}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -398,6 +398,12 @@ function wpseo_maybe_invalidate_directories() {
 		return false;
 	}
 
+	$access_type = get_filesystem_method();
+	if ( $access_type !== 'direct' ) {
+		return false;
+	}
+
+	// Prevent any output requesting credentials, even though we should be safe in 'direct' mode.
 	ob_start();
 	$credentials = request_filesystem_credentials( admin_url() );
 	ob_end_clean();

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -351,6 +351,7 @@ function wpseo_init() {
 		 * @param bool $skip_opcache_reset Whether the opcache reset should be skipped.
 		 */
 		if ( ! apply_filters( 'wpseo_skip_opcache_reset', $skip_opcache_reset ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
 			@opcache_reset();
 		}
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -342,18 +342,11 @@ function wpseo_init() {
 	WPSEO_Meta::init();
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
-		require_once ABSPATH . 'wp-admin/includes/file.php';
 
-		if ( function_exists( 'wp_opcache_invalidate' ) ) {
-			// Since WP 5.5.
-			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo-main.php' );
-			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo.php' );
-		}
-
-		$skip_opcache_reset = wpseo_maybe_invalidate_directories();
+		$skip_opcache_reset = wpseo_maybe_invalidate_opcache();
 
 		/**
-		 * Filter: Adds the possibility to skip the opcache reset if invalidation dir by dir was not performed.
+		 * Filter: Adds the possibility to skip the opcache reset if invalidation was not performed.
 		 *
 		 * @param bool $skip_opcache_reset Whether the opcache reset should be skipped.
 		 */
@@ -389,12 +382,14 @@ function wpseo_init() {
 }
 
 /**
- * Detects the FS access method and if possible invalidates the plugin directories.
+ * Detects if we can invalidate the opcache and does so.
  *
  * @return bool
  */
-function wpseo_maybe_invalidate_directories() {
-	if ( ! function_exists( 'wp_opcache_invalidate_directory' ) ) {
+function wpseo_maybe_invalidate_opcache() {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+
+	if ( ! function_exists( 'wp_opcache_invalidate' ) || ! function_exists( 'wp_opcache_invalidate_directory' ) ) {
 		return false;
 	}
 
@@ -412,6 +407,9 @@ function wpseo_maybe_invalidate_directories() {
 		return false;
 	}
 
+	// Since WP 5.5.
+	wp_opcache_invalidate( WPSEO_PATH . 'wp-seo-main.php' );
+	wp_opcache_invalidate( WPSEO_PATH . 'wp-seo.php' );
 	// Since WP 6.2.
 	wp_opcache_invalidate_directory( WPSEO_PATH . 'admin' );
 	wp_opcache_invalidate_directory( WPSEO_PATH . 'inc' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -342,9 +342,27 @@ function wpseo_init() {
 	WPSEO_Meta::init();
 
 	if ( version_compare( WPSEO_Options::get( 'version', 1 ), WPSEO_VERSION, '<' ) ) {
-		if ( function_exists( 'opcache_reset' ) ) {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Prevent notices when opcache.restrict_api is set.
-			@opcache_reset();
+		global $wp_filesystem;
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		/*
+		 * We invalidate each subdir and the main files instead of the whole `wordpress-seo` dir
+		 * to avoid any timeout or resource exhaustion when building from source.
+		 */
+		if ( function_exists( 'wp_opcache_invalidate' ) ) {
+			// Since WP 5.5.
+			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo-main.php' );
+			wp_opcache_invalidate( WPSEO_PATH . 'wp-seo.php' );
+		}
+		if ( function_exists( 'wp_opcache_invalidate_directory' ) ) {
+			// Since WP 6.2.
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'admin' );
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'inc' );
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'lib' );
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'src' );
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'vendor' );
+			wp_opcache_invalidate_directory( WPSEO_PATH . 'vendor_prefixed' );
 		}
 
 		new WPSEO_Upgrade();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to reduce the impact of the opcache reset call, by using it as a last resort if we cannot invalidate by file/dir, and introducing a filter to allow people to prevent it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the opcache invalidation on plugin upgrade, by trying to invalidate only the Yoast SEO files.
* Introduces a `wpseo_skip_opcache_reset` filter to allow users to skip the opcache reset which is performed if we can't invalidate selectively.

## Relevant technical choices:

* `wp_opcache_invalidate` has been introduced in WP 5.5 and `wp_opcache_invalidate_directory` in WP 6.2. Though we don't support them anymore, we want to avoid fatal errors or introducing problems with a different opcache policy.
* we perform selective invalidation only on filesystems that can be accessed directly because:
  *  on FTP/SSH access there could be a mismatch between the paths registered in the cache and the ones detected by the class travelling the directory tree
  * on FTP access, you may be requested the credentials on FS access if they are not stored e.g. in `wp-config.php`.
*  if selective invalidation is not possible, at the moment we want to keep the old `opcache_reset()` call, even though it may not be as useful as it was introduced (since WP itself may be invalidating folders when moving dirs on plugin upgrade).
* since opcache resetting is resource intensive, we introduce a filter to allow people skipping it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20654 
