### PR TITLE
Remove unused translations

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -58,16 +58,12 @@ class WPSEO_Metabox_Formatter {
 			'search_url'                         => '',
 			'post_edit_url'                      => '',
 			'base_url'                           => '',
-			'contentTab'                         => __( 'Readability', 'wordpress-seo' ),
-			'keywordTab'                         => __( 'Keyphrase:', 'wordpress-seo' ),
-			'removeKeyword'                      => __( 'Remove keyphrase', 'wordpress-seo' ),
 			'contentLocale'                      => get_locale(),
 			'userLocale'                         => get_user_locale(),
 			'translations'                       => $this->get_translations(),
 			'keyword_usage'                      => [],
 			'title_template'                     => '',
 			'metadesc_template'                  => '',
-			'intl'                               => $this->get_content_analysis_component_translations(),
 			'isRtl'                              => is_rtl(),
 			'isPremium'                          => YoastSEO()->helpers->product->is_premium(),
 			'siteIconUrl'                        => get_site_icon_url(),
@@ -181,7 +177,6 @@ class WPSEO_Metabox_Formatter {
 			 * @param bool $showMarkers Should the markers being enabled. Default = true.
 			 */
 			'show_markers'                       => apply_filters( 'wpseo_enable_assessment_markers', true ),
-			'analysisHeadingTitle'               => __( 'Analysis', 'wordpress-seo' ),
 			'zapierIntegrationActive'            => WPSEO_Options::get( 'zapier_integration_active', false ) ? 1 : 0,
 			'zapierConnectedStatus'              => ! empty( WPSEO_Options::get( 'zapier_subscription', [] ) ) ? 1 : 0,
 			'wordproofIntegrationActive'         => YoastSEO()->helpers->wordproof->is_active() ? 1 : 0,
@@ -199,28 +194,6 @@ class WPSEO_Metabox_Formatter {
 
 		$enabled_features = $enabled_features_repo->get_enabled_features()->parse_to_legacy_array();
 		return array_merge( $defaults, $enabled_features );
-	}
-
-	/**
-	 * Returns required yoast-component translations.
-	 *
-	 * @return string[]
-	 */
-	private function get_content_analysis_component_translations() {
-		// Esc_html is not needed because React already handles HTML in the (translations of) these strings.
-		return [
-			'locale'                                         => get_user_locale(),
-			'content-analysis.errors'                        => __( 'Errors', 'wordpress-seo' ),
-			'content-analysis.problems'                      => __( 'Problems', 'wordpress-seo' ),
-			'content-analysis.improvements'                  => __( 'Improvements', 'wordpress-seo' ),
-			'content-analysis.considerations'                => __( 'Considerations', 'wordpress-seo' ),
-			'content-analysis.good'                          => __( 'Good results', 'wordpress-seo' ),
-			'content-analysis.highlight'                     => __( 'Highlight this result in the text', 'wordpress-seo' ),
-			'content-analysis.nohighlight'                   => __( 'Remove highlight from the text', 'wordpress-seo' ),
-			'content-analysis.disabledButton'                => __( 'Marks are disabled in current view', 'wordpress-seo' ),
-			/* translators: Hidden accessibility text. */
-			'a11yNotice.opensInNewTab'                       => __( '(Opens in a new browser tab)', 'wordpress-seo' ),
-		];
 	}
 
 	/**

--- a/tests/WP/Formatter/Metabox_Formatter_Test.php
+++ b/tests/WP/Formatter/Metabox_Formatter_Test.php
@@ -33,7 +33,6 @@ final class Metabox_Formatter_Test extends TestCase {
 
 		$result = $class_instance->get_values();
 
-		$this->assertEquals( 'Readability', $result['contentTab'] );
 		$this->assertTrue( \array_key_exists( 'contentLocale', $result ) );
 		$this->assertTrue( \array_key_exists( 'translations', $result ) );
 		$this->assertTrue( \is_array( $result['translations'] ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This removes a couple of unused array keys.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes some unused translation information from our script data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* There should be no impact. But it is good to smoke test all editors to see that there are no sudden console errors.
* The smoke test should also happen in a language other than English and particularly check the translations in the Yoast metabox and even more specifically in the content analysis.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
