### PR TITLE
Makes sure the slug is synced correctly when the post is in draft.

### DIFF
--- a/packages/js/src/watchers/elementorWatcher.js
+++ b/packages/js/src/watchers/elementorWatcher.js
@@ -104,6 +104,25 @@ function getEditorData( editorDocument ) {
 	};
 }
 
+/**
+ * Source of this way of making the slug: https://byby.dev/js-slugify-string reason not to use Lodash is that they add a - between digits
+ * and characters, and WordPress does not do this.
+ *
+ * @param {string} postTitle The current post title.
+ *
+ * @returns {string} The generated slug value.
+ */
+function createSlug( postTitle ) {
+	return String( postTitle )
+		.normalize( "NFKD" )
+		.replace( /[\u0300-\u036f]/g, "" )
+		.trim()
+		.toLowerCase()
+		.replace( /[^a-z0-9 -]/g, "" )
+		.replace( /\s+/g, "-" )
+		.replace( /-+/g, "-" );
+}
+
 /* eslint-disable complexity */
 /**
  * Dispatches new data when the editor is dirty.
@@ -136,19 +155,7 @@ function handleEditorChange() {
 		dispatch( "yoast-seo/editor" ).setEditorDataTitle( editorData.title );
 
 		if ( data.status === "draft" || data.status === "auto-draft" ) {
-
-			// Source of this way of making the slug: https://byby.dev/js-slugify-string reason not to use Lodash is that they add a - between digits
-			// and characters, and WordPress does not do this.
-			const slug = String( editorData.title )
-				.normalize( "NFKD" )
-				.replace( /[\u0300-\u036f]/g, "" )
-				.trim()
-				.toLowerCase()
-				.replace( /[^a-z0-9 -]/g, "" )
-				.replace( /\s+/g, "-" )
-				.replace( /-+/g, "-" );
-
-			dispatch( "yoast-seo/editor" ).updateData( { slug: slug } );
+			dispatch( "yoast-seo/editor" ).updateData( { slug: createSlug( editorData.title ) } );
 		}
 	}
 
@@ -164,6 +171,7 @@ function handleEditorChange() {
 }
 
 /* eslint-enable complexity */
+
 
 /**
  * Removes highlighting from Elementor widgets and reset the highlighting button.

--- a/packages/js/src/watchers/elementorWatcher.js
+++ b/packages/js/src/watchers/elementorWatcher.js
@@ -1,4 +1,5 @@
 import { dispatch, select } from "@wordpress/data";
+import { cleanForSlug } from "@wordpress/url";
 import { debounce, get } from "lodash";
 import firstImageUrlInContent from "../helpers/firstImageUrlInContent";
 import { registerElementorUIHookAfter, registerElementorUIHookBefore } from "../helpers/elementorHook";
@@ -104,25 +105,6 @@ function getEditorData( editorDocument ) {
 	};
 }
 
-/**
- * Source of this way of making the slug: https://byby.dev/js-slugify-string reason not to use Lodash is that they add a - between digits
- * and characters, and WordPress does not do this.
- *
- * @param {string} postTitle The current post title.
- *
- * @returns {string} The generated slug value.
- */
-function createSlug( postTitle ) {
-	return String( postTitle )
-		.normalize( "NFKD" )
-		.replace( /[\u0300-\u036f]/g, "" )
-		.trim()
-		.toLowerCase()
-		.replace( /[^a-z0-9 -]/g, "" )
-		.replace( /\s+/g, "-" )
-		.replace( /-+/g, "-" );
-}
-
 /* eslint-disable complexity */
 /**
  * Dispatches new data when the editor is dirty.
@@ -155,7 +137,7 @@ function handleEditorChange() {
 		dispatch( "yoast-seo/editor" ).setEditorDataTitle( editorData.title );
 
 		if ( data.status === "draft" || data.status === "auto-draft" ) {
-			dispatch( "yoast-seo/editor" ).updateData( { slug: createSlug( editorData.title ) } );
+			dispatch( "yoast-seo/editor" ).updateData( { slug: cleanForSlug( editorData.title ) } );
 		}
 	}
 

--- a/packages/js/src/watchers/elementorWatcher.js
+++ b/packages/js/src/watchers/elementorWatcher.js
@@ -100,6 +100,7 @@ function getEditorData( editorDocument ) {
 		title: window.elementor.settings.page.model.get( "post_title" ),
 		excerpt: window.elementor.settings.page.model.get( "post_excerpt" ) || "",
 		imageUrl: getImageUrl( content ),
+		status: window.elementor.settings.page.model.get( "post_status" ),
 	};
 }
 
@@ -133,6 +134,22 @@ function handleEditorChange() {
 	if ( data.title !== editorData.title ) {
 		editorData.title = data.title;
 		dispatch( "yoast-seo/editor" ).setEditorDataTitle( editorData.title );
+
+		if ( data.status === "draft" || data.status === "auto-draft" ) {
+
+			// Source of this way of making the slug: https://byby.dev/js-slugify-string reason not to use Lodash is that they add a - between digits
+			// and characters, and WordPress does not do this.
+			const slug = String( editorData.title )
+				.normalize( "NFKD" )
+				.replace( /[\u0300-\u036f]/g, "" )
+				.trim()
+				.toLowerCase()
+				.replace( /[^a-z0-9 -]/g, "" )
+				.replace( /\s+/g, "-" )
+				.replace( /-+/g, "-" );
+
+			dispatch( "yoast-seo/editor" ).updateData( { slug: slug } );
+		}
 	}
 
 	if ( data.excerpt !== editorData.excerpt ) {
@@ -145,6 +162,7 @@ function handleEditorChange() {
 		dispatch( "yoast-seo/editor" ).setEditorDataImageUrl( editorData.imageUrl );
 	}
 }
+
 /* eslint-enable complexity */
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When you save a post with Elementor for the first time we override the slug to the `elementor-*` name. We don't want this to happen and we want to follow the correct slug.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an unneeded redirect would be created when a post was first published in Elementor.

## Relevant technical choices:

* I added a custom slug creator to make sure we are inline with what the WordPress backend also does when you publish a post.
* I also added a check to only sync this field when to post is still in draft. This is because when you have published a post the slug change needs to be conscious and unrelated to the post title changing.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Enable Elementor / Premium / Free.
* Create a new post in Elementor and change the title to `Test post`
* Publish the post and make sure the slug is `test-post`. Also make sure there are no new redirects in the redirect manager.
* Edit the post and change the title to something else. Update the post and make sure the slug is still the same.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Make sure this also works with different permalink structures.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
