### PR TITLE
Make sure image is null when it is '' so that the schema generator does not create an empty record.

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -626,7 +626,11 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		if ( $this->request_helper->is_rest_request() ) {
-			return $this->get_main_image_url_for_rest_request();
+			$url = $this->get_main_image_url_for_rest_request();
+			if ( $url === '' ) {
+				return null;
+			}
+			return $url;
 		}
 
 		if ( ! \is_singular() ) {

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -626,11 +626,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		}
 
 		if ( $this->request_helper->is_rest_request() ) {
-			$url = $this->get_main_image_url_for_rest_request();
-			if ( $url === '' ) {
-				return null;
-			}
-			return $url;
+			return $this->get_main_image_url_for_rest_request();
 		}
 
 		if ( ! \is_singular() ) {
@@ -762,7 +758,11 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		switch ( $this->page_type ) {
 			case 'Post_Type':
 				if ( $this->post instanceof WP_Post ) {
-					return $this->image->get_post_content_image( $this->post->ID );
+					$url = $this->image->get_post_content_image( $this->post->ID );
+					if ( $url === '' ) {
+						return null;
+					}
+					return $url;
 				}
 				return null;
 			default:


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to show an primary image if there is none.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where image node would be in the schema output for a rest request.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post without images and remember its ID
* Go to YOUR_BLOG_URL/wp-json/wp/v2/posts/POST_ID
* Make sure that without this PR/RC you see  
```"image": {
"@id": "http://basic.wordpress.test/bla/#primaryimage"
},
```
And no 
```"@type": "ImageObject",
"inLanguage": "en-US",
"@id": "http://basic.wordpress.test/sample-page/#primaryimage",
```
* now activate this RC/PR and make sure the following is gone.
```"image": {
"@id": "http://basic.wordpress.test/bla/#primaryimage"
},
```
* Now add an image to your post and make sure it shows up and there is a corresponding image object in the schema output.
```"@type": "ImageObject",
"inLanguage": "en-US",
"@id": "http://basic.wordpress.test/sample-page/#primaryimage",
```

* Final check: compare the schema output in the front-end to the rest output and make sure they are the same.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
