### PR TITLE
Tooltip on ai assessment buttons doesnt show

### DIFF
--- a/css/src/tooltips.css
+++ b/css/src/tooltips.css
@@ -72,7 +72,6 @@ button.yoast-tooltip {
 	animation-name: yoast-tooltip-appear;
 	animation-duration: 0.1s;
 	animation-timing-function: ease-in;
-	animation-delay: 0.4s;
 
 	animation-fill-mode: forwards;
 }

--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -23,7 +23,7 @@ const gradientEffect = {
 
 const AIFixesButtonBase = styled( IconButtonBase )`
 	overflow: hidden;
-	border: ${ props => props.pressed ? "none" : "1px solid #c7d2fe" }; /*indigo-200*/
+	border: ${ props => props.pressed ? "none" : "1px solid #A5B4FC" }; /*indigo-300*/
 	background-image: ${ props => props.pressed
 		? gradientEffect.pressedStateBackground
 		: gradientEffect.defaultStateBackground } !important;

--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -23,9 +23,7 @@ const gradientEffect = {
 
 const AIFixesButtonBase = styled( IconButtonBase )`
 	overflow: hidden;
-	border: ${ props => props.pressed ? "none" : "1px solid transparent" };
-	border-image: ${ props => props.pressed ? "none" : gradientEffect.defaultStateBorder };
-	clip-path: inset(0 round 3px);
+	border: ${ props => props.pressed ? "none" : "1px solid #c7d2fe" }; /*indigo-200*/
 	background-image: ${ props => props.pressed
 		? gradientEffect.pressedStateBackground
 		: gradientEffect.defaultStateBackground } !important;

--- a/packages/components/src/IconAIFixesButton.js
+++ b/packages/components/src/IconAIFixesButton.js
@@ -29,7 +29,7 @@ const IconAIFixesButton = function( props ) {
 			aria-label={ props.ariaLabel }
 			aria-pressed={ props.pressed }
 			pressedIconColor={ props.pressedIconColor }
-			hoverBackgroundColor={ props.hoverBackgroundColor }
+			// hoverBackgroundColor={ props.hoverBackgroundColor }
 			unpressedBorderColor={ props.unpressedBorderColor }
 			className={ props.className }
 		>
@@ -51,7 +51,7 @@ IconAIFixesButton.propTypes = {
 	pressedIconColor: PropTypes.string,
 	pressed: PropTypes.bool.isRequired,
 	unpressedBorderColor: PropTypes.string,
-	hoverBackgroundColor: PropTypes.string,
+	// hoverBackgroundColor: PropTypes.string,
 	className: PropTypes.string,
 };
 
@@ -63,7 +63,7 @@ IconAIFixesButton.defaultProps = {
 	unpressedBackground: "linear-gradient(to bottom right, #FAF3F7, #EFF6FF)",
 	pressedIconColor: colors.$color_white,
 	unpressedBorderColor: "linear-gradient(to bottom right, #CD82AB, #93C5FD)",
-	hoverBackgroundColor: "linear-gradient(to bottom right, #F3E5ED, #DBEAFE)",
+	// hoverBackgroundColor: "linear-gradient(to bottom right, #F3E5ED, #DBEAFE)",
 };
 
 export default IconAIFixesButton;

--- a/packages/components/src/IconAIFixesButton.js
+++ b/packages/components/src/IconAIFixesButton.js
@@ -62,6 +62,9 @@ IconAIFixesButton.defaultProps = {
 	pressedBackground: "linear- gradient(to bottom right, #A61E69, #3B82F6)",
 	unpressedBackground: "linear-gradient(to bottom right, #FAF3F7, #EFF6FF)",
 	pressedIconColor: colors.$color_white,
+	onClick: () => {},
+	onMouseEnter: () => {},
+	onMouseLeave: () => {},
 };
 
 export default IconAIFixesButton;

--- a/packages/components/src/IconAIFixesButton.js
+++ b/packages/components/src/IconAIFixesButton.js
@@ -29,8 +29,6 @@ const IconAIFixesButton = function( props ) {
 			aria-label={ props.ariaLabel }
 			aria-pressed={ props.pressed }
 			pressedIconColor={ props.pressedIconColor }
-			// hoverBackgroundColor={ props.hoverBackgroundColor }
-			unpressedBorderColor={ props.unpressedBorderColor }
 			className={ props.className }
 		>
 			{ props.children }
@@ -50,8 +48,6 @@ IconAIFixesButton.propTypes = {
 	unpressedBackground: PropTypes.string,
 	pressedIconColor: PropTypes.string,
 	pressed: PropTypes.bool.isRequired,
-	unpressedBorderColor: PropTypes.string,
-	// hoverBackgroundColor: PropTypes.string,
 	className: PropTypes.string,
 };
 
@@ -62,8 +58,6 @@ IconAIFixesButton.defaultProps = {
 	pressedBackground: "linear- gradient(to bottom right, #A61E69, #3B82F6)",
 	unpressedBackground: "linear-gradient(to bottom right, #FAF3F7, #EFF6FF)",
 	pressedIconColor: colors.$color_white,
-	unpressedBorderColor: "linear-gradient(to bottom right, #CD82AB, #93C5FD)",
-	// hoverBackgroundColor: "linear-gradient(to bottom right, #F3E5ED, #DBEAFE)",
 };
 
 export default IconAIFixesButton;

--- a/packages/components/src/IconAIFixesButton.js
+++ b/packages/components/src/IconAIFixesButton.js
@@ -21,6 +21,8 @@ const IconAIFixesButton = function( props ) {
 			type="button"
 			onClick={ props.onClick }
 			pressed={ props.pressed }
+			onMouseEnter={ props.onMouseEnter }
+			onMouseLeave={ props.onMouseLeave }
 			unpressedBoxShadowColor={ props.unpressedBoxShadowColor }
 			pressedBoxShadowColor={ props.pressedBoxShadowColor }
 			pressedBackground={ props.pressedBackground }
@@ -42,6 +44,8 @@ IconAIFixesButton.propTypes = {
 	id: PropTypes.string.isRequired,
 	ariaLabel: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
+	onMouseEnter: PropTypes.func,
+	onMouseLeave: PropTypes.func,
 	unpressedBoxShadowColor: PropTypes.string,
 	pressedBoxShadowColor: PropTypes.string,
 	pressedBackground: PropTypes.string,

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -35,9 +35,6 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
 .c1 {
   overflow: hidden;
   border: none;
-  border-image: none;
-  -webkit-clip-path: inset(0 round 3px);
-  clip-path: inset(0 round 3px);
   background-image: linear-gradient(to bottom right,#A61E69,#3B82F6) !important;
   box-shadow: inset 0 -2px 0 #B94986;
 }
@@ -91,10 +88,7 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
 
 .c1 {
   overflow: hidden;
-  border: 1px solid transparent;
-  border-image: linear-gradient(to bottom right,#CD82AB,#93C5FD) 1;
-  -webkit-clip-path: inset(0 round 3px);
-  clip-path: inset(0 round 3px);
+  border: 1px solid #A5B4FC;
   background-image: linear-gradient(to bottom right,#FAF3F7,#EFF6FF) !important;
   box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
 }

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -50,6 +50,8 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
   disabled={false}
   id="keyphraseInIntroductionAIFixes"
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   type="button"
 />
 `;
@@ -104,6 +106,8 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
   disabled={true}
   id="keyphraseDensityAIFixes"
   onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
   type="button"
 />
 `;

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -23,7 +23,7 @@ import { SparklesIcon } from "./sparkles-icon";
  */
 const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const aiFixesId = id + "AIFixes";
-	const ariaLabel = __( "Fix with AI", "wordpress-seo" );
+	const ariaLabel = __( "Optimize with AI", "wordpress-seo" );
 	const [ isModalOpen, , , setIsModalOpenTrue, setIsModalOpenFalse ] = useToggleState( false );
 	const activeAIButtonId = useSelect( select => select( "yoast-seo/editor" ).getActiveAIFixesButton(), [] );
 	const activeMarker = useSelect( select => select( "yoast-seo/editor" ).getActiveMarker(), [] );

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -51,6 +51,9 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 		} else {
 			setActiveAIFixesButton( aiFixesId );
 		}
+
+		// Dismiss the tooltip when the button is pressed.
+		setButtonClass( "" );
 	};
 
 	const handleClick = useCallback( () => {

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -29,7 +29,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const activeMarker = useSelect( select => select( "yoast-seo/editor" ).getActiveMarker(), [] );
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
-	const [buttonClass, setButtonClass] = useState( "" );
+	const [ buttonClass, setButtonClass ] = useState( "" );
 
 	/**
 	 * Handles the button press state.
@@ -108,7 +108,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 AIAssessmentFixesButton.propTypes = {
 	id: PropTypes.string.isRequired,
 	isPremium: PropTypes.bool,
-	className: PropTypes.string,
 };
 
 AIAssessmentFixesButton.defaultProps = {

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -87,7 +87,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 				onMouseEnter={ handleMouseEnter }
 				onMouseLeave={ handleMouseLeave }
 				id={ aiFixesId }
-				className={ buttonClass }
+				className={ `ai-button ${buttonClass}` }
 				pressed={ isButtonPressed }
 			>
 				<SparklesIcon pressed={ isButtonPressed } />

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -1,9 +1,8 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { useCallback, useRef } from "@wordpress/element";
+import { useCallback, useRef, useState } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 import { useSelect, useDispatch } from "@wordpress/data";
-import React, { useState } from 'react';
 
 /* Yoast dependencies */
 import { IconAIFixesButton } from "@yoast/components";
@@ -22,7 +21,7 @@ import { SparklesIcon } from "./sparkles-icon";
  *
  * @returns {JSX.Element} The AI Assessment Fixes button.
  */
-const AIAssessmentFixesButton = ({ id, isPremium, className } ) => {
+const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const aiFixesId = id + "AIFixes";
 	const ariaLabel = __( "Optimize with AI", "wordpress-seo" );
 	const [ isModalOpen, , , setIsModalOpenTrue, setIsModalOpenFalse ] = useToggleState( false );
@@ -30,7 +29,7 @@ const AIAssessmentFixesButton = ({ id, isPremium, className } ) => {
 	const activeMarker = useSelect( select => select( "yoast-seo/editor" ).getActiveMarker(), [] );
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
-	const [ buttonClass, setButtonClass ] = useState('');
+	const [buttonClass, setButtonClass] = useState( "" );
 
 	/**
 	 * Handles the button press state.

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -3,6 +3,7 @@ import { __ } from "@wordpress/i18n";
 import { useCallback, useRef } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 import { useSelect, useDispatch } from "@wordpress/data";
+import React, { useState } from 'react';
 
 /* Yoast dependencies */
 import { IconAIFixesButton } from "@yoast/components";
@@ -21,7 +22,7 @@ import { SparklesIcon } from "./sparkles-icon";
  *
  * @returns {JSX.Element} The AI Assessment Fixes button.
  */
-const AIAssessmentFixesButton = ( { id, isPremium } ) => {
+const AIAssessmentFixesButton = ({ id, isPremium, className } ) => {
 	const aiFixesId = id + "AIFixes";
 	const ariaLabel = __( "Optimize with AI", "wordpress-seo" );
 	const [ isModalOpen, , , setIsModalOpenTrue, setIsModalOpenFalse ] = useToggleState( false );
@@ -29,6 +30,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const activeMarker = useSelect( select => select( "yoast-seo/editor" ).getActiveMarker(), [] );
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
+	const [ buttonClass, setButtonClass ] = useState('');
 
 	/**
 	 * Handles the button press state.
@@ -67,16 +69,26 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	// The button is pressed when the active AI button id is the same as the current button id.
 	const isButtonPressed = activeAIButtonId === aiFixesId;
 
-	// Don't show the tooltip when the button is pressed.
-	const className = isButtonPressed ? "" : "yoast-tooltip yoast-tooltip-w";
+	// Add tooltip classes on mouse enter and remove them on mouse leave.
+	const handleMouseEnter = useCallback( () => {
+		// Add tooltip classes on mouse enter
+		setButtonClass( "yoast-tooltip yoast-tooltip-w" );
+	}, [] );
+
+	const handleMouseLeave = useCallback( () => {
+		// Remove tooltip classes on mouse leave
+		setButtonClass( "" );
+	}, [] );
 
 	return (
 		<>
 			<IconAIFixesButton
 				onClick={ handleClick }
 				ariaLabel={ ariaLabel }
+				onMouseEnter={ handleMouseEnter }
+				onMouseLeave={ handleMouseLeave }
 				id={ aiFixesId }
-				className={ className }
+				className={ buttonClass }
 				pressed={ isButtonPressed }
 			>
 				<SparklesIcon pressed={ isButtonPressed } />
@@ -97,6 +109,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 AIAssessmentFixesButton.propTypes = {
 	id: PropTypes.string.isRequired,
 	isPremium: PropTypes.bool,
+	className: PropTypes.string,
 };
 
 AIAssessmentFixesButton.defaultProps = {

--- a/packages/js/tests/ai-assessment-fixes/components/AIAssessmentFixesButton.test.js
+++ b/packages/js/tests/ai-assessment-fixes/components/AIAssessmentFixesButton.test.js
@@ -29,7 +29,7 @@ describe( "AIAssessmentFixesButton", () => {
 	test( "should find the correct aria-label in the document", () => {
 		render( <AIAssessmentFixesButton id="keyphraseDensity" isPremium={ false } /> );
 
-		const labelText = document.querySelector( 'button[aria-label="Fix with AI"]' );
+		const labelText = document.querySelector( 'button[aria-label="Optimize with AI"]' );
 		expect( labelText ).toBeInTheDocument();
 	} );
 
@@ -39,11 +39,11 @@ describe( "AIAssessmentFixesButton", () => {
 		expect( button ).toBeInTheDocument();
 	} );
 
-	test( "should find the button with tooltip when the button is NOT pressed", () => {
+	test( "should find the button without tooltip when the button is NOT hovered", () => {
 		render( <AIAssessmentFixesButton id="keyphraseDensity" isPremium={ true }  /> );
 
-		const buttonWithTooltip = document.getElementsByClassName( "yoast-tooltip yoast-tooltip-w" );
-		expect( buttonWithTooltip ).toHaveLength( 1 );
+		const buttonWithOutTooltip = document.getElementsByClassName( "ai-button" );
+		expect( buttonWithOutTooltip ).toHaveLength( 1 );
 	} );
 
 	test( "should find the button without tooltip when the button is pressed", () => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want the `Tooltip` of the AI assessment buttons to be visible on hover over the buttons and to update the text to be: _Optimize with AI_

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the tooltip on the AI assessment buttons would not be visible.

## Relevant technical choices:

* We have agreed on using a uniform color for the border of the AI assessment buttons. 

* I've refactored the logic that makes the tooltip to be shown by adding or removing the utility classes when the mouse hovers over the buttons. This logic is different than the logic for the other assessment buttons. 

* We have decided to remove the time that delayed the tooltip from being shown. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Yoast SEO and Yoast SEO Premium activated.
* Open or create a new post. Make sure to have enough content and also add a focus keyphrase.
* Use the block editor.
* Ensure that the keyphrase is not included in the first paragraph/introduction and that it isn't used more than once in the content.
* Open the Premium SEO analysis tab in the Yoast Premium SEO > SEO or in the Yoast SEO sidebar.
* Check that the Keyphrase in the introduction and Keyphrase density and Keyphrase distribution assessments aren't green and show the sparkle button of the AI assessments fixes project.
* Verify that the button has a sparkle icon with a gradient effect from purple to blue, and the border of the button has a uniform `indigo-300` (#a5b4fc) color and has rounded corners.
* Check that the button has a gray shadow at the bottom.
* Verify that when hovering over the button with the mouse, the cursor changes to a pointer.
* Verify that the tooltip with the "Optimize with AI" text is shown without delay. 
* Check that the button's background also changes to a slightly darker gradient effect.
* Verify that the gray shadow at the bottom of the button is still present.
* Check that when the button is pressed:
1. the tooltip disappears.
2. the background changes to a darker gradient effect from purple to blue and the sparkle icon turns white. 
3. the button should also have a dark-pink shadow at the bottom.


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [X] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1620
