### PR TITLE
Schedule the usermeta cleanup 24 hours into the future

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1146,7 +1146,7 @@ class WPSEO_Upgrade {
 	private function upgrade_226() {
 		if ( get_option( Cleanup_Integration::CURRENT_TASK_OPTION ) === false ) {
 			$cleanup_integration = YoastSEO()->classes->get( Cleanup_Integration::class );
-			$cleanup_integration->start_cron_job( 'clean_selected_empty_usermeta' );
+			$cleanup_integration->start_cron_job( 'clean_selected_empty_usermeta', DAY_IN_SECONDS );
 		}
 	}
 

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -248,7 +248,7 @@ class Cleanup_Integration implements Integration_Interface {
 	 *
 	 * @return void
 	 */
-	public function start_cron_job( $task_name, $schedule_time = \HOUR_IN_SECONDS ) {
+	public function start_cron_job( $task_name, $schedule_time = 3600 ) {
 		\update_option( self::CURRENT_TASK_OPTION, $task_name );
 		\wp_schedule_event(
 			( \time() + $schedule_time ),

--- a/src/integrations/cleanup-integration.php
+++ b/src/integrations/cleanup-integration.php
@@ -243,14 +243,15 @@ class Cleanup_Integration implements Integration_Interface {
 	/**
 	 * Starts the cleanup cron job.
 	 *
-	 * @param string $task_name The task name of the next cleanup task to run.
+	 * @param string $task_name     The task name of the next cleanup task to run.
+	 * @param int    $schedule_time The time in seconds to wait before running the first cron job. Default is 1 hour.
 	 *
 	 * @return void
 	 */
-	public function start_cron_job( $task_name ) {
+	public function start_cron_job( $task_name, $schedule_time = \HOUR_IN_SECONDS ) {
 		\update_option( self::CURRENT_TASK_OPTION, $task_name );
 		\wp_schedule_event(
-			( \time() + \HOUR_IN_SECONDS ),
+			( \time() + $schedule_time ),
 			'hourly',
 			self::CRON_HOOK
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* To accompany https://github.com/Yoast/wordpress-seo-premium/pull/4277, we want to schedule the Free cleanup further into the future, to avoid a second database operation if we can avoid it
* For that reason, we assume that in most cases Free and Premium will be updated within 24 hours from each other, so this delay of the cleanup schedule will cover most cases

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Schedules the usermeta cleanup further into the future, more specifically 24 hours after the Free upgrade.

## Relevant technical choices:

* We rely on the delay of the cleanup scheduling, because it covers most cases in the wild. But also, for the cases it doesn't cover, the fallback is not a severe one, we will just perform a second database iteration for the cleanup of the Premium usermeta, so we're us being pragmatic here.
* We had to turn `HOUR_IN_SECONDS` into `3600`  because it's a WP constant and it being a default parameter value breaks `composer install`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Extending the test instructions of [the original task](https://github.com/Yoast/wordpress-seo/pull/21307)**:
* If the first upgrade comes from Premium (so, if you use the `Yoast SEO Premium` field in the Yoast Test Helper), confirm that the `wpseo_cleanup_cron` scheduled action is set for the next hour
* If the first upgrade comes from Free (so, if you use the `Yoast SEO` field in the Yoast Test Helper), confirm that the `wpseo_cleanup_cron` scheduled action is set for the next day.
* For both cases, make sure that the `wpseo-cleanup-current-task` option is not present in the database, so clean that up if you happen to run a partial cleanup before.

Also:
* If you use only the Free RC while having the Premium's production (aka, previous) version, when the usermeta cleanup is performed and completed, you can confirm that the Mastodon usermeta isn't cleaned up, which is expected.
* If you have completed the cleanup, you can now upgrade to the new Premium RC/PR, perform the upgrade routine and once the scheduled action is ran, confirm that the Mastodon usermetas are now also cleaned up.

Also:
* Confirm that if you upgrade Free and then immediately upgrade Premium (aka, perform their upgrade routines), it doesn't create a duplicate `wpseo_cleanup_cron` scheduled action. 
* Or vice versa (upgrade Premium and then Free)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21317
