### PR TITLE
Fixes a bug where the attachment would never be marked as external.

### DIFF
--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -333,10 +333,12 @@ class Image_Helper {
 		if ( ! $use_link_table ) {
 			return WPSEO_Image_Utils::get_attachment_by_url( $url );
 		}
-		$cache_key = 'attachment_seo_link_object_' . $url;
-		$link      = \wp_cache_get( $cache_key, 'yoast-seo-attachment-link' );
+		$cache_key = 'attachment_seo_link_object_' . \md5( $url );
 
-		if ( $link === false ) {
+		$found = false;
+		$link  = \wp_cache_get( $cache_key, 'yoast-seo-attachment-link', false, $found );
+
+		if ( $found === false ) {
 			$link = $this->seo_links_repository->find_one_by_url( $url );
 			\wp_cache_set( $cache_key, $link, 'yoast-seo-attachment-link', \MINUTE_IN_SECONDS );
 		}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -333,8 +333,13 @@ class Image_Helper {
 		if ( ! $use_link_table ) {
 			return WPSEO_Image_Utils::get_attachment_by_url( $url );
 		}
+		$cache_key = 'attachment_seo_link_object_' . $url;
+		$link      = \wp_cache_get( $cache_key, 'yoast-seo-attachment-link' );
 
-		$link = $this->seo_links_repository->find_one_by_url( $url );
+		if ( $link === false ) {
+			$link = $this->seo_links_repository->find_one_by_url( $url );
+			\wp_cache_set( $cache_key, $link, 'yoast-seo-attachment-link', \MINUTE_IN_SECONDS );
+		}
 		if ( ! \is_a( $link, SEO_Links::class ) ) {
 			return WPSEO_Image_Utils::get_attachment_by_url( $url );
 		}

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -304,7 +304,8 @@ class Image_Helper {
 	 */
 	public function get_attachment_by_url( $url, $use_link_table = true ) {
 		// Don't try to do this for external URLs.
-		if ( $this->url_helper->get_link_type( $url ) === SEO_Links::TYPE_EXTERNAL ) {
+		$parsed_url = \wp_parse_url( $url );
+		if ( $this->url_helper->get_link_type( $parsed_url ) === SEO_Links::TYPE_EXTERNAL ) {
 			return 0;
 		}
 

--- a/tests/Unit/Helpers/Image_Helper_Test.php
+++ b/tests/Unit/Helpers/Image_Helper_Test.php
@@ -604,9 +604,10 @@ final class Image_Helper_Test extends TestCase {
 				]
 			);
 
+		$url = \md5( 'a_dir/something' );
 		Monkey\Functions\expect( 'wp_cache_get' )
 			->once()
-			->with( 'attachment_seo_link_object_a_dir/something', 'yoast-seo-attachment-link' )
+			->with( 'attachment_seo_link_object_' . $url, 'yoast-seo-attachment-link', false, false )
 			->andReturn( false );
 
 		$link                 = new SEO_Links_Mock();
@@ -617,37 +618,7 @@ final class Image_Helper_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_cache_set' )
 			->once()
-			->with( 'attachment_seo_link_object_a_dir/something', $link, 'yoast-seo-attachment-link', \MINUTE_IN_SECONDS );
-		$this->assertEquals( 17, $this->actual_instance->get_attachment_by_url( 'a_dir/something' ) );
-	}
-
-	/**
-	 * Tests the get_attachment_by_url function without using the SEO links table. Because the query result is cached
-	 *
-	 * @covers ::get_attachment_by_url
-	 * @return void
-	 */
-	public function test_get_attachment_by_url_with_existing_link_and_cache() {
-		Monkey\Functions\expect( 'wp_parse_url' )
-			->once()
-			->with( 'a_dir/something' )
-			->andReturn(
-				[
-					'scheme' => 'https',
-					'host'   => 'example.com',
-				]
-			);
-
-		$link                 = new SEO_Links_Mock();
-		$link->target_post_id = 17;
-		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_INTERNAL );
-		$this->options_helper->expects( 'get' )->with( 'disable-attachment' )->andReturn( true );
-		$this->indexable_seo_links_repository->expects( 'find_one_by_url' )->never();
-		Monkey\Functions\expect( 'wp_cache_get' )
-			->once()
-			->with( 'attachment_seo_link_object_a_dir/something', 'yoast-seo-attachment-link' )
-			->andReturn( $link );
-
+			->with( 'attachment_seo_link_object_' . $url, $link, 'yoast-seo-attachment-link', \MINUTE_IN_SECONDS );
 		$this->assertEquals( 17, $this->actual_instance->get_attachment_by_url( 'a_dir/something' ) );
 	}
 }

--- a/tests/Unit/Helpers/Image_Helper_Test.php
+++ b/tests/Unit/Helpers/Image_Helper_Test.php
@@ -604,11 +604,50 @@ final class Image_Helper_Test extends TestCase {
 					'host'   => 'example.com',
 				]
 			);
+
+		Monkey\Functions\expect( 'wp_cache_get' )
+			->once()
+			->with( 'attachment_seo_link_object_a_dir/something', 'yoast-seo-attachment-link' )
+			->andReturn( false );
+
 		$link                 = new SEO_Links_Mock();
 		$link->target_post_id = 17;
 		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_INTERNAL );
 		$this->options_helper->expects( 'get' )->with( 'disable-attachment' )->andReturn( true );
 		$this->indexable_seo_links_repository->expects( 'find_one_by_url' )->andReturn( $link );
