### PR TITLE
Add main entity of page link to org node if on the profilepage schema…

### DIFF
--- a/src/generators/schema/organization.php
+++ b/src/generators/schema/organization.php
@@ -52,6 +52,12 @@ class Organization extends Abstract_Schema_Piece {
 			$organization['sameAs'] = $same_as;
 		}
 
+		if ( \is_array( $this->context->schema_page_type ) && \in_array( 'ProfilePage', $this->context->schema_page_type, true ) ) {
+			$organization['mainEntityOfPage'] = [
+				'@id' => $this->context->main_schema_id,
+			];
+		}
+
 		return $organization;
 	}
 

--- a/tests/WP/Generators/Schema/Organization_Test.php
+++ b/tests/WP/Generators/Schema/Organization_Test.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Generators\Schema;
+
+use Yoast\WP\Lib\ORM;
+use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Generators\Schema\Organization;
+use Yoast\WP\SEO\Generators\Schema\Person;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
+use Yoast\WP\SEO\Memoizers\Presentation_Memoizer;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+use Yoast\WP\SEO\Values\Indexables\Indexable_Builder_Versions;
+
+/**
+ * Integration Test Class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Generators\Schema\Organization
+ */
+final class Organization_Test extends TestCase {
+
+	/**
+	 * The generator to test.
+	 *
+	 * @var Organization
+	 */
+	private $instance;
+
+	/**
+	 * The meta tags context.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $context;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$indexable_post_builder = new Indexable_Post_Builder(
+			\YoastSEO()->helpers->post,
+			\YoastSEO()->helpers->post_type,
+			\YoastSEO()->classes->get( Indexable_Builder_Versions::class ),
+			\YoastSEO()->helpers->meta
+		);
+
+		$indexable_post_builder->set_social_image_helpers(
+			\YoastSEO()->helpers->image,
+			\YoastSEO()->helpers->open_graph->image,
+			\YoastSEO()->helpers->twitter->image
+		);
+
+		$post_type = 'my-custom-post-type';
+		\register_post_type(
+			$post_type,
+			[
+				'public'      => true,
+				'has_archive' => true,
+				'description' => 'a cool post type',
+				'label'       => $post_type,
+			]
+		);
+
+		$post = [
+			'post_date'   => '1978-09-13 08:50:00',
+			'post_status' => 'publish',
+			'post_type'   => $post_type,
+		];
+
+		$post_id         = self::factory()->post->create( $post );
+		$indexable       = new Indexable();
+		$indexable->orm  = ORM::for_table( 'wp_yoast_indexable' );
+		$built_indexable = $indexable_post_builder->build( $post_id, $indexable );
+
+		$meta_tags_context_memoizer = new Meta_Tags_Context_Memoizer(
+			\YoastSEO()->helpers->blocks,
+			\YoastSEO()->helpers->current_page,
+			\YoastSEO()->classes->get( Indexable_Repository::class ),
+			\YoastSEO()->classes->get( Meta_Tags_Context::class ),
+			\YoastSEO()->classes->get( Presentation_Memoizer::class )
+		);
+		$this->context              = $meta_tags_context_memoizer->get( $built_indexable, 'page' );
+	}
+
+	/**
+	 * Tests that the type is properly set if everything is in the default setting.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_create_organization_schema() {
+		$this->context->site_user_id = 1;
+
+		$this->instance          = \YoastSEO()->classes->get( Organization::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = 'Organization';
+
+		$this->assertEquals( $expected, $webpage_schema_piece['@type'] );
+	}
+
+	/**
+	 * Tests that mainEntityOfPage gets set for Profile pages.
+	 *
+	 * @covers ::generate
+	 *
+	 * @return void
+	 */
+	public function test_create_organization_schema_for_profile_page() {
+		$this->context->site_user_id     = 1;
+		$this->context->schema_page_type = [ 'ProfilePage' ];
+
+		$this->instance          = \YoastSEO()->classes->get( Person::class );
+		$this->instance->context = $this->context;
+		$this->instance->helpers = \YoastSEO()->helpers;
+		$webpage_schema_piece    = $this->instance->generate();
+
+		$expected = $this->context->main_schema_id;
+
+		$this->assertEquals( $expected, $webpage_schema_piece['mainEntityOfPage']['@id'] );
+	}
+}

--- a/tests/WP/Generators/Schema/Organization_Test.php
+++ b/tests/WP/Generators/Schema/Organization_Test.php
@@ -6,7 +6,6 @@ use Yoast\WP\Lib\ORM;
 use Yoast\WP\SEO\Builders\Indexable_Post_Builder;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Generators\Schema\Organization;
-use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Memoizers\Presentation_Memoizer;
 use Yoast\WP\SEO\Models\Indexable;
@@ -119,7 +118,7 @@ final class Organization_Test extends TestCase {
 		$this->context->site_user_id     = 1;
 		$this->context->schema_page_type = [ 'ProfilePage' ];
 
-		$this->instance          = \YoastSEO()->classes->get( Person::class );
+		$this->instance          = \YoastSEO()->classes->get( Organization::class );
 		$this->instance->context = $this->context;
 		$this->instance->helpers = \YoastSEO()->helpers;
 		$webpage_schema_piece    = $this->instance->generate();


### PR DESCRIPTION
… page type.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We also want to output correct schema for a site that is only an organization

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a non released bug that the ProfilePage schema does not validate for sites that are set as Organization.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Set your site to Organization in the site representation: /wp-admin/admin.php?page=wpseo_page_settings#/site-representation.
- Create a new page and set the Page type In our Schema settings to Profile Page
- Check schema at RRT and make sure it is valid. You won't see the ProfilePage schema as recognized but that is expected behaviour.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
