### PR TITLE
WC Editor: add Yoast SEO block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ test.sh
 /js/dist/*
 /css/dist/*
 /packages/*/dist
+/blocks/**
 yarn-error.log
 coverage
 dependencies.json

--- a/config/grunt/task-config/copy.js
+++ b/config/grunt/task-config/copy.js
@@ -28,6 +28,7 @@ module.exports = {
 					"packages/js/images/**",
 					"inc/**",
 					"<%= paths.jsDist %>/**/*.js",
+					"blocks/**",
 					"languages/**",
 					"src/**",
 					"lib/**",

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -52,6 +52,7 @@ const getEntries = ( sourceDirectory = "./packages/js/src" ) => ( {
 	workouts: `${ sourceDirectory }/workouts.js`,
 	"wordproof-uikit": `${ sourceDirectory }/wordproof-uikit.js`,
 	"frontend-inspector-resources": `${ sourceDirectory }/frontend-inspector-resources.js`,
+	"woocommerce-editor-seo-block": `${ sourceDirectory }/woocommerce-editor/blocks/seo/index.js`,
 } );
 
 /**

--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -10,7 +10,7 @@ const { yoastExternals } = require( "./externals" );
 
 let analyzerPort = 8888;
 
-module.exports = function( { entry, output, combinedOutputFile, cssExtractFileName } ) {
+module.exports = function( { entry, output, combinedOutputFile, cssExtractFileName, plugins = [] } ) {
 	const exclude = /node_modules[/\\](?!(yoast-components|gutenberg|yoastseo|@wordpress|@yoast|parse5|chart.js)[/\\]).*/;
 	// The index of the babel-loader rule.
 	let ruleIndex = 0;
@@ -100,6 +100,7 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 			process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin( {
 				analyzerPort: analyzerPort++,
 			} ),
+			...plugins,
 		].filter( Boolean ),
 	};
 };

--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -3,6 +3,7 @@ const DependencyExtractionWebpackPlugin = require( "@wordpress/dependency-extrac
 const defaultConfig = require( "@wordpress/scripts/config/webpack.config" );
 const MiniCssExtractPlugin = require( "mini-css-extract-plugin" );
 const { BundleAnalyzerPlugin } = require( "webpack-bundle-analyzer" );
+const { camelCase, kebabCase } = require( "lodash" );
 
 // Internal dependencies
 const { yoastExternals } = require( "./externals" );
@@ -65,6 +66,9 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 					if ( request.startsWith( "@yoast/externals/" ) ) {
 						return [ "yoast", "externals", request.substr( 17 ) ];
 					}
+					if ( request.startsWith( "@woocommerce/" ) ) {
+						return [ "wc", camelCase( request.substring( 13 ) ) ];
+					}
 				},
 				/**
 				 * Handles requests to externals.
@@ -86,6 +90,9 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 					}
 					if ( request.startsWith( "@yoast/externals/" ) ) {
 						return "yoast-seo-externals-" + request.substr( 17 );
+					}
+					if ( request.startsWith( "@woocommerce/" ) ) {
+						return "wc-" + kebabCase( request.substring( 13 ) );
 					}
 				},
 			} ),

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -1,14 +1,15 @@
 // External dependencies
+const CopyWebpackPlugin = require( "copy-webpack-plugin" );
 const { existsSync, readdirSync } = require( "fs" );
-const { join } = require( "path" );
+const { join, resolve } = require( "path" );
 
 // Variables
 const root = join( __dirname, "../../" );
 
 // Internal dependencies
-const paths       = require( "./paths" );
+const paths = require( "./paths" );
 const packageJson = require( root + "package.json" );
-const baseConfig  = require( "./webpack.config.base" );
+const baseConfig = require( "./webpack.config.base" );
 const {
 	yoastPackages,
 	yoastExternals,
@@ -29,6 +30,17 @@ module.exports = [
 			},
 			combinedOutputFile: root + "src/generated/assets/plugin.php",
 			cssExtractFileName: "../../../css/dist/plugin-" + pluginVersionSlug + ".css",
+			plugins: [
+				new CopyWebpackPlugin( {
+					patterns: [
+						{
+							from: "**/block.json",
+							context: "packages/js/src",
+							to: resolve( "blocks" ),
+						},
+					],
+				} ),
+			],
 		}
 	),
 	baseConfig(

--- a/packages/js/.eslintrc.js
+++ b/packages/js/.eslintrc.js
@@ -45,6 +45,10 @@ module.exports = {
 					// In a similar fashion as the above. Ignore the PHP dependency for WordProof, or we have to install the PHP dependencies.
 					"vendor_prefixed/wordproof",
 					"^@wordpress/(annotations|api|edit-post|sanitize)$",
+					// Ignore the `@woocommerce` packages because they are currently not compatible with our Node version (required 16, we use 18).
+					// Because we don't bundle these, this is only relevant for our JS tests and IDE autocomplete.
+					// This is a temporary exception, and should be removed once the packages are compatible.
+					"^@woocommerce/(block-templates|product-editor)",
 					"^jquery$",
 				],
 			},

