### PR TITLE
Adds our SEO group to the WC layout templates

### DIFF
--- a/src/woocommerce-editor/user-interface/woocommerce-editor-seo-group.php
+++ b/src/woocommerce-editor/user-interface/woocommerce-editor-seo-group.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Yoast\WP\SEO\WooCommerce_Editor\User_Interface;
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Registers our SEO group to the WooCommerce layout templates.
+ *
+ * @link https://github.com/woocommerce/woocommerce/blob/trunk/docs/product-editor-development/block-template-lifecycle.md#registration
+ */
+class WooCommerce_Editor_SEO_Group implements Integration_Interface {
+
+	/**
+	 * No conditionals are needed because the hooks will just not be called when irrelevant.
+	 * Though this could be:
+	 * - when WooCommerce is active
+	 * - when the ProductBlockEditor feature is active
+	 */
+	use No_Conditionals;
+
+	public const GROUP_ID = 'yoast-seo';
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		/**
+		 * The template area is from the SimpleProductTemplate->get_area(), which is 'product-form'.
+		 * The block names are found in SimpleProductTemplate::GROUP_IDS, we are adding our block after the 'general' group.
+		 *
+		 * @see  \Automattic\WooCommerce\Internal\Admin\Features\ProductBlockEditor\ProductTemplates\SimpleProductTemplate
+		 * @link https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/ProductBlockEditor/ProductTemplates/README.md
+		 */
+		\add_action(
+			'woocommerce_block_template_area_product-form_after_add_block_general',
+			[ $this, 'add_seo_group' ]
+		);
+	}
+
+	/**
+	 * Adds our SEO group after the given block.
+	 *
+	 * @param BlockInterface $block A block.
+	 *
+	 * @return void
+	 */
+	public function add_seo_group( BlockInterface $block ) {
+		$parent = $block->get_parent();
+		if ( ! $parent ) {
+			return;
+		}
+
+		// Only add the group to a simple product. Effectively skipping variations.
+		if ( $parent->get_id() !== 'simple-product' ) {
+			return;
+		}
+
+		$parent->add_group(
+			[
+				'id'         => self::GROUP_ID,
+				'order'      => ( $block->get_order() + 5 ),
+				'attributes' => [
+					'title' => 'Yoast SEO',
+				],
+			]
+		);
+	}
+}

--- a/tests/Unit/WooCommerce_Editor/User_Interface/WooCommerce_Editor_SEO_Group_Test.php
+++ b/tests/Unit/WooCommerce_Editor/User_Interface/WooCommerce_Editor_SEO_Group_Test.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\WooCommerce_Editor\User_Interface;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\WooCommerce_Editor\User_Interface\WooCommerce_Editor_SEO_Group;
+
+/**
+ * Tests WooCommerce_Editor_SEO_Group.
+ *
+ * @group woocommerce-editor
+ * @coversDefaultClass \Yoast\WP\SEO\Woocommerce_Editor\User_Interface\WooCommerce_Editor_SEO_Group
+ */
+final class WooCommerce_Editor_SEO_Group_Test extends TestCase {
+
+	/**
+	 * The WooCommerce_Editor_SEO_Group.
+	 *
+	 * @var WooCommerce_Editor_SEO_Group
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new WooCommerce_Editor_SEO_Group();
+	}
+
+	/**
+	 * Tests the register_hooks method.
+	 *
+	 * @covers ::register_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Functions\expect( 'add_action' )
+			->with(
+				'woocommerce_block_template_area_product-form_after_add_block_general',
+				[
+					$this->instance,
+					'add_seo_group',
+				]
+			)
+			->once();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the happy path of add_seo_group.
+	 *
+	 * @covers ::add_seo_group
+	 *
+	 * @return void
+	 */
+	public function test_add_seo_group() {
+		$block  = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface' );
+		$parent = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface' );
+
+		$block->shouldReceive( 'get_parent' )->andReturn( $parent );
+		$block->shouldReceive( 'get_order' )->andReturn( 10 );
+		$parent->shouldReceive( 'get_id' )->andReturn( 'simple-product' );
+		$parent->shouldReceive( 'add_group' )->with(
+			[
+				'id'         => WooCommerce_Editor_SEO_Group::GROUP_ID,
+				'order'      => 15,
+				'attributes' => [
+					'title' => 'Yoast SEO',
+				],
+			]
+		)->once();
+
+		$this->instance->add_seo_group( $block );
+	}
+
+	/**
+	 * Tests that add_seo_group bails when the parent is falsy.
+	 *
+	 * @covers ::add_seo_group
+	 *
+	 * @return void
+	 */
+	public function test_add_seo_group_only_if_parent() {
+		$block = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface' );
+
+		$block->shouldReceive( 'get_parent' )->andReturn( null );
+		$block->shouldNotReceive( 'get_order' );
+
+		$this->instance->add_seo_group( $block );
+	}
+
+	/**
+	 * Tests that add_seo_group bails when the parent ID is not 'simple_product'.
+	 *
+	 * @covers ::add_seo_group
+	 *
+	 * @return void
+	 */
+	public function test_add_seo_group_only_on_simple_product() {
+		$block  = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface' );
+		$parent = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockTemplateInterface' );
+
+		$block->shouldReceive( 'get_parent' )->andReturn( $parent );
+		$block->shouldReceive( 'get_order' )->andReturn( 10 );
+		$parent->shouldReceive( 'get_id' )->andReturn( 'not-a-simple-product' );
+		$parent->shouldNotReceive( 'add_group' );
+
+		$this->instance->add_seo_group( $block );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add a SEO tab next to the General tab in the new Woo editor, when editing a simple product.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds our SEO group to the new WooCommerce block editor when editing a simple product.

## Relevant technical choices:

* I went with capitals in the class, namespace and test filename, i.e. `WooCommerce` and `SEO`. While not splitting on `_` in the folder structure due to them still being one word/acronym
* I went for the ID `yoast-seo`, i.e. prefixed with `yoast` to try to ensure if is unique
* I did not translate the title because it is our brand name (and changed it to be `Yoast SEO` due to upcoming design peek, though no logo seems possible)
 
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate WooCommerce
* Enable the new product editor beta: WooCommerce > Settings > Advanced > Features > New product editor
* Edit a product
* [x] Verify you have our `Yoast SEO` tab after the General tab: 
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/b52a50e3-17ac-4a7d-9c38-1d564f2618fe)
* Either edit a product with variations or add some variations
* Edit a product variation in the new product editor
* [x] Verify our SEO tab is not present here

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/190
