### PR TITLE
Composer: update dev dependencies + minor CS fixes

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -75,15 +75,23 @@ jobs:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
       # Check the codestyle of the files against a threshold of expected errors and warnings.
+      # Keep track of the exit code as it determines whether to run the branch check or not.
+      # Exit code 128 means the thresholds needs to be lowered. Other exit codes imply CS errors.
       - name: Check PHP code style against the thresholds
-        run: composer check-cs-thresholds
+        id: thresholds
+        run: |
+          set +e
+          composer check-cs-thresholds
+          exitcode="$?"
+          echo "EXITCODE=$exitcode" >> $GITHUB_OUTPUT
+          exit "$exitcode"
 
       # Check the codestyle only of the files which were changed in the current branch.
       # This step will only be executed if the threshold check exited with a failure status.
       # The results of this CS check will be shown inline in the PR via the CS2PR tool.
       # @link https://github.com/staabm/annotate-pull-request-from-checkstyle/
       - name: Check PHP code style for the changes made in the branch only
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.thresholds.outputs.EXITCODE != 128 }}
         id: phpcs
         run: composer check-branch-cs -- ${{ steps.base_branch.outputs.REF }}
 

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -159,6 +159,21 @@
 		</properties>
 	</rule>
 
+	<!-- Excluded in WPCS, but the exclusion does not work well with a code base using short arrays.
+		 This may lead to some duplicate notices, but rather that, than these issues not being flagged.
+		 Note: this change will be included in YoastCS 3.1.1 and this tweak can be removed after that.
+	-->
+	<rule ref="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Universal.WhiteSpace.CommaSpacing.TooMuchSpaceAfterInFunctionCall">
+		<severity>5</severity>
+	</rule>
+	<rule ref="Universal.WhiteSpace.CommaSpacing.NoSpaceAfterInFunctionCall">
+		<severity>5</severity>
+	</rule>
+
+
 	<!--
 	##########################################################################
 	SELECTIVE EXCLUSIONS

--- a/admin/class-plugin-availability.php
+++ b/admin/class-plugin-availability.php
@@ -91,7 +91,7 @@ class WPSEO_Plugin_Availability {
 				),
 				'_dependencies' => [
 					'WooCommerce' => [
-						'slug'        => 'woocommerce/woocommerce.php', // kept for backwards compatibility, in case external code uses get_dependencies(). Deprecated in 22.4.
+						'slug'        => 'woocommerce/woocommerce.php', // Kept for backwards compatibility, in case external code uses get_dependencies(). Deprecated in 22.4.
 						'conditional' => new WooCommerce_Conditional(),
 					],
 				],

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 		"symfony/dependency-injection": "^3.4",
 		"wordproof/wordpress-sdk": "1.3.5",
 		"yoast/wp-test-utils": "^1.2",
