### PR TITLE
Removes date and separator from Products meta description text editor field

### DIFF
--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -9,8 +9,8 @@ import { select } from "@wordpress/data";
 
 /**
  * Renders a badge with tooltip for mentions.
- * @param {JSX.node[]} mentionsName The name of the mentions.
- * @param {JSX.node[]} children The children of the tooltip.
+ * @param {string} mentionsName The name of the mentions.
+ * @param {JSX.node} children The children of the tooltip.
  * @returns {JSX.Element} The badge with a tooltip.
  */
 const MentionsWithTooltip = ( { mentionsName, children } ) => {
@@ -64,10 +64,11 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 	const isRtl = get( window, "wpseoScriptData.metabox.isRtl", false );
 	const getDate = select( "yoast-seo/editor" ).getDateFromSettings;
 	const isProduct = select( "yoast-seo/editor" ).getIsProduct();
+	const isPreviewField = fieldId === "yoast-google-preview-description-metabox" || fieldId === "yoast-google-preview-description-modal";
 	const dateCharacters = getDate().length;
 	const separatorCharacters = 3;
 	const newMentions = [];
-	if ( ! isProduct && fieldId === "yoast-google-preview-description-metabox"  || fieldId === "yoast-google-preview-description-modal" ) {
+	if ( ! isProduct && isPreviewField ) {
 		newMentions.push(
 			<Fill
 				name={ `yoast.replacementVariableEditor.additionalMentions.${fieldId}` }
@@ -75,15 +76,13 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 				<Root context={ { isRtl } }>
 					<MentionsWithTooltip mentionsName={ __( "Date", "wordpress-seo" ) }>
 						{ sprintf(
-						/* translators:
-						%s expands to the amount of chararacters */
+							/* translators: %s expands to the amount of characters */
 							_n( "The 'Date' variable is fixed and adds %s character to the length of your meta description.", "The 'Date' variable is fixed and adds %s characters to the length of your meta description.", dateCharacters, "wordpress-seo" ), dateCharacters ) }
 					</MentionsWithTooltip>
 					<span className="yst-p-1" />
 					<MentionsWithTooltip mentionsName={ __( "Separator", "wordpress-seo" ) }>
 						{ sprintf(
-						/* translators:
-						%s expands to the amount of chararacters */
+							/* translators: %s expands to the amount of characters */
 							_n( "The 'Separator' variable is fixed and adds %s character to the length of your meta description.", "The 'Separator' variable is fixed and adds %s characters to the length of your meta description.", separatorCharacters, "wordpress-seo" ), separatorCharacters ) }
 					</MentionsWithTooltip>
 				</Root>

--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -67,7 +67,7 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 	const dateCharacters = getDate().length;
 	const separatorCharacters = 3;
 	const newMentions = [];
-	if ( !isProduct && fieldId === "yoast-google-preview-description-metabox"  || fieldId === "yoast-google-preview-description-modal" ) {
+	if ( ! isProduct && fieldId === "yoast-google-preview-description-metabox"  || fieldId === "yoast-google-preview-description-modal" ) {
 		newMentions.push(
 			<Fill
 				name={ `yoast.replacementVariableEditor.additionalMentions.${fieldId}` }

--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -63,10 +63,11 @@ MentionsWithTooltip.propTypes = {
 const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 	const isRtl = get( window, "wpseoScriptData.metabox.isRtl", false );
 	const getDate = select( "yoast-seo/editor" ).getDateFromSettings;
+	const isProduct = select( "yoast-seo/editor" ).getIsProduct();
 	const dateCharacters = getDate().length;
 	const separatorCharacters = 3;
 	const newMentions = [];
-	if ( fieldId === "yoast-google-preview-description-metabox"  || fieldId === "yoast-google-preview-description-modal" ) {
+	if ( !isProduct && fieldId === "yoast-google-preview-description-metabox"  || fieldId === "yoast-google-preview-description-modal" ) {
 		newMentions.push(
 			<Fill
 				name={ `yoast.replacementVariableEditor.additionalMentions.${fieldId}` }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the date and the separator snippet variables in the meta description text field, to not be displayed for products. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `date` and `separator` replacements variables would inadvertently be displayed in the product's meta description text field. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Free 22.7-RC1 + WooCommerce plugins.
* Create a new product. 
* Go to the SEO/Search appearance tab of the Yoast SEO metabox, and check that the Meta description field doesn't show the Date and Separator variables.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The meta description fields replacement variables.

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments on the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or others.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1527