--- a/packages/js/src/woocommerce-editor/blocks/seo/block.json
+++ b/packages/js/src/woocommerce-editor/blocks/seo/block.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schemas.wp.org/trunk/block.json",
+  "apiVersion": 3,
+  "name": "yoast-seo/woocommerce-editor-seo",
+  "version": "0.0.0",
+  "title": "SEO",
+  "category": "widgets",
+  "icon": "plugins",
+  "description": "Yoast SEO for the WooCommerce Product Editor",
+  "attributes": {
+    "__contentEditable": {
+      "type": "string",
+      "__experimentalRole": "content"
+    }
+  },
+  "supports": {
+    "align": false,
+    "html": false,
+    "multiple": false,
+    "reusable": false,
+    "inserter": false,
+    "lock": false,
+    "__experimentalToolbar": false
+  },
+  "textdomain": "wordpress-seo",
+  "editorScript": "yoast-seo-woocommerce-editor-seo-block"
+}

--- a/packages/js/src/woocommerce-editor/blocks/seo/edit.js
+++ b/packages/js/src/woocommerce-editor/blocks/seo/edit.js
@@ -1,0 +1,39 @@
+import { useWooBlockProps } from "@woocommerce/block-templates";
+import { LocationProvider, Root } from "@yoast/externals/contexts";
+import PropTypes from "prop-types";
+import { SeoSlot } from "../../components/seo-slot-fill";
+
+/**
+ * Represent the Yoast SEO block in the editor.
+ *
+ * @param {Object} attributes The block attributes.
+ * @param {Object} context The block context. Contains the post type.
+ *
+ * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Edit = ( { attributes, context: { postType } } ) => {
+	/**
+	 * Provides all the necessary block props like the class name.
+	 *
+	 * Note: the `block.json` NEEDS to have an attribute or this will not be interactive.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/block-templates/src/hooks/use-woo-block-props/use-woo-block-props.ts
+	 * @link https://developer.wordpress.org/block-editor/reference-guides/packages/packages-block-editor/#useblockprops
+	 */
+	const blockProps = useWooBlockProps( attributes );
+
+	return <div { ...blockProps }>
+		<LocationProvider value="sidebar">
+			<Root context={ { locationContext: "product-seo", postType } }>
+				<SeoSlot />
+			</Root>
+		</LocationProvider>
+	</div>;
+};
+
+Edit.propTypes = {
+	attributes: PropTypes.object.isRequired,
+	context: PropTypes.object.isRequired,
+};

--- a/packages/js/src/woocommerce-editor/blocks/seo/index.js
+++ b/packages/js/src/woocommerce-editor/blocks/seo/index.js
@@ -1,0 +1,20 @@
+import { registerProductEditorBlockType } from "@woocommerce/product-editor";
+import block from "./block.json";
+import { Edit } from "./edit";
+
+const { name, ...metadata } = block;
+
+/**
+ * Registers the SEO block to the product editor.
+ *
+ * @link https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/product-editor/src/utils/register-product-editor-block-type.ts
+ * @link https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+registerProductEditorBlockType( {
+	name,
+	metadata,
+	settings: {
+		example: {},
+		edit: Edit,
+	},
+} );

--- a/packages/js/src/woocommerce-editor/components/seo-slot-fill.js
+++ b/packages/js/src/woocommerce-editor/components/seo-slot-fill.js
@@ -1,0 +1,17 @@
+import { createSlotFill } from "@wordpress/components";
+import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
+
+const SLOT_FILL_NAME = "yoast-seo/woocommerce-editor/seo";
+
+const { Slot, Fill } = createSlotFill( SLOT_FILL_NAME );
+
+/**
+ * @returns {JSX.Element} The element.
+ */
+export const SeoSlot = () => (
+	<Slot>
+		{ ( fills ) => sortComponentsByRenderPriority( fills ) }
+	</Slot>
+);
+
+export const SeoFill = Fill;