-		"yoast/yoastcs": "^3.0"
+		"yoast/yoastcs": "^3.1.0"
 	},
 	"suggest": {
 		"ext-bcmath": "For more accurate calculations",

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2564",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2561",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e2e44e18234a1cd0631f576a919a3cc7",
+    "content-hash": "7b8dfb1a43e163bbbc70e10be161e5ac",
     "packages": [
         {
             "name": "composer/installers",
@@ -1576,16 +1576,16 @@
         },
         {
             "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.2",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de"
+                "reference": "6db563514f27e19595a19f45a4bf757b6401194e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6483c9832e71973ed29cf71bd6b3f4fde438a9de",
-                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6db563514f27e19595a19f45a4bf757b6401194e",
+                "reference": "6db563514f27e19595a19f45a4bf757b6401194e",
                 "shasum": ""
             },
             "require": {
@@ -1623,13 +1623,17 @@
                     "email": "ahoj@jakubonderka.cz"
                 }
             ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
+            "description": "This tool checks the syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
+            "keywords": [
+                "lint",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.2"
+                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.4.0"
             },
-            "time": "2022-02-21T12:50:22+00:00"
+            "time": "2024-03-27T12:14:49+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -1885,22 +1889,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.9",
+            "version": "1.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
+                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
-                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/51609a5b89f928e0c463d6df80eb38eff1eaf544",
+                "reference": "51609a5b89f928e0c463d6df80eb38eff1eaf544",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -1969,20 +1973,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T14:50:00+00:00"
+            "time": "2024-03-17T23:44:50+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.27.0",
+            "version": "1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757"
+                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/86e4d5a4b036f8f0be1464522f4c6b584c452757",
-                "reference": "86e4d5a4b036f8f0be1464522f4c6b584c452757",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
+                "reference": "cd06d6b1a1b3c75b0b83f97577869fd85a3cd4fb",
                 "shasum": ""
             },
             "require": {
@@ -2014,9 +2018,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.27.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.28.0"
             },
-            "time": "2024-03-21T13:14:53+00:00"
+            "time": "2024-04-03T18:51:33+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2317,16 +2321,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.37",
+            "version": "8.5.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fce30f306cee78be33ba00c8f9a853f41db0491b"
+                "reference": "1ecad678646c817a29e55a32c930f3601c3f5a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fce30f306cee78be33ba00c8f9a853f41db0491b",
-                "reference": "fce30f306cee78be33ba00c8f9a853f41db0491b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1ecad678646c817a29e55a32c930f3601c3f5a8c",
+                "reference": "1ecad678646c817a29e55a32c930f3601c3f5a8c",
                 "shasum": ""
             },
             "require": {
@@ -2395,7 +2399,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.37"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.38"
             },
             "funding": [
                 {
@@ -2411,7 +2415,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-06T06:27:42+00:00"
+            "time": "2024-04-05T04:31:23+00:00"
         },
         {
             "name": "psr/container",
@@ -3508,32 +3512,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.14.1",
+            "version": "8.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "fea1fd6f137cc84f9cba0ae30d549615dbc6a926"
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/fea1fd6f137cc84f9cba0ae30d549615dbc6a926",
-                "reference": "fea1fd6f137cc84f9cba0ae30d549615dbc6a926",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7d1d957421618a3803b593ec31ace470177d7817",
+                "reference": "7d1d957421618a3803b593ec31ace470177d7817",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
                 "php": "^7.2 || ^8.0",
                 "phpstan/phpdoc-parser": "^1.23.1",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "squizlabs/php_codesniffer": "^3.9.0"
             },
             "require-dev": {
                 "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.10.37",
+                "phpstan/phpstan": "1.10.60",
                 "phpstan/phpstan-deprecation-rules": "1.1.4",
-                "phpstan/phpstan-phpunit": "1.3.14",
-                "phpstan/phpstan-strict-rules": "1.5.1",
-                "phpunit/phpunit": "8.5.21|9.6.8|10.3.5"
+                "phpstan/phpstan-phpunit": "1.3.16",
+                "phpstan/phpstan-strict-rules": "1.5.2",
+                "phpunit/phpunit": "8.5.21|9.6.8|10.5.11"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3557,7 +3561,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.14.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.15.0"
             },
             "funding": [
                 {
@@ -3569,20 +3573,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-08T07:28:08+00:00"
+            "time": "2024-03-09T15:20:58+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
                 "shasum": ""
             },
             "require": {
@@ -3592,11 +3596,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -3649,7 +3653,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-03-31T21:03:09+00:00"
         },
         {
             "name": "symfony/config",
@@ -4584,16 +4588,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
-                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
                 "shasum": ""
             },
             "require": {
@@ -4602,16 +4606,16 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.1.0",
-                "phpcsstandards/phpcsutils": "^1.0.8",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.10",
+                "squizlabs/php_codesniffer": "^3.9.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
                 "ext-iconv": "For improved results",
@@ -4642,24 +4646,24 @@
             },
             "funding": [
                 {
-                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "url": "https://opencollective.com/php_codesniffer",
                     "type": "custom"
                 }
             ],
-            "time": "2023-09-14T07:06:09+00:00"
+            "time": "2024-03-25T16:39:00+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
+                "reference": "a0f7d708794a738f328d7b6c94380fd1d6c40446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
-                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/a0f7d708794a738f328d7b6c94380fd1d6c40446",
+                "reference": "a0f7d708794a738f328d7b6c94380fd1d6c40446",
                 "shasum": ""
             },
             "require": {
@@ -4667,7 +4671,9 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.3.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
             },
             "type": "library",
             "extra": {
@@ -4704,9 +4710,10 @@
             ],
             "support": {
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-08-19T14:25:08+00:00"
+            "time": "2024-04-05T16:01:51+00:00"
         },
         {
             "name": "yoast/wp-test-utils",
@@ -4779,16 +4786,16 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "2ace63e7ea90a1610fb66279c314b321df029fd3"
+                "reference": "533b74e4ce234fb6ff1b02c87f84f227b5a95554"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2ace63e7ea90a1610fb66279c314b321df029fd3",
-                "reference": "2ace63e7ea90a1610fb66279c314b321df029fd3",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/533b74e4ce234fb6ff1b02c87f84f227b5a95554",
+                "reference": "533b74e4ce234fb6ff1b02c87f84f227b5a95554",
                 "shasum": ""
             },
             "require": {
@@ -4796,14 +4803,14 @@
                 "ext-tokenizer": "*",
                 "php": ">=7.2",
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.4",
                 "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.9",
+                "phpcsstandards/phpcsutils": "^1.0.10",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.17",
-                "slevomat/coding-standard": "^8.14.0",
-                "squizlabs/php_codesniffer": "^3.8.0",
-                "wp-coding-standards/wpcs": "^3.0.1"
+                "slevomat/coding-standard": "^8.15.0",
+                "squizlabs/php_codesniffer": "^3.9.1",
+                "wp-coding-standards/wpcs": "^3.1.0"
             },
             "require-dev": {
                 "phpcompatibility/php-compatibility": "^9.3.5",
@@ -4837,7 +4844,7 @@
                 "security": "https://github.com/Yoast/yoastcs/security/policy",
                 "source": "https://github.com/Yoast/yoastcs"
             },
-            "time": "2023-12-14T15:11:17+00:00"
+            "time": "2024-04-05T08:45:55+00:00"
         }
     ],
     "aliases": [],

