### PR TITLE
Adds fallback to main url when the indexable is not available.

### DIFF
--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -99,11 +99,13 @@ class Feed_Improvements implements Integration_Interface {
 	 * @return void
 	 */
 	public function send_canonical_header( $for_comments ) {
+
 		if ( $for_comments || \headers_sent() ) {
 			return;
 		}
+
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
-		if ( ! empty( $url ) && $url !== $this->meta->for_home_page()->canonical ) {
+		if ( ! empty( $url ) ) {
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -143,42 +143,35 @@ class Feed_Improvements implements Integration_Interface {
 		$queried_object = \get_queried_object();
 		// Don't call get_class with null. This gives a warning.
 		$class = ( $queried_object !== null ) ? \get_class( $queried_object ) : null;
+		$meta  = false;
 
 		switch ( $class ) {
 			// Post type archive feeds.
 			case 'WP_Post_Type':
 				$meta = $this->meta->for_post_type_archive( $queried_object->name );
-				if ( $meta ) {
-					$url = $meta->canonical;
-				}
 				break;
 			// Post comment feeds.
 			case 'WP_Post':
 				$meta = $this->meta->for_post( $queried_object->ID );
-				if ( $meta ) {
-					$url = $meta->canonical;
-				}
 				break;
 			// Term feeds.
 			case 'WP_Term':
 				$meta = $this->meta->for_term( $queried_object->term_id );
-				if ( $meta ) {
-					$url = $meta->canonical;
-				}
 				break;
 			// Author feeds.
 			case 'WP_User':
 				$meta = $this->meta->for_author( $queried_object->ID );
-				if ( $meta ) {
-					$url = $meta->canonical;
-				}
 				break;
 			// This would be NULL on the home page and on date archive feeds.
 			case null:
-				$url = $this->meta->for_home_page()->canonical;
+				$meta = $this->meta->for_home_page();
 				break;
 			default:
 				break;
+		}
+
+		if ( $meta ) {
+			return $meta->canonical;
 		}
 
 		return $url;

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -99,13 +99,11 @@ class Feed_Improvements implements Integration_Interface {
 	 * @return void
 	 */
 	public function send_canonical_header( $for_comments ) {
-
 		if ( $for_comments || \headers_sent() ) {
 			return;
 		}
-
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
-		if ( ! empty( $url ) ) {
+		if ( ! empty( $url ) && $url !== $this->meta->for_home_page()->canonical ) {
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -104,8 +104,12 @@ class Feed_Improvements implements Integration_Interface {
 			return;
 		}
 
+		$queried_object = \get_queried_object();
+		// Don't call get_class with null. This gives a warning.
+		$class = ( $queried_object !== null ) ? \get_class( $queried_object ) : null;
+
 		$url = $this->get_url_for_queried_object( $this->meta->for_home_page()->canonical );
-		if ( ! empty( $url ) ) {
+		if ( ( ! empty( $url ) && $url !== $this->meta->for_home_page()->canonical ) || $class === null ) {
 			\header( \sprintf( 'Link: <%s>; rel="canonical"', $url ), false );
 		}
 	}

--- a/src/integrations/front-end/feed-improvements.php
+++ b/src/integrations/front-end/feed-improvements.php
@@ -149,19 +149,31 @@ class Feed_Improvements implements Integration_Interface {
 		switch ( $class ) {
 			// Post type archive feeds.
 			case 'WP_Post_Type':
-				$url = $this->meta->for_post_type_archive( $queried_object->name )->canonical;
+				$meta = $this->meta->for_post_type_archive( $queried_object->name );
+				if ( $meta ) {
+					$url = $meta->canonical;
+				}
 				break;
 			// Post comment feeds.
 			case 'WP_Post':
-				$url = $this->meta->for_post( $queried_object->ID )->canonical;
+				$meta = $this->meta->for_post( $queried_object->ID );
+				if ( $meta ) {
+					$url = $meta->canonical;
+				}
 				break;
 			// Term feeds.
 			case 'WP_Term':
-				$url = $this->meta->for_term( $queried_object->term_id )->canonical;
+				$meta = $this->meta->for_term( $queried_object->term_id );
+				if ( $meta ) {
+					$url = $meta->canonical;
+				}
 				break;
 			// Author feeds.
 			case 'WP_User':
-				$url = $this->meta->for_author( $queried_object->ID )->canonical;
+				$meta = $this->meta->for_author( $queried_object->ID );
+				if ( $meta ) {
+					$url = $meta->canonical;
+				}
 				break;
 			// This would be NULL on the home page and on date archive feeds.
 			case null:


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug where we throw a PHP notice when the canonical URL of the parent page wasn't found.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a PHP notice would be thrown on RSS feeds when a canonical URL can not be created for its parent page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

_(in all cases, there should be no PHP notices thrown once you load the feeds)_

## Author case.
* Make sure you don't have `Remove post authors feeds` enabled in de crawl optimizations. And make sure you do have author archives enabled.
* Make sure you have 1 author with a post and an indexable.
* Create a fresh author without any posts or indexables.
* Much like the production version: go to http://basic.wordpress.test/author/{authorname}/feed/ where {authorname} is your author `with` a post. You should see `<link>http://basic.wordpress.test/author/{authorname}/</link>` In the network tab make sure you see a header in the request for the page with a `link` to `<http://basic.wordpress.test/author/{authorname}/>; rel="canonical"`

![image](https://github.com/Yoast/wordpress-seo/assets/12400734/a055d266-64b6-48ce-ad7f-abd263a8bdb3)

* Go to http://basic.wordpress.test/author/{authorname}/feed/ where {authorname} is your author `without` a post. You should see `<link>http://basic.wordpress.test/</link>`. Also make sure there is no canonical header.
 
## Term case
* Go to the archive page of a category and add /feed/. Much like the production version: make sure the `link` points to that category page and the Link header does the same.
* Remove the indexable for this category (or clean all indexables) and add the following filter:
```php
add_filter( 'wpseo_indexable_excluded_taxonomies', 'exclude_category' );
function exclude_category ( ) {
	return ['category'];
}
```
* Refresh and make sure the `link` now goes to the homepage. Also make sure there is no canonical header.


## Post case
* Go to a page and add at the end of its URL the `/feed/`. Much like the production version: make sure the `link` points to that specific page.
* Remove the indexable for this page (or clean all indexables) and add the following filter:
```php
add_filter( 'wpseo_indexable_excluded_post_types', 'exclude_page' );
function exclude_page( ) {
	return ['page'];
}
```
* Refresh and make sure the `link` now goes to the homepage. Also make sure there is no canonical header.

## CPT archive case
* Go to the archive page of a CPT and add /feed/. Much like the production version: make sure the `link` points to that specific page. For example `http://basic.wordpress.test/yoast-test-movies/feed` 
* Remove the indexable for this page (or clean all indexables) and add the following filter:
```php
add_filter( 'wpseo_indexable_excluded_post_types', 'exclude_page' );
function exclude_page( ) {
	return ['movie'];
}
```
* Refresh and make sure the `link` now goes to the homepage. Also make sure there is no canonical header.
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test the RSS feed for the homepage
  * Go to the homepage and add /feed/. Much like the production version: make sure the `link` tag and the Link header point to the homepage. For example `http://basic.wordpress.test/` 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
https://github.com/Yoast/wordpress-seo/issues/20436