+
+		Monkey\Functions\expect( 'wp_cache_set' )
+			->once()
+			->with( 'attachment_seo_link_object_a_dir/something', $link, 'yoast-seo-attachment-link', \MINUTE_IN_SECONDS );
+		$this->assertEquals( 17, $this->actual_instance->get_attachment_by_url( 'a_dir/something' ) );
+	}
+
+	/**
+	 * Tests the get_attachment_by_url function without using the SEO links table. Because the query result is cached
+	 *
+	 * @covers ::get_attachment_by_url
+	 * @return void
+	 */
+	public function test_get_attachment_by_url_with_existing_link_and_cache() {
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->with( 'a_dir/something' )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
+
+		$link                 = new SEO_Links_Mock();
+		$link->target_post_id = 17;
+		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_INTERNAL );
+		$this->options_helper->expects( 'get' )->with( 'disable-attachment' )->andReturn( true );
+		$this->indexable_seo_links_repository->expects( 'find_one_by_url' )->never();
+		Monkey\Functions\expect( 'wp_cache_get' )
+			->once()
+			->with( 'attachment_seo_link_object_a_dir/something', 'yoast-seo-attachment-link' )
+			->andReturn( $link );
 
 		$this->assertEquals( 17, $this->actual_instance->get_attachment_by_url( 'a_dir/something' ) );
 	}

--- a/tests/Unit/Helpers/Image_Helper_Test.php
+++ b/tests/Unit/Helpers/Image_Helper_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
+
 use Mockery;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -522,12 +523,41 @@ final class Image_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the get_attachment_by_url function with an external image url.
+	 *
+	 * @covers ::get_attachment_by_url
+	 * @return void
+	 */
+	public function test_get_attachment_by_url_with_external_url_image() {
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->with( 'https://example.com/image.jpg' )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
+		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_EXTERNAL );
+		$this->assertEquals( 0, $this->actual_instance->get_attachment_by_url( 'https://example.com/image.jpg' ) );
+	}
+
+	/**
 	 * Tests the get_attachment_by_url function with an external image.
 	 *
 	 * @covers ::get_attachment_by_url
 	 * @return void
 	 */
 	public function test_get_attachment_by_url_with_external_image() {
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->with( '' )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
 		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_EXTERNAL );
 		$this->assertEquals( 0, $this->actual_instance->get_attachment_by_url( '' ) );
 	}
