### PR TITLE
Fix import of `wpseo_titles`

### DIFF
--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -874,46 +874,6 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			unset( $rename, $taxonomy_names, $post_type_names, $defaults, $tax, $old_prefix, $new_prefix );
 		}
 
-		/*
-		 * Make sure the values of the variable option key options are cleaned as they
-		 * may be retained and would not be cleaned/validated then.
-		 */
-		if ( is_array( $option_value ) && $option_value !== [] ) {
-			foreach ( $option_value as $key => $value ) {
-				$switch_key = $this->get_switch_key( $key );
-
-				// Similar to validation routine - any changes made there should be made here too.
-				switch ( $switch_key ) {
-					/* Text fields. */
-					case 'title-':
-					case 'metadesc-':
-					case 'bctitle-ptarchive-':
-						$option_value[ $key ] = WPSEO_Utils::sanitize_text_field( $value );
-						break;
-
-					case 'separator':
-						if ( ! array_key_exists( $value, $this->get_separator_options() ) ) {
-							$option_value[ $key ] = false;
-						}
-						break;
-
-					/*
-					 * Boolean fields.
-					 */
-
-					/*
-					 * Covers:
-					 *  'noindex-'
-					 *  'hideeditbox-'
-					 */
-					default:
-						$option_value[ $key ] = WPSEO_Utils::validate_bool( $value );
-						break;
-				}
-			}
-			unset( $key, $value, $switch_key );
-		}
-
 		return $option_value;
 	}
 

