### PR TITLE
Replace .substr() with .substring() (or .slice()) in JS files since it's deprecated

### DIFF
--- a/apps/content-analysis/config/paths.js
+++ b/apps/content-analysis/config/paths.js
@@ -14,7 +14,7 @@ const envPublicUrl = process.env.PUBLIC_URL;
 function ensureSlash( inputPath, needsSlash ) {
 	const hasSlash = inputPath.endsWith( "/" );
 	if ( hasSlash && ! needsSlash ) {
-		return inputPath.substr( 0, inputPath.length - 1 );
+		return inputPath.substring( 0, inputPath.length - 1 );
 	} else if ( ! hasSlash && needsSlash ) {
 		return `${inputPath}/`;
 	}

--- a/config/webpack/webpack.config.base.js
+++ b/config/webpack/webpack.config.base.js
@@ -51,10 +51,10 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 						return [ "yoast", yoastExternals[ request ] ];
 					}
 					if ( request.startsWith( "lodash/" ) ) {
-						return [ "lodash", request.substr( 7 ) ];
+						return [ "lodash", request.substring( 7 ) ];
 					}
 					if ( request.startsWith( "lodash-es/" ) ) {
-						return [ "lodash", request.substr( 10 ) ];
+						return [ "lodash", request.substring( 10 ) ];
 					}
 					if ( request === "react-select" ) {
 						return [ "yoast", "reactSelect" ];
@@ -63,7 +63,7 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 						return [ "yoast", "reactSelectAsync" ];
 					}
 					if ( request.startsWith( "@yoast/externals/" ) ) {
-						return [ "yoast", "externals", request.substr( 17 ) ];
+						return [ "yoast", "externals", request.substring( 17 ) ];
 					}
 				},
 				/**
@@ -85,7 +85,7 @@ module.exports = function( { entry, output, combinedOutputFile, cssExtractFileNa
 						return "yoast-seo-react-select";
 					}
 					if ( request.startsWith( "@yoast/externals/" ) ) {
-						return "yoast-seo-externals-" + request.substr( 17 );
+						return "yoast-seo-externals-" + request.substring( 17 );
 					}
 				},
 			} ),

--- a/packages/components/src/GenerateId.js
+++ b/packages/components/src/GenerateId.js
@@ -6,7 +6,7 @@
  * @returns {string} A unique ID.
  */
 const generateId = () => {
-	return Math.random().toString( 36 ).substr( 2, 6 );
+	return Math.random().toString( 36 ).substring( 2, 6 );
 };
 
 /**

--- a/packages/js/src/helpers/createInterpolateElement.js
+++ b/packages/js/src/helpers/createInterpolateElement.js
@@ -110,7 +110,7 @@ function addText() {
 	if ( 0 === length ) {
 		return;
 	}
-	output.push( indoc.substr( offset, length ) );
+	output.push( indoc.substring( offset, offset + length ) );
 }
 
 /**
@@ -127,10 +127,7 @@ function addText() {
 function addChild( frame ) {
 	const { element, tokenStart, tokenLength, prevOffset, children } = frame;
 	const parent = stack[ stack.length - 1 ];
-	const text = indoc.substr(
-		parent.prevOffset,
-		tokenStart - parent.prevOffset
-	);
+	const text = indoc.substring( parent.prevOffset, tokenStart );
 
 	if ( text ) {
 		parent.children.push( text );
@@ -164,8 +161,8 @@ function closeOuterElement( endOffset ) {
 	} = stack.pop();
 
 	const text = endOffset
-		? indoc.substr( prevOffset, endOffset - prevOffset )
-		: indoc.substr( prevOffset );
+		? indoc.substring( prevOffset, endOffset )
+		: indoc.substring( prevOffset );
 
 	if ( text ) {
 		children.push( text );
@@ -173,7 +170,7 @@ function closeOuterElement( endOffset ) {
 
 	if ( null !== leadingTextStart ) {
 		output.push(
-			indoc.substr( leadingTextStart, tokenStart - leadingTextStart )
+			indoc.substring( leadingTextStart, tokenStart )
 		);
 	}
 
@@ -228,7 +225,7 @@ function proceed( conversionMap ) {
 					leadingTextStart: stackLeadingText,
 					tokenStart,
 				} = stack.pop();
-				output.push( indoc.substr( stackLeadingText, tokenStart ) );
+				output.push( indoc.substring( stackLeadingText, stackLeadingText + tokenStart ) );
 			}
 			addText();
 			return false;
@@ -237,9 +234,9 @@ function proceed( conversionMap ) {
 			if ( 0 === stackDepth ) {
 				if ( null !== leadingTextStart ) {
 					output.push(
-						indoc.substr(
+						indoc.substring(
 							leadingTextStart,
-							startOffset - leadingTextStart
+							startOffset
 						)
 					);
 				}
@@ -280,10 +277,7 @@ function proceed( conversionMap ) {
 			// Otherwise we're nested and we have to close out the current
 			// Block and add it as a innerBlock to the parent
 			const stackTop = stack.pop();
-			const text = indoc.substr(
-				stackTop.prevOffset,
-				startOffset - stackTop.prevOffset
-			);
+			const text = indoc.substring( stackTop.prevOffset, startOffset );
 			stackTop.children.push( text );
 			stackTop.prevOffset = startOffset + tokenLength;
 			const frame = createFrame(

--- a/packages/js/src/helpers/replacementVariableHelpers.js
+++ b/packages/js/src/helpers/replacementVariableHelpers.js
@@ -47,7 +47,7 @@ export function handlePrefixes( name ) {
 	const prefixes = [ "ct_", "cf_", "pt_" ];
 
 	// If there are no prefixes, replace underscores by spaces and return.
-	if ( ! prefixes.includes( name.substr( 0, 3 ) ) ) {
+	if ( ! prefixes.includes( name.substring( 0, 3 ) ) ) {
 		return name.replace( /_/g, " " );
 	}
 

--- a/packages/js/src/initializers/post-scraper.js
+++ b/packages/js/src/initializers/post-scraper.js
@@ -106,7 +106,7 @@ export default function initPostScraper( $, store, editorData ) {
 	 */
 	jQuery( document ).on( "ajaxComplete", function( ev, response, ajaxOptions ) {
 		const ajaxEndPoint = "/admin-ajax.php";
-		if ( ajaxEndPoint !== ajaxOptions.url.substr( 0 - ajaxEndPoint.length ) ) {
+		if ( ajaxEndPoint !== ajaxOptions.url.substring( ajaxOptions.url.length - ajaxEndPoint.length ) ) {
 			return;
 		}
 

--- a/packages/js/src/workouts/components/WorkoutsPage.js
+++ b/packages/js/src/workouts/components/WorkoutsPage.js
@@ -70,10 +70,10 @@ export default function WorkoutsPage( props ) {
 		if ( loading === true ) {
 			initWorkouts( workoutsSetting );
 			if ( window.location.hash && window.location.hash.length > 1 ) {
-				if ( window.location.hash.substr( 1 ) === "configuration" ) {
+				if ( window.location.hash.substring( 1 ) === "configuration" ) {
 					window.location.href = window.wpseoWorkoutsData.firstTimeConfigurationUrl;
 				} else {
-					openWorkout( window.location.hash.substr( 1 ) );
+					openWorkout( window.location.hash.substring( 1 ) );
 				}
 			}
 			return;

--- a/packages/yoastseo/spec/languageProcessing/languages/en/config/abbreviationsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/en/config/abbreviationsSpec.js
@@ -3,7 +3,7 @@ import englishAbbreviations from "../../../../../src/languageProcessing/language
 describe( "tests if all abbreviations end with a fullstop", function() {
 	englishAbbreviations.forEach( ( abbreviation ) =>{
 		it( abbreviation + " should end with a fullstop", function() {
-			const lastChar = abbreviation.substr( abbreviation.length - 1 );
+			const lastChar = abbreviation.substring( abbreviation.length - 1 );
 			expect( lastChar ).toBe( "." );
 		} );
 	} );

--- a/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/getClausesSplitOnStopWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/freeAuxiliaryParticipleOrder/getClausesSplitOnStopWords.js
@@ -33,7 +33,7 @@ function splitOnStopWords( sentence, stopwords ) {
 		}
 		const startIndex = sentence.indexOf( stopword );
 		const endIndex = sentence.length;
-		sentence = stripSpaces( sentence.substr( startIndex, endIndex ) );
+		sentence = stripSpaces( sentence.substring( startIndex, endIndex ) );
 	} );
 
 	// Push the remainder of the sentence in the clauses array.

--- a/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/getClauses.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/getClauses.js
@@ -205,7 +205,7 @@ const getClauses = function( sentence, options ) {
 		}
 
 		// Cut the sentence from the current index to the endIndex (start of next breaker, of end of sentence).
-		const clause = stripSpaces( sentence.substr( indices[ i ].index, endIndex - indices[ i ].index ) );
+		const clause = stripSpaces( sentence.substring( indices[ i ].index, endIndex ) );
 
 		const auxiliaryMatches = getAuxiliaryMatches( clause, options.regexes );
 		// If a clause doesn't have an auxiliary, we don't need it, so it can be filtered out.

--- a/packages/yoastseo/src/languageProcessing/languages/id/helpers/internal/stem.js
+++ b/packages/yoastseo/src/languageProcessing/languages/id/helpers/internal/stem.js
@@ -357,10 +357,10 @@ const stemPlural = function( word, morphologyData ) {
 		 * we compare the two parts of the word after stripping the variable first or first and second letter.
 		 *
 		 */
-		const firstPartBeginningTrimmed = firstPart.substr( 1 );
+		const firstPartBeginningTrimmed = firstPart.substring( 1 );
 		const secondPartBeginningTrimmed = ( secondPart.startsWith( "ng" ) || secondPart.startsWith( "ny" ) )
-			? secondPart.substr( 2 )
-			: secondPart.substr( 1 );
+			? secondPart.substring( 2 )
+			: secondPart.substring( 1 );
 
 		if ( firstPartBeginningTrimmed === secondPartBeginningTrimmed ) {
 			const nonPlurals = morphologyData.stemming.nonPluralReduplications;

--- a/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/findKeyphraseInSEOTitle.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ja/customResearches/findKeyphraseInSEOTitle.js
@@ -22,7 +22,7 @@ function adjustPosition( title, position ) {
 	}
 
 	// Retrieve the SEO title words before the keyphrase.
-	let titleBeforeKeyword = title.substr( 0, position );
+	let titleBeforeKeyword = title.substring( 0, position );
 	titleBeforeKeyword = getWords( titleBeforeKeyword );
 	// Retrieve the non-function words.
 	titleBeforeKeyword = titleBeforeKeyword.filter( word => ! functionWords.includes( word ) );

--- a/packages/yoastseo/src/languageProcessing/languages/ru/helpers/internal/stem.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ru/helpers/internal/stem.js
@@ -85,8 +85,8 @@ const findRvRegion = function( word, morphologyData ) {
  * @returns {string|null}	The word if the stemming rule could be applied or null otherwise.
  */
 const removeEndings = function( word, regex, region ) {
-	const prefix = word.substr( 0, region );
-	const ending = word.substr( prefix.length );
+	const prefix = word.substring( 0, region );
+	const ending = word.substring( prefix.length );
 
 	let currentRegex;
 
@@ -120,8 +120,8 @@ const removeEndings = function( word, regex, region ) {
  * @returns {string}	The stemmed word if the word has perfective prefix an verb suffix, otherwise the original word.
  */
 const removePerfectivePrefix = function( word, morphologyData, rv ) {
-	const prefix = word.substr( 0, rv );
-	const ending = word.substr( prefix.length );
+	const prefix = word.substring( 0, rv );
+	const ending = word.substring( prefix.length );
 
 	const perfectiveEndingsRegex = new RegExp( morphologyData.externalStemmer.regexPerfectiveEndings, "i" );
 
@@ -263,7 +263,7 @@ export default function stem( word, morphologyData ) {
 	// Step 4: There can be one of three options:
 	// 1. If the word ends in нн, remove the last letter.
 	if ( word.endsWith( morphologyData.externalStemmer.doubleN ) ) {
-		word = word.substr( 0, word.length - 1 );
+		word = word.substring( 0, word.length - 1 );
 	}
 
 	// 2. If the word ends in a SUPERLATIVE ending, remove it and then again the last letter if the word ends in "нн".

--- a/packages/yoastseo/src/languageProcessing/researches/findKeyphraseInSEOTitle.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeyphraseInSEOTitle.js
@@ -60,7 +60,7 @@ const adjustPosition = function( title, position ) {
 	}
 
 	// Strip all function words from the beginning of the SEO title.
-	const titleBeforeKeyword = title.substr( 0, position );
+	const titleBeforeKeyword = title.substring( 0, position );
 	if ( stripFunctionWordsFromStart( titleBeforeKeyword ) ) {
 		/*
 		 * Return position 0 if there are no words left in the SEO title before the keyword after filtering

--- a/packages/yoastseo/src/markers/addMarkSingleWord.js
+++ b/packages/yoastseo/src/markers/addMarkSingleWord.js
@@ -17,7 +17,7 @@ export default function( text ) {
 	// Get the actual word boundaries from the start of the text.
 	if ( strippedTextStart !== text ) {
 		const wordBoundaryStartIndex = text.search( escapeRegExp( strippedTextStart ) );
-		wordBoundaryStart = text.substr( 0, wordBoundaryStartIndex );
+		wordBoundaryStart = text.substring( 0, wordBoundaryStartIndex );
 	}
 
 	// Strip word boundaries at the end of the text.
@@ -25,7 +25,7 @@ export default function( text ) {
 	// Get the actual word boundaries from the end of the text.
 	if ( strippedTextEnd !== strippedTextStart ) {
 		const wordBoundaryEndIndex = strippedTextStart.search( escapeRegExp( strippedTextEnd ) ) + strippedTextEnd.length;
-		wordBoundaryEnd = strippedTextStart.substr( wordBoundaryEndIndex );
+		wordBoundaryEnd = strippedTextStart.substring( wordBoundaryEndIndex );
 	}
 
 	return wordBoundaryStart + "<yoastmark class='yoast-text-mark'>" + strippedTextEnd + "</yoastmark>" + wordBoundaryEnd;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replace `.substr()` with `.substring()` in JS files since it's deprecated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replacs `.substr()` with `.substring()` in JS files since it's deprecated.

## Relevant technical choices:

* In substr second parameter is length, in substring second parameter is offset, so corresponding calculation applied to convert length to officet.
* Also substr can consume negative values - in this case it starts counting from the end of the string.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* run unit tests and make sure that all tests pass
* do smoke test for different posts/editors to make sure that everything works as expected

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* this code can impact different part of the application so better to do smoke test to make sure that everything works as before.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #[20852](https://github.com/Yoast/wordpress-seo/issues/20852)
