### PR TITLE
Update indexable-post-meta-watcher.php

### DIFF
--- a/src/integrations/watchers/indexable-post-meta-watcher.php
+++ b/src/integrations/watchers/indexable-post-meta-watcher.php
@@ -78,9 +78,9 @@ class Indexable_Post_Meta_Watcher implements Integration_Interface {
 	 */
 	public function add_post_id( $meta_id, $post_id, $meta_key ) {
 		// Only register changes to our own meta.
-		if ( \strpos( $meta_key, WPSEO_Meta::$meta_prefix ) !== 0 ) {
-			return;
-		}
+	    if ( is_string( $meta_key ) && strpos( $meta_key, WPSEO_Meta::$meta_prefix ) !== 0 ) {
+	        return;
+	    }
 
 		if ( ! \in_array( $post_id, $this->post_ids_to_update, true ) ) {
 			$this->post_ids_to_update[] = (int) $post_id;


### PR DESCRIPTION
In this modification, I added a check using is_string() to ensure that $meta_key is indeed a string before calling strpos(). This prevents the error from occurring when $meta_key is an array.

## Context
`Fatal error: Uncaught TypeError: strpos(): Argument #1 ($haystack) must be of type string, array given in /share/public/content/plugins/wordpress-seo/src/integrations/watchers/indexable-post-meta-watcher.php:81 Stack trace: #0 /share/public/content/plugins/wordpress-seo/src/integrations/watchers/indexable-post-meta-watcher.php(81): strpos() #1 /share/public/wp/wp-includes/class-wp-hook.php(326): Yoast\WP\SEO\Integrations\Watchers\Indexable_Post_Meta_Watcher->add_post_id() #2 /share/public/wp/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() #3 /share/public/wp/wp-includes/plugin.php(517): WP_Hook->do_action() #4 /share/public/wp/wp-includes/meta.php(528): do_action() #5 /share/public/wp/wp-includes/post.php(2574): delete_metadata() #6 /share/public/content/plugins/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/class-sync.php(1116): delete_post_meta() #7 /share/public/content/plugins/cloudinary-image-management-and-manipulation-in-the-cloud-cdn/php/sync/class-upload-sync.php(182): Cloudinary\Sync->delete_cloudinary_meta() #8 /share/public/wp/wp-includes/class-wp-hook.php(324): Cloudinary\Sync\Upload_Sync->handle_bulk_actions() #9 /share/public/wp/wp-includes/plugin.php(205): WP_Hook->apply_filters() #10 /share/public/wp/wp-admin/upload.php(344): apply_filters() #11 {main} thrown in /share/public/content/plugins/wordpress-seo/src/integrations/watchers/indexable-post-meta-watcher.php on line 81`


*

## Summary
In this modification, I added a check using is_string() to ensure that $meta_key is indeed a string before calling strpos(). This prevents the error from occurring when $meta_key is an array.

## Method of Changelog
The error message you provided indicates that there is an issue with the add_post_id() method in the Indexable_Post_Meta_Watcher class. Specifically, the error is occurring because the strpos() function is expecting a string for the $haystack parameter, but it's receiving an array instead.

To fix this issue, you need to ensure that $meta_key is a string before using strpos(). Here's how you can modify the add_post_id() method to handle this:
*
Fixes #
Fixed this [open issue](https://github.com/Yoast/wordpress-seo/issues/21303)