### PR TITLE
Fix ES_WP_Query incompatibility issue

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -129,17 +129,9 @@ class Current_Page_Helper {
 	public function get_term_id() {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
-		if ( $wp_query->is_category() ) {
-			return $wp_query->get( 'cat' );
-		}
-		if ( $wp_query->is_tag() ) {
-			return $wp_query->get( 'tag_id' );
-		}
-		if ( $wp_query->is_tax() ) {
-			$queried_object = $wp_query->get_queried_object();
-			if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
-				return $queried_object->term_id;
-			}
+		$queried_object = $wp_query->get_queried_object();
+		if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
+			return $queried_object->term_id;
 		}
 
 		return 0;

--- a/tests/Unit/Helpers/Current_Page_Helper_Test.php
+++ b/tests/Unit/Helpers/Current_Page_Helper_Test.php
@@ -298,70 +298,6 @@ final class Current_Page_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Tests retrieval of the term id with no term page matches.
-	 *
-	 * @covers ::get_term_id
-	 *
-	 * @return void
-	 */
-	public function test_get_term_id() {
-		$this->wp_query_wrapper
-			->expects( 'get_main_query' )
-			->andReturn( $this->wp_query );
-
-		$this->wp_query->expects( 'is_category' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tag' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tax' )->andReturnFalse();
-
-		$this->assertEquals( 0, $this->instance->get_term_id() );
-	}
-
-	/**
-	 * Tests retrieval of the term id with category as current page.
-	 *
-	 * @covers ::get_term_id
-	 *
-	 * @return void
-	 */
-	public function test_get_term_id_for_category() {
-		$this->wp_query_wrapper
-			->expects( 'get_main_query' )
-			->andReturn( $this->wp_query );
-
-		$this->wp_query->expects( 'is_category' )->andReturnTrue();
-
-		$this->wp_query
-			->expects( 'get' )
-			->with( 'cat' )
-			->andReturn( 1 );
-
-		$this->assertEquals( 1, $this->instance->get_term_id() );
-	}
-
-	/**
-	 * Tests retrieval of the term id with tag as current page.
-	 *
-	 * @covers ::get_term_id
-	 *
-	 * @return void
-	 */
-	public function test_get_term_id_for_tag() {
-		$this->wp_query_wrapper
-			->expects( 'get_main_query' )
-			->andReturn( $this->wp_query );
-
-		$this->wp_query->expects( 'is_category' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tag' )->andReturnTrue();
-
-		$this->wp_query
-			->expects( 'get' )
-			->with( 'tag_id' )
-			->andReturn( 1 );
-
-		$this->assertEquals( 1, $this->instance->get_term_id() );
-	}
-
-	/**
 	 * Tests retrieval of the term id with a taxonomy as current page and no
 	 * wp_error given.
 	 *
@@ -373,10 +309,6 @@ final class Current_Page_Helper_Test extends TestCase {
 		$this->wp_query_wrapper
 			->expects( 'get_main_query' )
 			->andReturn( $this->wp_query );
-
-		$this->wp_query->expects( 'is_category' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tag' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tax' )->andReturnTrue();
 
 		$this->wp_query
 			->expects( 'get_queried_object' )
@@ -401,10 +333,6 @@ final class Current_Page_Helper_Test extends TestCase {
 		$this->wp_query_wrapper
 			->expects( 'get_main_query' )
 			->andReturn( $this->wp_query );
-
-		$this->wp_query->expects( 'is_category' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tag' )->andReturnFalse();
-		$this->wp_query->expects( 'is_tax' )->andReturnTrue();
 
 		$this->wp_query
 			->expects( 'get_queried_object' )

--- a/tests/WP/Helpers/Current_Page_Helper_Test.php
+++ b/tests/WP/Helpers/Current_Page_Helper_Test.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Tests\WP\Helpers;
 
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\WP\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 
@@ -15,25 +14,11 @@ use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
 final class Current_Page_Helper_Test extends TestCase {
 
 	/**
-	 * The options' helper.
-	 *
-	 * @var Options_Helper
-	 */
-	private $options_helper;
-
-	/**
 	 * The query wrapper.
 	 *
 	 * @var WP_Query_Wrapper
 	 */
 	private $query_wrapper;
-
-	/**
-	 * Whether we show the alternate message.
-	 *
-	 * @var bool
-	 */
-	private $show_alternate_message;
 
 	/**
 	 * The instance.
@@ -49,52 +34,73 @@ final class Current_Page_Helper_Test extends TestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		$this->options_helper         = new Options_Helper();
-		$this->query_wrapper          = new WP_Query_Wrapper();
-		$this->show_alternate_message = false;
 
-		$this->instance = new Current_Page_Helper( $this->query_wrapper );
+		$this->query_wrapper = new WP_Query_Wrapper();
+		$this->instance      = new Current_Page_Helper( $this->query_wrapper );
 	}
 
-	public function test_get_term_id() {
-		\register_taxonomy( 'test_tax_cat', 'post' );
+	/**
+	 * Tests if the id of a custom taxonomy is correctly retrieved.
+	 *
+	 * @covers ::get_term_id
+	 * @return void
+	 */
+	public function test_get_term_id_for_custom_taxonomy() {
+		\register_taxonomy( 'custom_taxonomy', 'post' );
 
-		\wp_insert_term( 'test1', 'test_tax_cat' );
-		$id = \get_term_by( 'name', 'test1', 'test_tax_cat' );
+		\wp_insert_term( 'test', 'custom_taxonomy' );
+		$term = \get_term_by( 'name', 'test', 'custom_taxonomy' );
 
-		// Set queried object to the newly created post.
 		global $wp_the_query;
 		$wp_the_query->queried_object = (object) [
-			'term_id'  => $id,
+			'term_id'  => $term->term_id,
 		];
 
-		$this->assertEquals( $id, $this->instance->get_term_id() );
+		$this->assertEquals( $term->term_id, $this->instance->get_term_id() );
+	}
+
+	/**
+	 * Tests if the id of a category is correctly retrieved.
+	 *
+	 * @covers ::get_term_id
+	 * @return void
+	 */
+	public function test_get_term_id_for_category() {
+		global $wp_the_query;
 
 		\wp_insert_term( 'test_cat', 'category' );
-		$id2 = \get_term_by( 'name', 'test_cat', 'category' );
+		$category = \get_term_by( 'name', 'test_cat', 'category' );
 
 		$wp_the_query->queried_object = (object) [
-			'term_id'  => $id2,
+			'term_id'  => $category->term_id,
 		];
 
-		$this->assertEquals( $id2, $this->instance->get_term_id() );
+		$this->assertEquals( $category->term_id, $this->instance->get_term_id() );
 
-		\wp_insert_term( 'test_tag', 'tag' );
-		$id3 = \get_term_by( 'name', 'test_tag', 'tag' );
+		\wp_insert_term( 'test_tag', 'post_tag' );
+		$tag = \get_term_by( 'name', 'test_tag', 'post_tag' );
 
 		$wp_the_query->queried_object = (object) [
-			'term_id'  => $id3,
+			'term_id'  => $tag->term_id,
 		];
+	}
 
-		$this->assertEquals( $id3, $this->instance->get_term_id() );
+	/**
+	 * Tests if the id of a post tag is correctly retrieved.
+	 *
+	 * @covers ::get_term_id
+	 * @return void
+	 */
+	public function test_get_term_id_for_post_tag() {
+		global $wp_the_query;
 
-		\wp_insert_term( 'test_tag', 'tagss' );
-		$id3 = \get_term_by( 'name', 'test_tag', 'tagss' );
+		\wp_insert_term( 'test_tag', 'post_tag' );
+		$tag = \get_term_by( 'name', 'test_tag', 'post_tag' );
 
 		$wp_the_query->queried_object = (object) [
-			'term_id'  => $id3,
+			'term_id'  => $tag->term_id,
 		];
 
-		$this->assertEquals( $id3, $this->instance->get_term_id() );
+		$this->assertEquals( $tag->term_id, $this->instance->get_term_id() );
 	}
 }

--- a/tests/WP/Helpers/Current_Page_Helper_Test.php
+++ b/tests/WP/Helpers/Current_Page_Helper_Test.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Helpers;
+
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
+
+/**
+ * Integration Test Class for the Current_Page_Helper class.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Helpers\Current_Page_Helper
+ */
+final class Current_Page_Helper_Test extends TestCase {
+
+	/**
+	 * The options' helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The query wrapper.
+	 *
+	 * @var WP_Query_Wrapper
+	 */
+	private $query_wrapper;
+
+	/**
+	 * Whether we show the alternate message.
+	 *
+	 * @var bool
+	 */
+	private $show_alternate_message;
+
+	/**
+	 * The instance.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->options_helper         = new Options_Helper();
+		$this->query_wrapper          = new WP_Query_Wrapper();
+		$this->show_alternate_message = false;
+
+		$this->instance = new Current_Page_Helper( $this->query_wrapper );
+	}
+
+	public function test_get_term_id() {
+		\register_taxonomy( 'test_tax_cat', 'post' );
+
+		\wp_insert_term( 'test1', 'test_tax_cat' );
+		$id = \get_term_by( 'name', 'test1', 'test_tax_cat' );
+
+		// Set queried object to the newly created post.
+		global $wp_the_query;
+		$wp_the_query->queried_object = (object) [
+			'term_id'  => $id,
+		];
+
+		$this->assertEquals( $id, $this->instance->get_term_id() );
+
+		\wp_insert_term( 'test_cat', 'category' );
+		$id2 = \get_term_by( 'name', 'test_cat', 'category' );
+
+		$wp_the_query->queried_object = (object) [
+			'term_id'  => $id2,
+		];
+
+		$this->assertEquals( $id2, $this->instance->get_term_id() );
+
+		\wp_insert_term( 'test_tag', 'tag' );
+		$id3 = \get_term_by( 'name', 'test_tag', 'tag' );
+
+		$wp_the_query->queried_object = (object) [
+			'term_id'  => $id3,
+		];
+
+		$this->assertEquals( $id3, $this->instance->get_term_id() );
+
+		\wp_insert_term( 'test_tag', 'tagss' );
+		$id3 = \get_term_by( 'name', 'test_tag', 'tagss' );
+
+		$wp_the_query->queried_object = (object) [
+			'term_id'  => $id3,
+		];
+
+		$this->assertEquals( $id3, $this->instance->get_term_id() );
+	}
+}

--- a/tests/WP/Helpers/Current_Page_Helper_Test.php
+++ b/tests/WP/Helpers/Current_Page_Helper_Test.php
@@ -56,6 +56,8 @@ final class Current_Page_Helper_Test extends TestCase {
 			'term_id'  => $term->term_id,
 		];
 
+		$wp_the_query->is_tax = true;
+
 		$this->assertEquals( $term->term_id, $this->instance->get_term_id() );
 	}
 
@@ -75,14 +77,10 @@ final class Current_Page_Helper_Test extends TestCase {
 			'term_id'  => $category->term_id,
 		];
 
+		$wp_the_query->is_category       = true;
+		$wp_the_query->query_vars['cat'] = $category->term_id;
+
 		$this->assertEquals( $category->term_id, $this->instance->get_term_id() );
-
-		\wp_insert_term( 'test_tag', 'post_tag' );
-		$tag = \get_term_by( 'name', 'test_tag', 'post_tag' );
-
-		$wp_the_query->queried_object = (object) [
-			'term_id'  => $tag->term_id,
-		];
 	}
 
 	/**
@@ -100,6 +98,9 @@ final class Current_Page_Helper_Test extends TestCase {
 		$wp_the_query->queried_object = (object) [
 			'term_id'  => $tag->term_id,
 		];
+
+		$wp_the_query->is_tag               = true;
+		$wp_the_query->query_vars['tag_id'] = $tag->term_id;
 
 		$this->assertEquals( $tag->term_id, $this->instance->get_term_id() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to address an issue created by `ES_WP_Query` used by WordPress VIP when Enterprise Search is enabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an incompatibility with `ES_WP_Query` library used by WordPress VIP Enterprise Search.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

<details>
  <summary>Install WP VIP development environment</summary>

* Make sure you're using the latest versions of `Node.js` and `npm\ (or at least `Node.js v18` and `npm v8`)
  * to check this use `nvm` by typing `nvm use` in the terminal
  * to install and use the latest `Node.js` and `npm` type: `nvm install 20 && nvm use 20`
* Install  `VIP_CLI`
  * type `npm install -g @automattic/vip`
* Clone the following repository: `https://github.com/Automattic/vip-go-skeleton`
  * this will create a directory `vip-go-skeleton`: take note of its full path
* Type the following command to create the development environment: `vip dev-env create --multisite=y --elasticsearch --app-code="VIP-GO-SKELETON-FULL-PATH" --slug=SITE-SLUG`
  * `VIP-GO-SKELETON-FULL-PATH` is the full path to the `vip-go-skeleton` directory. Mind it is double-quoted!
  * `SITE-SLUG` is a name you give to your dev environment
* Go in the `vip-go-skeleton` directory and edit the file `vip-config/vip-config.php` by adding the following lines:
  ```
  define( 'VIP_ENABLE_VIP_SEARCH', true );
  define( 'VIP_ENABLE_VIP_SEARCH_QUERY_INTEGRATION', true );
  ```
* Run Docker/OrbStack/Rancher
* Type `vip dev-env start --slug=SITE-SLUG` to start the environment. At the end of the process you should get something like the following:
  
<img width="1393" alt="Screenshot 2024-03-18 at 23 58 14" src="https://github.com/Yoast/wordpress-seo/assets/68744851/2a3bbbb4-0100-493b-abdf-6344a439f56c">

  * take note of the base URL of the local site (e.g. `example-site.vipdev.lndo.site)
  * edit `/etc/hosts` and add the following line:
    ```
    127.0.0.1 BASE-URL
    ```
  where `BASE-URL` is the base URL of your local site
* Stop the environment and start it again: 
  ```
  vip dev-env stop --slug=SITE-SLUG
  vip dev-env start --slug=SITE-SLUG
  ```
* Copy and paste the `LOGIN URL` in your browser: you should be able to view the admin area of your local site
* Follow the instruction in the section `Test Enterprise Search` of [this](https://docs.wpvip.com/vip-local-development-environment/use-enterprise-search/) document to make sure Enterprise Search works correctly
</details>

<details>
  <summary>Preliminary steps</summary>

* move into to the `vip-go-skeleton` directory
* Clone the [wordpress-seo](https://github.com/Yoast/wordpress-seo) repo in the `plugins` directory
* Create a file named `test.php` in the `client-mu-plugins` directory and paste into it the following:
  ```
  <?php
  /**
   * Plugin Name: Test
   * Description: Desc.
   * Author:      Name
   * License:     GNU General Public License v3 or later
   * License URI: http://www.gnu.org/licenses/gpl-3.0.html
   */

  function vip_sample_es_offload( $query ) {
      if ( $query->is_main_query() ) { //&& $query->is_tag() ) { // Conditions to offload to ES.
           $query->set( 'es', true );
      }
	  return $query;
  }
  add_action( 'pre_get_posts', 'vip_sample_es_offload' );
  ```
* Create a new tag 
* Edit the tag by specifying image, title, description both for facebook and X in the `social` tab of the metabox
* Visit the tag archive in the frontend, inspect the page source code and verify that in the head:
  * there's no `canonical` meta tag
  * none of the Twitter  meta tags except for `twitter:tag` are present
  * `og:title` and `og:description` does not show the values specified in the `social` tab but show the title and description of the tag
  * no `og:image` meta tag is present

</details>

<details>
  <summary>Test the fix</summary>

* Checkout this branch
* Visit again the tag in the frontend and verify that: 
  *the `canonical` meta tag is present
  * all of the OpenGraph and Twitter  meta tags are present and contain the correct values
* Perform the same checks for:
  * a custom taxonomy
  * a category 

</details>

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added ~unit~ integration tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#21171](https://github.com/Yoast/wordpress-seo/issues/21171)