--- a/config/composer/actions.php
+++ b/config/composer/actions.php
@@ -373,6 +373,11 @@ TPL;
 			$above_threshold = false;
 		}
 
+		$threshold_exact = true;
+		if ( \strpos( $phpcs_output, ' than the threshold, great job!' ) !== false ) {
+			$threshold_exact = false;
+		}
+
 		/*
 		 * Don't run the branch check in CI/GH Actions as it prevents the errors from being shown inline.
 		 * The GH Actions script will run this via a separate script step.
@@ -387,7 +392,15 @@ TPL;
 			@\passthru( 'composer check-branch-cs' );
 		}
 
-		exit( ( $above_threshold === true || $return > 2 ) ? $return : 0 );
+		$exit_code = 0;
+		if ( $above_threshold === true || $return > 2 ) {
+			$exit_code = $return;
+		}
+		elseif ( $threshold_exact === false ) {
+			$exit_code = 128;
+		}
+
+		exit( $exit_code );
 	}
 
 	/**

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -557,7 +557,6 @@ class WPSEO_Addon_Manager {
 			// We need to replace h2's and h3's with h4's because the styling expects that.
 			$changelog = str_replace( '</h2', '</h4', str_replace( '<h2', '<h4', $subscription->product->changelog ) );
 			$changelog = str_replace( '</h3', '</h4', str_replace( '<h3', '<h4', $changelog ) );
-
 		}
 
 		// If we're running this because we want to just show the plugin info in the version details modal, we can fallback to the Yoast Free constants, since that modal will not be accessible anyway in the event that the new Free version increases those constants.

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -315,7 +315,7 @@ class WPSEO_Upgrade {
 		$wpdb->query(
 			$wpdb->prepare(
 				'DELETE FROM %i WHERE %i LIKE %s AND autoload = "yes"',
-				[ $wpdb->options,'option_name', 'wpseo_sitemap_%' ]
+				[ $wpdb->options, 'option_name', 'wpseo_sitemap_%' ]
 			)
 		);
 	}
@@ -391,7 +391,7 @@ class WPSEO_Upgrade {
 				FROM %i
 				WHERE %i = %s AND %i LIKE %s
 				',
-				[ 'user_id','meta_value',$wpdb->usermeta,'meta_key', $meta_key,'meta_value','%wpseo-dismiss-about%' ]
+				[ 'user_id', 'meta_value', $wpdb->usermeta, 'meta_key', $meta_key, 'meta_value', '%wpseo-dismiss-about%' ]
 			),
 			ARRAY_A
 		);
@@ -445,7 +445,7 @@ class WPSEO_Upgrade {
 			$wpdb->prepare(
 				"DELETE FROM %i
 				WHERE %i = '_yst_content_links_processed'",
-				[ $wpdb->postmeta,'meta_key' ]
+				[ $wpdb->postmeta, 'meta_key' ]
 			)
 		);
 	}
@@ -651,7 +651,7 @@ class WPSEO_Upgrade {
 			$wpdb->prepare(
 				'DELETE FROM %i
 				WHERE %i LIKE %s',
-				[ $wpdb->options,'option_name', 'wpseo_sitemap_%' ]
+				[ $wpdb->options, 'option_name', 'wpseo_sitemap_%' ]
 			)
 		);
 	}
@@ -736,7 +736,7 @@ class WPSEO_Upgrade {
 			$wpdb->prepare(
 				'DELETE FROM %i
 				WHERE %i = %s',
-				[ $wpdb->usermeta,'meta_key', 'wp_yoast_promo_hide_premium_upsell_admin_block' ]
+				[ $wpdb->usermeta, 'meta_key', 'wp_yoast_promo_hide_premium_upsell_admin_block' ]
 			)
 		);
 
@@ -1190,7 +1190,7 @@ class WPSEO_Upgrade {
 			return;
 		}
 
-		$replacements = array_merge( [ Model::get_table_name( 'Indexable' ),'object_type','object_sub_type' ], $private_taxonomies );
+		$replacements = array_merge( [ Model::get_table_name( 'Indexable' ), 'object_type', 'object_sub_type' ], $private_taxonomies );
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
@@ -1226,7 +1226,7 @@ class WPSEO_Upgrade {
 		$wpdb->query(
 			$wpdb->prepare(
 				"UPDATE %i SET %i = NULL WHERE %i = 'post' AND %i = 'attachment'",
-				[ Model::get_table_name( 'Indexable' ),'permalink','object_type','object_sub_type' ]
+				[ Model::get_table_name( 'Indexable' ), 'permalink', 'object_type', 'object_sub_type' ]
 			)
 		);
 
@@ -1305,7 +1305,7 @@ class WPSEO_Upgrade {
 		$wpdb->query(
 			$wpdb->prepare(
 				'DELETE FROM %i WHERE %i LIKE %s',
-				[ $wpdb->options,'option_name' ,'wpseo_sitemap%validator%' ]
+				[ $wpdb->options, 'option_name', 'wpseo_sitemap%validator%' ]
 			)
 		);
 	}
@@ -1326,7 +1326,7 @@ class WPSEO_Upgrade {
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				'SELECT %i FROM %i WHERE %i = %s',
-				[ 'option_value',$wpdb->options,'option_name', $option_name ]
+				[ 'option_value', $wpdb->options, 'option_name', $option_name ]
 			),
 			ARRAY_A
 		);
@@ -1582,7 +1582,7 @@ class WPSEO_Upgrade {
 					"DELETE FROM %i
 					WHERE %i = 'post'
 					AND %i IS NOT NULL",
-					[ $indexable_table,'object_type','object_sub_type' ]
+					[ $indexable_table, 'object_type', 'object_sub_type' ]
 				)
 			);
 		}
@@ -1595,7 +1595,7 @@ class WPSEO_Upgrade {
 					WHERE %i = 'post'
 					AND %i IS NOT NULL
 					AND %i NOT IN ( " . implode( ', ', array_fill( 0, count( $included_post_types ), '%s' ) ) . ' )',
-					array_merge( [ $indexable_table,'object_type','object_sub_type','object_sub_type' ], $included_post_types )
+					array_merge( [ $indexable_table, 'object_type', 'object_sub_type', 'object_sub_type' ], $included_post_types )
 				)
 			);
 		}
@@ -1628,7 +1628,7 @@ class WPSEO_Upgrade {
 					"DELETE FROM %i
 					WHERE %i = 'term'
 					AND %i IS NOT NULL",
-					[ $indexable_table,'object_type','object_sub_type' ]
+					[ $indexable_table, 'object_type', 'object_sub_type' ]
 				)
 			);
 		}
@@ -1641,7 +1641,7 @@ class WPSEO_Upgrade {
 					WHERE %i = 'term'
 					AND %i IS NOT NULL
 					AND %i NOT IN ( " . implode( ', ', array_fill( 0, count( $included_taxonomies ), '%s' ) ) . ' )',
-					array_merge( [ $indexable_table,'object_type','object_sub_type','object_sub_type' ], $included_taxonomies )
+					array_merge( [ $indexable_table, 'object_type', 'object_sub_type', 'object_sub_type' ], $included_taxonomies )
 				)
 			);
 		}
@@ -1731,7 +1731,7 @@ class WPSEO_Upgrade {
 				WHERE %i = 'unindexed'
 				AND %i NOT IN ( 'home-page', 'date-archive', 'post-type-archive', 'system-page' )
 				AND %i IS NULL",
-				[ Model::get_table_name( 'Indexable' ),'post_status','object_type','object_id' ]
+				[ Model::get_table_name( 'Indexable' ), 'post_status', 'object_type', 'object_id' ]
 			)
 		);
 
@@ -1759,7 +1759,7 @@ class WPSEO_Upgrade {
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM %i WHERE %i = 'user'",
-				[ Model::get_table_name( 'Indexable' ),'object_type' ]
+				[ Model::get_table_name( 'Indexable' ), 'object_type' ]
 			)
 		);
 
@@ -1790,7 +1790,7 @@ class WPSEO_Upgrade {
 		$object_ids           = wp_list_pluck( $filtered_duplicates, 'object_id' );
 		$newest_indexable_ids = wp_list_pluck( $filtered_duplicates, 'newest_id' );
 
-		$replacements   = array_merge( [ Model::get_table_name( 'Indexable' ),'object_id' ], array_values( $object_ids ), array_values( $newest_indexable_ids ) );
+		$replacements   = array_merge( [ Model::get_table_name( 'Indexable' ), 'object_id' ], array_values( $object_ids ), array_values( $newest_indexable_ids ) );
 		$replacements[] = $object_type;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -898,7 +898,8 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool True if capabilities are sufficient, false otherwise.
 	 */
 	protected function can_manage_options() {
-		return is_network_admin() && current_user_can( 'wpseo_manage_network_options' ) || ! is_network_admin() && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
+		return ( is_network_admin() && current_user_can( 'wpseo_manage_network_options' ) )
+			|| ( ! is_network_admin() && WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' ) );
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -830,7 +830,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		 * {@internal This clean-up action can only be done effectively once the taxonomies
 		 *            and post_types have been registered, i.e. at the end of the init action.}}
 		 */
-		if ( isset( $original ) && current_filter() === 'wpseo_double_clean_titles' || did_action( 'wpseo_double_clean_titles' ) > 0 ) {
+		if ( ( isset( $original ) && current_filter() === 'wpseo_double_clean_titles' ) || did_action( 'wpseo_double_clean_titles' ) > 0 ) {
 			$rename = [
 				'title-'           => 'title-tax-',
 				'metadesc-'        => 'metadesc-tax-',

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -180,10 +180,10 @@ class WPSEO_Sitemaps_Cache_Validator {
 		}
 
 		/*
-		* Add slashes to the LIKE "_" single character wildcard.
-		*
-		* We can't use `esc_like` here because we need the % in the query.
-		*/
+		 * Add slashes to the LIKE "_" single character wildcard.
+		 *
+		 * We can't use `esc_like` here because we need the % in the query.
+		 */
 		$where   = [];
 		$where[] = sprintf( "option_name LIKE '%s'", addcslashes( '_transient_' . $like, '_' ) );
 		$where[] = sprintf( "option_name LIKE '%s'", addcslashes( '_transient_timeout_' . $like, '_' ) );

--- a/src/editors/application/analysis-features/enabled-analysis-features-repository.php
+++ b/src/editors/application/analysis-features/enabled-analysis-features-repository.php
@@ -17,14 +17,14 @@ class Enabled_Analysis_Features_Repository {
 	/**
 	 * All plugin features.
 	 *
-	 * @var Analysis_Feature_Interface[] $plugin_features
+	 * @var Analysis_Feature_Interface[]
 	 */
 	private $plugin_features;
 
 	/**
 	 * The list of analysis features.
 	 *
-	 * @var Analysis_Features_List $enabled_analysis_features
+	 * @var Analysis_Features_List
 	 */
 	private $enabled_analysis_features;
 

--- a/src/editors/domain/analysis-features/analysis-feature.php
+++ b/src/editors/domain/analysis-features/analysis-feature.php
@@ -10,7 +10,7 @@ class Analysis_Feature {
 	/**
 	 * If the feature is enabled.
 	 *
-	 * @var bool $is_enabled
+	 * @var bool
 	 */
 	private $is_enabled;
 

--- a/src/editors/domain/analysis-features/analysis-features-list.php
+++ b/src/editors/domain/analysis-features/analysis-features-list.php
@@ -10,7 +10,7 @@ class Analysis_Features_List {
 	/**
 	 * The features.
 	 *
-	 * @var array<Analysis_Feature> $features
+	 * @var array<Analysis_Feature>
 	 */
 	private $features = [];
 

--- a/src/generators/breadcrumbs-generator.php
+++ b/src/generators/breadcrumbs-generator.php
@@ -156,7 +156,7 @@ class Breadcrumbs_Generator implements Generator_Interface {
 			}
 		);
 
-		$crumbs = \array_map( [ $this,'get_post_type_crumb' ], $indexables );
+		$crumbs = \array_map( [ $this, 'get_post_type_crumb' ], $indexables );
 
 		if ( $breadcrumbs_home !== '' ) {
 			$crumbs[0]['text'] = $breadcrumbs_home;

--- a/src/helpers/schema/html-helper.php
+++ b/src/helpers/schema/html-helper.php
@@ -71,6 +71,6 @@ class HTML_Helper {
 	 * @return bool
 	 */
 	private function is_non_empty_string_or_stringable( $html ) {
-		return ( \is_string( $html ) || \is_object( $html ) && \method_exists( $html, '__toString' ) ) && ! empty( $html );
+		return ( \is_string( $html ) || ( \is_object( $html ) && \method_exists( $html, '__toString' ) ) ) && ! empty( $html );
 	}
 }

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -106,8 +106,7 @@ class Url_Helper {
 	 */
 	public function get_url_path( $url ) {
 		if ( \is_string( $url ) === false
-			&& \is_object( $url ) === false
-			|| ( \is_object( $url ) === true && \method_exists( $url, '__toString' ) === false )
+			&& ( \is_object( $url ) === false || \method_exists( $url, '__toString' ) === false )
 		) {
 			return '';
 		}
@@ -124,8 +123,7 @@ class Url_Helper {
 	 */
 	public function get_url_host( $url ) {
 		if ( \is_string( $url ) === false
-			&& \is_object( $url ) === false
-			|| ( \is_object( $url ) === true && \method_exists( $url, '__toString' ) === false )
+			&& ( \is_object( $url ) === false || \method_exists( $url, '__toString' ) === false )
 		) {
 			return '';
 		}

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -60,13 +60,14 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 	 * @return void
 	 */
 	public function maybe_disable_feeds() {
-		if ( \is_singular() && $this->is_true( 'remove_feed_post_comments' )
+		if ( ( \is_singular() && $this->is_true( 'remove_feed_post_comments' ) )
 			|| ( \is_author() && $this->is_true( 'remove_feed_authors' ) )
 			|| ( \is_category() && $this->is_true( 'remove_feed_categories' ) )
 			|| ( \is_tag() && $this->is_true( 'remove_feed_tags' ) )
 			|| ( \is_tax() && $this->is_true( 'remove_feed_custom_taxonomies' ) )
 			|| ( \is_post_type_archive() && $this->is_true( 'remove_feed_post_types' ) )
-			|| ( \is_search() && $this->is_true( 'remove_feed_search' ) ) ) {
+			|| ( \is_search() && $this->is_true( 'remove_feed_search' ) )
+		) {
 			\remove_action( 'wp_head', 'feed_links_extra', 3 );
 		}
 	}

--- a/src/values/twitter/images.php
+++ b/src/values/twitter/images.php
@@ -32,7 +32,6 @@ class Images extends Base_Images {
 		$this->twitter_image = $twitter_image;
 	}
 
-
 	/**
 	 * Adds an image to the list by image ID.
 	 *

--- a/tests/Unit/Admin/Suggested_Plugins_Construct_Test.php
+++ b/tests/Unit/Admin/Suggested_Plugins_Construct_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Admin;
 
 use WPSEO_Plugin_Availability;
 use Yoast_Notification_Center;
+
 /**
  * Test class for WPSEO_Suggested_Plugins::__construct.
  *

--- a/tests/Unit/Doubles/Integrations/Settings_Integration_Double.php
+++ b/tests/Unit/Doubles/Integrations/Settings_Integration_Double.php
@@ -36,9 +36,9 @@ final class Settings_Integration_Double extends Settings_Integration {
 	 * Retrieves the organization schema values from Local SEO for defaults in Site representation fields.
 	 * Specifically for the org-vat-id, org-tax-id, org-email and org-phone options.
 	 *
-	 * @param array<string|int|bool> $post_types The post types.
+	 * @param array<string|int|bool> $defaults The settings defaults.
 	 *
-	 * @return array<string|int|bool> The schema.
+	 * @return array<string|int|bool> The settings defaults with local seo overides.
 	 */
 	public function get_defaults_from_local_seo( $defaults ) {
 		return parent::get_defaults_from_local_seo( $defaults );

--- a/tests/WP/Admin/Watchers/Indexable_Ancestor_Watcher_Test.php
+++ b/tests/WP/Admin/Watchers/Indexable_Ancestor_Watcher_Test.php
@@ -118,13 +118,13 @@ final class Indexable_Ancestor_Watcher_Test extends TestCase {
 		$this->assertSame( [ (string) $post1->ID, (string) $post2->ID ], $this->instance->get_object_ids_for_term( $term_id, $child_indexables ) );
 	}
 
-		/**
-		 * Gets all indexable records for a post.
-		 *
-		 * @param WP_Post $post The post to get indexables for.
-		 *
-		 * @return Indexable[] The indexbales for hte post.
-		 */
+	/**
+	 * Gets all indexable records for a post.
+	 *
+	 * @param WP_Post $post The post to get indexables for.
+	 *
+	 * @return Indexable[] The indexbales for hte post.
+	 */
 	protected function get_indexables_for( WP_Post $post ) {
 		$orm = Model::of_type( 'Indexable' );
 

--- a/tests/WP/Inc/Upgrade_Test.php
+++ b/tests/WP/Inc/Upgrade_Test.php
@@ -652,7 +652,7 @@ final class Upgrade_Test extends TestCase {
 	/**
 	 * Tests the remove_indexable_rows_for_non_public_taxonomies method.
 	 *
-	 * @covers WPSEO_Upgrade::remove_indexable_rows_for_non_public_post_taxonomies
+	 * @covers WPSEO_Upgrade::remove_indexable_rows_for_non_public_taxonomies
 	 *
 	 * @return void
 	 */
@@ -714,7 +714,7 @@ final class Upgrade_Test extends TestCase {
 	/**
 	 * Tests the remove_indexable_rows_for_non_public_taxonomies method in case no public taxonomies are present.
 	 *
-	 * @covers WPSEO_Upgrade::remove_indexable_rows_for_non_public_post_taxonomies
+	 * @covers WPSEO_Upgrade::remove_indexable_rows_for_non_public_taxonomies
 	 *
 	 * @return void
 	 */
@@ -885,7 +885,7 @@ final class Upgrade_Test extends TestCase {
 	/**
 	 * Tests the test_remove_indexable_rows_for_disabled_authors_archive method.
 	 *
-	 * @covers WPSEO_Upgrade::test_remove_indexable_rows_for_disabled_authors_archive
+	 * @covers WPSEO_Upgrade::remove_indexable_rows_for_disabled_authors_archive
 	 *
 	 * @return void
 	 */

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -13,7 +13,7 @@ use Yoast\WP\SEO\Tests\WP\TestCase;
  * Class Post_Type_Sitemap_Provider_Test.
  *
  * @group sitemaps
- * @coversDefaultClass \Yoast\WP\SEO\Models\SEO_Links\WPSEO_Post_Type_Sitemap_Provider
+ * @coversDefaultClass \WPSEO_Post_Type_Sitemap_Provider
  */
 final class Post_Type_Sitemap_Provider_Test extends TestCase {
 

--- a/tests/WP/Sitemaps/Renderer_Test.php
+++ b/tests/WP/Sitemaps/Renderer_Test.php
@@ -196,7 +196,7 @@ final class Renderer_Test extends TestCase {
 	/**
 	 * Tests getting the fallback url if the plugin is loaded from a different domain.
 	 *
-	 * @covers Sitemaps_Renderer_Double::get_xsl_url
+	 * @covers WPSEO_Sitemaps_Renderer::get_xsl_url
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Context

* Update dev dependencies

## Summary

This PR can be summarized in the following changelog entry:

* Update dev dependencies

## Relevant technical choices:

### Composer: update dev dependencies

Nearly all dev dependencies have had new releases. This commit updates the plugin to use the new versions.

For linting, the upgrade will get us preliminary PHP 8.4 support.
For testing, the upgrades will get us continued support for running the tests via a PHAR file after the latest PHPUnit releases, as well as preliminary PHP 8.4 support.
For CS, the upgrades will get us improved syntax support for PHP 8.3, more documentation and a range of bug fixes.

### CS/check thresholds: require exact match for thresholds

This changes the implementation of the coding standards threshold check to require that both the `YOASTCS_THRESHOLD_ERRORS` environment variable, as well as the `YOASTCS_THRESHOLD_WARNINGS` environment variable match the current status exactly.

This prevents PR A fixing some issues and forgetting to update the threshold, which then would allow PR B to introduce new issues.

### PHPCS: minor ruleset tweak

### CS: various minor fixes 

### Tests: fix invalid `@covers` tags

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_