### PR TITLE
Exclude keyphrases from complex words

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-statements */
 
 import wordComplexity from "../../../src/languageProcessing/researches/wordComplexity.js";
+import keywordForms from "../../../src/languageProcessing/researches/wordComplexity.js";
 import Paper from "../../../src/values/Paper";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
@@ -172,6 +173,29 @@ describe( "test with different language specific helper and config", () => {
 		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperGerman );
 		researcher.addConfig( "wordComplexity", wordComplexityConfigGerman );
 		researcher.addResearchData( "morphology", premiumDataDe );
+
+		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
+		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );
+	} );
+
+	it( "uses returns an empty array and 0% " +
+		"when there are only function words and keyphrases in the text.", () => {
+		let paper = new Paper( "The paradigm is hard to understand" );
+		let researcher = new EnglishResearcher( paper );
+		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperEnglish );
+		researcher.addConfig( "wordComplexity", wordComplexityConfigEnglish );
+		researcher.addResearchData( "morphology", premiumDataEn );
+		keywordForms = [ "paradigm", "paradigms" ];
+
+		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
+		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );
+
+		paper = new Paper( "Tiene usted una nueva computadora." );
+		researcher = new SpanishResearcher( paper );
+		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperSpanish );
+		researcher.addConfig( "wordComplexity", wordComplexityConfigSpanish );
+		researcher.addResearchData( "morphology", premiumDataEs );
+		keywordForms = [ "nueva computadora", "nuevas computadoras" ];
 
 		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );

--- a/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-statements */
 
 import wordComplexity from "../../../src/languageProcessing/researches/wordComplexity.js";
-import keywordForms from "../../../src/languageProcessing/researches/wordComplexity.js";
+import keyphraseForms from "../../../src/languageProcessing/researches/wordComplexity.js";
 import Paper from "../../../src/values/Paper";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
@@ -185,7 +185,7 @@ describe( "test with different language specific helper and config", () => {
 		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperEnglish );
 		researcher.addConfig( "wordComplexity", wordComplexityConfigEnglish );
 		researcher.addResearchData( "morphology", premiumDataEn );
-		keywordForms = [ "paradigm", "paradigms" ];
+		keyphraseForms = [ "paradigm", "paradigms" ];
 
 		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );
@@ -195,7 +195,7 @@ describe( "test with different language specific helper and config", () => {
 		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperSpanish );
 		researcher.addConfig( "wordComplexity", wordComplexityConfigSpanish );
 		researcher.addResearchData( "morphology", premiumDataEs );
-		keywordForms = [ "nueva computadora", "nuevas computadoras" ];
+		keyphraseForms = [ "nueva computadora", "nuevas computadoras" ];
 
 		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );

--- a/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/wordComplexitySpec.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-statements */
 
 import wordComplexity from "../../../src/languageProcessing/researches/wordComplexity.js";
-import keyphraseForms from "../../../src/languageProcessing/researches/wordComplexity.js";
 import Paper from "../../../src/values/Paper";
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher";
 import GermanResearcher from "../../../src/languageProcessing/languages/de/Researcher";
@@ -178,24 +177,21 @@ describe( "test with different language specific helper and config", () => {
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );
 	} );
 
