### PR TITLE
Fix coverage report for the WPSEO_Suggested_Plugins class

### DIFF
--- a/tests/Unit/Admin/Suggested_Plugins_Add_Notifications_Test.php
+++ b/tests/Unit/Admin/Suggested_Plugins_Add_Notifications_Test.php
@@ -18,6 +18,9 @@ final class Suggested_Plugins_Add_Notifications_Test extends Suggested_Plugins_T
 	 * Tests the adding of notifications.
 	 *
 	 * @covers WPSEO_Suggested_Plugins::add_notifications
+	 * @covers WPSEO_Suggested_Plugins::get_yoast_seo_suggested_plugins_notification
+	 * @covers WPSEO_Suggested_Plugins::create_install_suggested_plugin_message
+	 * @covers WPSEO_Suggested_Plugins::create_more_information_link
 	 * @dataProvider data_add_notifications
 	 *
 	 * @param array<string, array<string, string|bool|array<string, Conditional>>> $plugins_with_dependencies The data of plugins with dependencies.

--- a/tests/Unit/Admin/Suggested_Plugins_Construct_Test.php
+++ b/tests/Unit/Admin/Suggested_Plugins_Construct_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Admin;
+
+use WPSEO_Plugin_Availability;
+use Yoast_Notification_Center;
+/**
+ * Test class for WPSEO_Suggested_Plugins::__construct.
+ *
+ * @covers WPSEO_Suggested_Plugins::__construct
+ */
+final class Suggested_Plugins_Construct_Test extends Suggested_Plugins_TestCase {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers WPSEO_Suggested_Plugins::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct() {
+		$this->assertInstanceOf(
+			WPSEO_Plugin_Availability::class,
+			$this->getPropertyValue( $this->instance, 'availability_checker' )
+		);
+
+		$this->assertInstanceOf(
+			Yoast_Notification_Center::class,
+			$this->getPropertyValue( $this->instance, 'notification_center' )
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the coverage report that [the original PR](https://github.com/Yoast/wordpress-seo/pull/21198) fail to properly increase.
* While we were at it, we added unit tests for the constructor of `WPSEO_Suggested_Plugins` too.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Properly reports increase in test coverage in the `WPSEO_Suggested_Plugins` class.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For devs:
  * Please be critical in judging whether those tags are properly used. Those new covered functions are passed through the tests but they are not tested against expected values, so feel free to reject this PR, if the tags are added incorrectly here.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
