### PR TITLE
Remove the 100% height from the Autocomplete button

### DIFF
--- a/packages/ui-library/src/elements/autocomplete/style.css
+++ b/packages/ui-library/src/elements/autocomplete/style.css
@@ -30,7 +30,6 @@
 		.yst-autocomplete__button {
 			@apply
 			yst-w-full
-			yst-h-full
 			yst-rounded-md
 			yst-bg-white
 			yst-shadow-sm


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Technically not a `fix-before-release` but affected now with the latest (18.1.2) Gutenberg plugin active and not using the Query monitor plugin to hide the notice from the body.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a PHP notice in the settings would influence the styling of some of our inputs.
* [@yoast/ui-library 0.1.0] Removes the 100% height styling from the Autocomplete `.yst-autocomplete__button` class.

## Relevant technical choices:

* Not sure why the 100% height was there, seems unaffected with removing it (negatively that is).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Plugin**
* Activate Premium
* Activate Gutenberg plugin (currently 18.1.2) to get a notice appearing
* Deactivate Query Monitor (to make the notice output on the page)
* Go to the settings > Site representation
* Ensure the representation is set as organization
* Verify the number of employees field looks normal again (see issue for before)
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/21aab098-f735-49f8-aeec-726d401f4d90)
* Switch representation to person
* Verify the select a user field looks normal again
* Go to Site basics and scroll down to Site policies
* Verify all those fields look normal again
* You could repeat the same steps again after deactivating Premium to verify the upsells are fixed too

**UI library' storybook [dev only]**
* Start the UI library' storybook: `yarn workspace @yoast/ui-library storybook`
* Go to the Autocomplete element
* Verify it still looks normal
* Go to the AutocompleField component
* Verify it still looks normal
* You can even go to the Form under patterns and scroll down, more Autocomplete in use

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Autocomplete and AutocompleteField from the UI library

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1500
