### PR TITLE
WIP: Create FTC via WP CLI

### DIFF
--- a/src/commands/First_Time_Configuration_Command.php
+++ b/src/commands/First_Time_Configuration_Command.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Yoast\WP\SEO\Commands;
+
+use WP_CLI;
+use WP_CLI\Utils;
+use Yoast\WP\Lib\Model;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_General_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Indexing_Complete_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Post_Type_Archive_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexable_Term_Indexation_Action;
+use Yoast\WP\SEO\Actions\Indexing\Indexation_Action_Interface;
+use Yoast\WP\SEO\Actions\Indexing\Indexing_Prepare_Action;
+use Yoast\WP\SEO\Actions\Indexing\Post_Link_Indexing_Action;
+use Yoast\WP\SEO\Actions\Indexing\Term_Link_Indexing_Action;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Main;
+
+/**
+ * Command to generate indexables for all posts and terms.
+ */
+class First_Time_Configuration_Command implements Command_Interface {
+
+	/**
+	 * The main command.
+	 *
+	 * @param array|null $args       The arguments.
+	 * @param array|null $assoc_args The associative arguments.
+	 *
+	 * @return void
+	 */
+	public function first_time_configuration() {
+		/*WP_CLI::confirm( \__( 'Do you want to run the SEO data optimization?', 'wordpress-seo' ) );
+
+		WP_CLI::runcommand( 'yoast index', $options = [] );
+		
+		WP_CLI::line( "SEO data optimization completed successfully");
+		*/
+
+		$options=['organization', 'person'];
+
+		$chosen_option = $this->ask( \__( 'Does your site represent an Organization or aPerson?'. 'wordpress-seo' ), $options );
+
+		WP_CLI::line( $chosen_option );
+
+	}
+	/**
+	 * Gets the namespace.
+	 *
+	 * @return string
+	 */
+	public static function get_namespace() {
+		return Main::WP_CLI_NAMESPACE;
+	}
+	
+	private function ask( $question, $options = [] ) {
+		if ( ! empty( $options ) ) {
+			fwrite( STDOUT, $question . ' [' . implode( ',', $options ) . '] ' );
+
+			$answer = strtolower( trim( fgets( STDIN ) ) );
+
+			if ( ! in_array( $answer, $options, true ) ) {
+				WP_CLI::error( 'Invalid answer', false );
+				return $this->ask( $question, $options );
+			}
+			return $answer;
+		}
+
+		fwrite( STDOUT, $question );
+
+		return fgets( STDIN );
+	}
+}


### PR DESCRIPTION
⚠️ THIS IS VERY MUCH A WORK IN PROGRESS ⚠️ 

TODO: 
* Maybe, it would be nice to create separate commands per FTC step and then combine them for the whole `wp yoast first_time_configuration` command
* Maybe, create interactivity methods to facilitate having a FTC-like progress, but this time in CLI
  * like, extending the WP_CLI::confirm() method, to NOT exit when `n` is selected
  * and stuff of that nature

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a feature for WP CLI users to fill in the necessary data for their website.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
