### PR TITLE
21120 number of employees can be focussed while disabled

### DIFF
--- a/packages/js/src/settings/components/formik-autocomplete-field.js
+++ b/packages/js/src/settings/components/formik-autocomplete-field.js
@@ -1,6 +1,5 @@
 import { useCallback, useState, useEffect } from "@wordpress/element";
 import { AutocompleteField } from "@yoast/ui-library";
-import classNames from "classnames";
 import { useField } from "formik";
 import PropTypes from "prop-types";
 
@@ -9,12 +8,11 @@ import PropTypes from "prop-types";
  * @param {Object} props The props object.
  * @param {string} props.name The field name.
  * @param {string} props.id The field id.
- * @param {boolean} props.disabled Whether the field is disabled.
  * @param {string} props.className The className.
  * @param {array} props.options The options.
  * @returns {JSX.Element} The page select component.
  */
-const FormikAutocompleteField = ( { name, id, disabled, options, className, ...props } ) => {
+const FormikAutocompleteField = ( { name, id, options, ...props } ) => {
 	const [ field, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );
 	const [ selectedLabel, setSelectedLabel ] = useState( "" );
 
@@ -53,7 +51,6 @@ const FormikAutocompleteField = ( { name, id, disabled, options, className, ...p
 			selectedLabel={ selectedLabel }
 			onChange={ handleChange }
 			onQueryChange={ handleQueryChange }
-			className={ classNames( className, disabled && "yst-autocomplete--disabled" ) }
 			{ ...props }
 		>
 			{ options && options.map( ( option ) =>
@@ -69,14 +66,10 @@ const FormikAutocompleteField = ( { name, id, disabled, options, className, ...p
 FormikAutocompleteField.propTypes = {
 	name: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
-	className: PropTypes.string,
-	disabled: PropTypes.bool,
 	options: PropTypes.array,
 };
 
 FormikAutocompleteField.defaultProps = {
-	disabled: false,
-	className: "",
 	options: [],
 };
 

--- a/packages/js/src/settings/components/formik-autocomplete-field.js
+++ b/packages/js/src/settings/components/formik-autocomplete-field.js
@@ -8,7 +8,6 @@ import PropTypes from "prop-types";
  * @param {Object} props The props object.
  * @param {string} props.name The field name.
  * @param {string} props.id The field id.
- * @param {string} props.className The className.
  * @param {array} props.options The options.
  * @returns {JSX.Element} The page select component.
  */

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -30,10 +30,9 @@ PageSelectOptionsContent.propTypes = {
  * @param {Object} props The props object.
  * @param {string} props.name The field name.
  * @param {string} props.id The field id.
- * @param {string} props.className The className.
  * @returns {JSX.Element} The page select component.
  */
-const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
+const FormikPageSelectField = ( { name, id, ...props } ) => {
 	const siteBasicsPolicies = useSelectSettings( "selectPreference", [], "siteBasicsPolicies", {} );
 	const pages = useSelectSettings( "selectPagesWith", [ siteBasicsPolicies ], values( siteBasicsPolicies ) );
 	const { fetchPages } = useDispatchSettings();
@@ -85,7 +84,6 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 			placeholder={ __( "None", "wordpress-seo" ) }
 			selectedLabel={ selectedPage?.name }
 			onQueryChange={ handleQueryChange }
-			className={ classNames( className, props.disabled && "yst-autocomplete--disabled" ) }
 			nullable={ true }
 			/* translators: Hidden accessibility text. */
 			clearButtonScreenReaderText={ __( "Clear selection", "wordpress-seo" ) }
@@ -143,8 +141,6 @@ const FormikPageSelectField = ( { name, id, className = "", ...props } ) => {
 FormikPageSelectField.propTypes = {
 	name: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
-	className: PropTypes.string,
-	disabled: PropTypes.bool,
 };
 
 export default FormikPageSelectField;

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -113,7 +113,6 @@ const Autocomplete = forwardRef( ( {
 }, ref ) => {
 	const getDisplayValue = useCallback( constant( selectedLabel ), [ selectedLabel ] );
 	const svgAriaProps = useSvgAria();
-	const tabIndex = disabled ? { tabIndex: -1 } : {};
 
 	return (
 		<Combobox
@@ -125,8 +124,8 @@ const Autocomplete = forwardRef( ( {
 				"yst-autocomplete",
 				disabled && "yst-autocomplete--disabled",
 				className ) }
+			disabled={ disabled }
 			{ ...props }
-
 		>
 			{ label && <div className="yst-flex yst-items-center yst-mb-2">
 				<Combobox.Label { ...labelProps }>{ label }</Combobox.Label>
@@ -146,7 +145,6 @@ const Autocomplete = forwardRef( ( {
 						placeholder={ placeholder }
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }
-						{ ...tabIndex }
 					/>
 					{ props.nullable && selectedLabel &&
 					<ClearSelection

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -123,7 +123,8 @@ const Autocomplete = forwardRef( ( {
 			className={ classNames(
 				"yst-autocomplete",
 				disabled && "yst-autocomplete--disabled",
-				className ) }
+				className,
+			) }
 			disabled={ disabled }
 			{ ...props }
 		>

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -147,11 +147,12 @@ const Autocomplete = forwardRef( ( {
 						onChange={ onQueryChange }
 					/>
 					{ props.nullable && selectedLabel &&
-					<ClearSelection
-						onChange={ onChange }
-						svgAriaProps={ svgAriaProps }
-						screenReaderText={ clearButtonScreenReaderText }
-					/> }
+						<ClearSelection
+							onChange={ onChange }
+							svgAriaProps={ svgAriaProps }
+							screenReaderText={ clearButtonScreenReaderText }
+						/>
+					}
 					{ ! validation?.message && (
 						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
 					) }

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -108,10 +108,12 @@ const Autocomplete = forwardRef( ( {
 	className,
 	buttonProps,
 	clearButtonScreenReaderText,
+	disabled,
 	...props
 }, ref ) => {
 	const getDisplayValue = useCallback( constant( selectedLabel ), [ selectedLabel ] );
 	const svgAriaProps = useSvgAria();
+	const tabIndex = disabled ? { tabIndex: -1 } : {};
 
 	return (
 		<Combobox
@@ -119,8 +121,12 @@ const Autocomplete = forwardRef( ( {
 			as="div"
 			value={ value }
 			onChange={ onChange }
-			className={ classNames( "yst-autocomplete", className ) }
+			className={ classNames(
+				"yst-autocomplete",
+				disabled && "yst-autocomplete--disabled",
+				className ) }
 			{ ...props }
+
 		>
 			{ label && <div className="yst-flex yst-items-center yst-mb-2">
 				<Combobox.Label { ...labelProps }>{ label }</Combobox.Label>
@@ -140,9 +146,14 @@ const Autocomplete = forwardRef( ( {
 						placeholder={ placeholder }
 						displayValue={ getDisplayValue }
 						onChange={ onQueryChange }
+						{ ...tabIndex }
 					/>
 					{ props.nullable && selectedLabel &&
-					<ClearSelection onChange={ onChange } svgAriaProps={ svgAriaProps } screenReaderText={ clearButtonScreenReaderText } /> }
+					<ClearSelection
+						onChange={ onChange }
+						svgAriaProps={ svgAriaProps }
+						screenReaderText={ clearButtonScreenReaderText }
+					/> }
 					{ ! validation?.message && (
 						<SelectorIcon className="yst-autocomplete__button-icon" { ...svgAriaProps } />
 					) }
@@ -187,6 +198,7 @@ const propTypes = {
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
 	clearButtonScreenReaderText: PropTypes.string,
+	disabled: PropTypes.bool,
 };
 Autocomplete.propTypes = propTypes;
 
@@ -202,6 +214,7 @@ Autocomplete.defaultProps = {
 	className: "",
 	buttonProps: {},
 	clearButtonScreenReaderText: "Clear",
+	disabled: false,
 };
 
 export default Autocomplete;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Disable the focus for formik autocomplete fields.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disable focus on `Number of Employees` field when it is disabled. 
* [@yoast/ui-library 0.0.1] Adds disabled styling to `AutoComplete` component.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate only Yoast SEO free, without premium.
* Go to `Yoast SEO`->`Settings`->`Site representation`
* [ ] Try to tab the fields to reach the `Number of Employees` and check it is not focusable.
* Go to `Yoast SEO`->`Settings`->`Site basics`
* [ ] Try to tab the fields to reach the Site policies fields and check they are not focusable.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes ["Number of employees" can be focussed while disabled](https://github.com/Yoast/wordpress-seo/issues/21120)