--- a/packages/js/src/settings/components/formik-media-select-field.js
+++ b/packages/js/src/settings/components/formik-media-select-field.js
@@ -63,7 +63,7 @@ const FormikMediaSelectField = ( {
 	const fallbackMedia = useSelectSettings( "selectMediaById", [ fallbackMediaId ], fallbackMediaId );
 	const { fetchMedia, addOneMedia } = useDispatchSettings();
 	const error = useMemo( () => get( errors, mediaIdName, "" ), [ errors, mediaIdName ] );
-	const disabled = useMemo( () => isDisabled || isDummy || isMediaError, [ isDummy, isDisabled, isMediaError ] );
+	const disabled = useMemo( () => isDisabled || isDummy, [ isDummy, isDisabled ] );
 	const { ids: describedByIds, describedBy } = useDescribedBy( `field-${ id }-id`, { description, error } );
 	const previewMedia = useMemo( () => {
 		if ( mediaId > 0 ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where some Yoast SEO settings could not be imported correctly.
* Fixes a bug where a "Failed to retrieve media" error could prevent selecting a different image or removing the current selection.

## Relevant technical choices:

* Note that "Tagline" is not a Yoast settings, but we update the WP settings for that. This is why the value is not exported nor imported.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

In a site with Yoast SEO Free + Premium (they can be the latest released versions):
1. install the Test Helper and enable the custom post types and taxonomies (Books, Movies and their taxonomies)
2. visit the Yoast settings and make sure to set customized, non-default, recognizable values for the following settings:

* Site basics:
  * Website name
  * Alternate website name 
  * title separator
  * Publishing principles (*)
  * Ownership / Funding info (*)
  * Actionable feedback policy (*)
  * Corrections policy (*)
  * Ethics policy (*)
  * Diversity policy (*)
  * Diversity staffing report (*)
* Site representation - set "Organization":
  * Organ. name
  * Alt. organ. name
  * Organization logo (*)
  * Org description
  * Org email address
  * org phone number
  * org legal name
  * org founding date
  * org number of employees
  * vat id
  * tax id
  * iso 6523
  * DUNS
  * LEI code
  * NAICS
* Content types - Homepage:
  * SEO Title
  * Meta description
  * Social title
  * Social description
  * Social image (*)
* Content types - Posts/Pages/Books/Movies:
  * SEO title
  * Meta description
  * social image (*)
  * social title
  * social desc
  * Page type
  * article type (if present)
  * For custom types archives:
    * SEO title
    * meta desc
    * Social image (*)
    * Social title
    * social description
    * breadcrumbs title
* Categories & tags - Categories (the builtin one)
  * Show the categories prefix in the slug
* Categories & tags - every single taxonomy:
  * SEO title
  * Meta description
  * social image (*)
  * social title
  * social desc
  * Also change some of the "Show categories in search results" and "Enable SEO controls and assessments" settings
* Advanced - Breadcrumbs:
  * Separator
  * Anchor text for the Homepage
  * Prefix for the breadcrumb path
  * Prefix for archive breadcrumbs
  * Prefix for search page breadcrumbs
  * Breadcrumb for 404 page
  * Bold the last page
  * Set various values for all the dropdown menus under "Breadcrumbs for post types" and "Breadcrumbs for taxonomies"
* Advanced - Author archives:
  * SEO title
  * Meta description
  * Social title
  * Social description
  * Social image (*)
* Advanced - Date archives:
  * SEO title
  * Meta description
  * Social title
  * Social description
  * Social image (*)
* Advanced - Format archives:
  * SEO title
  * Meta description
  * Social title
  * Social description
  * Social image (*)
* Advanced - Special pages:
  * Internal search pages - page title
  * 404 error pages - page title
* Advanced - Media pages:  
  * Set Enable media pages to `on`
  * SEO Title
  * Meta description
  * Page type
  * Article type
* Advanced - RSS:
  * Content to put before each post in the feed
  * Content to put after each post in the feed

* (*) this marks ID-dependent settings that may not be preserved across sites - this means that you may not see the (same) image or selected page after the import to a new site
  * note that the images, even if not visible, should be set, so you should see the "Remove image" link and you should be able to select another image (this is fixed in this PR, it used to be a problem)

* Save the settings
* visit Yoast SEO > Tools and export the settings
* go to the backend of a site with Yoast SEO containing this patch + Premium 
* visit Yoast SEO > Tools and import the settings you exported
* visit the Yoast SEO Settings and check for each one of the options above that the import has been successful
* get back to the Export site
* visit the Yoast SEO Settings
* in the Site Representation section, switch to "Person"
* select a user and a logo
* export the settings once more and import them in the other site
* check that the site representation settings are on "Person" now
  * the two settings are ID-dependent settings that may not be preserved across sites - this means that you may not see the (same) image or selected user after the import to a new site
  * note that the images, even if not visible, should be set, so you should see the "Remove image" link and you should be able to select another image (this is fixed in this PR, it used to be a problem)

**Specifically test the UX improvement on errors in the media fetching**:
* We need to see what happens when the settings upon page load query media and that query fails unexpectedly.
* To do that, add the following filter in your site, so that we fail media requests:
```
add_filter( 'rest_pre_dispatch', 'fail_rest_api_request', 10, 3 );

function fail_rest_api_request( $result, $server, $request ) {
    if ( $request->get_route() === '/wp/v2/media' ) {
        $response = new WP_REST_Response();
        $response->set_status( 500 );
        $response->set_data( array(
            'error' => 'failed',
            'message' => 'Failed to process the request',
        ) );

        // Return the failed response
        return $response;
    }

    // If not the endpoint you want to fail, return the original result
    return $result;
}
```
* Go to a settings page that has a media selector, like the `Content types->Homepage->Social media appearance`

**Without this PR**:
* It would show the following UX, but the user wouldnt be able to go and select an image:
![image](https://github.com/Yoast/wordpress-seo/assets/12400734/e1fc7516-5178-434a-860d-3fc8fc0566e5)

**With this PR**:
* It would show a similar UX, but this time the user would also be able to go and select an image:
![image](https://github.com/Yoast/wordpress-seo/assets/12400734/f56dfc64-0b7b-44b1-bf88-bc0dc50bfe68)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #17333
