### PR TITLE
Add additional filters to the image presenter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2527",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2523",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=253",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -20,7 +20,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Image tags that we output for each image.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected static $image_tags = [
 		'width'  => 'width',
@@ -68,7 +68,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Gets the raw value of a presentation.
 	 *
-	 * @return array The raw value.
+	 * @return array<string,int> The raw value.
 	 */
 	public function get() {
 		$images = [];
@@ -88,9 +88,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Run the image content through the `wpseo_opengraph_image` filter.
 	 *
-	 * @param array $image The image.
+	 * @param array<string,int> $image The image.
 	 *
-	 * @return array The filtered image.
+	 * @return array<string,int> The filtered image.
 	 */
 	protected function filter( $image ) {
 		/**
@@ -104,7 +104,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['url'] = $image_url;
 		}
 
-		$image_type = $image['type'] ?? null;
+		$image_type = ( $image['type'] ?? null );
 		/**
 		 * Filter: 'wpseo_opengraph_image_type' - Allow changing the Open Graph image type.
 		 *
@@ -116,7 +116,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['type'] = $image_type;
 		}
 
-		$image_width = $image['width'] ?? null;
+		$image_width = ( $image['width'] ?? null );
 		/**
 		 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
 		 *
@@ -128,7 +128,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['width'] = $image_width;
 		}
 
-		$image_height = $image['height'] ?? null;
+		$image_height = ( $image['height'] ?? null );
 		/**
 		 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
 		 *

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -23,9 +23,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	 * @var array
 	 */
 	protected static $image_tags = [
-		'width'     => 'width',
-		'height'    => 'height',
-		'type'      => 'type',
+		'width'  => 'width',
+		'height' => 'height',
+		'type'   => 'type',
 	];
 
 	/**
@@ -100,46 +100,44 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$image_url = \trim( \apply_filters( 'wpseo_opengraph_image', $image['url'], $this->presentation ) );
-		if ( ! empty( $image_url ) ) {
+		if ( ! empty( $image_url ) && \is_string( $image_url ) ) {
 			$image['url'] = $image_url;
 		}
 
-		if ( isset( $image['type'] ) ) {
-			/**
-			 * Filter: 'wpseo_opengraph_image_type' - Allow changing the Open Graph image type.
-			 *
-			 * @param string                 $image_url    The type of the Open Graph image.
-			 * @param Indexable_Presentation $presentation The presentation of an indexable.
-			 */
-			$image_type = \trim( \apply_filters( 'wpseo_opengraph_image_type', $image['type'], $this->presentation ) );
-			if ( ! empty( $image_type ) ) {
-				$image['type'] = $image_type;
-			}
+		$image_type = $image['type'] ?? null;
+		/**
+		 * Filter: 'wpseo_opengraph_image_type' - Allow changing the Open Graph image type.
+		 *
+		 * @param string                 $image_type   The type of the Open Graph image.
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		$image_type = \trim( \apply_filters( 'wpseo_opengraph_image_type', $image_type, $this->presentation ) );
+		if ( ! empty( $image_type ) && \is_string( $image_type ) ) {
+			$image['type'] = $image_type;
 		}
 
-		if ( isset( $image['width'] ) ) {
-			/**
-			 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
-			 *
-			 * @param string                 $image_url    The width of the Open Graph image.
-			 * @param Indexable_Presentation $presentation The presentation of an indexable.
-			 */
-			$image_width = (int) \apply_filters( 'wpseo_opengraph_image_width', $image['width'], $this->presentation );
-			if ( ! empty( $image_width ) && $image_width > 0 ) {
-				$image['width'] = $image_width;
-			}
+		$image_width = $image['width'] ?? null;
+		/**
+		 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
+		 *
+		 * @param string                 $image_width  The width of the Open Graph image.
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		$image_width = (int) \apply_filters( 'wpseo_opengraph_image_width', $image_width, $this->presentation );
+		if ( ! empty( $image_width ) && \is_numeric( $image_width ) && $image_width > 0 ) {
+			$image['width'] = $image_width;
 		}
-		if ( isset( $image['height'] ) ) {
-			/**
-			 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
-			 *
-			 * @param string                 $image_url    The height of the Open Graph image.
-			 * @param Indexable_Presentation $presentation The presentation of an indexable.
-			 */
-			$image_height = (int) \apply_filters( 'wpseo_opengraph_image_height', $image['height'], $this->presentation );
-			if ( ! empty( $image_height ) && $image_height > 0 ) {
-				$image['height'] = $image_height;
-			}
+
+		$image_height = $image['height'] ?? null;
+		/**
+		 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
+		 *
+		 * @param string                 $image_height The height of the Open Graph image.
+		 * @param Indexable_Presentation $presentation The presentation of an indexable.
+		 */
+		$image_height = (int) \apply_filters( 'wpseo_opengraph_image_height', $image_height, $this->presentation );
+		if ( ! empty( $image_height ) && \is_numeric( $image_height ) && $image_height > 0 ) {
+			$image['height'] = $image_height;
 		}
 
 		return $image;

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -99,9 +99,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		 * @param string                 $image_url    The URL of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		$image_url = \trim( \apply_filters( 'wpseo_opengraph_image', $image['url'], $this->presentation ) );
+		$image_url = \apply_filters( 'wpseo_opengraph_image', $image['url'], $this->presentation );
 		if ( ! empty( $image_url ) && \is_string( $image_url ) ) {
-			$image['url'] = $image_url;
+			$image['url'] = \trim( $image_url );
 		}
 
 		$image_type = ( $image['type'] ?? null );
@@ -111,9 +111,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		 * @param string                 $image_type   The type of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		$image_type = \trim( \apply_filters( 'wpseo_opengraph_image_type', $image_type, $this->presentation ) );
+		$image_type = \apply_filters( 'wpseo_opengraph_image_type', $image_type, $this->presentation );
 		if ( ! empty( $image_type ) && \is_string( $image_type ) ) {
-			$image['type'] = $image_type;
+			$image['type'] = \trim( $image_type );
 		}
 
 		$image_width = ( $image['width'] ?? null );

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -104,7 +104,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['url'] = \trim( $image_url );
 		}
 
-		$image_type = ( $image['type'] ?? null );
+		$image_type = ( $image['type'] ?? '' );
 		/**
 		 * Filter: 'wpseo_opengraph_image_type' - Allow changing the Open Graph image type.
 		 *
@@ -116,7 +116,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['type'] = \trim( $image_type );
 		}
 
-		$image_width = ( $image['width'] ?? null );
+		$image_width = ( $image['width'] ?? '' );
 		/**
 		 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
 		 *
@@ -128,7 +128,7 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 			$image['width'] = $image_width;
 		}
 
-		$image_height = ( $image['height'] ?? null );
+		$image_height = ( $image['height'] ?? '' );
 		/**
 		 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
 		 *

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -120,11 +120,11 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
 		 *
-		 * @param string                 $image_width  The width of the Open Graph image.
+		 * @param int                    $image_width  The width of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$image_width = (int) \apply_filters( 'wpseo_opengraph_image_width', $image_width, $this->presentation );
-		if ( ! empty( $image_width ) && \is_numeric( $image_width ) && $image_width > 0 ) {
+		if ( ! empty( $image_width ) && $image_width > 0 ) {
 			$image['width'] = $image_width;
 		}
 
@@ -132,11 +132,11 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		/**
 		 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
 		 *
-		 * @param string                 $image_height The height of the Open Graph image.
+		 * @param int                    $image_height The height of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$image_height = (int) \apply_filters( 'wpseo_opengraph_image_height', $image_height, $this->presentation );
-		if ( ! empty( $image_height ) && \is_numeric( $image_height ) && $image_height > 0 ) {
+		if ( ! empty( $image_height ) && $image_height > 0 ) {
 			$image['height'] = $image_height;
 		}
 

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -94,14 +94,52 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 	 */
 	protected function filter( $image ) {
 		/**
-		 * Filter: 'wpseo_opengraph_image' - Allow changing the Open Graph image.
+		 * Filter: 'wpseo_opengraph_image' - Allow changing the Open Graph image url.
 		 *
 		 * @param string                 $image_url    The URL of the Open Graph image.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
 		$image_url = \trim( \apply_filters( 'wpseo_opengraph_image', $image['url'], $this->presentation ) );
-		if ( ! empty( $image_url ) && \is_string( $image_url ) ) {
+		if ( ! empty( $image_url ) ) {
 			$image['url'] = $image_url;
+		}
+
+		if ( isset( $image['type'] ) ) {
+			/**
+			 * Filter: 'wpseo_opengraph_image_type' - Allow changing the Open Graph image type.
+			 *
+			 * @param string                 $image_url    The type of the Open Graph image.
+			 * @param Indexable_Presentation $presentation The presentation of an indexable.
+			 */
+			$image_type = \trim( \apply_filters( 'wpseo_opengraph_image_type', $image['type'], $this->presentation ) );
+			if ( ! empty( $image_type ) ) {
+				$image['type'] = $image_type;
+			}
+		}
+
+		if ( isset( $image['width'] ) ) {
+			/**
+			 * Filter: 'wpseo_opengraph_image_width' - Allow changing the Open Graph image width.
+			 *
+			 * @param string                 $image_url    The width of the Open Graph image.
+			 * @param Indexable_Presentation $presentation The presentation of an indexable.
+			 */
+			$image_width = (int) \apply_filters( 'wpseo_opengraph_image_width', $image['width'], $this->presentation );
+			if ( ! empty( $image_width ) && $image_width > 0 ) {
+				$image['width'] = $image_width;
+			}
+		}
+		if ( isset( $image['height'] ) ) {
+			/**
+			 * Filter: 'wpseo_opengraph_image_height' - Allow changing the Open Graph image height.
+			 *
+			 * @param string                 $image_url    The height of the Open Graph image.
+			 * @param Indexable_Presentation $presentation The presentation of an indexable.
+			 */
+			$image_height = (int) \apply_filters( 'wpseo_opengraph_image_height', $image['height'], $this->presentation );
+			if ( ! empty( $image_height ) && $image_height > 0 ) {
+				$image['height'] = $image_height;
+			}
 		}
 
 		return $image;

--- a/tests/Unit/Presenters/Open_Graph/Image_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Image_Presenter_Test.php
@@ -119,7 +119,12 @@ final class Image_Presenter_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_filter() {
-		$image = [ 'url' => 'https://example.com/image.jpg' ];
+		$image = [
+			'url'    => 'https://example.com/image.jpg',
+			'width'  => '100',
+			'height' => '150',
+			'type'   => 'jpg',
+		];
 
 		$this->presentation->open_graph_images = [ $image ];
 
@@ -128,7 +133,32 @@ final class Image_Presenter_Test extends TestCase {
 			->with( 'https://example.com/image.jpg', $this->presentation )
 			->andReturn( 'https://example.com/filtered_image.jpg' );
 
-		$this->assertEquals( [ [ 'url' => 'https://example.com/filtered_image.jpg' ] ], $this->instance->get() );
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_image_width' )
+			->once()
+			->with( '100', $this->presentation )
+			->andReturn( '110' );
+
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_image_height' )
+			->once()
+			->with( '150', $this->presentation )
+			->andReturn( '160' );
+
+		Monkey\Filters\expectApplied( 'wpseo_opengraph_image_type' )
+			->once()
+			->with( 'jpg', $this->presentation )
+			->andReturn( 'png' );
+
+		$this->assertEquals(
+			[
+				[
+					'url'    => 'https://example.com/filtered_image.jpg',
+					'width'  => '110',
+					'height' => '160',
+					'type'   => 'png',
+				],
+			],
+			$this->instance->get()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to allow users to filter all og:image properties.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds additional filter options for the `og:image` meta tags.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add an OG image to a post.
* Make sure you have: `meta property="og:image" <meta property="og:image:width"  <meta property="og:image:height"<meta property="og:image:type"`  in your source code.
* Add the following filter and make sure the values change:

```

add_filter( 'wpseo_opengraph_image', 'change_opengraph_image_url' );
add_filter( 'wpseo_opengraph_image_width', 'change_opengraph_image_width' );
add_filter( 'wpseo_opengraph_image_height', 'change_opengraph_image_height' );
add_filter( 'wpseo_opengraph_image_type', 'change_opengraph_image_type' );

function change_opengraph_image_url( $url ) {
	return 'https://example.com/uploads/2019/03/image.png';
}

function change_opengraph_image_width( $width ) {
	return 10408;
}

function change_opengraph_image_height ( $height ) {
	return 4800;
}
function change_opengraph_image_type ( $type ) {
	return 'type';
}
```
* Smoke test nothing changes when there is no OG image.
*  Smoke test that the first content image is still used as OG image and that the values are not overwritten when the filters are disabled but are when they are enabled.
* Smoke test there are no differences in meta when switching between trunk and this pr with no filters enabled.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
