### PR TITLE
Don't show sparkle buttons for scenarios we don't cover

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -248,13 +248,22 @@ describe( "Tests for the keyphrase density assessment for languages with morphol
 			"The keyphrase was found 32 times. That's more than the recommended maximum of 29 times for a text of this length. " +
 			"<a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
 	} );
-	it( "returns `hasAIFixes` to be true when the result is BAD", function() {
+	it( "returns `hasAIFixes` to be false when the keyphrase is overused", function() {
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );
 		buildTree( paper, researcher );
 
 		const result = new KeyphraseDensityAssessment().getResult( paper, researcher );
 		expect( result.getScore() ).toBe( -10 );
+		expect( result.hasAIFixes() ).toBeFalsy();
+	} );
+	it( "returns `hasAIFixes` to be true when there is not enough occurrence in the text", function() {
+		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 2 ), { keyword: "keyword", locale: "en_EN" } );
+		const researcher = new EnglishResearcher( paper );
+		buildTree( paper, researcher );
+
+		const result = new KeyphraseDensityAssessment().getResult( paper, researcher );
+		expect( result.getScore() ).toBe( 4 );
 		expect( result.hasAIFixes() ).toBeTruthy();
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -257,7 +257,7 @@ describe( "Tests for the keyphrase density assessment for languages with morphol
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.hasAIFixes() ).toBeFalsy();
 	} );
-	it( "returns `hasAIFixes` to be true when there is not enough occurrence in the text", function() {
+	it( "returns `hasAIFixes` to be true when there is not enough keyphrase occurrence in the text", function() {
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 2 ), { keyword: "keyword", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );
 		buildTree( paper, researcher );

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeywordDensityAssessmentSpec.js
@@ -248,7 +248,7 @@ describe( "Tests for the keyphrase density assessment for languages with morphol
 			"The keyphrase was found 32 times. That's more than the recommended maximum of 29 times for a text of this length. " +
 			"<a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
 	} );
-	it( "returns `hasAIFixes` to be false when the keyphrase is overused", function() {
+	it( "sets `hasAIFixes` to be false when the keyphrase is overused", function() {
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );
 		buildTree( paper, researcher );
@@ -257,7 +257,7 @@ describe( "Tests for the keyphrase density assessment for languages with morphol
 		expect( result.getScore() ).toBe( -10 );
 		expect( result.hasAIFixes() ).toBeFalsy();
 	} );
-	it( "returns `hasAIFixes` to be true when there is not enough keyphrase occurrence in the text", function() {
+	it( "sets `hasAIFixes` to be true when the keyphrase is underused", function() {
 		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 2 ), { keyword: "keyword", locale: "en_EN" } );
 		const researcher = new EnglishResearcher( paper );
 		buildTree( paper, researcher );

--- a/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/SubHeadingsKeywordAssessmentSpec.js
@@ -6,17 +6,6 @@ import Factory from "../../../../src/helpers/factory";
 const matchKeywordAssessment = new SubheadingsKeywordAssessment();
 
 describe( "An assessment for matching keywords in subheadings", () => {
-	it( "returns `hasAIFixes` to be true when the result is BAD", function() {
-		const mockPaper = new Paper();
-		const assessment = matchKeywordAssessment.getResult(
-			mockPaper,
-			Factory.buildMockResearcher( { count: 1, matches: 0, percentReflectingTopic: 0 } )
-		);
-
-		expect( assessment.getScore() ).toEqual( 3 );
-		expect( assessment.hasAIFixes() ).toBeTruthy();
-	} );
-
 	it( "returns a bad score and appropriate feedback when none of the subheadings contain the keyphrase: no matches.", function() {
 		const mockPaper = new Paper();
 		const assessment = matchKeywordAssessment.getResult(

--- a/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeywordDensityAssessment.js
@@ -118,7 +118,8 @@ class KeyphraseDensityAssessment extends Assessment {
 		assessmentResult.setScore( calculatedScore.score );
 		assessmentResult.setText( calculatedScore.resultText );
 		assessmentResult.setHasMarks( this._keyphraseCount.count > 0 );
-		if ( calculatedScore.score < 9 ) {
+		// Only shows the AI button when there is not enough keyphrase density.
+		if ( calculatedScore.score === this._config.scores.underMinimum ) {
 			assessmentResult.setHasAIFixes( true );
 		}
 		return assessmentResult;

--- a/packages/yoastseo/src/scoring/assessments/seo/SubHeadingsKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/SubHeadingsKeywordAssessment.js
@@ -58,9 +58,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( calculatedResult.score < 9 ) {
-			assessmentResult.setHasAIFixes( true );
-		}
+
 		return assessmentResult;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to show the sparkle buttons for scenarios we currently do not cover in our prompts.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Don't show the AI button for _keyphrase in subheading_ assessment and for _keyphrase density_ when the keyphrase is overused in the text.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

⚠️ Testing only in Free is sufficient

* Create a post in Block/Gutenberg editor
* Add some content to the post. You can use [this post](https://yix.lfg.mybluehost.me/website_795f068c/wp-admin/post.php?post=87&action=edit) alongside the focus keyphrase
   * The post above will return 🔴 for Keyphrase in subheading
   * `Keyphrase in subheading: Use more keyphrases or synonyms in your H2 and H3 subheadings!`
* Confirm that next to Keyphrase in subheading you don't see the AI button
* Adjust the subheadings so that you get the following feedback from the keyphrase in subheading assessment:
   * `More than 75% of your higher-level subheadings reflect the topic of your copy. That's too much. Don't over-optimize!`
   * To achieve this feedback (if you're using the post above), you can add "calypso music" to both subheadings
* Confirm that next to Keyphrase in subheading you don't see the AI button
* Confirm that Keyphrase density doesn't recognize any keyphrase occurrence in the text
* Confirm that next to Keyphrase density assessment you SEE the AI button
* Now add the focus keyphrase 2 times
* Confirm that next to Keyphrase density assessment you SEE the AI button
* Add more focus keyphrase so that now there are 22 keyphrase occurrences in the text
* Confirm that next to Keyphrase density assessment you DON'T see the AI button

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact other than what's already covered in the testing instructions above

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4353
