### PR TITLE
Adds the date to the meta description length when the description is empty

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/word/countMetaDescriptionLengthSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/word/countMetaDescriptionLengthSpec.js
@@ -11,7 +11,12 @@ describe( "the meta description length research", function() {
 		expect( result ).toBe( 44 );
 	} );
 
-	it( "returns the length (0) of the description", function() {
+	it( "returns the length of the description when the meta description is empty", function() {
+		const result = metaDescriptionLength( "9 September 2021", "" );
+		expect( result ).toBe( 19 );
+	} );
+
+	it( "returns the length of the description when both fields are empty", function() {
 		const result = metaDescriptionLength( "", "" );
 		expect( result ).toBe( 0 );
 	} );

--- a/packages/yoastseo/src/languageProcessing/helpers/word/countMetaDescriptionLength.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/word/countMetaDescriptionLength.js
@@ -1,16 +1,16 @@
 /**
- * Check the length of the description.
+ * Returns the total length of the meta description (including the date if present).
  *
  * @param {string}  date          The date.
  * @param {string}  description   The meta description.
  *
- * @returns {number} The length of the description.
+ * @returns {number} The total length of the meta description.
  */
 export default function( date, description ) {
 	let descriptionLength = description.length;
 	/* If the meta description is preceded by a date, two spaces and a hyphen (" - ") are added as well. Therefore,
 	three needs to be added to the total length. */
-	if ( date !== "" && descriptionLength > 0 ) {
+	if ( date !== "" ) {
 		descriptionLength += date.length + 3;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When adding the fixed variables in #21184, it became clear that we were not showing anything in the length progress bar when no description was entered by the user. This PR fixes that, by always counting the date + separator (14 characters, leading to an orange progress bar, or red for cornerstone content), even when no description has been provided. Of course, for products or taxonomies, the date is not shown, and thus the length indicator will still not show. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the character count of the meta description field would not include the automatically added date and separator when no additional content was provided. 
* [yoastseo] Fixes a bug where the character count of the meta description field would not include the automatically added date and separator when no additional content was provided. 

## Relevant technical choices:

* The length calculation of the meta description now always includes the date, even if the user-provided content is empty. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post. 
* Check the meta description field in the Search Appearance settings. 
* Confirm that an orange bar is displayed below the field (and the date and separator badges are present).
* When you inspect the element, confirm that the `<progress>` element has the attribute `value=14`. 
* Confirm that for products or taxonomies, **no** bar is displayed (and the date and separator badges are **not** present).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The length calculation of the meta description.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1529