--- a/packages/js/tests/__mocks__/@woocommerce/block-templates.js
+++ b/packages/js/tests/__mocks__/@woocommerce/block-templates.js
@@ -1,0 +1,1 @@
+module.exports = jest.fn();

--- a/packages/js/tests/woocommerce-editor/blocks/seo/__snapshots__/edit.test.js.snap
+++ b/packages/js/tests/woocommerce-editor/blocks/seo/__snapshots__/edit.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Edit has a slot 1`] = `
+<div
+  data-testid="1"
+>
+  Foo
+</div>
+`;
+
+exports[`Edit provides the location 1`] = `
+<div
+  data-testid="1"
+>
+  sidebar
+</div>
+`;
+
+exports[`Edit provides the locationContext 1`] = `
+<div
+  data-testid="1"
+>
+  product-seo
+</div>
+`;
+
+exports[`Edit renders 1`] = `
+<div
+  data-testid="1"
+/>
+`;

--- a/packages/js/tests/woocommerce-editor/blocks/seo/edit.test.js
+++ b/packages/js/tests/woocommerce-editor/blocks/seo/edit.test.js
@@ -1,0 +1,68 @@
+import { SlotFillProvider } from "@wordpress/components";
+import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
+import { Edit } from "../../../../src/woocommerce-editor/blocks/seo/edit";
+import { SeoFill } from "../../../../src/woocommerce-editor/components/seo-slot-fill";
+import { render, screen } from "../../../test-utils";
+
+jest.mock( "@woocommerce/block-templates", () => ( {
+	useWooBlockProps: arg => arg,
+} ) );
+
+describe( "Edit", () => {
+	it( "renders", () => {
+		render( <Edit attributes={ { "data-testid": 1 } } context={ { postType: "product" } } /> );
+
+		expect( screen.getByTestId( 1 ) ).toMatchSnapshot();
+	} );
+
+	it( "has a slot", () => {
+		render( <SlotFillProvider>
+			<Edit attributes={ { "data-testid": 1 } } context={ { postType: "product" } } />
+			<SeoFill>Foo</SeoFill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "Foo" ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 1 ) ).toMatchSnapshot();
+	} );
+
+	it( "provides the location", () => {
+		render( <SlotFillProvider>
+			<Edit attributes={ { "data-testid": 1 } } context={ { postType: "product" } } />
+			<SeoFill>
+				<LocationConsumer>
+					{ ( location ) => location }
+				</LocationConsumer>
+			</SeoFill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "sidebar" ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 1 ) ).toMatchSnapshot();
+	} );
+
+	it( "provides the locationContext", () => {
+		render( <SlotFillProvider>
+			<Edit attributes={ { "data-testid": 1 } } context={ { postType: "product" } } />
+			<SeoFill>
+				<RootContext.Consumer>
+					{ ( { locationContext } ) => locationContext }
+				</RootContext.Consumer>
+			</SeoFill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "product-seo" ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 1 ) ).toMatchSnapshot();
+	} );
+
+	it( "provides the postType", () => {
+		render( <SlotFillProvider>
+			<Edit attributes={ {} } context={ { postType: "product" } } />
+			<SeoFill>
+				<RootContext.Consumer>
+					{ ( { postType } ) => postType }
+				</RootContext.Consumer>
+			</SeoFill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "product" ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/tests/woocommerce-editor/components/__snapshots__/seo-slot-fill.test.js.snap
+++ b/packages/js/tests/woocommerce-editor/components/__snapshots__/seo-slot-fill.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SeoSlotFill sorts the fills by renderPriority 1`] = `
+<div
+  data-testid="1"
+>
+  <div>
+    10
+  </div>
+  <div>
+    200
+  </div>
+</div>
+`;

