### PR TITLE
Prevent fatals with the Howto block in rare situations

### DIFF
--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = ! is_numeric( $attributes['days'] ) ? 0 : floatval( $attributes['days'] );
-		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : floatval( $attributes['hours'] );
-		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : floatval( $attributes['minutes'] );
+		$days    = ! is_numeric( $attributes['days'] ) ? 0 : intval( $attributes['days'] );
+		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : intval( $attributes['hours'] );
+		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : intval( $attributes['minutes'] );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = ! is_numeric( $attributes['days'] ) ? 0 : intval( $attributes['days'] );
-		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : intval( $attributes['hours'] );
-		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : intval( $attributes['minutes'] );
+		$days    = ! \is_numeric( $attributes['days'] ) ? 0 : \intval( $attributes['days'] );
+		$hours   = ! \is_numeric( $attributes['hours'] ) ? 0 : \intval( $attributes['hours'] );
+		$minutes = ! \is_numeric( $attributes['minutes'] ) ? 0 : \intval( $attributes['minutes'] );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = empty( $attributes['days'] ) ? 0 : $attributes['days'];
-		$hours   = empty( $attributes['hours'] ) ? 0 : $attributes['hours'];
-		$minutes = empty( $attributes['minutes'] ) ? 0 : $attributes['minutes'];
+		$days    = ! is_numeric( $attributes['days'] ) ? 0 : intval( $attributes['days'] );
+		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : intval( $attributes['hours'] );
+		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : intval( $attributes['minutes'] );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = ! \is_numeric( $attributes['days'] ) ? 0 : \intval( $attributes['days'] );
-		$hours   = ! \is_numeric( $attributes['hours'] ) ? 0 : \intval( $attributes['hours'] );
-		$minutes = ! \is_numeric( $attributes['minutes'] ) ? 0 : \intval( $attributes['minutes'] );
+		$days    = \intval( $attributes['days'] ?? 0 );
+		$hours   = \intval( $attributes['hours'] ?? 0 );
+		$minutes = \intval( $attributes['minutes'] ?? 0 );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = ! is_numeric( $attributes['days'] ) ? 0 : intval( $attributes['days'] );
-		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : intval( $attributes['hours'] );
-		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : intval( $attributes['minutes'] );
+		$days    = ! is_numeric( $attributes['days'] ) ? 0 : floatval( $attributes['days'] );
+		$hours   = ! is_numeric( $attributes['hours'] ) ? 0 : floatval( $attributes['hours'] );
+		$minutes = ! is_numeric( $attributes['minutes'] ) ? 0 : floatval( $attributes['minutes'] );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );

--- a/src/generators/schema/howto.php
+++ b/src/generators/schema/howto.php
@@ -46,9 +46,9 @@ class HowTo extends Abstract_Schema_Piece {
 			return;
 		}
 
-		$days    = \intval( $attributes['days'] ?? 0 );
-		$hours   = \intval( $attributes['hours'] ?? 0 );
-		$minutes = \intval( $attributes['minutes'] ?? 0 );
+		$days    = \intval( ( $attributes['days'] ?? 0 ) );
+		$hours   = \intval( ( $attributes['hours'] ?? 0 ) );
+		$minutes = \intval( ( $attributes['minutes'] ?? 0 ) );
 
 		if ( ( $days + $hours + $minutes ) > 0 ) {
 			$data['totalTime'] = \esc_attr( 'P' . $days . 'DT' . $hours . 'H' . $minutes . 'M' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent fatal errors on PHP 8+ when trying to use arithmetic operations on strings.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents a fatal error in an uncommon case where the duration of a how-to block contains non-numeric values.

## Relevant technical choices:

* We only prevent storing strings as duration in javascript in the block editor. However, a string may still be stored via other means (we should probably prevent that as well). When PHP tries to perform arithmetic operations on strings, it will start [throwing fatals as of PHP 8](https://github.com/php/php-src/pull/5331). This PR checks if the value can be numeric and if so, casts it to an integer. All other cases will return a 0.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

We need request manipulation to test this PR. Manipulation is needed as the "normal" editing of the post does not allow for these values to be submitted. Firefox allows for this request manipulation out of the box, so these instructions use the Firefox browser.

![image](https://github.com/Yoast/wordpress-seo/assets/34372510/03602b06-1a2a-4f38-88f3-aba6c45b4bf2)

* Make sure you are running PHP 8+ (PHP 7 will throw warnings instead of errors I believe)
* Add a How-to block to a post and fill it out with all the details, including a valid duration.
* Click the button to update the post while you have your network inspector open.
* Rightclick the POST request to `https://basic.wordpress.test/wp-json/wp/v2/posts/###?_locale=user` and click `Edit and resend`.
* In the additional window, look for the body of the request and scroll to the first instance of `\"hours\":\"1\"` (where the 1 is the value you filled for the hours in the howto block.
* Change this 1 to a letter and click 'send'.
* Without this PR, the editor and the page on the frontend of the site should both throw a fatal error.
* With this PR, the duration will simply be cast to 0.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The How-To block.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
