### PR TITLE
Breadcrumbs:  HTML wrap filtering improved (Accessibility purpose)

### DIFF
--- a/src/integrations/blocks/breadcrumbs-block.php
+++ b/src/integrations/blocks/breadcrumbs-block.php
@@ -64,6 +64,13 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 	private $request_helper;
 
 	/**
+	 * The wrapper element.
+	 *
+	 * @var string
+	 */
+	private $wrapper_element;
+
+	/**
 	 * Siblings_Block constructor.
 	 *
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer     The context.
@@ -133,6 +140,24 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 			$class_name .= ' ' . \esc_attr( $attributes['className'] );
 		}
 
-		return '<div class="' . $class_name . '">' . $presenter->present() . '</div>';
+		return '<' . $this->get_wrapper_element() . ' class="' . $class_name . '">' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
+	}
+
+	/**
+	 * Retrieves the crumb element name.
+	 *
+	 * @return string The element to use.
+	 */
+	protected function get_wrapper_element() {
+		if ( ! $this->wrapper_element ) {
+			$this->wrapper_element = \esc_attr( \apply_filters( 'wpseo_breadcrumb_wrapper_element', 'div' ) );
+			$this->wrapper_element = \tag_escape( $this->wrapper_element );
+
+			if ( ! \is_string( $this->wrapper_element ) || $this->wrapper_element === '' ) {
+				$this->wrapper_element = 'div';
+			}
+		}
+
+		return $this->wrapper_element;
 	}
 }

--- a/src/integrations/blocks/breadcrumbs-block.php
+++ b/src/integrations/blocks/breadcrumbs-block.php
@@ -161,7 +161,7 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 			}
 		}
 
-		return '<' . $this->get_wrapper_element() . ' class="' . sanitize_html_class( $class_name, $default_class_name ) . '"' . $added_attributes_output . '>' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
+		return '<' . $this->get_wrapper_element() . ' class="' . esc_attr( $class_name ) . '"' . $added_attributes_output . '>' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
 	}
 
 	/**

--- a/src/integrations/blocks/breadcrumbs-block.php
+++ b/src/integrations/blocks/breadcrumbs-block.php
@@ -134,13 +134,14 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 		$presenter->presentation = $presentation;
 		$presenter->replace_vars = $this->replace_vars;
 		$presenter->helpers      = $this->helpers;
-		$class_name              = 'yoast-breadcrumbs';
+		$default_class_name      = 'yoast-breadcrumbs';
+		$class_name              = \apply_filters( 'wpseo_breadcrumb_wrapper_classname', $default_class_name );
 
 		if ( ! empty( $attributes['className'] ) ) {
 			$class_name .= ' ' . \esc_attr( $attributes['className'] );
 		}
 
-		return '<' . $this->get_wrapper_element() . ' class="' . $class_name . '">' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
+		return '<' . $this->get_wrapper_element() . ' class="' . sanitize_html_class( $class_name, $default_class_name ) . '">' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
 	}
 
 	/**

--- a/src/integrations/blocks/breadcrumbs-block.php
+++ b/src/integrations/blocks/breadcrumbs-block.php
@@ -135,19 +135,40 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 		$presenter->replace_vars = $this->replace_vars;
 		$presenter->helpers      = $this->helpers;
 		$default_class_name      = 'yoast-breadcrumbs';
+		/**
+		 * Filter: 'wpseo_breadcrumb_wrapper_classname' - Allow changing the HTML output of the Yoast SEO breadcrumbs wrapper classname.
+		 *
+		 * @param string  $class_name   The classname of the wrapper (default "yoast-breadcrumbs").
+		 * @author Geoffrey Crofte
+		 */
 		$class_name              = \apply_filters( 'wpseo_breadcrumb_wrapper_classname', $default_class_name );
+		/**
+		 * Filter: 'wpseo_breadcrumb_wrapper_attributes' - Allow adding attributes to the HTML output of the Yoast SEO breadcrumbs wrapper.
+		 *
+		 * @param array   $added_attributes   The added attributes using an array of this type: `array('aria-label' => __('Breadcrumbs') )`
+		 * @author Geoffrey Crofte (geoffreycrofte.com)
+		 */
+		$added_attributes        = \apply_filters( 'wpseo_breadcrumb_wrapper_attributes', array() );
+		$added_attributes_output = '';
 
 		if ( ! empty( $attributes['className'] ) ) {
 			$class_name .= ' ' . \esc_attr( $attributes['className'] );
 		}
 
-		return '<' . $this->get_wrapper_element() . ' class="' . sanitize_html_class( $class_name, $default_class_name ) . '">' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
+		if ( ! empty( $added_attributes ) && is_array( $added_attributes ) ) {
+			foreach ($added_attributes as $attr_name => $attr_value) {
+				$added_attributes_output .= ' ' . esc_attr( $attr_name ) . '="' . esc_attr( $attr_value ) . '"'; 
+			}
+		}
+
+		return '<' . $this->get_wrapper_element() . ' class="' . sanitize_html_class( $class_name, $default_class_name ) . '"' . $added_attributes_output . '>' . $presenter->present() . '</' . $this->get_wrapper_element() . '>';
 	}
 
 	/**
-	 * Retrieves the crumb element name.
+	 * Retrieves the breadcrumb global wrapper element name.
 	 *
 	 * @return string The element to use.
+	 * @author Geoffrey Crofte (geoffreycrofte.com)
 	 */
 	protected function get_wrapper_element() {
 		if ( ! $this->wrapper_element ) {


### PR DESCRIPTION
## Context
This PR brings some new filters to help developers customize the HTML output of the breadcrumbs.

Following accessibility good practice, a breadcrumbs is a `nav` element with a distinguisable label.
I need to be able to edit the default `div` element to replace it, and also add some custom attributes like an explicit `role` or `aria-label`.

Adding these filters should help me reach my goals.

PS. my first time contributing here, sorry if I didn't take the right initial branch, the readme don't tell much about that. (unless I missed the info)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* changelog: enhancement - adds a `wpseo_breadcrumb_wrapper_classname` filter to customize the wrapper classname
* changelog: enhancement - adds a `wpseo_breadcrumb_wrapper_attributes` filter to customize the wrapper attributes list
* changelog: enhancement - adds a `wpseo_breadcrumb_wrapper_element` filter to customize the wrapper HTML element

## Relevant technical choices:

* I tried to follow the existing code base found on near code
* I documented the new hooks
* I kept the default behavior (meaning if you don't use the hooks, you won't see changes)
* I've changed the block's PHP files, but I sincerely don't know if it needs more than that.

## Test instructions

To test the hooks and changes, you can use this code:

```php
add_filter( 'wpseo_breadcrumb_wrapper_element', 'rework_yoast_bc_wrapper_html_element' );
function rework_yoast_bc_wrapper_html_element() {
  return 'nav';
}
 
add_filter( 'wpseo_breadcrumb_wrapper_classname', 'rework_yoast_bc_wrapper_html_classname' );
function rework_yoast_bc_wrapper_html_classname( $default ) {
  return $default . " " . 'my-new-class';
}
 
add_filter( 'wpseo_breadcrumb_wrapper_attributes', 'rework_yoast_bc_wrapper_html_attributes' );
function rework_yoast_bc_wrapper_html_attributes() {
  return array(
          'aria-label' => __("Breadcrumbs"),
          'role'       => 'navigation'
        );
}
```

#### Relevant test scenarios
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Breadcrumbs block: double check that default behavior is still there.
* Try the code provided above to check the HTML editions on the breacrumbs block in front-end

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set. (I used the `Trunk` default branch)

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