--- a/packages/js/tests/woocommerce-editor/components/seo-slot-fill.test.js
+++ b/packages/js/tests/woocommerce-editor/components/seo-slot-fill.test.js
@@ -1,0 +1,40 @@
+import { Fill, SlotFillProvider } from "@wordpress/components";
+import SidebarItem from "../../../src/components/SidebarItem";
+import { SeoFill, SeoSlot } from "../../../src/woocommerce-editor/components/seo-slot-fill";
+import { render, screen } from "../../test-utils";
+
+describe( "SeoSlotFill", () => {
+	it( "fills the slot", () => {
+		render( <SlotFillProvider>
+			<SeoSlot />
+			<SeoFill>Foo</SeoFill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "Foo" ) ).toBeInTheDocument();
+	} );
+
+	it( "fills the slot when using the name", () => {
+		render( <SlotFillProvider>
+			<SeoSlot />
+			<Fill name="yoast-seo/woocommerce-editor/seo">Foo</Fill>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "Foo" ) ).toBeInTheDocument();
+	} );
+
+	it( "sorts the fills by renderPriority", () => {
+		render( <SlotFillProvider>
+			<div data-testid={ 1 }>
+				<SeoSlot />
+				<SeoFill>
+					<SidebarItem renderPriority={ 200 }>200</SidebarItem>
+					<SidebarItem renderPriority={ 10 }>10</SidebarItem>
+				</SeoFill>
+			</div>
+		</SlotFillProvider> );
+
+		expect( screen.getByText( "200" ) ).toBeInTheDocument();
+		expect( screen.getByText( "10" ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 1 ) ).toMatchSnapshot();
+	} );
+} );

--- a/src/conditionals/conditional-interface.php
+++ b/src/conditionals/conditional-interface.php
@@ -8,9 +8,9 @@ namespace Yoast\WP\SEO\Conditionals;
 interface Conditional {
 
 	/**
-	 * Returns whether or not this conditional is met.
+	 * Returns whether this conditional is met.
 	 *
-	 * @return bool Whether or not the conditional is met.
+	 * @return bool Whether the conditional is met.
 	 */
 	public function is_met();
 }

--- a/src/loadable-interface.php
+++ b/src/loadable-interface.php
@@ -10,7 +10,7 @@ interface Loadable_Interface {
 	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function get_conditionals();
 }

--- a/src/woocommerce-editor/framework/woocommerce-product-block-editor-conditional.php
+++ b/src/woocommerce-editor/framework/woocommerce-product-block-editor-conditional.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Yoast\WP\SEO\WooCommerce_Editor\Framework;
+
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+use Yoast\WP\SEO\Conditionals\Conditional;
+
+/**
+ * Conditional that is met when the WooCommerce Product Block Editor feature is enabled.
+ */
+class WooCommerce_Product_Block_Editor_Conditional implements Conditional {
+
+	/**
+	 * Returns whether this conditional is met.
+	 *
+	 * @return bool Whether the conditional is met.
+	 */
+	public function is_met() {
+		if ( ! \class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			return false;
+		}
+
+		return FeaturesUtil::feature_is_enabled( 'product_block_editor' );
+	}
+}

--- a/src/woocommerce-editor/user-interface/woocommerce-editor-seo-block.php
+++ b/src/woocommerce-editor/user-interface/woocommerce-editor-seo-block.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yoast\WP\SEO\WooCommerce_Editor\User_Interface;
+
+use Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface;
+use Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\WooCommerce_Editor\Framework\WooCommerce_Product_Block_Editor_Conditional;
+
+/**
+ * Registers our SEO block to WooCommerce.
+ * And adds it to the SEO group in the WooCommerce Product Block Editor.
+ *
+ * @link https://github.com/woocommerce/woocommerce/blob/trunk/docs/product-editor-development/block-template-lifecycle.md#registration
+ */
+class WooCommerce_Editor_SEO_Block implements Integration_Interface {
+
+	/**
+	 * Only continue with this integration when WooCommerce is active and the product block editor feature is available.
+	 *
+	 * @return string[]
+	 */
+	public static function get_conditionals() {
+		return [ WooCommerce_Conditional::class, WooCommerce_Product_Block_Editor_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'register_block' ] );
+
+		/**
+		 * Adds this SEO block to the SEO group.
+		 *
+		 * @see \Yoast\WP\SEO\WooCommerce_Editor\User_Interface\WooCommerce_Editor_SEO_Group
+		 */
+		\add_action(
+			'woocommerce_block_template_area_product-form_after_add_block_' . WooCommerce_Editor_SEO_Group::GROUP_ID,
+			[ $this, 'add_seo_block' ]
+		);
+	}
+
+	/**
+	 * Registers the blocks using the metadata loaded from the `block.json` file.
+	 * Behind the scenes, it also registers all assets so they can be enqueued through the block editor in the
+	 * corresponding context.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/register_block_type/
+	 *
+	 * @return void
+	 */
+	public function register_block() {
+		if ( ! \class_exists( '\Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry' ) ) {
+			return;
+		}
+
+		BlockRegistry::get_instance()
+			->register_block_type_from_metadata( \WPSEO_PATH . 'blocks/woocommerce-editor/blocks/seo/block.json' );
+	}
+
+	/**
+	 * Adds our SEO block after the given block.
+	 *
+	 * @param BlockInterface $block A block.
+	 *
+	 * @return void
+	 */
+	public function add_seo_block( BlockInterface $block ) {
+		$block->add_block(
+			[
+				'id'        => 'yoast-seo-woocommerce-editor-seo',
+				'blockName' => 'yoast-seo/woocommerce-editor-seo',
+				'order'     => 10,
+			]
+		);
+	}
+}

