### PR TITLE
Add defensive coding to stop deprecation warnings

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -552,9 +552,13 @@ class WPSEO_Addon_Manager {
 	 * @return stdClass The converted subscription.
 	 */
 	protected function convert_subscription_to_plugin( $subscription, $yoast_free_data = null, $plugin_info = false, $plugin_file = '' ) {
-		// We need to replace h2's and h3's with h4's because the styling expects that.
-		$changelog = str_replace( '</h2', '</h4', str_replace( '<h2', '<h4', $subscription->product->changelog ) );
-		$changelog = str_replace( '</h3', '</h4', str_replace( '<h3', '<h4', $changelog ) );
+		$changelog = '';
+		if ( isset( $subscription->product->changelog ) ) {
+			// We need to replace h2's and h3's with h4's because the styling expects that.
+			$changelog = str_replace( '</h2', '</h4', str_replace( '<h2', '<h4', $subscription->product->changelog ) );
+			$changelog = str_replace( '</h3', '</h4', str_replace( '<h3', '<h4', $changelog ) );
+
+		}
 
 		// If we're running this because we want to just show the plugin info in the version details modal, we can fallback to the Yoast Free constants, since that modal will not be accessible anyway in the event that the new Free version increases those constants.
 		$defaults = [
@@ -563,7 +567,7 @@ class WPSEO_Addon_Manager {
 		];
 
 		return (object) [
-			'new_version'      => $subscription->product->version,
+			'new_version'      => ( $subscription->product->version ?? '' ),
 			'name'             => $subscription->product->name,
 			'slug'             => $subscription->product->slug,
 			'plugin'           => $plugin_file,

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -653,7 +653,6 @@ final class Addon_Manager_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_convert_subscription_to_plugin( $subscription, $expected_result ) {
-		$this->stubTranslationFunctions();
 
 		$result = $this->instance->convert_subscription_to_plugin( $subscription );
 		$this->assertEquals( $expected_result, $result );

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -643,54 +643,86 @@ final class Addon_Manager_Test extends TestCase {
 	/**
 	 * Tests the conversion from a subscription to a plugin array.
 	 *
+	 * @dataProvider convert_subscription_to_plugin_dataprovider
+	 *
 	 * @covers ::convert_subscription_to_plugin
+	 *
+	 * @param object $subscription    The subscription to convert.
+	 * @param object $expected_result The expected result.
 	 *
 	 * @return void
 	 */
-	public function test_convert_subscription_to_plugin() {
+	public function test_convert_subscription_to_plugin( $subscription, $expected_result ) {
 		$this->stubTranslationFunctions();
 
-		$this->assertEquals(
-			(object) [
-				'new_version'      => '10.0',
-				'name'             => 'Extension',
-				'slug'             => 'yoast-seo-wordpress-premium',
-				'plugin'           => '',
-				'url'              => 'https://example.org/store',
-				'last_update'      => 'yesterday',
-				'homepage'         => 'https://example.org/store',
-				'download_link'    => 'https://example.org/extension.zip',
-				'package'          => 'https://example.org/extension.zip',
-				'sections'         => [
-					'changelog' => 'changelog',
-					'support'   => '<h4>Need support?</h4><p>You can probably find an answer to your question in our <a href="https://yoast.com/help/">help center</a>. If you still need support and have an active subscription for this product, please email <a href="mailto:support@yoast.com">support@yoast.com</a>.</p>',
-				],
-				'icons'            => [
-					'2x' => 'https://yoa.st/yoast-seo-icon',
-				],
-				'update_supported' => true,
-				'banners'          => [
-					'high' => 'https://yoa.st/yoast-seo-banner-premium',
-					'low'  => 'https://yoa.st/yoast-seo-banner-low-premium',
-				],
-				'tested'           => \YOAST_SEO_WP_TESTED,
-				'requires_php'     => \YOAST_SEO_PHP_REQUIRED,
-				'requires'         => null,
+		$result = $this->instance->convert_subscription_to_plugin( $subscription );
+		$this->assertEquals( $expected_result, $result );
+	}
+
+	/**
+	 * Data provider for test_convert_subscription_to_plugin.
+	 *
+	 * @return array<string, array<string, object>> The data for test_convert_subscription_to_plugin.
+	 */
+	public static function convert_subscription_to_plugin_dataprovider() {
+		$full_subscription    = [
+			'version'      => '10.0',
+			'name'         => 'Extension',
+			'slug'         => 'yoast-seo-wordpress-premium',
+			'last_updated' => 'yesterday',
+			'store_url'    => 'https://example.org/store',
+			'download'     => 'https://example.org/extension.zip',
+			'changelog'    => 'changelog',
+		];
+		$partial_subscription = $full_subscription;
+		unset( $partial_subscription['changelog'] );
+		unset( $partial_subscription['version'] );
+
+		$expected_plugin_conversion_with_proper_subscription_data  = [
+			'new_version'      => '10.0',
+			'name'             => 'Extension',
+			'slug'             => 'yoast-seo-wordpress-premium',
+			'plugin'           => '',
+			'url'              => 'https://example.org/store',
+			'last_update'      => 'yesterday',
+			'homepage'         => 'https://example.org/store',
+			'download_link'    => 'https://example.org/extension.zip',
+			'package'          => 'https://example.org/extension.zip',
+			'sections'         => [
+				'changelog' => 'changelog',
+				'support'   => '<h4>Need support?</h4><p>You can probably find an answer to your question in our <a href="https://yoast.com/help/">help center</a>. If you still need support and have an active subscription for this product, please email <a href="mailto:support@yoast.com">support@yoast.com</a>.</p>',
 			],
-			$this->instance->convert_subscription_to_plugin(
-				(object) [
-					'product' => (object) [
-						'version'      => '10.0',
-						'name'         => 'Extension',
-						'slug'         => 'yoast-seo-wordpress-premium',
-						'last_updated' => 'yesterday',
-						'store_url'    => 'https://example.org/store',
-						'download'     => 'https://example.org/extension.zip',
-						'changelog'    => 'changelog',
-					],
-				]
-			)
-		);
+			'icons'            => [
+				'2x' => 'https://yoa.st/yoast-seo-icon',
+			],
+			'update_supported' => true,
+			'banners'          => [
+				'high' => 'https://yoa.st/yoast-seo-banner-premium',
+				'low'  => 'https://yoa.st/yoast-seo-banner-low-premium',
+			],
+			'tested'           => \YOAST_SEO_WP_TESTED,
+			'requires_php'     => \YOAST_SEO_PHP_REQUIRED,
+			'requires'         => null,
+		];
+		$expected_plugin_conversion_with_partial_subscription_data = $expected_plugin_conversion_with_proper_subscription_data;
+
+		$expected_plugin_conversion_with_partial_subscription_data['sections']['changelog'] = '';
+		$expected_plugin_conversion_with_partial_subscription_data['new_version']           = '';
+
+		return [
+			'Converting a subscription with full data'    => [
+				'subscription'    => (object) [
+					'product' => (object) $full_subscription,
+				],
+				'expected_result' => (object) $expected_plugin_conversion_with_proper_subscription_data,
+			],
+			'Converting a subscription with partial data' => [
+				'subscription'    => (object) [
+					'product' => (object) $partial_subscription,
+				],
+				'expected_result' => (object) $expected_plugin_conversion_with_partial_subscription_data,
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to stop showing deprecation warnings when retrieving data for our paid add-ons doesn't populate variables as expected.
* We would like to fix the underlying bug of not having those variables properly populated, but after code inspection, we can't see something that could have interfere with that. Meaning, it might have been a (temporary?) issue of the external service (in this case, MyYoast).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Stops showing deprecation warnings when retrieving data for paid add-ons goes wrong.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

You need xDebug to test the fix, since we can't replicate the root cause
* Have an active subscription in yoast.com 
  * (I think the easiest way is to create a http://main.local/ site in LocalWP, because I have already created a subscription for that site)
  * Make that site have a PHP 8.1+
* Have at least one add-on active in your local site (Premium is an add-on for this part)
* Put a breakpoint in the `$this->set_site_information_transient( $this->site_information );` line in `WPSEO_Addon_Manager::get_myyoast_site_information()
* Delete all transients from the site (or wait 1 minute idle)
* Go to Dashboard->Updates and wait until the code is paused in your breakpoint
* The data we get from MyYoast contain 5 subscriptions (one for each add-on), find the one you have active in the `$this->site_information->subscriptions` array and nullify its `changelog` and `version` attributes:
``` 
$this->site_information->subscriptions[2]->product->changelog = null
```
and 
```
$this->site_information->subscriptions[2]->product->version = null
```
(where '2' is the key of the WooCommerce SEO subscription, for example)

**Without this PR**:
* You get two deprecation notices:
  * `PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`
  * `PHP Deprecated:  version_compare(): Passing null to parameter #2 ($version2) of type string is deprecated`

**With this PR**:
* You get no deprecation notices

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* For impact checking, you need to have a site with a subscription
* Regression test checking for updates in the add-ons you have a subscription for
  * Also try with an expired subscription
  * Do that in the Dashboard->Updates page and in the Plugins->All plugins page
* Regression test viewing details for each add-on, by clicking the `View details` link in the plugins page 
  * Quickly smoke test https://github.com/Yoast/wordpress-seo/pull/17554

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
