### PR TITLE
Use different snippet editor wrappers in Elementor and block editor

### DIFF
--- a/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
+++ b/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
@@ -1,19 +1,22 @@
 /* External dependencies */
+
 import { SearchIcon } from "@heroicons/react/solid";
+import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { useSvgAria } from "@yoast/ui-library/src";
 import styled from "styled-components";
 
 /* Internal dependencies */
 import EditorModal from "../../../containers/EditorModal";
-import SnippetEditorWrapper from "../../../containers/SnippetEditor";
-
+import BlockEditorSnippetEditor from "../../../containers/SnippetEditor";
+import ElementorSnippetEditor from "../../../elementor/containers/SnippetEditor";
 
 const StyledHeroIcon = styled( SearchIcon )`
 	width: 18px;
 	height: 18px;
 	margin: 3px;
 `;
+
 
 /**
  * The Search Appearance Modal.
@@ -22,6 +25,7 @@ const StyledHeroIcon = styled( SearchIcon )`
  */
 const SearchAppearanceModal = () => {
 	const svgAriaProps = useSvgAria();
+	const isElementorEditor = useSelect( select => select( "yoast-seo/editor" ).getIsElementorEditor(), [] );
 
 	return (
 		<EditorModal
@@ -30,7 +34,9 @@ const SearchAppearanceModal = () => {
 			shouldCloseOnClickOutside={ false }
 			SuffixHeroIcon={ <StyledHeroIcon className="yst-text-slate-500" { ...svgAriaProps } /> }
 		>
-			<SnippetEditorWrapper showCloseButton={ false } hasPaperStyle={ false } />
+			{ isElementorEditor === true && <ElementorSnippetEditor showCloseButton={ false } hasPaperStyle={ false } /> }
+			{ isElementorEditor === false && <BlockEditorSnippetEditor showCloseButton={ false } hasPaperStyle={ false } /> }
+
 		</EditorModal>
 	);
 };

--- a/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
+++ b/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
@@ -1,5 +1,4 @@
 /* External dependencies */
-
 import { SearchIcon } from "@heroicons/react/solid";
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
@@ -16,7 +15,6 @@ const StyledHeroIcon = styled( SearchIcon )`
 	height: 18px;
 	margin: 3px;
 `;
-
 
 /**
  * The Search Appearance Modal.
@@ -36,7 +34,6 @@ const SearchAppearanceModal = () => {
 		>
 			{ isElementorEditor === true && <ElementorSnippetEditor showCloseButton={ false } hasPaperStyle={ false } /> }
 			{ isElementorEditor === false && <BlockEditorSnippetEditor showCloseButton={ false } hasPaperStyle={ false } /> }
-
 		</EditorModal>
 	);
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug where the snippet editor in the Elementor sidebar would not correctly render the replacement variables values.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the snippet editor in the Elementor sidebar would not correctly render the replacement variables values.

## Relevant technical choices:

* We introduced the bug with [this PR](https://github.com/Yoast/wordpress-seo/pull/20627): we were using two different `SearchAppearanceModal` components before, one for the block editor and one for Elementor. The PR unifies the two modals but would use the same `SnippetEditorContainer` both for block editor and Elementor.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with Elementor
* Open the Yoast sidebar and click on `Search appearance`
  * [ ] Verify the replacement variables in the snippet editor are correctly parsed (i.e., you don't see `%%SEP%%` or `%%TITLE` but the actual values for those replacement variables
* [ ] Perform the same check in the block editor  

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#20908](https://github.com/Yoast/wordpress-seo/issues/20908)