-	it( "uses returns an empty array and 0% " +
-		"when there are only function words and keyphrases in the text.", () => {
-		let paper = new Paper( "The paradigm is hard to understand" );
+	it( "returns an empty array and 0% when there are only function words and keyphrases in the text.", () => {
+		let paper = new Paper( "These new paradigms are hard to understand.", { keyword: "paradigm" } );
 		let researcher = new EnglishResearcher( paper );
 		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperEnglish );
 		researcher.addConfig( "wordComplexity", wordComplexityConfigEnglish );
 		researcher.addResearchData( "morphology", premiumDataEn );
-		keyphraseForms = [ "paradigm", "paradigms" ];
 
 		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );
 
-		paper = new Paper( "Tiene usted una nueva computadora." );
+		paper = new Paper( "Contamos con lo más nuevo en computadoras.", { keyword: "nueva computadora" } );
 		researcher = new SpanishResearcher( paper );
 		researcher.addHelper( "checkIfWordIsComplex", wordComplexityHelperSpanish );
 		researcher.addConfig( "wordComplexity", wordComplexityConfigSpanish );
 		researcher.addResearchData( "morphology", premiumDataEs );
-		keyphraseForms = [ "nueva computadora", "nuevas computadoras" ];
 
 		expect( wordComplexity( paper, researcher ).complexWords ).toEqual( [] );
 		expect( wordComplexity( paper, researcher ).percentage ).toEqual( 0 );

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -3,7 +3,8 @@ import { flatMap, get } from "lodash";
 import getSentences from "../helpers/sentence/getSentences";
 import getWords from "../helpers/word/getWords";
 import removeHtmlBlocks from "../helpers/html/htmlParser";
-import { filterShortcodesFromHTML } from "../helpers/sanitize/filterShortcodesFromTree";
+import { filterShortcodesFromHTML } from "../helpers";
+import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString";
 
 /**
  * An object containing the results of the complex words research for a single sentence.
@@ -36,41 +37,18 @@ const getComplexWords = function( currentSentence, researcher ) {
 	const checkIfWordIsFunction = researcher.getHelper( "checkIfWordIsFunction" );
 	const premiumData = get( researcher.getData( "morphology" ), language, false );
 
-	const allWords = getWords( currentSentence );
+	// Retrieve all words from the sentence.
+	let words = getWords( currentSentence );
+
+	// Filters out keyphrase forms and synonyms because we consider them not to be complex.
+	const topicForms = researcher.getResearch( "morphology" );
+	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
+	const foundTopicForms = findTopicFormsInString( topicForms, currentSentence, true, researcher.paper.getLocale(), matchWordCustomHelper );
+	words = words.filter( word => ! foundTopicForms.matches.includes( word ) );
 
 	// Filters out function words because function words are not complex.
 	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
-	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) );
-
-	/**
-	 * Matches forms of words in the keyphrase against the complex words.
-	 *
-	 * @param {Object}      topicForms       The object with word forms of all (content) words from the keyphrase and eventually synonyms,
-	 * comes in a shape {
-	 *                     keyphraseForms: [[ form1, form2, ... ], [ form1, form2, ... ]],
-	 *                     synonymsForms: [
-	 *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
-	 *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
-	 *                          [[ form1, form2, ... ], [ form1, form2, ... ]],
-	 *                     ],
-	 *                  }
-	 * @param {string}      text                    The string to match the word forms against.
-	 * @param {boolean}     useSynonyms             Whether to use synonyms as if it was keyphrase or not (depends on the assessment).
-	 * @param {string}      locale                  The locale of the paper.
-	 * @param {function}    matchWordCustomHelper   The language-specific helper function to match word in text.
-	 *
-	 * @returns {array} Words with the keyphrases filtered out if a full match was found with the keyword.
-	 */
-	const findTopicFormsInString = function (topicForms, text, useSynonyms, locale, matchWordCustomHelper) {
-		// First check if the keyword is found in the text
-		const matchedTopicForms = ( findTopicFormsInString )( topicForms, text, useSynonyms, locale, matchWordCustomHelper );
-
-		// If a full match found with the keyword form, filter out keyphrase forms because they are allowed to be complex.
-		if (result.percentWordMatches === 100) ( topicForms.keyphraseForms )
-		{
-			return words.filter( word => ! ( findTopicFormsInString ? findTopicFormsInString( topicForms, text, useSynonyms, locale, matchWordCustomHelper ) : matchedTopicForms.includes( word ) ) );
-		}
-	}
+	words = words.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) );
 
 	const result = {
 		complexWords: [],

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -41,10 +41,9 @@ const getComplexWords = function( currentSentence, researcher ) {
 	const allWords = getWords( currentSentence );
 	// Filters out function words because function words are not complex.
 	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
-	const wordsWithoutFunctionWords = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) );
 	// Filters out keyphrases because they are allowed to be complex.
 	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
