### PR TITLE
Enables AI suggestions for taxonomies

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
 use Yoast\WP\SEO\Presenters\Admin\Alert_Presenter;
 
 /**
@@ -149,7 +150,7 @@ class WPSEO_Taxonomy {
 			wp_enqueue_media(); // Enqueue files needed for upload functionality.
 
 			$asset_manager->enqueue_style( 'metabox-css' );
-			$asset_manager->enqueue_style( 'scoring' );
+			$asset_manager->enqueue_style( 'ai-generator' );
 			$asset_manager->enqueue_script( 'term-edit' );
 
 			/**
@@ -161,7 +162,7 @@ class WPSEO_Taxonomy {
 			$asset_manager->localize_script( 'term-edit', 'wpseoAdminL10n', WPSEO_Utils::get_admin_l10n() );
 
 			$script_data = [
-				'analysis'          => [
+				'analysis'              => [
 					'plugins' => [
 						'replaceVars' => [
 							'no_parent_text'           => __( '(no parent)', 'wordpress-seo' ),
@@ -181,16 +182,19 @@ class WPSEO_Taxonomy {
 						'log_level'               => WPSEO_Utils::get_analysis_worker_log_level(),
 					],
 				],
-				'media'             => [
+				'media'                 => [
 					// @todo replace this translation with JavaScript translations.
 					'choose_image' => __( 'Use Image', 'wordpress-seo' ),
 				],
-				'metabox'           => $this->localize_term_scraper_script( $tag_id ),
-				'userLanguageCode'  => WPSEO_Language_Utils::get_language( get_user_locale() ),
-				'isTerm'            => true,
-				'postId'            => $tag_id,
-				'usedKeywordsNonce' => wp_create_nonce( 'wpseo-keyword-usage' ),
-				'linkParams'        => WPSEO_Shortlinker::get_query_params(),
+				'metabox'               => $this->localize_term_scraper_script( $tag_id ),
+				'userLanguageCode'      => WPSEO_Language_Utils::get_language( get_user_locale() ),
+				'isTerm'                => true,
+				'postId'                => $tag_id,
+				'termType'              => $this->get_taxonomy(),
+				'usedKeywordsNonce'     => wp_create_nonce( 'wpseo-keyword-usage' ),
+				'linkParams'            => WPSEO_Shortlinker::get_query_params(),
+				'pluginUrl'             => plugins_url( '', WPSEO_FILE ),
+				'wistiaEmbedPermission' => YoastSEO()->classes->get( Wistia_Embed_Permission_Repository::class )->get_value_for_user( get_current_user_id() ),
 			];
 			$asset_manager->localize_script( 'term-edit', 'wpseoScriptData', $script_data );
 			$asset_manager->enqueue_user_language_script();
@@ -413,7 +417,7 @@ class WPSEO_Taxonomy {
 	/**
 	 * Prepares the replace vars for localization.
 	 *
-	 * @return array The replacement variables.
+	 * @return array<string, string> The replacement variables.
 	 */
 	private function get_replace_vars() {
 		$term_id = $this::get_tag_id();
@@ -447,7 +451,7 @@ class WPSEO_Taxonomy {
 	/**
 	 * Prepares the recommended replace vars for localization.
 	 *
-	 * @return array The recommended replacement variables.
+	 * @return array<string> The recommended replacement variables.
 	 */
 	private function get_recommended_replace_vars() {
 		$recommended_replace_vars = new WPSEO_Admin_Recommended_Replace_Vars();
@@ -466,7 +470,7 @@ class WPSEO_Taxonomy {
 	/**
 	 * Returns an array with shortcode tags for all registered shortcodes.
 	 *
-	 * @return array
+	 * @return array<string> Array with shortcode tags.
 	 */
 	private function get_valid_shortcode_tags() {
 		$shortcode_tags = [];

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -241,7 +241,7 @@ const SiteFeatures = () => {
 								isPremiumLink="https://yoa.st/get-ai-generator"
 								title={ __( "AI title & description generator", "wordpress-seo" ) }
 							>
-								<p>{ __( "Use AI to write SEO titles and meta descriptions for your posts and pages. It speeds up your work and does some of the thinking for you!", "wordpress-seo" ) }</p>
+								<p>{ __( "Use AI to write SEO titles and meta descriptions for your content. It speeds up your work and does some of the thinking for you!", "wordpress-seo" ) }</p>
 								<LearnMoreLink id="link-ai-generator" link="https://yoa.st/ai-generator-feature" ariaLabel={ __( "AI title & description generator", "wordpress-seo" ) } />
 							</FeatureCard>
 							<FeatureCard

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -64,9 +64,9 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 					{ isProductCopy
 						? createInterpolateElement(
 							sprintf(
-								/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
+								/* translators: %1$s and %2$s are anchor tags; %3$s is the arrow icon. */
 								__(
-									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for product titles and meta descriptions to make your pages rank high and make you look good on social media. %1$sLearn more%2$s%3$s",
+									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for product titles and meta descriptions to make your content rank high and look good on social media. %1$sLearn more%2$s%3$s",
 									"wordpress-seo"
 								),
 								"<a>",
@@ -77,9 +77,9 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 						)
 						: createInterpolateElement(
 							sprintf(
-								/* translators: %1$s and %2$s are anchor tag; %3$s is the arrow icon. */
+								/* translators: %1$s and %2$s are anchor tags; %3$s is the arrow icon. */
 								__(
-									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for titles and meta descriptions to make your pages rank high and make you look good on social media. %1$sLearn more%2$s%3$s",
+									"Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for titles and meta descriptions to make your content rank high and look good on social media. %1$sLearn more%2$s%3$s",
 									"wordpress-seo"
 								),
 								"<a>",

--- a/packages/js/src/term-edit.js
+++ b/packages/js/src/term-edit.js
@@ -8,6 +8,7 @@ import initTabs from "./initializers/metabox-tabs";
 import initTermScraper from "./initializers/term-scraper";
 import initializeInsights from "./insights/initializer";
 import { termsTmceId } from "./lib/tinymce";
+import initializeAiGenerator from "./ai-generator/initialize";
 
 domReady( () => {
 	// Backwards compatibility globals.
@@ -35,4 +36,12 @@ domReady( () => {
 
 	// Initialize the insights.
 	initializeInsights();
+
+	// Don't initialize the AI generator for WooCommerce categories and tags.
+	const AI_IGNORED_TAXONOMIES = [ "product_cat", "product_tag" ];
+
+	if ( window.wpseoScriptData.termType && ! AI_IGNORED_TAXONOMIES.includes( window.wpseoScriptData.termType ) ) {
+		// Initialize the AI Generator upsell.
+		initializeAiGenerator();
+	}
 } );

--- a/tests/WP/Taxonomy/Taxonomy_Test.php
+++ b/tests/WP/Taxonomy/Taxonomy_Test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\WP\Taxonomy;
 
+use WPSEO_Admin_Asset_Manager;
 use WPSEO_Taxonomy;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
@@ -11,6 +12,134 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
  * @coversDefaultClass WPSEO_Taxonomy
  */
 final class Taxonomy_Test extends TestCase {
+
+	/**
+	 * Holds the instance of the class being tested.
+	 *
+	 * @var WPSEO_Taxonomy
+	 */
+	private $class_instance;
+
+	/**
+	 * Holds the term identifier.
+	 *
+	 * @var int
+	 */
+	private $term_id;
+
+	/**
+	 * Sets up the tests by setting the class instance.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Create a new term.
+		$this->class_instance = new WPSEO_Taxonomy();
+		$this->term_id        = \wp_create_term( 'cat', 'post_tag' )['term_id'];
+
+		// Create a user and set it as the current user.
+		$user = $this->factory->user->create_and_get();
+		\wp_set_current_user( $user->ID );
+
+		// Register the assets.
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+		$asset_manager->register_assets();
+	}
+
+	/**
+	 * Tears down the tests by resetting the scripts and styles.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		// Dequeue all Yoast SEO scripts and styles.
+		$wp_scripts = \wp_scripts();
+		$wp_styles  = \wp_styles();
+
+		foreach ( $wp_scripts->registered as $wp_script ) {
+			if ( \strpos( $wp_script->src, 'wordpress-seo' ) !== false ) {
+				\wp_dequeue_script( $wp_script->handle );
+			}
+		}
+
+		foreach ( $wp_styles->registered as $wp_style ) {
+			if ( \strpos( $wp_style->src, 'wordpress-seo' ) !== false ) {
+				\wp_dequeue_style( $wp_style->handle );
+			}
+		}
+	}
+
+	/**
+	 * Tests that the right scripts are enqueued on pages unrelated to terms.
+	 *
+	 * @covers ::admin_enqueue_scripts
+	 *
+	 * @return void
+	 */
+	public function test_admin_enqueue_scripts_default() {
+		// Verify that yoast-seo-scoring is registered but not enqueued.
+		$this->assertTrue( \wp_style_is( 'yoast-seo-scoring', 'registered' ) );
+		$this->assertFalse( \wp_style_is( 'yoast-seo-scoring' ) );
+
+		// Verify that on a page unrelated to terms, no scripts are enqueued.
+		$this->class_instance->admin_enqueue_scripts();
+		$this->assertFalse( \wp_style_is( 'yoast-seo-scoring' ) );
+	}
+
+	/**
+	 * Tests that the right scripts are enqueued on the term overview.
+	 *
+	 * @covers ::admin_enqueue_scripts
+	 *
+	 * @return void
+	 */
+	public function test_admin_enqueue_scripts_term_overview() {
+		// Go to the term overview page.
+		global $pagenow;
+		$pagenow = 'edit-tags.php';
+
+		// Verify no scripts are enqueued yet.
+		$this->assertFalse( \wp_style_is( 'yoast-seo-scoring' ) );
+
+		// Verify that the right scripts are enqueued.
+		$this->class_instance->admin_enqueue_scripts();
+		$this->assertTrue( \wp_style_is( 'yoast-seo-scoring' ) );
+		$this->assertTrue( \wp_style_is( 'yoast-seo-monorepo' ) );
+		$this->assertTrue( \wp_script_is( 'yoast-seo-edit-page' ) );
+	}
+
+	/**
+	 * Tests that the right scripts are enqueued on the term edit page.
+	 *
+	 * @covers ::admin_enqueue_scripts
+	 * @covers ::localize_term_scraper_script
+	 *
+	 * @return void
+	 */
+	public function test_admin_enqueue_scripts_term_edit() {
+		// Go to the term edit page.
+		global $pagenow;
+		$pagenow = 'term.php';
+
+		// Set the _GET variables.
+		$_GET['tag_ID']   = (string) $this->term_id;
+		$_GET['taxonomy'] = 'post_tag';
+
+		// Verify no scripts are enqueued yet.
+		$this->assertFalse( \wp_style_is( 'yoast-seo-scoring' ) );
+
+		// Verify that the right scripts are enqueued.
+		$this->class_instance->admin_enqueue_scripts();
+		$this->assertTrue( \wp_style_is( 'yoast-seo-scoring' ) );
+		$this->assertTrue( \wp_style_is( 'yoast-seo-monorepo' ) );
+		$this->assertTrue( \wp_style_is( 'yoast-seo-metabox-css' ) );
+		$this->assertTrue( \wp_style_is( 'yoast-seo-ai-generator' ) );
+		$this->assertTrue( \wp_script_is( 'yoast-seo-term-edit' ) );
+	}
 
 	/**
 	 * Make sure certain pages are marked as term edit.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to enable the AI generator functionality for taxonomies as well. This PR enables the "Use AI" button for taxonomies in Free (with an upsell for the actual AI generator functionality in Premium). It also changes some copy so that's it's clear that our functionality is more generic. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enables the AI generator functionality for taxonomies.

## Relevant technical choices:

* I've added an integration test for PHP, I did not add tests for the (small) JS changes. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free, not Premium.
* In the Settings, confirm that the AI generator functionality is greyed out. 
* Confirm that the card copy reads: `Use AI to write SEO titles and meta descriptions for your content. It speeds up your work and does some of the thinking for you!`.
* Create a new taxonomy (e.g. a category, tag, or a custom taxonomy). 
* Confirm that a 'Use AI' button is shown when editing the taxonomy that you just created.
* Confirm that clicking on the 'Use AI' button renders a modal with an upsell.
* Confirm that the microcopy reads `Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for titles and meta descriptions to make your content rank high and look good on social media. Learn more ->`.

#### Confirm that 'Use AI' is not shown for Woo taxonomies.
* Activate WooCommerce.
* Create a new Woo taxonomy (a Woo product category or Woo product tag).
* Confirm that the 'Use AI' button is not shown when editing the taxonomy that you just created.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different taxonomies/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The AI generator functionality for posts / products is unchanged, save for some copy changes.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/339
