### PR TITLE
Fix PHP deprecation error when passing null instead of string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2550",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2549",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2555",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2550",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=267",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -317,11 +317,11 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return string The correct link.
 	 */
 	public function adjacent_rel_url( $link, $rel, $presentation = null ) {
-		if ( $link === \home_url( '/' ) || \is_null( $this->$rel ) ) {
+		if ( $link === \home_url( '/' ) ) {
 			return $link;
 		}
 
-		if ( $rel === 'next' || $rel === 'prev' ) {
+		if ( ( $rel === 'next' || $rel === 'prev' ) && ( ! \is_null( $this->$rel ) ) ){
 			// Reconstruct url if it's relative.
 			if ( \class_exists( WP_HTML_Tag_Processor::class ) ) {
 				$processor = new WP_HTML_Tag_Processor( $this->$rel );

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -317,7 +317,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return string The correct link.
 	 */
 	public function adjacent_rel_url( $link, $rel, $presentation = null ) {
-		if ( $link === \home_url( '/' ) ) {
+		if ( $link === \home_url( '/' ) || is_null( $this->$rel ) ) {
 			return $link;
 		}
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -108,7 +108,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Open Graph specific presenters that should be output on error pages.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected $open_graph_error_presenters = [
 		'Open_Graph\Locale',
@@ -119,7 +119,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Twitter card specific presenters.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected $twitter_card_presenters = [
 		'Twitter\Card',
@@ -133,7 +133,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Slack specific presenters.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected $slack_presenters = [
 		'Slack\Enhanced_Data',
@@ -142,7 +142,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The Webmaster verification specific presenters.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected $webmaster_verification_presenters = [
 		'Webmaster\Baidu',
@@ -155,7 +155,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Presenters that are only needed on singular pages.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected $singular_presenters = [
 		'Meta_Author',
@@ -170,7 +170,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * The presenters we want to be last in our output.
 	 *
-	 * @var string[]
+	 * @var array<string>
 	 */
 	protected $closing_presenters = [
 		'Schema',
@@ -193,7 +193,7 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
-	 * @return array The conditionals.
+	 * @return array<string> The conditionals.
 	 */
 	public static function get_conditionals() {
 		return [ Front_End_Conditional::class ];
@@ -284,8 +284,8 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Filters the next and prev links in the query loop block.
 	 *
-	 * @param string $html  The HTML output.
-	 * @param array  $block The block.
+	 * @param string                   $html  The HTML output.
+	 * @param array<string|array|null> $block The block.
 	 * @return string The filtered HTML output.
 	 */
 	public function query_loop_next_prev( $html, $block ) {
@@ -317,7 +317,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return string The correct link.
 	 */
 	public function adjacent_rel_url( $link, $rel, $presentation = null ) {
-		if ( $link === \home_url( '/' ) || is_null( $this->$rel ) ) {
+		if ( $link === \home_url( '/' ) ) {
 			return $link;
 		}
 
@@ -340,9 +340,9 @@ class Front_End_Integration implements Integration_Interface {
 	/**
 	 * Filters our robots presenter, but only when wp_robots is attached to the wp_head action.
 	 *
-	 * @param array $presenters The presenters for current page.
+	 * @param array<string> $presenters The presenters for current page.
 	 *
-	 * @return array The filtered presenters.
+	 * @return array<string> The filtered presenters.
 	 */
 	public function filter_robots_presenter( $presenters ) {
 		if ( ! \function_exists( 'wp_robots' ) ) {

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -321,7 +321,7 @@ class Front_End_Integration implements Integration_Interface {
 			return $link;
 		}
 
-		if ( ( $rel === 'next' || $rel === 'prev' ) && ( ! \is_null( $this->$rel ) ) ){
+		if ( ( $rel === 'next' || $rel === 'prev' ) && ( ! \is_null( $this->$rel ) ) ) {
 			// Reconstruct url if it's relative.
 			if ( \class_exists( WP_HTML_Tag_Processor::class ) ) {
 				$processor = new WP_HTML_Tag_Processor( $this->$rel );

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -317,7 +317,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return string The correct link.
 	 */
 	public function adjacent_rel_url( $link, $rel, $presentation = null ) {
-		if ( $link === \home_url( '/' ) || is_null( $this->$rel ) ) {
+		if ( $link === \home_url( '/' ) || \is_null( $this->$rel ) ) {
 			return $link;
 		}
 

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -123,7 +123,7 @@ final class Front_End_Integration_Test extends TestCase {
 	/**
 	 * Data provider for the test_adjacent_rel_url test.
 	 *
-	 * @return array
+	 * @return array<array<string>>
 	 */
 	public static function data_provider_adjacent_rel_url() {
 		return [

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -155,6 +155,13 @@ final class Front_End_Integration_Test extends TestCase {
 				'next'     => '<a href="/?query-1-page=4">Next</a>',
 				'expected' => 'https://example.org/?query-1-page=2',
 			],
+			'prev link is null' => [
+				'link'     => 'https://example.org/',
+				'rel'      => 'prev',
+				'prev'     => null,
+				'next'     => '<a href="/?query-1-page=4">Next</a>',
+				'expected' => 'https://example.org/',
+			],
 			'full url' => [
 				'link'     => 'https://example.org/?query-1-page=2',
 				'rel'      => 'prev',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  We want to avoid a PHP deprecation error when instantiating a `WP_HTML_Tag_Processor` by passing `null` as parameter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a PHP deprecation error would be thrown, when trying to convert a relative URL to an absolute one, with the provided value being `null`.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you are testing this PR with a version of PHP >= 8.1 and you have Query Monitor active
* Create a post in the block editor
  * insert a `query loop` block
  * in the block sidebar, toggle `Inherit query from template` off
    <img width="298" alt="Screenshot 2024-04-23 at 15 41 26" src="https://github.com/Yoast/wordpress-seo/assets/68744851/38c663af-162e-4f80-9337-d88cd0bc2c1d">

  *  Select the pagination block that has been automatically added, click on the three vertical dots and select `delete`
    <img width="764" alt="Screenshot 2024-04-23 at 15 32 02" src="https://github.com/Yoast/wordpress-seo/assets/68744851/18797a75-3106-42bf-86a1-7ed14bca1d36">
* Visit the post in the frontend and verify in Query Monitor that you don't get a PHP deprecation error stating: `strlen(): Passing null to parameter #1 ($string) of type string is deprecated`

 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#21256](https://github.com/Yoast/wordpress-seo/issues/21256)
