### PR TITLE
Center the content of the metabox

### DIFF
--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -43,6 +43,7 @@
   max-width: 600px;
   width: 100%;
   height: auto;
+  min-height: 100%;
   vertical-align: top;
   border: 1px solid rgba( 0,0,0,0.2 );
 }
@@ -68,28 +69,38 @@
   padding: 16px;
 }
 
-.wpseo-metabox .postbox-header {
-  border-bottom: 1px solid #ddd;
-}
-
-.edit-post-meta-boxes-area__container .wpseo-metabox .inside {
-  background-color: #f1f5f9;
-  display: flex;
-  justify-content: center;
-  padding: 32px !important;
-}
-
-.edit-post-meta-boxes-area__container .wpseo-metabox.closed .inside {
-  display: none;
-}
-
 .wpseo-metabox-content {
   max-width: 800px;
+  padding-top: 16px;
 }
 
-form#post .wpseo-metabox .wpseo-metabox-content,
-.wpseo-taxonomy-metabox-postbox .wpseo-metabox-content {
-  padding-top: 16px;
+/* Target only the block-editor. */
+.edit-post-meta-boxes-area__container {
+  .wpseo-metabox {
+    .postbox-header {
+      border-bottom: 1px solid #ddd;
+    }
+
+    .inside {
+      background-color: #f1f5f9;
+    }
+
+    .wpseo-metabox-content {
+      max-width: none;
+      padding-top: 32px;
+      padding-right: 8px;
+      padding-bottom: 8px;
+      padding-left: 8px;
+    }
+
+    .wpseo-metabox-menu, .wpseo-meta-section {
+      margin: 0 auto;
+    }
+
+    .wpseo-meta-section.active {
+      display: block;
+    }
+  }
 }
 
 .wpseo-metabox-menu {

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -69,15 +69,26 @@
   padding: 16px;
 }
 
+.wpseo-metabox .postbox-header {
+  border-bottom: 1px solid #ddd;
+}
+
+.wpseo-metabox .inside {
+  background-color: #f1f5f9;
+  display: flex;
+  justify-content: center;
+  padding: 32px !important;
+}
+
 .wpseo-metabox-content {
   max-width: 800px;
-  padding-top: 16px;
+  background-color: #f1f5f9;
 }
 
 .wpseo-metabox-menu {
   max-width: 600px;
   padding: 0;
-  background-color: #fff;
+  background-color: #f1f5f9;
 }
 
 .wpseo-metabox-menu ul {

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -73,7 +73,7 @@
   border-bottom: 1px solid #ddd;
 }
 
-.wpseo-metabox .inside {
+.edit-post-meta-boxes-area__container .wpseo-metabox .inside {
   background-color: #f1f5f9;
   display: flex;
   justify-content: center;
@@ -82,13 +82,16 @@
 
 .wpseo-metabox-content {
   max-width: 800px;
-  background-color: #f1f5f9;
+}
+
+form#post .wpseo-metabox .wpseo-metabox-content,
+.wpseo-taxonomy-metabox-postbox .wpseo-metabox-content {
+  padding-top: 16px;
 }
 
 .wpseo-metabox-menu {
   max-width: 600px;
   padding: 0;
-  background-color: #f1f5f9;
 }
 
 .wpseo-metabox-menu ul {

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -79,6 +79,10 @@
   padding: 32px !important;
 }
 
+.edit-post-meta-boxes-area__container .wpseo-metabox.closed .inside {
+  display: none;
+}
+
 .wpseo-metabox-content {
   max-width: 800px;
 }

--- a/css/src/metabox.css
+++ b/css/src/metabox.css
@@ -42,7 +42,6 @@
   display: none;
   max-width: 600px;
   width: 100%;
-  min-height: 100%;
   height: auto;
   vertical-align: top;
   border: 1px solid rgba( 0,0,0,0.2 );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Provide a nicer user experience in the block editor when using wide screens

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the look of the Yoast SEO metabox in the block editor by centering it and making it stand-out more with using a background color.

## Relevant technical choices:

* Targeting some specific classes to try and make this only in the block-editor in pure CSS
* ~~Removing `min-height: 100%` to prevent issues with `display: flex`~~
* ~~Check for `.closed` ourselves because `display: flex` overrides the `display: none`~~
* Switched to not using `display: flex`, as the width became as wide as need, resulting in it jumping when you open/close sections

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* I enabled all our plugins to test the extra tabs in our metabox
* Edit a post in the block editor
* [ ] Verify our metabox is now centered
* [ ] Verify the background color is `slate-100` (e.g. `#f1f5f9`, see https://tailwindcss.com/docs/customizing-colors)
* [ ] Verify the padding around the content of our metabox is 32px (24px + 8px for the left, right and bottom)
* [ ] Verify closing and opening sections in our metabox does not alter the width of it
* [ ] Verify hiding our whole metabox can be done
* Show another metabox: Options (top right 3 dots button) > Preferences (at the bottom) > General > Advanced > Enable something there (I had `Custom fields` there)
![image](https://github.com/Yoast/wordpress-seo/assets/35524806/79cdb18e-baf9-4b8e-aa7b-b57663519362)
* [ ] Verify you can still re-order the metaboxes either by the buttons or by drag & drop
* Change the browser size:
  * ...to mobile size (or open the browser console/inspector and use the mobile mode)
  * [ ] Verify it still looks good/as expected
  * ...to large desktop size (or use the zoom feature of the inspector "mobile" mode)
  * [ ] Verify it still looks good/as expected
* Depending on whether you have one or two rows of metabox tabs:
  * Go to the Yoast Settings and enable or disable the inclusive language analysis
  * Disable some of our plugins if still two rows?
* Go back to the post edit
* [x] Verify the width still does not change when closing and opening sections (try closing all)
* Edit a post in the classic editor (install and set it up so you can switch)
* [x] Verify our metabox is unchanged
* Edit a term (i.e. classic editor)
* [x] Verify our metabox is unchanged

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

![image](https://github.com/Yoast/wordpress-seo/assets/35524806/a3e61ccb-293a-4031-8967-4bffa0ba82e0)

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21425
