### PR TITLE
Fix metabox and sidebar elements order

### DIFF
--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -28,9 +28,6 @@ import { BlackFridayPromotion } from "../BlackFridayPromotion";
 import { isWooCommerceActive } from "../../helpers/isWooCommerceActive";
 import { withMetaboxWarningsCheck } from "../higherorder/withMetaboxWarningsCheck";
 
-import { MetaboxErrorFallback } from "../metabox-error-fallback";
-
-import { ErrorBoundary } from "@yoast/ui-library";
 const BlackFridayProductEditorChecklistPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayProductEditorChecklistPromotion );
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
 

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -52,85 +52,83 @@ export default function MetaboxFill( { settings } ) {
 		<>
 			{ isWordProofIntegrationActive() && <WordProofAuthenticationModals /> }
 			<Fill name="YoastMetabox">
-				<ErrorBoundary FallbackComponent={ MetaboxErrorFallback }>
-					<SidebarItem
-						key="warning"
-						renderPriority={ 1 }
+				<SidebarItem
+					key="warning"
+					renderPriority={ 1 }
+				>
+					<Warning />
+				</SidebarItem>
+				<SidebarItem
+					key="time-constrained-notification"
+					renderPriority={ 2 }
+				>
+					{ shouldShowWooCommerceChecklistPromo && <BlackFridayProductEditorChecklistPromotionWithMetaboxWarningsCheck /> }
+					<BlackFridayPromotionWithMetaboxWarningsCheck image={ null } hasIcon={ false } location={ "metabox" } />
+				</SidebarItem>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
+					<KeywordInput
+						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
+					/>
+					{ ! window.wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
+						<SEMrushRelatedKeyphrases />
+					</Fill> }
+				</SidebarItem> }
+				<SidebarItem key="search-appearance" renderPriority={ 9 }>
+					<MetaboxCollapsible
+						id={ "yoast-snippet-editor-metabox" }
+						title={ __( "Search appearance", "wordpress-seo" ) } initialIsOpen={ true }
 					>
-						<Warning />
-					</SidebarItem>
-					<SidebarItem
-						key="time-constrained-notification"
-						renderPriority={ 2 }
-					>
-						{ shouldShowWooCommerceChecklistPromo && <BlackFridayProductEditorChecklistPromotionWithMetaboxWarningsCheck /> }
-						<BlackFridayPromotionWithMetaboxWarningsCheck image={ null } hasIcon={ false } location={ "metabox" } />
-					</SidebarItem>
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
-						<KeywordInput
-							isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
-						/>
-						{ ! window.wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
-							<SEMrushRelatedKeyphrases />
-						</Fill> }
-					</SidebarItem> }
-					<SidebarItem key="search-appearance" renderPriority={ 9 }>
-						<MetaboxCollapsible
-							id={ "yoast-snippet-editor-metabox" }
-							title={ __( "Search appearance", "wordpress-seo" ) } initialIsOpen={ true }
-						>
-							<SnippetEditor hasPaperStyle={ false } />
-						</MetaboxCollapsible>
-					</SidebarItem>
-					{ settings.isContentAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
-						<ReadabilityAnalysis
+						<SnippetEditor hasPaperStyle={ false } />
+					</MetaboxCollapsible>
+				</SidebarItem>
+				{ settings.isContentAnalysisActive && <SidebarItem key="readability-analysis" renderPriority={ 10 }>
+					<ReadabilityAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+					/>
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
+					<Fragment>
+						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
+							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 						/>
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="seo-analysis" renderPriority={ 20 }>
-						<Fragment>
-							<SeoAnalysis
-								shouldUpsell={ settings.shouldUpsell }
-								shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-							/>
-							{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="metabox" /> }
-						</Fragment>
-					</SidebarItem> }
-					{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem key="inclusive-language-analysis" renderPriority={ 21 }>
-						<InclusiveLanguageAnalysis />
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
-						{ settings.shouldUpsell && <KeywordUpsell /> }
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
-						<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
-							<WincherSEOPerformanceModal location="metabox" />
-						</SidebarItem>
-					}
-					{ settings.shouldUpsell && ! isTerm && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
-						<InternalLinkingSuggestionsUpsell />
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
-						<CollapsibleCornerstone />
-					</SidebarItem> }
-					{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
-						<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
-							<AdvancedSettings />
-						</MetaboxCollapsible>
-					</SidebarItem> }
-					{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 50 }>
-						<SchemaTabContainer />
-					</SidebarItem> }
-					<SidebarItem
-						key="social"
-						renderPriority={ -1 }
-					>
-						<SocialMetadataPortal target="wpseo-section-social" />
+						{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="metabox" /> }
+					</Fragment>
+				</SidebarItem> }
+				{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem key="inclusive-language-analysis" renderPriority={ 21 }>
+					<InclusiveLanguageAnalysis />
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
+					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
+					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
+						<WincherSEOPerformanceModal location="metabox" />
 					</SidebarItem>
-					{ settings.isInsightsEnabled && <SidebarItem key="insights" renderPriority={ 52 }>
-						<InsightsCollapsible location="metabox" />
-					</SidebarItem> }
-				</ErrorBoundary>
+				}
+				{ settings.shouldUpsell && ! isTerm && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
+					<CollapsibleCornerstone />
+				</SidebarItem> }
+				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 40 }>
+					<MetaboxCollapsible id={ "collapsible-advanced-settings" } title={ __( "Advanced", "wordpress-seo" ) }>
+						<AdvancedSettings />
+					</MetaboxCollapsible>
+				</SidebarItem> }
+				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 50 }>
+					<SchemaTabContainer />
+				</SidebarItem> }
+				<SidebarItem
+					key="social"
+					renderPriority={ -1 }
+				>
+					<SocialMetadataPortal target="wpseo-section-social" />
+				</SidebarItem>
+				{ settings.isInsightsEnabled && <SidebarItem key="insights" renderPriority={ 52 }>
+					<InsightsCollapsible location="metabox" />
+				</SidebarItem> }
 			</Fill>
 		</>
 	);

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -21,8 +21,6 @@ import SidebarCollapsible from "../SidebarCollapsible";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
 import KeywordUpsell from "../modals/KeywordUpsell";
