### PR TITLE
Add "x.com" as possible domain for the Twitter validation

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -285,7 +285,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 			return $twitter_id;
 		}
 
-		if ( preg_match( '`^http(?:s)?://(?:www\.)?twitter\.com/(?P<handle>[A-Za-z0-9_]{1,25})/?$`', $twitter_id, $matches ) ) {
+		if ( preg_match( '`^http(?:s)?://(?:www\.)?(?:twitter|x)\.com/(?P<handle>[A-Za-z0-9_]{1,25})/?$`', $twitter_id, $matches ) ) {
 			return $matches['handle'];
 		}
 

--- a/packages/js/src/settings/helpers/validation.js
+++ b/packages/js/src/settings/helpers/validation.js
@@ -40,7 +40,7 @@ addMethod( string, "isValidTwitterUrlOrHandle", function() {
 			}
 
 			const TWITTER_HANDLE_REGEXP = /^[A-Za-z0-9_]{1,25}$/;
-			const TWITTER_URL_REGEXP = /^https?:\/\/(?:www\.)?twitter\.com\/(?<handle>[A-Za-z0-9_]{1,25})\/?$/;
+			const TWITTER_URL_REGEXP = /^https?:\/\/(?:www\.)?(?:twitter|x)\.com\/(?<handle>[A-Za-z0-9_]{1,25})\/?$/;
 
 			return TWITTER_HANDLE_REGEXP.test( input ) || TWITTER_URL_REGEXP.test( input );
 		}

--- a/tests/WP/Inc/Options/Option_Social_Test.php
+++ b/tests/WP/Inc/Options/Option_Social_Test.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Inc\Options;
+
+use WPSEO_Option_Social;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration Test Class.
+ */
+final class Option_Social_Test extends TestCase {
+
+	/**
+	 * Tests if the validate_twitter_id() is validating as expected.
+	 *
+	 * @dataProvider provider_test_validate_twitter_id_return_value
+	 * @covers       \WPSEO_Option_Social::validate_twitter_id
+	 *
+	 * @param string|false $expected      The expected return value.
+	 * @param string       $twitter_id    The twitter id to be validated.
+	 * @param bool         $strip_at_sign Whether to strip the `@` sign. Defaults to true.
+	 *
+	 * @return void
+	 */
+	public function test_validate_twitter_id_return_value(
+		$expected,
+		string $twitter_id,
+		bool $strip_at_sign = true
+	): void {
+		/**
+		 * The WPSEO_Option_Social instance.
+		 *
+		 * @var WPSEO_Option_Social $wpseo_option_titles
+		 */
+		$wpseo_option_titles = WPSEO_Option_Social::get_instance();
+
+		$this->assertEquals( $expected, $wpseo_option_titles->validate_twitter_id( $twitter_id, $strip_at_sign ) );
+	}
+
+	/**
+	 * Data provider for test_validate_twitter_id_return_value().
+	 *
+	 * @return array<array{0: string|false, 1: string, 2: bool}>
+	 */
+	public static function provider_test_validate_twitter_id_return_value(): array {
+		return [
+			'Twitter domain and secure protocol'   => [ 'yoast', 'https://twitter.com/yoast' ],
+			'Twitter domain and unsecure protocol' => [ 'yoast', 'http://twitter.com/yoast' ],
+			'X domain and secure protocol'         => [ 'yoast', 'https://x.com/yoast' ],
+			'X domain and unsecure protocol'       => [ 'yoast', 'http://x.com/yoast' ],
+			'Invalid domain'                       => [ false, 'https://example.com/yoast' ],
+			'Handle with @'                        => [ 'yoast', '@yoast' ],
+			'Handle without @ but no stripping'    => [ 'yoast', 'yoast', false ],
+			'Handle without @ but with stripping'  => [ false, '@yoast', false ],
+			'Length and characters check'          => [
+				'thisIS25characterslong1_3',
+				'https://x.com/thisIS25characterslong1_3',
+			],
+			'Too long'                             => [ false, 'https://x.com/thisis26characterslong1234' ],
+			'Invalid character'                    => [ false, 'https://x.com/invalidchars!' ],
+			'HTML should be stripped'              => [ 'yoast', 'https://x.com/<div>yoast</div>' ],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds `x.com` as possible domain for the Twitter validation in our site representation settings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the settings, in `Site representation > Other profiles > Twitter`
* Enter a Twitter profile with `x.com`, like `https://x.com/yoast`
* Verify you do not get a validation warning and can save
* Enter a Twitter profile with `twitter.com`, like `https://twitter.com/yoast`
* Verify you do not get a validation warning and can save
* Enter another domain and verify you get a validation warning
* Test with just the handle too?

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/186