@@ -539,7 +569,15 @@ final class Image_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_attachment_by_url_with_existing_indexable() {
-
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->with( '' )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
 		$indexable                  = new Indexable_Mock();
 		$indexable->object_type     = 'post';
 		$indexable->object_sub_type = 'attachment';
@@ -557,6 +595,15 @@ final class Image_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_attachment_by_url_with_existing_link() {
+		Monkey\Functions\expect( 'wp_parse_url' )
+			->once()
+			->with( 'a_dir/something' )
+			->andReturn(
+				[
+					'scheme' => 'https',
+					'host'   => 'example.com',
+				]
+			);
 		$link                 = new SEO_Links_Mock();
 		$link->target_post_id = 17;
 		$this->url_helper->expects( 'get_link_type' )->andReturn( SEO_Links::TYPE_INTERNAL );

--- a/tests/Unit/Helpers/Image_Helper_Test.php
+++ b/tests/Unit/Helpers/Image_Helper_Test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\Unit\Helpers;
 
 use Brain\Monkey;
-
 use Mockery;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;

--- a/tests/WP/Helpers/Get_Attachment_By_Url_Image_Helper_Test.php
+++ b/tests/WP/Helpers/Get_Attachment_By_Url_Image_Helper_Test.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Helpers;
+
+use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration Test Class for the Image_Helper class.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Needed to show specific method being tested in this file.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Image_Helper
+ */
+final class Get_Attachment_By_Url_Image_Helper_Test extends TestCase {
+
+	/**
+	 * The instance.
+	 *
+	 * @var Image_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new Image_Helper( \YoastSEO()->classes->get( Indexable_Repository::class ), \YoastSEO()->classes->get( SEO_Links_Repository::class ), \YoastSEO()->helpers->options, \YoastSEO()->helpers->url );
+		\YoastSEO()->helpers->options->set( 'disable-attachment', true );
+
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->prefix . 'yoast_seo_links',
+			[
+				'url'                 => 'a_dir/something',
+				'type'                => 'internal',
+				'indexable_id'        => '101',
+				'post_id'             => '110',
+				'target_post_id'      => '112',
+				'target_indexable_id' => '344',
+				'id'                  => '113',
+			]
+		);
+	}
+
+	/**
+	 * Tests if the query cached is filled when `get_attachment_by_url` is called multiple times.
+	 *
+	 * @covers ::get_attachment_by_url
+	 * @return void
+	 */
+	public function test_get_attachment_by_url_with_existing_link_and_cache() {
+		$url       = 'a_dir/something';
+		$cache_key = 'attachment_seo_link_object_' . \md5( $url );
+		$link      = $this->instance->get_attachment_by_url( $url );
+
+		$link_cache = \wp_cache_get( $cache_key, 'yoast-seo-attachment-link' );
+		$this->assertSame( $link, $link_cache->target_post_id );
+
+		$this->assertSame( 112, $this->instance->get_attachment_by_url( 'a_dir/something' ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want unneeded database calls for external images.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes two unnecessary queries on pages where external images are of SEO interest, like author pages with Gravatar author images.
* Removes a duplicated query on author pages with internal images.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable QM.
* Make sure author archives are enabled.
* Make an author and set the author of a post to this author.
* Go to the author archive page.
* Without this PR/RC make sure you see the following queries in QM, twice:
```
SELECT `target_post_id`
FROM `wp_yoast_seo_links`
WHERE `url` = '{A_Gravatar_URL}'
LIMIT 1
```

* Take note of the schema and meta tags output on the page.
* Enable the PR and make sure the queries are gone.
* Compare the schema and meta tags to the output without the RC and make sure they are the same.

* Install a plugin to allow local author images like https://wordpress.org/plugins/simple-local-avatars/
* Set an image for the author and make sure the queries show up once due to caching the query result. Take note of the schema and meta tags on that page
* Confirm that without this PR the meta tags and schema stays the same, but the query appears now duplicated.


--- 
To test the object cache:
* Install a plugin for persistant object cache for example https://wordpress.org/plugins/sqlite-object-cache/
* Enable the plugin and go to the statistic page for this plugin this would be /wp-admin/options-general.php?page=sqlite_object_cache_settings&tab=stats
* Make sure you do not see the group `yoast-seo-attachment-link`
* Refresh your author archive page and make sure you only see the `Yoast\W\S\R\SEO_Links_Repository->find_one_by_url()` query once. Refresh withing 1 minute and make sure the query is gone as well.
* Wait for a minute and refresh again the query should be back.


Read ahead since the following steps need to be done quickly in a row (all steps should be done within a single minute).
* Go to the author profile page and upload a new image `but do not save yet`.
* Refresh the author archive page and see 1 query and note the url in the query. For me this was 
```
SELECT `target_post_id`
FROM `wp_yoast_seo_links`
WHERE `url` = 'http://basic.wordpress.test/wp-content/uploads/2024/02/904-200x300-1.jpg'
LIMIT 1
``` 
So `http://basic.wordpress.test/wp-content/uploads/2024/02/904-200x300-1.jpg`
* Save the author profile page (so that the new image is saved)
* Refresh the author archive page and make sure the query is there with the new url. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This changes the behavior of how we get image metadata for schema and meta tags for external images. So it would be good to test adding images to posts and making sure everything still gets handled the same.
  * It would be nice to test edge cases as well, so check for posts with (resized) content image, feature image, og/twitter image or any combination of the above. Posts with How-to blocks (with images in a step description!) too. Whenever we can, we should test with external images in those cases too.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
