### PR TITLE
Update open-graph-locale-generator.php

### DIFF
--- a/src/generators/open-graph-locale-generator.php
+++ b/src/generators/open-graph-locale-generator.php
@@ -77,6 +77,7 @@ class Open_Graph_Locale_Generator implements Generator_Interface {
 			'en_PI', // English (Pirate).
 			'en_UD', // English (Upside Down).
 			'en_US', // English (US).
+			'en_AU', // English (Australia).
 			'em_ZM',
 			'eo_EO', // Esperanto.
 			'es_ES', // Spanish (Spain).


### PR DESCRIPTION

## Context


* Existing Wordpress installations with the language configured "English (Australia)" get their locale overrode to en-US by Yoast. 

## Summary

* English (Australia) was not present in the allowed locales, which is referenced to an out of date Facebook acceptable locale list from 2018. 
* The simple one line fix is by adding en-AU, the locale is then maintained for Australian (English) websites.

## Relevant technical choices:

* N/A

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

* Set the Wordpress language to English (Australia)
* Verify HTML code output now shows locale="en-AU"

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Set the Wordpress language to English (Australia)
* Verify HTML code output now shows locale="en-AU"

## Impact check

* Minimal impact, simply allows a valid locale for Australian websites. No other countries are effected. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ x During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21125
