### PR TITLE
Re-instate original checks

### DIFF
--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -129,7 +129,7 @@ class Current_Page_Helper {
 	public function get_term_id() {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
-		if ( $wp_query->is_tax || $wp_query->is_tag || $wp_query->is_category ) {
+		if ( $wp_query->is_tax() || $wp_query->is_tag() || $wp_query->is_category() ) {
 			$queried_object = $wp_query->get_queried_object();
 			if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
 				return $queried_object->term_id;

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -129,7 +129,7 @@ class Current_Page_Helper {
 	public function get_term_id() {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
-		if( $wp_query->is_tax || $wp_query->is_tag || $wp_query->is_category ) {
+		if ( $wp_query->is_tax || $wp_query->is_tag || $wp_query->is_category ) {
 			$queried_object = $wp_query->get_queried_object();
 			if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
 				return $queried_object->term_id;

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -129,9 +129,11 @@ class Current_Page_Helper {
 	public function get_term_id() {
 		$wp_query = $this->wp_query_wrapper->get_main_query();
 
-		$queried_object = $wp_query->get_queried_object();
-		if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
-			return $queried_object->term_id;
+		if( $wp_query->is_tax || $wp_query->is_tag || $wp_query->is_category ) {
+			$queried_object = $wp_query->get_queried_object();
+			if ( $queried_object && ! \is_wp_error( $queried_object ) ) {
+				return $queried_object->term_id;
+			}
 		}
 
 		return 0;

--- a/tests/Unit/Helpers/Current_Page_Helper_Test.php
+++ b/tests/Unit/Helpers/Current_Page_Helper_Test.php
@@ -306,13 +306,21 @@ final class Current_Page_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_term_id_for_taxonomy() {
-		$this->wp_query_wrapper
-			->expects( 'get_main_query' )
-			->andReturn( $this->wp_query );
+		$wp_query = Mockery::mock( WP_Query::class );
 
-		$this->wp_query
+		$wp_query
+			->expects( 'is_tax' )
+			->once()
+			->andReturnTrue();
+
+		$wp_query
 			->expects( 'get_queried_object' )
 			->andReturn( (object) [ 'term_id' => 1 ] );
+
+		$this->wp_query_wrapper
+			->expects( 'get_main_query' )
+			->once()
+			->andReturn( $wp_query );
 
 		Monkey\Functions\expect( 'is_wp_error' )
 			->once()
@@ -330,13 +338,22 @@ final class Current_Page_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_term_id_for_taxonomy_that_gives_wp_error() {
-		$this->wp_query_wrapper
-			->expects( 'get_main_query' )
-			->andReturn( $this->wp_query );
 
-		$this->wp_query
+		$wp_query = Mockery::mock( WP_Query::class );
+
+		$wp_query
+			->expects( 'is_tax' )
+			->once()
+			->andReturnTrue();
+
+		$wp_query
 			->expects( 'get_queried_object' )
 			->andReturnTrue();
+
+		$this->wp_query_wrapper
+			->expects( 'get_main_query' )
+			->once()
+			->andReturn( $wp_query );
 
 		Monkey\Functions\expect( 'is_wp_error' )
 			->once()


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to reinstate the original checks in the `get_term_id` method to keep the exact same behaviour.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Re-instates the original checks in the `get_term_id` method to ensure API backward compatibility.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preliminary steps
* Create a file `test.php` in the `mu-plugins` directory of your WordPress installation and paste in it the following snippet
  ```
  <?php
  add_action('wp_head', 'test');
 
  function test() {
          $h = YoastSEO()->helpers->current_page->get_term_id();
          die(var_dump($h));
  }
  ``` 

#### Test the fix 
* Without this branch checked out
  * visit a category in the frontend and verify you get a number
  * visit a post in the frontend and verify nothing is printed on screen (or something like `/app/public/wp-content/themes/twentytwentyfour/functions.php:212:string ''`)
* With this branch checked out
  * visit a post in the frontend and verify `0` is printed on screen

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21258 