--- a/tests/Unit/WooCommerce_Editor/Framework/WooCommerce_Product_Block_Editor_Conditional_Test.php
+++ b/tests/Unit/WooCommerce_Editor/Framework/WooCommerce_Product_Block_Editor_Conditional_Test.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\WooCommerce_Editor\Framework;
+
+use Error;
+use Mockery;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\WooCommerce_Editor\Framework\WooCommerce_Product_Block_Editor_Conditional;
+
+/**
+ * Tests WooCommerce_Product_Block_Editor_Conditional.
+ *
+ * @group woocommerce-editor
+ * @coversDefaultClass \Yoast\WP\SEO\WooCommerce_Editor\Framework\WooCommerce_Product_Block_Editor_Conditional
+ */
+final class WooCommerce_Product_Block_Editor_Conditional_Test extends TestCase {
+
+	/**
+	 * The WooCommerce_Product_Block_Editor_Conditional.
+	 *
+	 * @var WooCommerce_Product_Block_Editor_Conditional
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new WooCommerce_Product_Block_Editor_Conditional();
+	}
+
+	/**
+	 * Tests is_met.
+	 *
+	 * @covers ::is_met
+	 *
+	 * @return void
+	 */
+	public function test_is_met() {
+		try {
+			$this->instance->is_met();
+		} catch ( Error $e ) {
+			$this->fail( 'The is_met method should not throw an error when FeaturesUtil class is not available.' );
+		}
+
+		$registry = Mockery::mock( 'alias:\Automattic\WooCommerce\Utilities\FeaturesUtil' );
+
+		$registry->shouldReceive( 'feature_is_enabled' )->andReturn( true, false );
+
+		$this->assertTrue( $this->instance->is_met() );
+		$this->assertFalse( $this->instance->is_met() );
+	}
+}