-import { ErrorBoundary } from "@yoast/ui-library";
-import { SidebarErrorFallback } from "../sidebar-error-fallback";
 
 /* eslint-disable complexity */
 /**
@@ -43,76 +41,74 @@ export default function SidebarFill( { settings } ) {
 	return (
 		<Fragment>
 			<Fill name="YoastSidebar">
-				<ErrorBoundary FallbackComponent={ SidebarErrorFallback }>
-					<SidebarItem key="warning" renderPriority={ 1 }>
-						<Warning />
-						<div style={ { margin: "0 16px" } }>
-							{ FirstEligibleNotification && <FirstEligibleNotification /> }
-						</div>
-					</SidebarItem>
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
-						<KeywordInput
-							isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
-						/>
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="seo" renderPriority={ 10 }>
-						<Fragment>
-							<SeoAnalysis
-								shouldUpsell={ settings.shouldUpsell }
-								shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-							/>
-							{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="sidebar" /> }
-						</Fragment>
-					</SidebarItem> }
-					{ settings.isContentAnalysisActive && <SidebarItem key="readability" renderPriority={ 20 }>
-						<ReadabilityAnalysis
+				<SidebarItem key="warning" renderPriority={ 1 }>
+					<Warning />
+					<div style={ { margin: "0 16px" } }>
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
+					</div>
+				</SidebarItem>
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
+					<KeywordInput
+						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
+					/>
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="seo" renderPriority={ 10 }>
+					<Fragment>
+						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
+							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 						/>
-					</SidebarItem> }
-					{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem key="inclusive-language-analysis" renderPriority={ 21 }>
-						<InclusiveLanguageAnalysis />
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
-						{ settings.shouldUpsell && <KeywordUpsell /> }
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive && <SidebarItem renderPriority={ 23 }>
-						<WincherSEOPerformanceModal
-							location="sidebar"
-						/>
-					</SidebarItem> }
-					{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
-						<InternalLinkingSuggestionsUpsell />
-					</SidebarItem> }
-					<SidebarItem key="search-appearance" renderPriority={ 26 }>
-						<SearchAppearanceModal />
-					</SidebarItem>
-					{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 27 }>
-						<SocialAppearanceModal
-							useOpenGraphData={ settings.useOpenGraphData }
-							useTwitterData={ settings.useTwitterData }
-						/>
-					</SidebarItem> }
-					{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 28 }>
-						<SidebarCollapsible
-							title={ __( "Schema", "wordpress-seo" ) }
-						>
-							<SchemaTabContainer />
-						</SidebarCollapsible>
-					</SidebarItem> }
-					{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 29 }>
-						<SidebarCollapsible
-							title={ __( "Advanced", "wordpress-seo" ) }
-						>
-							<AdvancedSettings />
-						</SidebarCollapsible>
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
-						<CollapsibleCornerstone />
-					</SidebarItem> }
-					{ settings.isInsightsEnabled && <SidebarItem renderPriority={ 32 }>
-						<InsightsModal location="sidebar" />
-					</SidebarItem> }
-				</ErrorBoundary>
+						{ settings.shouldUpsell && <PremiumSEOAnalysisModal location="sidebar" /> }
+					</Fragment>
+				</SidebarItem> }
+				{ settings.isContentAnalysisActive && <SidebarItem key="readability" renderPriority={ 20 }>
+					<ReadabilityAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+					/>
+				</SidebarItem> }
+				{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem key="inclusive-language-analysis" renderPriority={ 21 }>
+					<InclusiveLanguageAnalysis />
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
+					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive && <SidebarItem renderPriority={ 23 }>
+					<WincherSEOPerformanceModal
+						location="sidebar"
+					/>
+				</SidebarItem> }
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 25 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
+				<SidebarItem key="search-appearance" renderPriority={ 26 }>
+					<SearchAppearanceModal />
+				</SidebarItem>
+				{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 27 }>
+					<SocialAppearanceModal
+						useOpenGraphData={ settings.useOpenGraphData }
+						useTwitterData={ settings.useTwitterData }
+					/>
+				</SidebarItem> }
+				{ settings.displaySchemaSettings && <SidebarItem key="schema" renderPriority={ 28 }>
+					<SidebarCollapsible
+						title={ __( "Schema", "wordpress-seo" ) }
+					>
+						<SchemaTabContainer />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.displayAdvancedTab && <SidebarItem key="advanced" renderPriority={ 29 }>
+					<SidebarCollapsible
+						title={ __( "Advanced", "wordpress-seo" ) }
+					>
+						<AdvancedSettings />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem key="cornerstone" renderPriority={ 30 }>
+					<CollapsibleCornerstone />
+				</SidebarItem> }
+				{ settings.isInsightsEnabled && <SidebarItem renderPriority={ 32 }>
+					<InsightsModal location="sidebar" />
+				</SidebarItem> }
 			</Fill>
 		</Fragment>
 	);

--- a/packages/js/src/components/slots/MetaboxSlot.js
+++ b/packages/js/src/components/slots/MetaboxSlot.js
@@ -1,6 +1,8 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
 import TopLevelProviders from "../TopLevelProviders";
+import { ErrorBoundary } from "@yoast/ui-library";
+import { MetaboxErrorFallback } from "../metabox-error-fallback";
 
 /**
  * Renders the metabox portal.
@@ -16,11 +18,13 @@ export default function MetaboxSlot( { theme } ) {
 			theme={ theme }
 			location={ "metabox" }
 		>
-			<Slot name="YoastMetabox">
-				{ ( fills ) => {
-					return sortComponentsByRenderPriority( fills );
-				} }
-			</Slot>
+			<ErrorBoundary FallbackComponent={ MetaboxErrorFallback }>
+				<Slot name="YoastMetabox">
+					{ ( fills ) => {
+						return sortComponentsByRenderPriority( fills );
+					} }
+				</Slot>
+			</ErrorBoundary>
 		</TopLevelProviders>
 	);
 }

--- a/packages/js/src/components/slots/SidebarSlot.js
+++ b/packages/js/src/components/slots/SidebarSlot.js
@@ -1,6 +1,8 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../helpers/sortComponentsByRenderPriority";
 import TopLevelProviders from "../TopLevelProviders";
+import { ErrorBoundary } from "@yoast/ui-library";
+import { SidebarErrorFallback } from "../sidebar-error-fallback";
 
 /**
  * Renders the Sidebar slot.
@@ -16,11 +18,13 @@ export default function SidebarSlot( { theme } ) {
 			theme={ theme }
 			location={ "sidebar" }
 		>
-			<Slot name="YoastSidebar">
-				{ ( fills ) => {
-					return sortComponentsByRenderPriority( fills );
-				} }
-			</Slot>
+			<ErrorBoundary FallbackComponent={ SidebarErrorFallback }>
+				<Slot name="YoastSidebar">
+					{ ( fills ) => {
+						return sortComponentsByRenderPriority( fills );
+					} }
+				</Slot>
+			</ErrorBoundary>
 		</TopLevelProviders>
 	);
 }

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -24,8 +24,6 @@ import WincherSEOPerformanceModal from "../../../containers/WincherSEOPerformanc
 import { isWordProofIntegrationActive } from "../../../helpers/wordproof";
 import WordProofAuthenticationModals from "../../../components/modals/WordProofAuthenticationModals";
 import KeywordUpsell from "../../../components/modals/KeywordUpsell";
-import { ErrorBoundary } from "@yoast/ui-library";
-import { ElementorErrorFallback } from "../elementor-error-fallback";
 
 /* eslint-disable complexity */
 /**

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -57,81 +57,79 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 		<>
 			{ isWordProofIntegrationActive() && <WordProofAuthenticationModals /> }
 			<Fill name="YoastElementor">
-				<ErrorBoundary FallbackComponent={ ElementorErrorFallback }>
-					<SidebarItem renderPriority={ 1 }>
-						<Alert />
-						{ FirstEligibleNotification && <FirstEligibleNotification /> }
-					</SidebarItem>
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
-						<KeywordInput
-							isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
-						/>
-						{ ! window.wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
-							<SEMrushRelatedKeyphrases />
-						</Fill> }
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 10 }>
-						<Fragment>
-							<SeoAnalysis
-								shouldUpsell={ settings.shouldUpsell }
-								shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
-								shouldUpsellHighlighting={ settings.shouldUpsell }
-							/>
-							{ settings.shouldUpsell && <PremiumSEOAnalysisModal /> }
-						</Fragment>
-					</SidebarItem> }
-					{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 15 }>
-						<ReadabilityAnalysis
+				<SidebarItem renderPriority={ 1 }>
+					<Alert />
+					{ FirstEligibleNotification && <FirstEligibleNotification /> }
+				</SidebarItem>
+				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
+					<KeywordInput
+						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }
+					/>
+					{ ! window.wpseoScriptData.metabox.isPremium && <Fill name="YoastRelatedKeyphrases">
+						<SEMrushRelatedKeyphrases />
+					</Fill> }
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 10 }>
+					<Fragment>
+						<SeoAnalysis
 							shouldUpsell={ settings.shouldUpsell }
+							shouldUpsellWordFormRecognition={ settings.isWordFormRecognitionActive }
 							shouldUpsellHighlighting={ settings.shouldUpsell }
 						/>
+						{ settings.shouldUpsell && <PremiumSEOAnalysisModal /> }
+					</Fragment>
+				</SidebarItem> }
+				{ settings.isContentAnalysisActive && <SidebarItem renderPriority={ 15 }>
+					<ReadabilityAnalysis
+						shouldUpsell={ settings.shouldUpsell }
+						shouldUpsellHighlighting={ settings.shouldUpsell }
+					/>
+				</SidebarItem> }
+				{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem renderPriority={ 19 }>
+					<InclusiveLanguageAnalysis
+						shouldUpsellHighlighting={ settings.shouldUpsell }
+					/>
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
+					{ settings.shouldUpsell && <KeywordUpsell /> }
+				</SidebarItem> }
+				{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
+					<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
+						<WincherSEOPerformanceModal location="sidebar" shouldCloseOnClickOutside={ false } />
 					</SidebarItem> }
-					{ settings.isInclusiveLanguageAnalysisActive && <SidebarItem renderPriority={ 19 }>
-						<InclusiveLanguageAnalysis
-							shouldUpsellHighlighting={ settings.shouldUpsell }
-						/>
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && <SidebarItem key="additional-keywords-upsell" renderPriority={ 22 }>
-						{ settings.shouldUpsell && <KeywordUpsell /> }
-					</SidebarItem> }
-					{ settings.isKeywordAnalysisActive && settings.isWincherIntegrationActive &&
-						<SidebarItem key="wincher-seo-performance" renderPriority={ 23 }>
-							<WincherSEOPerformanceModal location="sidebar" shouldCloseOnClickOutside={ false } />
-						</SidebarItem> }
-					{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 24 }>
-						<InternalLinkingSuggestionsUpsell />
-					</SidebarItem> }
-					<SidebarItem renderPriority={ 25 }>
-						<SearchAppearanceModal />
-					</SidebarItem>
-					{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 26 }>
-						<SocialAppearanceModal
-							useOpenGraphData={ settings.useOpenGraphData }
-							useTwitterData={ settings.useTwitterData }
-						/>
-					</SidebarItem> }
-					{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 28 }>
-						<SidebarCollapsible
-							title={ __( "Schema", "wordpress-seo" ) }
-						>
-							<SchemaTabContainer />
-						</SidebarCollapsible>
-					</SidebarItem> }
-					{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 29 }>
-						<SidebarCollapsible
-							title={ __( "Advanced", "wordpress-seo" ) }
-							buttonId="yoast-seo-elementor-advanced-button"
-						>
-							<AdvancedSettings location="sidebar" />
-						</SidebarCollapsible>
-					</SidebarItem> }
-					{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
-						<CollapsibleCornerstone />
-					</SidebarItem> }
-					{ settings.isInsightsEnabled && <SidebarItem renderPriority={ 32 }>
-						<InsightsModal location="elementor" />
-					</SidebarItem> }
-				</ErrorBoundary>
+				{ settings.shouldUpsell && <SidebarItem key="internal-linking-suggestions-upsell" renderPriority={ 24 }>
+					<InternalLinkingSuggestionsUpsell />
+				</SidebarItem> }
+				<SidebarItem renderPriority={ 25 }>
+					<SearchAppearanceModal />
+				</SidebarItem>
+				{ ( settings.useOpenGraphData || settings.useTwitterData ) && <SidebarItem key="social-appearance" renderPriority={ 26 }>
+					<SocialAppearanceModal
+						useOpenGraphData={ settings.useOpenGraphData }
+						useTwitterData={ settings.useTwitterData }
+					/>
+				</SidebarItem> }
+				{ settings.displaySchemaSettings && <SidebarItem renderPriority={ 28 }>
+					<SidebarCollapsible
+						title={ __( "Schema", "wordpress-seo" ) }
+					>
+						<SchemaTabContainer />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.displayAdvancedTab && <SidebarItem renderPriority={ 29 }>
+					<SidebarCollapsible
+						title={ __( "Advanced", "wordpress-seo" ) }
+						buttonId="yoast-seo-elementor-advanced-button"
+					>
+						<AdvancedSettings location="sidebar" />
+					</SidebarCollapsible>
+				</SidebarItem> }
+				{ settings.isCornerstoneActive && <SidebarItem renderPriority={ 30 }>
+					<CollapsibleCornerstone />
+				</SidebarItem> }
+				{ settings.isInsightsEnabled && <SidebarItem renderPriority={ 32 }>
+					<InsightsModal location="elementor" />
+				</SidebarItem> }
 			</Fill>
 		</>
 	);

--- a/packages/js/src/elementor/components/slots/ElementorSlot.js
+++ b/packages/js/src/elementor/components/slots/ElementorSlot.js
@@ -1,5 +1,7 @@
 import { Slot } from "@wordpress/components";
 import sortComponentsByRenderPriority from "../../../helpers/sortComponentsByRenderPriority";
+import { ErrorBoundary } from "@yoast/ui-library";
+import { ElementorErrorFallback } from "../elementor-error-fallback";
 
 /**
  * Renders the Elementor slot.
@@ -8,8 +10,10 @@ import sortComponentsByRenderPriority from "../../../helpers/sortComponentsByRen
  */
 export default function ElementorSlot() {
 	return (
-		<Slot name="YoastElementor">
-			{ ( fills ) => sortComponentsByRenderPriority( fills ) }
-		</Slot>
+		<ErrorBoundary FallbackComponent={ ElementorErrorFallback }>
+			<Slot name="YoastElementor">
+				{ ( fills ) => sortComponentsByRenderPriority( fills ) }
+			</Slot>
+		</ErrorBoundary>
 	);
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/pull/20907 we introduced a bug which disrupts the order of the elements in the metabox and sidebar when Yoast SEO Premium is activated. This PR fixes it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the elements in the Yoast sidebar and metabox are displayed in an incorrect order if Yoast SEO Premium is activated.

## Relevant technical choices:

* The error boundary enclosing the components if `MetaboxFill`, `SidebarFill` and `ElementorFill` has been removed and placed around the components in `MetaboxSlot`, SidebarSlot` and `ElementorSlot`. This because the components inside each fill are accessed and ordered in the corresponding slots, and because they are all enclosed in the error boundary are seen as a single giant component. Once Premium adds its 3 components to the metabox/sidebar,  these 4 components are then ordered.

<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Preliminary step: install and activate Yoast SEO Premium


<details>
  <summary>Testing the classic and block editor metabox error boundary</summary>

* Copy the following snippet right after the imports in `assets/js/src/metabox.js` (Yoast SEO Premium)
  ```
  const Bomb = () => {
    throw new Error("Kaboom!");
  }
  ```
* Find the `Fill` component with `name="YoastMetabox"`and copy the following snippet after a `</SidebarItem>` closing tag inside that component: `<Bomb />`
  * this will throw an exception inside the metabox
* Re-build Premium Javascript packages by issuing `grunt build:js` in the command line
* Edit a post and verify:
  * [ ] the metabox looks as follows 
  <img width="652" alt="Screenshot 2024-04-03 at 15 16 42" src="https://github.com/Yoast/wordpress-seo/assets/68744851/9556044a-a5f6-43ed-8db0-828b9360bef4">

  * [ ] the metabox tabs are not active
  * [ ] the `Refresh page` button refreshes the page (the error would stay)
 
</details>

<details>
  <summary>Testing the  block editor sidebar error boundary</summary>

#### Testing the block editor sidebar
* Now find the `Fill` component with `name="YoastSidebar"` and add the same `<Bomb />` snippet after a `</SidebarItem>` closing tag inside that component

* Build again the javascript packages
* Edit a post and verify:
  * [ ] the sidebar looks as follows:
    <img width="342" alt="Screenshot 2024-04-03 at 15 16 42" src="https://github.com/Yoast/wordpress-seo/assets/68744851/113600f8-3340-4f89-95ec-39328a671900">
  * [ ] the `Refresh page` button refreshes the page (the error would stay)
 
</details>

<details>
  <summary>Testing the Elementor sidebar error boundary</summary>

* Copy the previous two snippets of code in  `assets/js/src/elementor/initializers/initializeSidebar.js`
  * the first snippet right after the imports
  * the second snippet after a  `</SidebarItem>` closing tag inside the `Fill` component with `name="YoastElementor"`

* Build the javascript packages again
* Edit a post and verify:
  * [ ] the sidebar looks as follows:
  <img width="342" alt="Screenshot 2024-04-03 at 15 51 08" src="https://github.com/Yoast/wordpress-seo/assets/68744851/4a6be1bc-66dc-4921-883c-fedbe6d76fa7">
 * [ ] the `Refresh page` button refreshes the page (the error would stay)

</details>

<details>
  <summary>Verify the correct order of the elements</summary>

* Preliminary step: remove all the code you have added in the previous test steps

* Edit a post in the block editor and verify
  * [ ] the metabox looks as follows
   <img width="655" alt="metabox" src="https://github.com/Yoast/wordpress-seo/assets/68744851/6fa920f2-bade-46be-8bf0-de642c6f69f3">

  * [ ] the sidebar looks as follows
    <img width="295" alt="sidebar" src="https://github.com/Yoast/wordpress-seo/assets/68744851/35bdd822-c474-4d6b-b3ad-d786bab2dd93">

* [ ] Edit a post in the classic editor and verify the metabox looks as follows
  <img width="652" alt="classic metabox" src="https://github.com/Yoast/wordpress-seo/assets/68744851/1b9cc261-4986-4dde-975f-ffbcc79a9c4d">

* [ ] Edit a post with Elementor and verify the sidebar looks as follows
<img width="327" alt="Elementor" src="https://github.com/Yoast/wordpress-seo/assets/68744851/6601050a-8e65-4d12-8214-6a00c2e902f7">

</details>

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#1530](https://github.com/Yoast/plugins-automated-testing/issues/1530)
