### PR TITLE
Adds exception to the breadcrumb generator that ignores ancestor on the homepage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2620",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2601",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=294",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -89,7 +89,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 *
 	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
-	 * @return array An array of associative arrays that each have a 'text' and a 'url'.
+	 * @return array<string[]> An array of associative arrays that each have a 'text' and a 'url'.
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
@@ -136,9 +136,11 @@ class Breadcrumbs_Generator implements Generator_Interface {
 				}
 			}
 		}
-
-		// Get all ancestors of the indexable and append itself to get all indexables in the full crumb.
-		$indexables   = $this->repository->get_ancestors( $context->indexable );
+		$indexables = [];
+		if ( ! \in_array( $this->current_page_helper->get_page_type(), [ 'Home_Page', 'Static_Home_Page' ], true ) ) {
+			// Get all ancestors of the indexable and append itself to get all indexables in the full crumb.
+			$indexables = $this->repository->get_ancestors( $context->indexable );
+		}
 		$indexables[] = $context->indexable;
 
 		if ( ! empty( $static_ancestors ) ) {
@@ -154,34 +156,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			}
 		);
 
-		$callback = function ( Indexable $ancestor ) {
-			$crumb = [
-				'url'  => $ancestor->permalink,
-				'text' => $ancestor->breadcrumb_title,
-			];
-			switch ( $ancestor->object_type ) {
-				case 'post':
-					$crumb = $this->get_post_crumb( $crumb, $ancestor );
-					break;
-				case 'post-type-archive':
-					$crumb = $this->get_post_type_archive_crumb( $crumb, $ancestor );
-					break;
-				case 'term':
-					$crumb = $this->get_term_crumb( $crumb, $ancestor );
-					break;
-				case 'system-page':
-					$crumb = $this->get_system_page_crumb( $crumb, $ancestor );
-					break;
-				case 'user':
-					$crumb = $this->get_user_crumb( $crumb, $ancestor );
-					break;
-				case 'date-archive':
-					$crumb = $this->get_date_archive_crumb( $crumb );
-					break;
-			}
-			return $crumb;
-		};
-		$crumbs   = \array_map( $callback, $indexables );
+		$crumbs = \array_map( [ $this,'get_post_type_crumb' ], $indexables );
 
 		if ( $breadcrumbs_home !== '' ) {
 			$crumbs[0]['text'] = $breadcrumbs_home;
@@ -224,10 +199,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified post crumb.
 	 *
-	 * @param array     $crumb    The crumb.
+	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	private function get_post_crumb( $crumb, $ancestor ) {
 		$crumb['id'] = $ancestor->object_id;
@@ -236,12 +211,52 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	}
 
 	/**
+	 * Adds the correct ID to the crumb array based on the ancestor provided.
+	 *
+	 * @param Indexable $ancestor The ancestor indexable.
+	 *
+	 * @return string[]
+	 */
+	private function get_post_type_crumb( Indexable $ancestor ) {
+		$crumb = [
+			'url'  => $ancestor->permalink,
+			'text' => $ancestor->breadcrumb_title,
+		];
+
+		switch ( $ancestor->object_type ) {
+			case 'post':
+				$crumb = $this->get_post_crumb( $crumb, $ancestor );
+				break;
+			case 'post-type-archive':
+				$crumb = $this->get_post_type_archive_crumb( $crumb, $ancestor );
+				break;
+			case 'term':
+				$crumb = $this->get_term_crumb( $crumb, $ancestor );
+				break;
+			case 'system-page':
+				$crumb = $this->get_system_page_crumb( $crumb, $ancestor );
+				break;
+			case 'user':
+				$crumb = $this->get_user_crumb( $crumb, $ancestor );
+				break;
+			case 'date-archive':
+				$crumb = $this->get_date_archive_crumb( $crumb );
+				break;
+			default:
+				// Handle unknown object types (optional).
+				break;
+		}
+
+		return $crumb;
+	}
+
+	/**
 	 * Returns the modified post type crumb.
 	 *
-	 * @param array     $crumb    The crumb.
+	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	private function get_post_type_archive_crumb( $crumb, $ancestor ) {
 		$crumb['ptarchive'] = $ancestor->object_sub_type;
@@ -252,10 +267,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified term crumb.
 	 *
-	 * @param array     $crumb    The crumb.
+	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	private function get_term_crumb( $crumb, $ancestor ) {
 		$crumb['term_id']  = $ancestor->object_id;
@@ -267,10 +282,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified system page crumb.
 	 *
-	 * @param array     $crumb    The crumb.
+	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	private function get_system_page_crumb( $crumb, $ancestor ) {
 		if ( $ancestor->object_sub_type === 'search-result' ) {
@@ -287,10 +302,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified user crumb.
 	 *
-	 * @param array     $crumb    The crumb.
+	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	private function get_user_crumb( $crumb, $ancestor ) {
 		$display_name  = \get_the_author_meta( 'display_name', $ancestor->object_id );
@@ -302,9 +317,9 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Returns the modified date archive crumb.
 	 *
-	 * @param array $crumb The crumb.
+	 * @param string[] $crumb The crumb.
 	 *
-	 * @return array The crumb.
+	 * @return string[] The crumb.
 	 */
 	protected function get_date_archive_crumb( $crumb ) {
 		$home_url = $this->url_helper->home();
@@ -380,10 +395,10 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	/**
 	 * Adds a crumb for the current page, if we're on an archive page or paginated post.
 	 *
-	 * @param array     $crumbs            The array of breadcrumbs.
+	 * @param string[]  $crumbs            The array of breadcrumbs.
 	 * @param Indexable $current_indexable The current indexable.
 	 *
-	 * @return array The breadcrumbs.
+	 * @return string[] The breadcrumbs.
 	 */
 	protected function add_paged_crumb( array $crumbs, $current_indexable ) {
 		$is_simple_page = $this->current_page_helper->is_simple_page();

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -89,7 +89,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 *
 	 * @param Meta_Tags_Context $context The meta tags context.
 	 *
-	 * @return array<string[]> An array of associative arrays that each have a 'text' and a 'url'.
+	 * @return array<array<int,string>> An array of associative arrays that each have a 'text' and a 'url'.
 	 */
 	public function generate( Meta_Tags_Context $context ) {
 		$static_ancestors = [];
@@ -202,7 +202,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return string[] The crumb.
+	 * @return array<int,string> The crumb.
 	 */
 	private function get_post_crumb( $crumb, $ancestor ) {
 		$crumb['id'] = $ancestor->object_id;
@@ -270,7 +270,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 	 * @param string[]  $crumb    The crumb.
 	 * @param Indexable $ancestor The indexable.
 	 *
-	 * @return string[] The crumb.
+	 * @return array<int,string> The crumb.
 	 */
 	private function get_term_crumb( $crumb, $ancestor ) {
 		$crumb['term_id']  = $ancestor->object_id;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to run an unnecessary query on the homepage that will always return zero results.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes an unnecessary query relating to breadcrumb generation on the homepage.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable query monitor
Do these steps for a static and non static homepage:
* Without this PR, go to the homepage and make sure you see the following query (from the `Yoast\WP\SEO\Repositories\Indexable_Hierarchy_Repository->find_ancestors` caller).
![image](https://github.com/Yoast/wordpress-seo/assets/6975345/ce1e3602-db42-46f7-b594-9a0926ce8456)
* Look at your schema output and take note of the breadcrumb. It should look like:
```
{
	            "@type": "BreadcrumbList",
	            "@id": "http://basic.wordpress.test/#breadcrumb",
	            "itemListElement": [
	                {
	                    "@type": "ListItem",
	                    "position": 1,
	                    "name": "Home"
	                }
	            ]
	        },
```
* Enable this PR. and make sure that the query is gone, and the schema output stays the same.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This touches parts of the breadcrumb schema generation. So smoke testing normal pages/posts and pages with ancestors is needed.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
