### PR TITLE
Add is_string check to safeguard against array meta keys.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2560",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2559",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2561",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2560",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/integrations/watchers/indexable-post-meta-watcher.php
+++ b/src/integrations/watchers/indexable-post-meta-watcher.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use WPSEO_Meta;
+use Yoast\WP\SEO\Conditionals\Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
@@ -21,14 +22,14 @@ class Indexable_Post_Meta_Watcher implements Integration_Interface {
 	/**
 	 * An array of post IDs that need to be updated.
 	 *
-	 * @var array
+	 * @var array<int>
 	 */
 	protected $post_ids_to_update = [];
 
 	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public static function get_conditionals() {
 		return [ Migrations_Conditional::class ];
@@ -78,7 +79,7 @@ class Indexable_Post_Meta_Watcher implements Integration_Interface {
 	 */
 	public function add_post_id( $meta_id, $post_id, $meta_key ) {
 		// Only register changes to our own meta.
-		if ( \strpos( $meta_key, WPSEO_Meta::$meta_prefix ) !== 0 ) {
+		if ( \is_string( $meta_key ) && \strpos( $meta_key, WPSEO_Meta::$meta_prefix ) !== 0 ) {
 			return;
 		}
 

--- a/src/integrations/watchers/indexable-post-meta-watcher.php
+++ b/src/integrations/watchers/indexable-post-meta-watcher.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Integrations\Watchers;
 
 use WPSEO_Meta;
-use Yoast\WP\SEO\Conditionals\Conditional;
 use Yoast\WP\SEO\Conditionals\Migrations_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It seems there are scenario's where `deleted_post_meta` is called with an array as the `meta_keys` parameter. We want to safeguard our code, since that gives a fatal in php 8.1

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where there would be a fatal error when deleting post meta in php 8.1 and higher. props to @izzygld

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you are on php 8.1 or higher.
* Add the following code to your functions.php or a mu plugin.
```
add_action( 'admin_init', 'admin_init_cb', 1 );
function admin_init_cb() {
	do_action( 'deleted_post_meta', 1, null, ['this','is','an','array'] );
}
```
* Without this PR/RC make sure you get an fatal error.
* With this pr make sure this error is gone.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This touches the way we handle post meta. So it would be good to smoke test setting some values in the sidebare/metabox. Like the focus keyphrase.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
