### PR TITLE
Add an integration to check the `Requires Yoast SEO` header.

### DIFF
--- a/src/conditionals/check-required-version-conditional.php
+++ b/src/conditionals/check-required-version-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional for the CHECK_REQUIRED_VERSION feature flag.
+ */
+class Check_Required_Version_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'CHECK_REQUIRED_VERSION';
+	}
+}

--- a/src/initializers/plugin-headers.php
+++ b/src/initializers/plugin-headers.php
@@ -12,7 +12,7 @@ class Plugin_Headers implements Initializer_Interface {
 	use No_Conditionals;
 
 	/**
-	 * Hooks into WooCommerce.
+	 * Hooks into the list of the plugin headers.
 	 *
 	 * @return void
 	 */

--- a/src/initializers/plugin-headers.php
+++ b/src/initializers/plugin-headers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoast\WP\SEO\Initializers;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+
+/**
+ * Adds custom headers to the list of plugin headers to read.
+ */
+class Plugin_Headers implements Initializer_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Hooks into WooCommerce.
+	 *
+	 * @return void
+	 */
+	public function initialize() {
+		\add_filter( 'extra_plugin_headers', [ $this, 'add_requires_yoast_seo_header' ] );
+	}
+
+	/**
+	 * Add the `Requires Yoast SEO` header to the list of headers.
+	 *
+	 * @param array<string> $headers The headers.
+	 *
+	 * @return array<string> The updated headers.
+	 */
+	public function add_requires_yoast_seo_header( $headers ) {
+		$headers[] = 'Requires Yoast SEO';
+		return $headers;
+	}
+}

--- a/src/integrations/admin/check-required-version.php
+++ b/src/integrations/admin/check-required-version.php
@@ -76,7 +76,7 @@ class Check_Required_Version implements Integration_Interface {
 			}
 		}
 