--- a/tests/Unit/WooCommerce_Editor/User_Interface/WooCommerce_Editor_SEO_Block_Test.php
+++ b/tests/Unit/WooCommerce_Editor/User_Interface/WooCommerce_Editor_SEO_Block_Test.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\WooCommerce_Editor\User_Interface;
+
+use Brain\Monkey;
+use Error;
+use Mockery;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast\WP\SEO\WooCommerce_Editor\User_Interface\WooCommerce_Editor_SEO_Block;
+
+/**
+ * Tests WooCommerce_Editor_SEO_Block.
+ *
+ * @group woocommerce-editor
+ * @coversDefaultClass \Yoast\WP\SEO\Woocommerce_Editor\User_Interface\WooCommerce_Editor_SEO_Block
+ */
+final class WooCommerce_Editor_SEO_Block_Test extends TestCase {
+
+	/**
+	 * The WooCommerce_Editor_SEO_Block.
+	 *
+	 * @var WooCommerce_Editor_SEO_Block
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new WooCommerce_Editor_SEO_Block();
+	}
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @covers ::get_conditionals
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[
+				'Yoast\WP\SEO\Conditionals\WooCommerce_Conditional',
+				'Yoast\WP\SEO\WooCommerce_Editor\Framework\WooCommerce_Product_Block_Editor_Conditional',
+			],
+			WooCommerce_Editor_SEO_Block::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the register_hooks method.
+	 *
+	 * @covers ::register_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Functions\expect( 'add_action' )
+			->with( 'admin_init', [ $this->instance, 'register_block' ] )
+			->once();
+
+		Monkey\Functions\expect( 'add_action' )
+			->with(
+				'woocommerce_block_template_area_product-form_after_add_block_yoast-seo',
+				[ $this->instance, 'add_seo_block' ]
+			)
+			->once();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests add_seo_block.
+	 *
+	 * @covers ::add_seo_block
+	 *
+	 * @return void
+	 */
+	public function test_add_seo_block() {
+		$block = Mockery::mock( '\Automattic\WooCommerce\Admin\BlockTemplates\BlockInterface' );
+
+		$block->shouldReceive( 'add_block' )
+			->with(
+				[
+					'id'        => 'yoast-seo-woocommerce-editor-seo',
+					'blockName' => 'yoast-seo/woocommerce-editor-seo',
+					'order'     => 10,
+				]
+			)
+			->once();
+
+		$this->instance->add_seo_block( $block );
+	}
+
+	/**
+	 * Tests register_block.
+	 *
+	 * @covers ::register_block
+	 *
+	 * @return void
+	 */
+	public function test_register_block() {
+		try {
+			$this->instance->register_block();
+		} catch ( Error $e ) {
+			$this->fail( 'The register_block method should not throw an error when the BlockRegistry class does not exist.' );
+		}
+
+		$registry = Mockery::mock( 'alias:\Automattic\WooCommerce\Admin\Features\ProductBlockEditor\BlockRegistry' );
+
+		$registry->shouldReceive( 'get_instance' )->andReturn( $registry );
+		$registry->shouldReceive( 'register_block_type_from_metadata' )
+			->with( \WPSEO_PATH . 'blocks/woocommerce-editor/blocks/seo/block.json' )
+			->once();
+
+		$this->instance->register_block();
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Add placeholder (slot) to our SEO tab.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tooling (copy to `blocks` and `artifact` folders) support for `block.json` files within `packages/js/src`. 
* Prevent bundling of any `@woocommerce/` packages, expecting them to all be available on the window within a WP environment.
* Adds a "edit" only `yoast-seo/woocommerce-editor-seo` block, for usage in the WooCommerce product block editor.

## Relevant technical choices:

* For the block registration, we need access to the `block.json` file. Therefore, we need to ensure the path is the same in development and production (zip).
[This commit](https://github.com/Yoast/wordpress-seo/commit/33ca60e97b382da20f3255b8548d8e88b41f9a21) solves that by effectively making the root blocks folder the "dist" or "build" folder for our block.json files.
When bundling, any `block.json` files found (within our entry scripts) are copied over to the root blocks folder.
Keeping the folder structure in place from `packages/js/src` onwards.
When creating an artifact, the blocks root folder is copied to the artifact folder.
Note: the webpack copy currently has no support for any CSS or JS alongside, but the artifact copy ignore extensions already.
[Slack context](https://yoast.slack.com/archives/C03KU0EHCNQ/p1708009384072779)
* Don't bundle WC packages, they are provided by WooCommerce when in the WP environment. I could not add them as JS dependencies for usage in our tests due to them requiring us to use Node v16. Therefore, I added an ignore on our linting rule (and needing to mock out their functionality, though perhaps I would've done that either way)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* There is actually nothing to see yet. The added JS tests should verify the contexts and slot/fill works as expected.
However, you could render a Fill too to verify it works in development and "production", e.g. adding the following within `Edit.js`:
```js
<SeoFill>
	<h1>Hello, I'm rendering</h1>
</SeoFill>
```
* Build like usual
* [ ] Verify there is now a `blocks` folder at root level that contains the `block.json` from this new block
* [ ] Verify the Fill renders, as the code points to the root/blocks folder location.
* Run `grunt artifact`
* [ ] Verify the artifact contains the same `blocks` folder
* Deploy the zip in an environment
* [ ] Verify the Fill renders, as the code points to the blocks folder location.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not needed to test this PR in isolation, there is nothing that actually shows up within this PR. In the full feature, the tab will have content via the added code here.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The build & artifact

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/189
