### PR TITLE
Adapt feedback strings and translator comments for the Previously used keyphrase assessment

### DIFF
--- a/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -28,7 +28,7 @@ describe( "checks for keyword doubles", function() {
 		expect( plugin.scoreAssessment( { id: 1, count: 2 }, paper ).score ).toBe( 1 );
 		expect( plugin.scoreAssessment( { id: 1, count: 2, postTypeToDisplay: "Paper" }, paper ).text ).toBe( "<a href='https://yoa.st/33x' " +
 			"target='_blank'>Previously used keyphrase</a>: You've used this keyphrase <a href='http://search?keyword&post_type=Paper' " +
-			"target='_blank'> multiple times before</a>. <a href='https://yoa.st/33y' target='_blank'>" +
+			"target='_blank'>multiple times before</a>. <a href='https://yoa.st/33y' target='_blank'>" +
 			"Do not use your keyphrase more than once</a>." );
 
 		expect( plugin.scoreAssessment( { id: 0, count: 0 }, paper ).score ).toBe( 9 );
@@ -41,7 +41,7 @@ describe( "checks for keyword doubles", function() {
 		const plugin = new PreviouslyUsedKeywords( app, args );
 		expect( plugin.scoreAssessment( { id: 1, count: 2, postTypeToDisplay: "post" }, paper ).text ).toBe( "<a href='https://yoa.st/33x' " +
 			"target='_blank'>Previously used keyphrase</a>: You've used this keyphrase " +
-			"<a href='http://search?keyword%2Fbla&post_type=post' target='_blank'> multiple times before</a>. " +
+			"<a href='http://search?keyword%2Fbla&post_type=post' target='_blank'>multiple times before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 	} );
 } );
@@ -87,7 +87,7 @@ describe( "previously used keyphrase when postTypeToDisplay is defined and count
 
 	it( "correctly creates feedback when postTypeToDisplay is defined", () => {
 		expect( result.text ).toEqual( "<a href='https://yoa.st/33x' target='_blank'>Previously used keyphrase</a>: " +
-			"You've used this keyphrase <a href='http://search?keyword&post_type=Post' target='_blank'> multiple times before</a>. " +
+			"You've used this keyphrase <a href='http://search?keyword&post_type=Post' target='_blank'>multiple times before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 	} );
 } );

--- a/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
@@ -90,7 +90,7 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 			text: sprintf(
 				/* translators:
 				%1$s expands to a link to an article on yoast.com,
-				%2$s expands to an anchor tag. */
+				%2$s expands to an anchor end tag. */
 				__( "%1$sPreviously used keyphrase%2$s: You've not used this keyphrase before, very good.", "wordpress-seo" ),
 				this.urlTitle,
 				"</a>"
@@ -101,8 +101,8 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 	if ( count === 1 ) {
 		url = `<a href='${this.postUrl.replace( "{id}", id )}' target='_blank'>`;
 		return {
-			/* translators: %1$s and %2$s expand to an admin link where the keyword is already used. %3$s and %4$s
-			expand to links on yoast.com, %4$s expands to the anchor end tag. */
+			/* translators: %1$s expands to an admin link where the keyphrase is already used,
+			 %2$s expands to the anchor end tag, %3$s and %4$s expand to links on yoast.com. */
 			text: sprintf( __(
 				// eslint-disable-next-line max-len
 				"%3$sPreviously used keyphrase%2$s: You've used this keyphrase %1$sonce before%2$s. %4$sDo not use your keyphrase more than once%2$s.",
@@ -126,9 +126,8 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 		}
 
 		return {
-			/* translators: %1$s and $3$s expand to the admin search page for the keyword, %2$d expands to the number
-			of times this keyword has been used before, %4$s and %5$s expand to links to yoast.com, %6$s expands to
-			the anchor end tag */
+			/* translators: %1$s expands to a link to the admin search page for the keyphrase,
+			 %2$d expands to the anchor end tag, %3$s and %4$s expand to links to yoast.com */
 			text: sprintf( __(
 				// eslint-disable-next-line max-len
 				"%3$sPreviously used keyphrase%2$s: You've used this keyphrase %1$smultiple times before%2$s. %4$sDo not use your keyphrase more than once%2$s.",

--- a/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
@@ -105,14 +105,13 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 			expand to links on yoast.com, %4$s expands to the anchor end tag. */
 			text: sprintf( __(
 				// eslint-disable-next-line max-len
-				"%3$sPreviously used keyphrase%5$s: You've used this keyphrase %1$sonce before%2$s. %4$sDo not use your keyphrase more than once%5$s.",
+				"%3$sPreviously used keyphrase%2$s: You've used this keyphrase %1$sonce before%2$s. %4$sDo not use your keyphrase more than once%2$s.",
 				"wordpress-seo"
 			),
 			url,
 			"</a>",
 			this.urlTitle,
-			this.urlCallToAction,
-			"</a>"
+			this.urlCallToAction
 			),
 			score: 6,
 		};
@@ -132,15 +131,13 @@ PreviouslyUsedKeyword.prototype.scoreAssessment = function( previouslyUsedKeywor
 			the anchor end tag */
 			text: sprintf( __(
 				// eslint-disable-next-line max-len
-				"%4$sPreviously used keyphrase%6$s: You've used this keyphrase %1$s multiple times before%3$s. %5$sDo not use your keyphrase more than once%6$s.",
+				"%3$sPreviously used keyphrase%2$s: You've used this keyphrase %1$smultiple times before%2$s. %4$sDo not use your keyphrase more than once%2$s.",
 				"wordpress-seo"
 			),
 			url,
-			count,
 			"</a>",
 			this.urlTitle,
-			this.urlCallToAction,
-			"</a>"
+			this.urlCallToAction
 			),
 			score: 1,
 		};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* In a [previous PR](https://github.com/Yoast/wordpress-seo/pull/19800), we adapted the feedback string of the previously used keyphrase assessment where one variable was removed. However, the translator's comment was not yet adapted to reflect the new string. Additionally, the unused variable was still passed as the argument of the translation function.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unused translator function parameters and improves translator comments for the _previously used keyphrase_ assessment strings.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
