### PR TITLE
Allow multiple FAQ blocks

### DIFF
--- a/packages/js/src/structured-data-blocks/faq/block.js
+++ b/packages/js/src/structured-data-blocks/faq/block.js
@@ -40,9 +40,10 @@ registerBlockType( block, {
 	 * @returns {Component} The display component.
 	 */
 	save: ( { attributes } ) => {
-		return <Faq.Content { ...attributes } />;
+		const blockProps = useBlockProps.save( attributes );
+
+		return <Faq.Content { ...blockProps } />;
 	},
-	/* eslint-enable react/display-name */
 
 	deprecated: [
 		{

--- a/packages/js/src/structured-data-blocks/faq/block.json
+++ b/packages/js/src/structured-data-blocks/faq/block.json
@@ -14,9 +14,6 @@
     "SEO",
     "Structured Data"
   ],
-  "supports": {
-    "multiple": false
-  },
   "textdomain": "wordpress-seo",
   "attributes": {
     "questions": {

--- a/packages/js/src/structured-data-blocks/how-to/block.js
+++ b/packages/js/src/structured-data-blocks/how-to/block.js
@@ -40,9 +40,10 @@ registerBlockType( block, {
 	 * @returns {Component} The display component.
 	 */
 	save: ( { attributes } ) => {
-		return <HowTo.Content { ...attributes } />;
+		const blockProps = useBlockProps.save( attributes );
+
+		return <HowTo.Content { ...blockProps } />;
 	},
-	/* eslint-enable react/display-name */
 
 	deprecated: [
 		{


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* https://github.com/Yoast/wordpress-seo/pull/21329 introduced a limitation of 1 FAQ block per post by mistake, and removed a class from the resulting output for the FAQ and the How To block.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug preventing multiple _FAQ_ blocks from being added to a post/page.
* Fixes a bug where a class was missing in the output of the _FAQ_ and _How-To_ blocks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* **Important:** test using an artifact instead of just building from the source, since there is an integral part of this PR that is related to copying the blocks JSON to a dist dir and finding it there.

#### 1. Multiple FAQ blocks

##### New blocks
* create a post and add two or more FAQ blocks
  * add some questions and answers
  * publish it and check the Schema: the page should be a `FAQPage` with `mainEntity` set to all the `Question` pieces from all the FAQ blocks combined

###### Upgrading
* on another site, install Free 22.6
* create a post and add two or more FAQ blocks
* add some questions and answers and publish
_* if you now upgrade to 22.7 and edit the post you'll see a warning telling you that you cannot use the block twice._
* upgrade to the zip containing this fix
* edit the post and see that there is no warning now
* inspect the Schema and check it's right
* edit the FAQ blocks again and verify everything's working

#### 2. Block markup

##### New blocks
* create a post and add a FAQ block and a How To block, with some content
* publish it and inspect the source of the page in the frontend
* check that the FAQ block is outputted as `<div class="schema-faq wp-block-yoast-faq-block">` and the How-to block as `<div class="schema-how-to wp-block-yoast-how-to-block">`

###### Upgrading from 22.6 or earlier
* on another site, install Free 22.6
* create a post and add a FAQ block and a How To block, with some content
* publish it
* upgrade to this version
* edit the post and see that you don't get any warning
* apply a small change somewhere in the content and save
* check that the FAQ block is outputted as `<div class="schema-faq wp-block-yoast-faq-block">` and the How-to block as `<div class="schema-how-to wp-block-yoast-how-to-block">`

###### Upgrading from 22.6 or earlier
* on another site, install Free 22.7
* create a post and add a FAQ block and a How To block, with some content
* publish it
* upgrade to this version
* edit the post and see that you get warning like these ones:
![Screenshot 2024-05-23 at 13-04-33 Edit Post “Blocks” ‹ Become Church — WordPress](https://github.com/Yoast/wordpress-seo/assets/15989132/8410c887-b088-4213-b10f-e477b7345899)
* click on the "Attempt recovery" buttons and see they are restored
* update the post and inspect the frontend
* check that the FAQ block is outputted as `<div class="schema-faq wp-block-yoast-faq-block">` and the How-to block as `<div class="schema-how-to wp-block-yoast-how-to-block">`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21401
Fixes #21403