-	const words = wordsWithoutFunctionWords.filter( word => ! ( findKeywordFormInString ? findKeywordFormInString( word ) : keywordForms.includes( word ) ) );
+	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) || findKeywordFormInString ? findKeywordFormInString( word ) : keywordForms.includes( word ) )
 	const result = {
 		complexWords: [],
 		sentence: currentSentence,

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -40,7 +40,7 @@ const getComplexWords = function( currentSentence, researcher ) {
 	// Retrieve all words from the sentence.
 	let words = getWords( currentSentence );
 
-	// Filters out keyphrase forms and synonyms because we consider them not to be complex.
+	// Filters out keyphrase forms (but not synonyms) because we consider them not to be complex.
 	const topicForms = researcher.getResearch( "morphology" );
 	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
 	const foundTopicForms = findTopicFormsInString( topicForms, currentSentence, false, researcher.paper.getLocale(), matchWordCustomHelper );

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -43,7 +43,9 @@ const getComplexWords = function( currentSentence, researcher ) {
 	 * and keyphrases (because they are allowed to be complex).
 	 * Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
 	 */
-	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) || findKeywordFormInString ? findKeywordFormInString( word ) : keywordForms.includes( word ) )
+	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) :
+		 functionWords.includes( word ) ) || findKeywordFormInString ? findKeywordFormInString( word ) :
+		 keywordForms.includes( word ) );
 	const result = {
 		complexWords: [],
 		sentence: currentSentence,

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -39,10 +39,10 @@ const getComplexWords = function( currentSentence, researcher ) {
 	const premiumData = get( researcher.getData( "morphology" ), language, false );
 
 	const allWords = getWords( currentSentence );
-	// Filters out function words because function words are not complex.
-	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
-	// Filters out keyphrases because they are allowed to be complex.
-	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
+	/** Filters out function words (because function words are not complex)
+	 * and keyphrases (because they are allowed to be complex).
+	 * Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
+	 */
 	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) || findKeywordFormInString ? findKeywordFormInString( word ) : keywordForms.includes( word ) )
 	const result = {
 		complexWords: [],

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -43,7 +43,7 @@ const getComplexWords = function( currentSentence, researcher ) {
 	// Filters out keyphrase forms and synonyms because we consider them not to be complex.
 	const topicForms = researcher.getResearch( "morphology" );
 	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
-	const foundTopicForms = findTopicFormsInString( topicForms, currentSentence, true, researcher.paper.getLocale(), matchWordCustomHelper );
+	const foundTopicForms = findTopicFormsInString( topicForms, currentSentence, false, researcher.paper.getLocale(), matchWordCustomHelper );
 	words = words.filter( word => ! foundTopicForms.matches.includes( word ) );
 
 	// Filters out function words because function words are not complex.

--- a/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
+++ b/packages/yoastseo/src/languageProcessing/researches/wordComplexity.js
@@ -34,12 +34,17 @@ const getComplexWords = function( currentSentence, researcher ) {
 	const functionWords = researcher.getConfig( "functionWords" );
 	const wordComplexityConfig = researcher.getConfig( "wordComplexity" );
 	const checkIfWordIsFunction = researcher.getHelper( "checkIfWordIsFunction" );
+	const findKeywordFormInString = researcher.getHelper( "findKeywordFormsInString" );
+	const keywordForms = researcher.getData( "findKeywordFormsInString" );
 	const premiumData = get( researcher.getData( "morphology" ), language, false );
 
 	const allWords = getWords( currentSentence );
 	// Filters out function words because function words are not complex.
 	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
-	const words = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) );
+	const wordsWithoutFunctionWords = allWords.filter( word => ! ( checkIfWordIsFunction ? checkIfWordIsFunction( word ) : functionWords.includes( word ) ) );
+	// Filters out keyphrases because they are allowed to be complex.
+	// Words are converted to lowercase before processing to avoid excluding function words that start with a capital letter.
+	const words = wordsWithoutFunctionWords.filter( word => ! ( findKeywordFormInString ? findKeywordFormInString( word ) : keywordForms.includes( word ) ) );
 	const result = {
 		complexWords: [],
 		sentence: currentSentence,

--- a/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
@@ -159,7 +159,7 @@ Below is a detailed overview of how scores for the readability assessments are c
 |Red	|3	|< 50 characters	|**Not enough content**: **please add some content to enable a good analysis**.|
 
 ### 9) Word complexity (only in Premium)
-**What it does**: Checks whether the text contains complex words
+**What it does**: Checks whether the text contains complex words that are not in the keyphrase
 
 **When applies**: When the (sanitized) text has more than 50 characters
 

--- a/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
@@ -159,7 +159,7 @@ Below is a detailed overview of how scores for the readability assessments are c
 |Red	|3	|< 50 characters	|**Not enough content**: **please add some content to enable a good analysis**.|
 
 ### 9) Word complexity (only in Premium)
-**What it does**: Checks whether the text contains complex words that are not in the keyphrase
+**What it does**: Checks whether the text contains complex words. Word forms from the keyphrase are excluded.
 
 **When applies**: When the (sanitized) text has more than 50 characters
 
@@ -169,10 +169,10 @@ Below is a detailed overview of how scores for the readability assessments are c
 
 **Call to action URL**: https://yoa.st/4lt (link placement is in bold in the feedback strings)
 
-|Traffic light	|Score|	Criterion| 	Feedback                                                                                                                                        |
-|-------|------	|----- |--------------------------------------------------------------------------------------------------------------------------------------------------|
-|Orange	(cornerstone: red) |6 (cornerstone: 3) |	If the complex words are more than 10% in the text | **Word complexity**: X% of the words in your text are considered complex. **Try to use shorter and more familiar words to improve readability**. |
-|Green	|9 |	If the complex words are less than 10% in the text              | **Word complexity**: You are not using too many complex words, which makes your text easy to read. Good job!                                     |
+| Traffic light             | Score              | Criterion                                          | Feedback                                                                                                                                         |
+|---------------------------|--------------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
+| Orange (cornerstone: red) | 6 (cornerstone: 3) | If the complex words are more than 10% in the text | **Word complexity**: X% of the words in your text are considered complex. **Try to use shorter and more familiar words to improve readability**. |
+| Green                     | 9                  | If the complex words are less than 10% in the text | **Word complexity**: You are not using too many complex words, which makes your text easy to read. Good job!                                     |
 
 ### 10) Text alignment (only in Premium)
 **What it does**: Checks whether there is an over-use of center-alignment in the text.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* It's justified for a keyphrase to be a complex words because:
1. It is usually a word that the user searched for and therefore knows
2. keyphrases repeat in a text, sometimes with synonyms, which makes them easier to understand (if not used too many times)
3. Complex words tend to be infrequent and therefore "niche" words, and which is relevant for keyphrases as well, that are totally acceptable to apply in some cases to a "niche" audience.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves _the word complexity assessment_ by preventing keyphrases from being marked as complex.
* [wordpress-seo-premium] Improves _the word complexity assessment_ by excluding keyphrases from the words targeted by the assessment.
* [shopify-seo] Improves _the word complexity assessment_ by excluding keyphrases from the words targeted by the assessment.

## Relevant technical choices:

* Excluding the site name (because it is much more complex to do) and potentially words from the title (which needs more consideration of pros and cons) was moved to this issue: https://github.com/orgs/Yoast/projects/51/views/16?pane=issue&itemId=63025532 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**WordPress**
* Create a post with the following text of 147 words:
>  Wild violets come in over 100 different varieties. Although they all are edible, some are more palatable than others. The common blue violet is the most harvested. Flowers have 5 petals and a symmetrical, butterfly shape with varying hues of blue. The stem is bent at the point where the flower is attached giving the flower its characteristic drooping appearance. Leaves are green and heart-shaped. Beginning foragers should only harvest the flowers of the violet. Leaves are edible but because the leaves are easily confused with other non-edible plants it is important to stick with the sure bet if you are unfamiliar with violets and their look-alikes. Violet flowers can be used to garnish salads or flavor vinegar and syrup. Pick them fresh for salads or freeze them while you continue to collect enough of the desired quantity for an infused vinegar or syrup recipe.
* Confirm that the Word complexity assessment feedback is green.
* Add the following words: `exchequer, manipulation, counterintuitive, paradigm, elevation`.
* Confirm that the word complexity feedback says `10% of the words in your text are considered complex. Try to use shorter and more familiar words to improve readability.`
* Add the word `counterintuitive` as the keyphrase.
* Confirm that the word complexity assessment changed to green.
* Click on the eye icon and confirm that the word `counterintuitive` is not highlighted.
* Add the word `manipulation` as a synonym.
* Click on the eye icon and confirm that the word `manipulation` is still highlighted (synonyms are still considered complex). 

* Create a post with the following text:
> All you’re doing is whisking the dry and wet ingredients together separately, and then combining everything. Expect a thick batter. If desired, sprinkle coarse sugar on top of the muffins before baking. It adds a sweet crunch that also happens to make homemade muffins look like they came from a bakery display case.
> Zucchini muffins are vegetable delivery vehicles that even picky vege-skeptics will love. You can’t taste the vegetable because the zucchini takes on the flavor of the cinnamon-spiced batter. Hop on over to my zucchini cake and chocolate zucchini cake recipes… you can’t even see that sneaky vegetable inside! For even more inspiration, here are 20+ of my favorite zucchini recipes.
* Confirm that the Word complexity assessment gives a green traffic light 🍏 
* Add `homemade` as a keyphrase
* Click on the highlighting button of the Word complexity assessment
* Confirm that 5 words are highlighted: `whisking, separately, combining, vege-skeptics, cinnamon-spiced`
* Confirm that the word `homemade` is not highlighted
* Remove `homemade` from the keyphrase field
* Save the post as a draft
* Click on the eye icon of word complexity assessment and make sure that `homemade` is highlighted as complex.

**Shopify**
1. Create a product
2. Repeat the above testing steps.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/Yoast/lingo-other-tasks/issues/273