-		$requires_yoast_seo = ! empty( $info['Requires Yoast SEO'] ) ? $info['Requires Yoast SEO'] : null;
+		$requires_yoast_seo = ! empty( $info['Requires Yoast SEO'] ) ? $info['Requires Yoast SEO'] : false;
 
 		if ( ! $this->check_requirement( $requires_yoast_seo ) ) {
 			$error = \sprintf(
@@ -126,12 +126,12 @@ class Check_Required_Version implements Integration_Interface {
 	/**
 	 * Check whether the required Yoast SEO version is installed.
 	 *
-	 * @param string $required_version The required version.
+	 * @param string|bool $required_version The required version.
 	 *
 	 * @return bool Whether the required version is installed, or no version is required.
 	 */
 	private function check_requirement( $required_version ) {
-		if ( ! $required_version ) {
+		if ( $required_version === false ) {
 			return true;
 		}
 

--- a/src/integrations/admin/check-required-version.php
+++ b/src/integrations/admin/check-required-version.php
@@ -73,7 +73,7 @@ class Check_Required_Version implements Integration_Interface {
 
 			return new WP_Error(
 				'incompatible_yoast_seo_required_version',
-				\__( 'The package could not be installed.', 'wordpress-seo' ),
+				\__( 'The package could not be installed because it\'s not supported by the currently installed Yoast SEO version.', 'wordpress-seo' ),
 				$error
 			);
 		}

--- a/src/integrations/admin/check-required-version.php
+++ b/src/integrations/admin/check-required-version.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use Plugin_Upgrader;
 use WP_Error;
 use WP_Upgrader;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Check_Required_Version_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -16,8 +16,6 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
  */
 class Check_Required_Version implements Integration_Interface {
 
-	use No_Conditionals;
-
 	/**
 	 * Initializes the integration.
 	 *
@@ -26,6 +24,15 @@ class Check_Required_Version implements Integration_Interface {
 	public function register_hooks() {
 		\add_filter( 'upgrader_source_selection', [ $this, 'check_required_version' ], 10, 3 );
 		\add_filter( 'install_plugin_overwrite_comparison', [ $this, 'update_comparison_table' ], 10, 3 );
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return string[] The conditionals based on which this loadable should be active.
+	 */
+	public static function get_conditionals() {
+		return [ Check_Required_Version_Conditional::class ];
 	}
 
 	/**

--- a/src/integrations/admin/check-required-version.php
+++ b/src/integrations/admin/check-required-version.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WP_Error;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * The Check_Required_Version class.
+ *
+ * This class checks if the required version of Yoast SEO is installed.
+ * It also adds the `Requires Yoast SEO` header to the list of headers and updates the comparison table for the plugin overwrite.
+ */
+class Check_Required_Version implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'upgrader_source_selection', [ $this, 'check_required_version' ] );
+		\add_filter( 'extra_plugin_headers', [ $this, 'add_requires_yoast_seo_header' ] );
+		\add_filter( 'install_plugin_overwrite_comparison', [ $this, 'update_comparison_table' ], 10, 3 );
+	}
+
+	/**
+	 * Checks if the required version of Yoast SEO is installed.
+	 *
+	 * The code is partly inspired by Plugin_Upgrader::check_package() in wp-admin/includes/class-plugin-upgrader.php.
+	 *
+	 * @param string $source File source location.
+	 *
+	 * @return string|WP_Error The source location or a WP_Error object if the required version is not installed.
+	 */
+	public function check_required_version( $source ) {
+		global $wp_filesystem;
+
+		$info = [];
+
+		if ( \is_wp_error( $source ) ) {
+			return $source;
+		}
+
+		$working_directory = \str_replace( $wp_filesystem->wp_content_dir(), \trailingslashit( \WP_CONTENT_DIR ), $source );
+		if ( ! \is_dir( $working_directory ) ) { // Confidence check, if the above fails, let's not prevent installation.
+			return $source;
+		}
+
+		// Check that the folder contains at least 1 valid plugin.
+		$files = \glob( $working_directory . '*.php' );
+		if ( $files ) {
+			foreach ( $files as $file ) {
+				$info = \get_plugin_data( $file, false, false );
+				if ( ! empty( $info['Name'] ) ) {
+					break;
+				}
+			}
+		}
+
+		$requires_yoast_seo = ( $info['Requires Yoast SEO'] ?? null );
+
+		if ( ! $this->check_requirement( $requires_yoast_seo ) ) {
+			$error = \sprintf(
+				/* translators: 1: Current Yoast SEO version, 2: Version required by the uploaded plugin. */
+				\__( 'The Yoast SEO version on your site is %1$s, however the uploaded plugin requires %2$s.', 'wordpress-seo' ),
+				\WPSEO_VERSION,
+				$requires_yoast_seo
+			);
+
+			return new WP_Error(
+				'incompatible_yoast_seo_required_version',
+				\__( 'The package could not be installed.', 'wordpress-seo' ),
+				$error
+			);
+		}
+
+		return $source;
+	}
+
+	/**
+	 * Add the `Requires Yoast SEO` header to the list of headers.
+	 *
+	 * @param array<string> $headers The headers.
+	 *
+	 * @return array<string> The updated headers.
+	 */
+	public function add_requires_yoast_seo_header( $headers ) {
+		$headers[] = 'Requires Yoast SEO';
+		return $headers;
+	}
+
+	/**
+	 * Update the comparison table for the plugin installation when overwriting an existing plugin.
+	 *
+	 * @param string        $table               The output table with Name, Version, Author, RequiresWP, and RequiresPHP info.
+	 * @param array<string> $current_plugin_data Array with current plugin data.
+	 * @param array<string> $new_plugin_data     Array with uploaded plugin data.
+	 *
+	 * @return string The updated comparison table.
+	 */
+	public function update_comparison_table( $table, $current_plugin_data, $new_plugin_data ) {
+		$requires_yoast_seo_current = ( $current_plugin_data['Requires Yoast SEO'] ?? null );
+		$requires_yoast_seo_new     = ( $new_plugin_data['Requires Yoast SEO'] ?? null );
+
+		if ( $requires_yoast_seo_current || $requires_yoast_seo_new ) {
+			$new_row = \sprintf(
+				'<tr><td class="name-label">%1$s</td><td>%2$s</td><td>%3$s</td></tr>',
+				\__( 'Required Yoast SEO version', 'wordpress-seo' ),
+				( $requires_yoast_seo_current ?? '-' ),
+				( $requires_yoast_seo_new ?? '-' )
+			);
+
+			$table = \str_replace( '</tbody>', $new_row . '</tbody>', $table );
+		}
+
+		return $table;
+	}
+
+	/**
+	 * Check whether the required Yoast SEO version is installed.
+	 *
+	 * @param string $required_version The required version.
+	 *
+	 * @return bool Whether the required version is installed, or no version is required.
+	 */
+	private function check_requirement( $required_version ) {
+		if ( ! $required_version ) {
+			return true;
+		}
+
+		return \version_compare( \WPSEO_VERSION, $required_version . '-RC0', '>=' );
+	}
+}

--- a/src/integrations/admin/check-required-version.php
+++ b/src/integrations/admin/check-required-version.php
@@ -23,7 +23,6 @@ class Check_Required_Version implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'upgrader_source_selection', [ $this, 'check_required_version' ] );
-		\add_filter( 'extra_plugin_headers', [ $this, 'add_requires_yoast_seo_header' ] );
 		\add_filter( 'install_plugin_overwrite_comparison', [ $this, 'update_comparison_table' ], 10, 3 );
 	}
 
@@ -79,18 +78,6 @@ class Check_Required_Version implements Integration_Interface {
 		}
 
 		return $source;
-	}
-
-	/**
-	 * Add the `Requires Yoast SEO` header to the list of headers.
-	 *
-	 * @param array<string> $headers The headers.
-	 *
-	 * @return array<string> The updated headers.
-	 */
-	public function add_requires_yoast_seo_header( $headers ) {
-		$headers[] = 'Requires Yoast SEO';
-		return $headers;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents the installation of addons requiring a higher Yoast SEO version than the current one if the `YOAST_SEO_CHECK_REQUIRED_VERSION` is set.

## Relevant technical choices:

* We need to inject the custom header via an initializer since the cache might be primed with the plugins data earlier in the process
* I did not add tests since the methods are not easy to trigger outside the flow of the plugin update

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Important**: Use the provided zips (see [Slack](https://yoast.slack.com/archives/C03KU0EHCNQ/p1724853605240619))

* Connect a site (e.g. a TasteWP site) to MyYoast (you need all the addons, not just Premium)
* install and activate Free 22.7-requirement-check
* set the feature flag by adding `define( 'YOAST_SEO_CHECK_REQUIRED_VERSION', true );` to `wp-config.php`
  * if you can't (TasteWP doesn't allow you for example), install and activate the `set-feature-flag.zip` plugin
* install and activate VideoSEO 14.8
* visit the Dashboard > Updates
  * you should see that both Free and VideoSEO can be upgraded
* Select **only** VideoSEO and update
* See that you get this message and VideoSEO is not updated
![Screenshot 2024-08-13 at 16-17-40 Update Plugins ‹ Shiny Cave — WordPress](https://github.com/user-attachments/assets/5afdfae4-ff0f-4937-93d5-4e32c3a8449c)
* Visit the Plugins page
* click on "update now" **only** for VideoSEO
* See that the update fails with the alert `Update failed: The package could not be installed because it's not supported by the currently installed Yoast SEO version.`
* Upload VideoSEO 14.9
* See that you get this message and VideoSEO is not updated
![Screenshot 2024-09-02 at 11 02 09](https://github.com/user-attachments/assets/6fb89dac-763c-4beb-9f67-ddf899e93e88)
* install and activate Free 23.2-requirement-check
* try to update VideoSEO in any way and see it works now
* install and activate Premium 23.2
* visit the Dashboard > Updates
  * you should see that both Free and Premium can be upgraded
* Select **only** Premium and update
* See that you get this message and Premium is not updated
![Screenshot 2024-08-13 at 15-31-07 Update Plugins ‹ Shiny Cave — WordPress](https://github.com/user-attachments/assets/cf17f07b-c46c-4123-90eb-0743f386f11c)
* Visit the Plugins page
* click on "update now" **only** for Premium
* See that the update fails with the alert `Update failed: The package could not be installed because it's not supported by the currently installed Yoast SEO version.`
* Upload Premium 23.3
* See that you get this message and Premium is not updated
![Screenshot 2024-08-13 at 15-34-41 Upload Plugin ‹ Shiny Cave — WordPress](https://github.com/user-attachments/assets/b9388674-886e-4d50-85f9-f79d7d83dd43)
* if you want, check that the above works even if Premium is not active (but Free still needs to be active for the check to be working)
* install Free 23.3-requirement-check
* try to update Premium in any way and see it works now
* Upload any Premium ZIP to overwrite the existing Premium and see that you get a new "Required Yoast SEO" row in the table outlining the plugin params:
![Screenshot 2024-08-14 at 12-04-48 Upload Plugin ‹ Display Airport — WordPress](https://github.com/user-attachments/assets/7dca5017-8b5b-4374-9948-03f22ee08881)
* Finally, remove the feature flag or disable the small plugin and recheck the above to see that all the upgrades are allowed now instead.


 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/roadmap/issues/448
