### PR TITLE
Prevents interactions between spans in the meta description field

### DIFF
--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -79,12 +79,13 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 							/* translators: %s expands to the amount of characters */
 							_n( "The 'Date' variable is fixed and adds %s character to the length of your meta description.", "The 'Date' variable is fixed and adds %s characters to the length of your meta description.", dateCharacters, "wordpress-seo" ), dateCharacters ) }
 					</MentionsWithTooltip>
-					<span className="yst-p-1" />
+					&nbsp;
 					<MentionsWithTooltip mentionsName={ __( "Separator", "wordpress-seo" ) }>
 						{ sprintf(
 							/* translators: %s expands to the amount of characters */
 							_n( "The 'Separator' variable is fixed and adds %s character to the length of your meta description.", "The 'Separator' variable is fixed and adds %s characters to the length of your meta description.", separatorCharacters, "wordpress-seo" ), separatorCharacters ) }
 					</MentionsWithTooltip>
+					&nbsp;
 				</Root>
 			</Fill>
 		);

--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -66,7 +66,7 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 	const isProduct = select( "yoast-seo/editor" ).getIsProduct();
 	const isPreviewField = fieldId === "yoast-google-preview-description-metabox" || fieldId === "yoast-google-preview-description-modal";
 	const dateCharacters = getDate().length;
-	const separatorCharacters = 3;
+	const emDashCharacters = 3;
 	const newMentions = [];
 	if ( ! isProduct && isPreviewField ) {
 		newMentions.push(
@@ -83,7 +83,7 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 					<MentionsWithTooltip mentionsName={ "—" }>
 						{ sprintf(
 							/* translators: %s expands to the amount of characters */
-							_n( "The em dash (—) is fixed and adds %s character to the length of your meta description.", "The em dash (—) is fixed and adds %s characters to the length of your meta description.", separatorCharacters, "wordpress-seo" ), separatorCharacters ) }
+							_n( "The em dash (—) is fixed and adds %s character to the length of your meta description.", "The em dash (—) is fixed and adds %s characters to the length of your meta description.", emDashCharacters, "wordpress-seo" ), emDashCharacters ) }
 					</MentionsWithTooltip>
 					&nbsp;
 				</Root>

--- a/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
+++ b/packages/js/src/shared-admin/helpers/search-appearance-description-mention.js
@@ -80,10 +80,10 @@ const filterReplacementVariableEditorMentions = ( mentions, { fieldId } ) => {
 							_n( "The 'Date' variable is fixed and adds %s character to the length of your meta description.", "The 'Date' variable is fixed and adds %s characters to the length of your meta description.", dateCharacters, "wordpress-seo" ), dateCharacters ) }
 					</MentionsWithTooltip>
 					&nbsp;
-					<MentionsWithTooltip mentionsName={ __( "Separator", "wordpress-seo" ) }>
+					<MentionsWithTooltip mentionsName={ "—" }>
 						{ sprintf(
 							/* translators: %s expands to the amount of characters */
-							_n( "The 'Separator' variable is fixed and adds %s character to the length of your meta description.", "The 'Separator' variable is fixed and adds %s characters to the length of your meta description.", separatorCharacters, "wordpress-seo" ), separatorCharacters ) }
+							_n( "The em dash (—) is fixed and adds %s character to the length of your meta description.", "The em dash (—) is fixed and adds %s characters to the length of your meta description.", separatorCharacters, "wordpress-seo" ), separatorCharacters ) }
 					</MentionsWithTooltip>
 					&nbsp;
 				</Root>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In Firefox, selecting the first word of the description added to the meta description field would also select the fixed variable "Separator". This PR prevents that by adding `&nbsp;` after (and between) the fixed variables.
* Also, in this PR we change the "Separator" to the em dash, to make it's clear that's it's not the same as the "Separator" replacement variable. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where lack of an element between the fixed variables and the text input by the user could lead to interactions. 
* Fixes an unreleased bug where the fixed variable for Google's separator could be confused with the "Separator" replacement variable. 

## Relevant technical choices:

* We're using `&nbsp;` as that's the de facto standard to create spacing between elements throughout our codebase.
* We've added "—" as an untranslatable string. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post.
* Open the search appearance settings (in the metabox or the sidebar). 
* Confirm that in the meta description field, there is now an em dash ("—") as a fixed variable instead of "Separator".
* Add some extra text after the fixed variables.
* Confirm that double-clicking the first word of the added text does not also select the fixed variable for the em dash. Note: this behaviour previously was reproducible in Firefox, not in Chrome, so I suggest to try different browsers here. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The spacing between the fixed variables.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1529
