### PR TITLE
1404 minor organizations founding date field looks broken in new chrome version

### DIFF
--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -379,7 +379,7 @@ const SiteRepresentation = () => {
 									/>
 									<FormikWithErrorFieldWithDummy
 										as={ TextField }
-										className="yst-w-1/2"
+										className="yst-w-3/5"
 										name="wpseo_titles.org-founding-date"
 										id="input-wpseo_titles-org-founding-date"
 										label={ __( "Organization's founding date", "wordpress-seo" ) }

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -383,7 +383,6 @@ const SiteRepresentation = () => {
 										name="wpseo_titles.org-founding-date"
 										id="input-wpseo_titles-org-founding-date"
 										label={ __( "Organization's founding date", "wordpress-seo" ) }
-										placeholder={ __( "Select a date...", "wordpress-seo" ) }
 										type="date"
 										isDummy={ ! isPremium }
 									/>

--- a/packages/ui-library/src/elements/text-input/index.js
+++ b/packages/ui-library/src/elements/text-input/index.js
@@ -21,7 +21,6 @@ const TextInput = forwardRef( ( {
 		ref={ ref }
 		type={ type }
 		className={ classNames(
-			! props?.value && "yst-text-input--empty",
 			"yst-text-input",
 			disabled && "yst-text-input--disabled",
 			readOnly && "yst-text-input--read-only",

--- a/packages/ui-library/src/elements/text-input/stories.js
+++ b/packages/ui-library/src/elements/text-input/stories.js
@@ -1,7 +1,6 @@
 // eslint-disable react/display-name
 import { StoryComponent } from ".";
 import { component } from "./docs";
-import { useState, useCallback } from "@wordpress/element";
 
 export default {
 	title: "1) Elements/Text input",
@@ -22,17 +21,7 @@ export const Factory = {
 	},
 };
 
-const Template = args => {
-	const [ value, setValue ] = useState( args?.value );
-	const handleChange = useCallback( ( e )=>{
-		setValue( e.target.value );
-	}, [] );
-	return (
-		<StoryComponent { ...args } onChange={ handleChange } value={ value } />
-	);
-};
-
-export const DatePicker = Template.bind( {} );
+export const DatePicker = StoryComponent.bind( {} );
 
 DatePicker.parameters = {
 	controls: { disable: false },
@@ -40,7 +29,6 @@ DatePicker.parameters = {
 
 DatePicker.args = {
 	type: "date",
-	placeholder: "Add a date here...",
 };
 
 DatePicker.storyName = "Date picker input";

--- a/packages/ui-library/src/elements/text-input/style.css
+++ b/packages/ui-library/src/elements/text-input/style.css
@@ -10,7 +10,7 @@
 			yst-rounded-md
 			yst-shadow-sm
 			yst-text-sm
-			yst-text-slate-800		
+			yst-text-slate-800
 			yst-bg-white
 			focus:yst-outline-none
 			focus:yst-ring-primary-500
@@ -31,18 +31,6 @@
 			yst-text-slate-500
 			yst-bg-slate-50
 			yst-cursor-default;
-		}
-
-		.yst-text-input[type="date"]::-webkit-calendar-picker-indicator{
-			@apply yst-p-0 yst-bg-center yst-bg-contain yst-w-5 yst-h-5;
-			background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="rgba(148, 163, 184, 1)" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>');
-		}
-		.yst-text-input--empty[type="date"]:not(:focus)::-webkit-datetime-edit {
-			@apply yst-opacity-0;
-		}
-		.yst-text-input--empty[type="date"]:not(:focus)::before {
-			content: attr(placeholder);
-			@apply yst-text-slate-400 yst-flex-grow;
 		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Organization's Site founding date would span 2 lines in Chrome, by removing our placeholder.
* [@yoast/ui-library 0.1.0] Fixes a bug where the `TextInput` with type `date` would span 2 lines in Chrome, by removing our placeholder and icon overrides.

## Relevant technical choices:

* Decided to remove the overrides to keep it simple. Context: https://yoast.slack.com/archives/C03KU0EHCNQ/p1709204321095249

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Plugin
* Go to Settings > Site representation
* Represent an organization
* Go to the founding date 
* [ ] Verify it is now on a single line again
* [ ] Verify the width is the same as the field below
* [ ] Verify the placeholder "Select a date..." is gone
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/452870df-e0f5-4adc-956e-344977b13a0f)

#### Storybook (dev only)
* Build the storybook
* Go to the TextInput element story
* [ ] Verify the `Date picker input` is as expected (no more placeholder & icon override in Chrome)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1404
