### PR TITLE
WC editor: create initial Yoast editor integration in JS

### DIFF
--- a/packages/js/src/initializers/pluggable.js
+++ b/packages/js/src/initializers/pluggable.js
@@ -1,4 +1,3 @@
-import { dispatch } from "@wordpress/data";
 import Pluggable from "../lib/Pluggable";
 
 // Holds the singleton used in getPluggable.
@@ -12,10 +11,10 @@ let pluggable = null;
 const getPluggable = () => {
 	if ( pluggable === null ) {
 		// Uses the initialized Pluggable plugin in `post-scraper.js` or `term-scraper.js` if available. If not, initiates a new Pluggable plugin.
-		const refresh = dispatch( "yoast-seo/editor" ).runAnalysis;
 		pluggable = window.YoastSEO.app && window.YoastSEO.app.pluggable
 			? window.YoastSEO.app.pluggable
-			: new Pluggable( refresh );
+			// In Elementor we use the `analysis.run` function to run the analysis. Everywhere else we use the `refresh` function.
+			: new Pluggable( window.YoastSEO.analysis.run || window.YoastSEO.app.refresh );
 	}
 
 	return pluggable;

--- a/packages/js/src/woocommerce-editor/initialize.js
+++ b/packages/js/src/woocommerce-editor/initialize.js
@@ -1,0 +1,95 @@
+import { select } from "@wordpress/data";
+import domReady from "@wordpress/dom-ready";
+import { registerPlugin } from "@wordpress/plugins";
+import { debounce, get, noop } from "lodash";
+import { Paper } from "yoastseo";
+import { refreshDelay } from "../analysis/constants";
+import CustomAnalysisData from "../analysis/CustomAnalysisData";
+import getApplyMarks from "../analysis/getApplyMarks";
+import handleWorkerError from "../analysis/handleWorkerError";
+import YoastMarkdownPlugin from "../analysis/plugins/markdown-plugin";
+import YoastReplaceVarPlugin from "../analysis/plugins/replacevar-plugin";
+import YoastReusableBlocksPlugin from "../analysis/plugins/reusable-blocks-plugin";
+import { initShortcodePlugin } from "../analysis/plugins/shortcode-plugin";
+import refreshAnalysis, { initializationDone } from "../analysis/refreshAnalysis";
+import { createAnalysisWorker, getAnalysisConfiguration } from "../analysis/worker";
+import { collectData } from "../initializers/analysis";
+import initEditorStore from "../initializers/editor-store";
+import { pluginReady, pluginReloaded, registerModification, registerPlugin as registerPluggablePlugin } from "../initializers/pluggable";
+import initializeUsedKeywords from "../initializers/used-keywords-assessment";
+
+const PLUGIN_NAME = "yoast-seo-for-woocommerce-products";
+const STORE_NAME = "yoast-seo/editor";
+
+const customAnalysisData = new CustomAnalysisData();
+
+domReady( () => {
+	// Initialize the global YoastSEO object.
+	window.YoastSEO = window.YoastSEO || {};
+
+	// Initialize the editor store.
+	window.YoastSEO.store = initEditorStore();
+
+	// Initialize the analysis.
+	window.YoastSEO.app = window.YoastSEO.app || {};
+	window.YoastSEO.analysis = window.YoastSEO.analysis || {};
+	window.YoastSEO.analysis.worker = createAnalysisWorker();
+	window.YoastSEO.analysis.collectData = () => Paper.parse( collectData() );
+	window.YoastSEO.analysis.applyMarks = getApplyMarks();
+	window.YoastSEO.app.refresh = debounce( () => refreshAnalysis(
+		window.YoastSEO.analysis.worker,
+		() => window.YoastSEO.analysis.collectData,
+		window.YoastSEO.analysis.applyMarks,
+		window.YoastSEO.store,
+		/**
+		 * Ignore these scores.
+		 * For posts, the PostDataCollector' saveScores and more is used. Which updates the publish box, traffic light, admin bar and the hidden
+		 * field to save the score.
+		 * In the Woo editor, we currently do not have any of these. The save itself should be arranged by syncing our store with the post metadata.
+		 */
+		{
+			saveScores: noop,
+			saveContentScore: noop,
+			saveInclusiveLanguageScore: noop,
+		}
+	), refreshDelay );
+	window.YoastSEO.app.analyzeTimer = window.YoastSEO.app.refresh;
+	window.YoastSEO.app.registerCustomDataCallback = customAnalysisData.register;
+	// Initialize the pluggable system.
+	window.YoastSEO.app.registerPlugin = registerPluggablePlugin;
+	window.YoastSEO.app.registerModification = registerModification;
+	window.YoastSEO.app.pluginReady = pluginReady;
+	window.YoastSEO.app.pluginReloaded = pluginReloaded;
+
+	// Initialize analysis plugins.
+	window.YoastSEO.wp = window.YoastSEO.wp || {};
+	window.YoastSEO.wp.replaceVarsPlugin = new YoastReplaceVarPlugin( window.YoastSEO.app, window.YoastSEO.store );
+	initShortcodePlugin( window.YoastSEO.app, window.YoastSEO.store );
+	initializeUsedKeywords( window.YoastSEO.app.refresh, "get_focus_keyword_usage_and_post_types", window.YoastSEO.store );
+	( new YoastReusableBlocksPlugin(
+		window.YoastSEO.app.registerPlugin,
+		window.YoastSEO.app.registerModification,
+		window.YoastSEO.app.refresh
+	) ).register();
+	if ( get( window, "wpseoScriptData.metabox.markdownEnabled", false ) ) {
+		( new YoastMarkdownPlugin( window.YoastSEO.app.registerPlugin, window.YoastSEO.app.registerModification ) ).register();
+	}
+
+	// Start the analysis worker.
+	window.YoastSEO.analysis.worker.initialize( getAnalysisConfiguration( {
+		useCornerstone: select( STORE_NAME ).isCornerstoneContent(),
+	} ) )
+		.then( () => {
+			jQuery( window ).trigger( "YoastSEO:ready" );
+			initializationDone();
+			window.YoastSEO.app.refresh();
+		} )
+		.catch( handleWorkerError );
+
+	// Initialize the Yoast SEO app.
+	registerPlugin( PLUGIN_NAME, {
+		name: PLUGIN_NAME,
+		scope: "woocommerce-product-block-editor",
+		render: () => null,
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Initialize our editor integration: create out editor store and analysis and expose our APIs

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Initializes our WooCommerce block editor integration in JavaScript, creating our editor store and analysis and exposing our APIs.

## Relevant technical choices:

**Pluggable**: try `YoastSEO.analysis.run` before `YoastSEO.app.refresh` to refresh the analysis.
This is because I implemented a mix between the current block editor and Elementor. Not exposing `YoastSEO.app.pluggable`, like in Elementor, to try to move to a more module state of pluggable, where we can use the imports internally. But then not using the `runAnalysis`, because that would require having the store subscribes in place and there is really no need as it is an action from outside that updates the store.

**collectData**: Normally, this is used in Elementor only, but it seems nice to use the data from the store via the selector instead of the `getState` from the store directly. However, I ran into the `YoastSEO.app.rawData` being expected in our replacement variable plugin (see code comment). This is not a problem in Elementor because it has its own replacement variable plugin. I decided to add a workaround where I expose the rawData inside that function (so also in Elementor).
Note that more data is missing due to using this Elementor way (added a task in the setup phase tracking issue).

**APIs**
Trying to follow the block editor approach for now, as the WC has that too. So I investigated our initial APIs, to try to get a grip on what I actually need to provide in this PR: https://docs.google.com/document/d/1xWficRbaXISfU4eosSfY66RawDg9lTsMqPqMVAY89iQ

Kept the actual working of individual plugins the same for now. Will add another task to check.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Regression
* Edit a post in the classic, block and Elementor editors
* Smoke test the replacement variables (are they there in the previews?)
* Smoke test the analysis (are they updating?)

#### Woo
* Activate WooCommerce
* Enable the new product editor beta: WooCommerce > Settings > Advanced > Features > New product editor
* Edit a product
* Check the public API in the browser console: `YoastSEO` should contain (most should not be different than in the editor):
  * `store`: the instance of our store. You can try to run `getState` on it to see our initial state? If you are feeling brave, you can even try a `dispatch` (maybe `dispatch({type:"SNIPPET_EDITOR_REFRESH", time: 1})` for a dummy update
  * `app`: this is some of our analysis interface. You can try to run `refresh` to see some updates in the store regarding the analysis results
  * `analysis`: this is some more analysis API. You can try to run `collectData` to see the Paper that will be passed to the analysis worker -- and after that you can check `app.rawData` to see it before the modifications from pluggable
  * `wp.replaceVarsPlugin`: our replacement variable plugin, you can try to run `getReplacementSource({})` to see some defaults with data from PHP

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* You can check the regression here, but PR alone is not that interesting as a stand-alone

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/191
