### PR TITLE
Modals are not opening in Elementor editor if visiting the sidebar for the 2nd time

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModal.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModal.js
@@ -12,7 +12,6 @@ import { NewButton, ButtonStyledLink } from "@yoast/components";
 import { ModalContainer } from "./modals/Container";
 import Modal from "./modals/Modal";
 import { ReactComponent as YoastIcon } from "../../images/Yoast_icon_kader.svg";
-import { isCloseEvent } from "./modals/editorModals/EditorModal.js";
 
 /**
  * Redux container for the RelatedKeyPhrasesModal modal.
@@ -29,7 +28,6 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 		super( props );
 
 		this.onModalOpen      = this.onModalOpen.bind( this );
-		this.onModalClose     = this.onModalClose.bind( this );
 		this.onLinkClick      = this.onLinkClick.bind( this );
 		this.listenToMessages = this.listenToMessages.bind( this );
 	}
@@ -46,21 +44,6 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 		}
 
 		this.props.onOpen( this.props.location );
-	}
-
-	/**
-	 * Handles the close event for the modal.
-	 *
-	 * @param {Event} event The event passed to the onRequestClose.
-	 *
-	 * @returns {void}
-	 */
-	onModalClose( event ) {
-		if ( ! isCloseEvent( event ) ) {
-			return;
-		}
-
-		this.props.onClose();
 	}
 
 	/**
@@ -171,7 +154,7 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 	 * @returns {wp.Element} The RelatedKeyPhrasesModal modal component.
 	 */
 	render() {
-		const { keyphrase, location, whichModalOpen, isLoggedIn, shouldCloseOnClickOutside } = this.props;
+		const { keyphrase, location, whichModalOpen, isLoggedIn, shouldCloseOnClickOutside, onClose } = this.props;
 
 		return (
 			<Fragment>
@@ -187,7 +170,7 @@ class SEMrushRelatedKeyphrasesModal extends Component {
 				{ keyphrase && whichModalOpen === location &&
 					<Modal
 						title={ __( "Related keyphrases", "wordpress-seo" ) }
-						onRequestClose={ this.onModalClose }
+						onRequestClose={ onClose }
 						icon={ <YoastIcon /> }
 						additionalClassName="yoast-related-keyphrases-modal"
 						shouldCloseOnClickOutside={ shouldCloseOnClickOutside }

--- a/packages/js/src/components/WincherSEOPerformanceModal.js
+++ b/packages/js/src/components/WincherSEOPerformanceModal.js
@@ -13,7 +13,6 @@ import { MetaboxButton } from "./MetaboxButton";
 import { ModalContainer } from "./modals/Container";
 import Modal from "./modals/Modal";
 import { ReactComponent as YoastIcon } from "../../images/Yoast_icon_kader.svg";
-import { isCloseEvent } from "./modals/editorModals/EditorModal.js";
 import SidebarButton from "./SidebarButton";
 import WincherSEOPerformance from "../containers/WincherSEOPerformance";
 
@@ -31,7 +30,7 @@ const StyledHeroIcon = styled( ChartBarIcon )`
  *
  * @returns {void}
  */
-export function openModal( props ) {
+function openModal( props ) {
 	const { keyphrases, onNoKeyphraseSet, onOpen, location } = props;
 
 	if ( ! keyphrases.length ) {
@@ -52,22 +51,6 @@ export function openModal( props ) {
 }
 
 /**
- * Handles the close event for the modal.
- *
- * @param {Object} props The props to use.
- * @param {Event} event The event passed to the closeModal.
- *
- * @returns {void}
- */
-export function closeModal( props, event ) {
-	if ( ! isCloseEvent( event ) ) {
-		return;
-	}
-
-	props.onClose();
-}
-
-/**
  * The WincherSEOPerformanceModal modal.
  *
  * @param {Object} props The props to use.
@@ -81,10 +64,6 @@ export default function WincherSEOPerformanceModal( props ) {
 		openModal( props );
 	}, [ openModal, props ] );
 
-	const onModalClose = useCallback( ( event ) => {
-		closeModal( props, event );
-	}, [ closeModal, props ] );
-
 	const title = __( "Track SEO performance", "wordpress-seo" );
 
 	const svgAriaProps = useSvgAria();
@@ -94,7 +73,7 @@ export default function WincherSEOPerformanceModal( props ) {
 			{ whichModalOpen === location &&
 			<Modal
 				title={ title }
-				onRequestClose={ onModalClose }
+				onRequestClose={ props.onClose }
 				icon={ <YoastIcon /> }
 				additionalClassName="yoast-wincher-seo-performance-modal yoast-gutenberg-modal__no-padding"
 				shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
@@ -140,6 +119,10 @@ WincherSEOPerformanceModal.propTypes = {
 		"postpublish",
 	] ),
 	shouldCloseOnClickOutside: PropTypes.bool,
+	keyphrases: PropTypes.array.isRequired,
+	onNoKeyphraseSet: PropTypes.func.isRequired,
+	onOpen: PropTypes.func.isRequired,
+	onClose: PropTypes.func.isRequired,
 };
 
 WincherSEOPerformanceModal.defaultProps = {

--- a/packages/js/src/components/modals/editorModals/EditorModal.js
+++ b/packages/js/src/components/modals/editorModals/EditorModal.js
@@ -1,35 +1,9 @@
+import { Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { useCallback, Fragment } from "@wordpress/element";
-import Modal from "../Modal";
-import PropTypes from "prop-types";
-import { intersection } from "lodash";
-import SidebarButton from "../../SidebarButton";
 import { LocationProvider } from "@yoast/externals/contexts";
-
-/**
- * Returns false for events passed to onRequestClose, that should not lead to the modal closing.
- * Returns true for events that indeed should lead to the modal closing.
- *
- * @param {Event} event The event that was passed to onRequestClose.
- *
- * @returns {boolean} False when this event should not lead to closing to modal. True otherwise.
- */
-export const isCloseEvent = ( event ) => {
-	let shouldClose = true;
-	if ( event?.type === "blur" ) {
-		// Catch any blur events that are not supposed to blur to modal, by identifying the clicked item.
-		const { relatedTarget } = event;
-
-		// Blur events to a non-focusable HTML element do not have a relatedTarget.
-		if ( relatedTarget ) {
-			// Modal should not close if the modal blurs because the media modal is clicked
-			const mediaModalClasses = [ "media-modal", "wp-core-ui" ];
-			shouldClose = intersection( mediaModalClasses, Array.from( relatedTarget.classList ) ).length !== mediaModalClasses.length;
-		}
-	}
-
-	return shouldClose;
-};
+import PropTypes from "prop-types";
+import SidebarButton from "../../SidebarButton";
+import Modal from "../Modal";
 
 /**
  * Returns a button in a div that can be used to open the modal.
@@ -38,68 +12,56 @@ export const isCloseEvent = ( event ) => {
  *
  * @returns {*} A button wrapped in a div.
  */
-const EditorModal = ( { id, postTypeName, children, title, isOpen, close, open,
-	shouldCloseOnClickOutside, showChangesWarning, SuffixHeroIcon } ) => {
-	const requestClose = useCallback( ( event ) => {
-		// Prevent the modal from closing when the event is a false positive.
-		if ( ! isCloseEvent( event ) ) {
-			return;
+const EditorModal = ( { id, postTypeName, children, title, isOpen, close, open, shouldCloseOnClickOutside, showChangesWarning, SuffixHeroIcon } ) => (
+	<Fragment>
+		{ isOpen &&
+			<LocationProvider value="modal">
+				<Modal
+					title={ title }
+					onRequestClose={ close }
+					additionalClassName="yoast-collapsible-modal yoast-post-settings-modal"
+					id="id"
+					shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
+				>
+					<div className="yoast-content-container">
+						<div className="yoast-modal-content">
+							{ children }
+						</div>
+					</div>
+					<div className="yoast-notice-container">
+						<hr />
+						<div className="yoast-button-container">
+							{ showChangesWarning && <p>
+								{
+									/* Translators: %s translates to the Post Label in singular form */
+									sprintf( __( "Make sure to save your %s for changes to take effect", "wordpress-seo" ), postTypeName )
+								}
+							</p> }
+							<button
+								className="yoast-button yoast-button--primary yoast-button--post-settings-modal"
+								type="button"
+								onClick={ close }
+							>
+								{
+									/* Translators: %s translates to the Post Label in singular form */
+									sprintf( __( "Return to your %s", "wordpress-seo" ), postTypeName )
+								}
+							</button>
+						</div>
+					</div>
+				</Modal>
+			</LocationProvider>
 		}
-
-		close();
-	}, [ close ] );
-
-	return (
-		<Fragment>
-			{ isOpen &&
-				<LocationProvider value="modal">
-					<Modal
-						title={ title }
-						onRequestClose={ requestClose }
-						additionalClassName="yoast-collapsible-modal yoast-post-settings-modal"
-						id="id"
-						shouldCloseOnClickOutside={ shouldCloseOnClickOutside }
-					>
-						<div className="yoast-content-container">
-							<div className="yoast-modal-content">
-								{ children }
-							</div>
-						</div>
-						<div className="yoast-notice-container">
-							<hr />
-							<div className="yoast-button-container">
-								{ showChangesWarning && <p>
-									{
-										/* Translators: %s translates to the Post Label in singular form */
-										sprintf( __( "Make sure to save your %s for changes to take effect", "wordpress-seo" ), postTypeName )
-									}
-								</p> }
-								<button
-									className="yoast-button yoast-button--primary yoast-button--post-settings-modal"
-									type="button"
-									onClick={ requestClose }
-								>
-									{
-										/* Translators: %s translates to the Post Label in singular form */
-										sprintf( __( "Return to your %s", "wordpress-seo" ), postTypeName )
-									}
-								</button>
-							</div>
-						</div>
-					</Modal>
-				</LocationProvider>
-			}
-			<SidebarButton
-				id={ id + "-open-button" }
-				title={ title }
-				SuffixHeroIcon={ SuffixHeroIcon }
-				// Fall back to the pencil square SVG icon if no hero icon has been passed.
-				suffixIcon={ SuffixHeroIcon ? null : { size: "20px", icon: "pencil-square" } }
-				onClick={ open }
-			/>
-		</Fragment>
-	);
-};
+		<SidebarButton
+			id={ id + "-open-button" }
+			title={ title }
+			SuffixHeroIcon={ SuffixHeroIcon }
+			// Fall back to the pencil square SVG icon if no hero icon has been passed.
+			suffixIcon={ SuffixHeroIcon ? null : { size: "20px", icon: "pencil-square" } }
+			onClick={ open }
+		/>
+	</Fragment>
+);
 
 EditorModal.propTypes = {
 	id: PropTypes.string.isRequired,

--- a/packages/js/src/hooks/use-mutation-observer.js
+++ b/packages/js/src/hooks/use-mutation-observer.js
@@ -1,0 +1,18 @@
+import { useEffect } from "@wordpress/element";
+
+/**
+ * Hook to use a mutation observer.
+ *
+ * @param {HTMLElement} observe The element to observe.
+ * @param {function} callback The callback to call when a mutation is observed.
+ * @param {MutationObserverInit} options The options to pass to the observer.
+ *
+ * @returns {void}
+ */
+export const useMutationObserver = ( observe, callback, options = { childList: true, subtree: true } ) => {
+	useEffect( () => {
+		const observer = new MutationObserver( callback );
+		observer.observe( observe, options );
+		return () => observer.disconnect();
+	}, [ observe, callback ] );
+};

--- a/packages/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
+++ b/packages/js/tests/components/SEMrushRelatedKeyphrasesModal.test.js
@@ -60,17 +60,6 @@ describe( "SEMrushRelatedKeyphrasesModal", () => {
 		} );
 	} );
 
-	describe( "onModalClose", () => {
-		it( "successfully calls the close method", async() => {
-			render( <SEMrushRelatedKeyphrasesModal { ...props } keyphrase="yoast seo" isLoggedIn={ true } whichModalOpen="metabox" /> );
-
-			const closeModalButton = screen.getByLabelText( "Close dialog" );
-			fireEvent.click( closeModalButton );
-
-			expect( props.onClose ).toHaveBeenCalled();
-		} );
-	} );
-
 	describe( "onLinkClick", () => {
 		it( "successfully opens the popup when the user is not logged in, " +
 			"a keyphrase is present and the 'Get related keyphrases' button is clicked", () => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where our modals would not open when visiting our sidebar in Elementor for the second time.

## Relevant technical choices:

**Always render our React Tree**
Elementor removes the element we rendered in. This left ghost renders on the page. In order to fix this, we now:
* always render our React tree (in a div we add to the body)
* instead of full render, we only add a div when the Yoast tab is active
* use a mutation observer to check the div exists
* create and render the portal to the div with the contents of our sidebar

This all seems pretty hacky, but I couldn't think of a better way to get the portal to only be created when the element exists.
Other changes here:
* Hiding the `elementor-control` is needed now as before the React render would replace the contents of it
* Removed the StyleSheetManager as the `elementor-panel-inner` is not there on initial load. I'm not sure why we needed to target the styles, it seems to work fine with rendering them in the head

**Remove the close event check of the editor modal**
The `shouldCloseOnClickOutside` determines outside click, the on close does not need to check this anymore.
[The issue where this close event check was introduced](https://github.com/Yoast/wordpress-seo/pull/16363) was intended to fix the immediate close of the modal in Elementor, just like this PR

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Issue**
* To double check extendability, enable our Premium, Video and News add-ons.
* Edit a post in Elementor
* Open the Yoast sidebar
* Go to somewhere else (e.g. settings)
* Open the Yoast sidebar again
* Try to open a modal of ours i.e. Search Appearance/Social Media Appearance/Insight etc.
* [ ] Verify it no longer immediately closes
* [ ] Verify you see the related keyphrases (or any Premium thing)
* [ ] Verify you see the Video collapsible
* [ ] Verify you see the News collapsible

**Editor modals**
* Edit a post in the block editor
* Open the Yoast sidebar
* Ensure you have a focus keyphrase
* Click on Get related keyphrases to open the Semrush modal
  * Approve if needed, so you get the modal, not the browser popup
* [ ] Verify the modal still closes when clicking outside
* [ ] Open again and verify the modal still closes on clicking the x button
* Click on Track SEO performance to open the Wincher modal
* [ ] Verify the modal still closes when clicking outside
* [ ] Open again and verify the modal still closes on clicking the x button
* Click on the Search appearance to open the modal
* [ ] Verify the modal still closes on clicking the x button
* [ ] Open again and verify the modal still closes on clicking the return to your post button
* Click on the Social appearance to open the modal
* [ ] Verify the modal still closes on clicking the x button
* [ ] Open again and verify the modal still closes on clicking the return to your post button
* Click on the Insights to open the modal
* [ ] Verify the modal still closes when clicking outside
* [ ] Open again and verify the modal still closes on clicking the x button
* [ ] Open again and verify the modal still closes on clicking the return to your post button

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The modals in our editors

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1559
