### PR TITLE
Take into account future changes to WordPress options autoload.

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -314,7 +314,7 @@ class WPSEO_Upgrade {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
 		$wpdb->query(
 			$wpdb->prepare(
-				'DELETE FROM %i WHERE %i LIKE %s AND autoload = "yes"',
+				'DELETE FROM %i WHERE %i LIKE %s AND autoload IN ("on", "yes")',
 				[ $wpdb->options,'option_name', 'wpseo_sitemap_%' ]
 			)
 		);

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -315,7 +315,7 @@ class WPSEO_Upgrade {
 		$wpdb->query(
 			$wpdb->prepare(
 				'DELETE FROM %i WHERE %i LIKE %s AND autoload IN ("on", "yes")',
-				[ $wpdb->options,'option_name', 'wpseo_sitemap_%' ]
+				[ $wpdb->options, 'option_name', 'wpseo_sitemap_%' ]
 			)
 		);
 	}

--- a/tests/WP/Inc/Upgrade_Test.php
+++ b/tests/WP/Inc/Upgrade_Test.php
@@ -258,7 +258,7 @@ final class Upgrade_Test extends TestCase {
 				"SELECT *
 				FROM %i
 				WHERE option_name LIKE %s
-				AND autoload = 'yes'",
+				AND autoload IN ('on', 'yes')",
 				[ $wpdb->options, 'wpseo_sitemap_%' ]
 			)
 		);
@@ -268,7 +268,7 @@ final class Upgrade_Test extends TestCase {
 				"SELECT *
 				FROM %i
 				WHERE option_name LIKE %s
-				AND autoload = 'no'",
+				AND autoload IN ('off', 'no')",
 				[ $wpdb->options, 'wpseo_sitemap_%' ]
 			)
 		);
@@ -397,8 +397,7 @@ final class Upgrade_Test extends TestCase {
 			$wpdb->prepare(
 				'SELECT *
 				FROM %i
-				WHERE option_name LIKE %s
-				AND autoload = "yes"',
+				WHERE option_name LIKE %s',
 				[ $wpdb->options, 'wpseo_sitemap_%' ]
 			)
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to future-proof out plugin by taking into account the changes that will be introduced in WordPress 6.6 by [this](https://core.trac.wordpress.org/ticket/42441) ticket.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates `upgrade_36` upgrade routine and its integration tests to accomodate for the new options autoload behaviour that will be introduced in WordPress 6.6.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With a MySQL client perform the following query to create a new row in the `wp_options`:
```
INSERT INTO wp_options ( option_name, option_value, autoload )
VALUES ( 'wpseo_sitemap_test', 'test', 'yes' );
```
* Go to `Tools` -> `Yoast test`
  * In `Plugin options & database versions` set `DB Version` = `3.5` for Yoast SEO
  * click save
* [ ] Verify the option `wpseo_sitemap_test` has been removed from the database (together with all the other `wpseo_sitemap_%` option as an effect of the 9.0 upgrade routine... )

* Now perform the same steps as above but with the following query:
```
INSERT INTO wp_options ( option_name, option_value, autoload )
VALUES ( 'wpseo_sitemap_test', 'test', 'on' );
```
* [ ] Verify the option `wpseo_sitemap_test` has been removed from the database

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have ~added unit~ adapted integration tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#21293](https://github.com/Yoast/wordpress-seo/issues/21293)
