### PR TITLE
Change 'blue' to 'indigo' in all AI branded components (Toast and AI …

### DIFF
--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -6,9 +6,9 @@ const yoastPrimary50 = "#FAF3F7";
 const yoastPrimary100 = "#F3E5ED";
 const yoastPrimary400 = "#B94986";
 const yoastPrimary500 = "#A61E69";
-const yoastIndigo50 = "EEF2FF";
-const yoastIndigo100 = "E0E7FF";
-const yoastIndigo500 = "6366F1";
+const yoastIndigo50 = "#EEF2FF";
+const yoastIndigo100 = "#E0E7FF";
+const yoastIndigo500 = "#6366F1";
 
 const direction = "to bottom right";
 

--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -35,11 +35,6 @@ const AIFixesButtonBase = styled( IconButtonBase )`
 		? gradientEffect.pressedStateBackground
 		: gradientEffect.hoverStateBackground } !important;
 	}
-
-	@supports ((border-image: ${gradientEffect.defaultStateBorder}) and (border-radius: 3px)) {
-		border: ${props => props.pressed ? "none" : "1px solid transparent"};
-		border-image: ${props => props.pressed ? "none" : gradientEffect.defaultStateBorder};
-	}
 `;
 
 export default AIFixesButtonBase;

--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -4,23 +4,26 @@ import IconButtonBase from "./IconButtonBase";
 
 const yoastPrimary50 = "#FAF3F7";
 const yoastPrimary100 = "#F3E5ED";
+const yoastPrimary300 = "#CD82AB";
 const yoastPrimary400 = "#B94986";
 const yoastPrimary500 = "#A61E69";
 const yoastIndigo50 = "#EEF2FF";
 const yoastIndigo100 = "#E0E7FF";
+const yoastIndigo300 = "#A5B4FC";
 const yoastIndigo500 = "#6366F1";
 
 const direction = "to bottom right";
 
 const gradientEffect = {
 	defaultStateBackground: `linear-gradient(${direction}, ${yoastPrimary50}, ${yoastIndigo50})`,
+	defaultStateBorder: `linear-gradient(${direction}, ${yoastPrimary300}, ${yoastIndigo300}) 1`,
 	hoverStateBackground: `linear-gradient(${direction}, ${yoastPrimary100}, ${yoastIndigo100})`,
 	pressedStateBackground: `linear-gradient(${direction}, ${yoastPrimary500}, ${yoastIndigo500})`,
 };
 
 const AIFixesButtonBase = styled( IconButtonBase )`
 	overflow: hidden;
-	border: ${ props => props.pressed ? "none" : "1px solid #A5B4FC" }; /*indigo-300*/
+	border: ${ props => props.pressed ? "none" : `1px solid ${yoastIndigo300}` }; /*indigo-300*/
 	background-image: ${ props => props.pressed
 		? gradientEffect.pressedStateBackground
 		: gradientEffect.defaultStateBackground } !important;
@@ -31,6 +34,11 @@ const AIFixesButtonBase = styled( IconButtonBase )`
 		background-image:  ${ props => props.pressed
 		? gradientEffect.pressedStateBackground
 		: gradientEffect.hoverStateBackground } !important;
+	}
+
+	@supports ((border-image: ${gradientEffect.defaultStateBorder}) and (border-radius: 3px)) {
+		border: ${props => props.pressed ? "none" : "1px solid transparent"};
+		border-image: ${props => props.pressed ? "none" : gradientEffect.defaultStateBorder};
 	}
 `;
 

--- a/packages/components/src/AIFixesButton.js
+++ b/packages/components/src/AIFixesButton.js
@@ -4,21 +4,18 @@ import IconButtonBase from "./IconButtonBase";
 
 const yoastPrimary50 = "#FAF3F7";
 const yoastPrimary100 = "#F3E5ED";
-const yoastPrimary300 = "#CD82AB";
 const yoastPrimary400 = "#B94986";
 const yoastPrimary500 = "#A61E69";
-const blue50 = "#EFF6FF";
-const blue100 = "#DBEAFE";
-const blue300 = "#93C5FD";
-const blue500 = "#3B82F6";
+const yoastIndigo50 = "EEF2FF";
+const yoastIndigo100 = "E0E7FF";
+const yoastIndigo500 = "6366F1";
 
 const direction = "to bottom right";
 
 const gradientEffect = {
-	defaultStateBackground: `linear-gradient(${direction}, ${yoastPrimary50}, ${blue50})`,
-	defaultStateBorder: `linear-gradient(${direction}, ${yoastPrimary300}, ${blue300}) 1`,
-	hoverStateBackground: `linear-gradient(${direction}, ${yoastPrimary100}, ${blue100})`,
-	pressedStateBackground: `linear-gradient(${direction}, ${yoastPrimary500}, ${blue500})`,
+	defaultStateBackground: `linear-gradient(${direction}, ${yoastPrimary50}, ${yoastIndigo50})`,
+	hoverStateBackground: `linear-gradient(${direction}, ${yoastPrimary100}, ${yoastIndigo100})`,
+	pressedStateBackground: `linear-gradient(${direction}, ${yoastPrimary500}, ${yoastIndigo500})`,
 };
 
 const AIFixesButtonBase = styled( IconButtonBase )`

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -35,12 +35,12 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
 .c1 {
   overflow: hidden;
   border: none;
-  background-image: linear-gradient(to bottom right,#A61E69,#3B82F6) !important;
+  background-image: linear-gradient(to bottom right,#A61E69,6366F1) !important;
   box-shadow: inset 0 -2px 0 #B94986;
 }
 
 .c1:hover {
-  background-image: linear-gradient(to bottom right,#A61E69,#3B82F6) !important;
+  background-image: linear-gradient(to bottom right,#A61E69,6366F1) !important;
 }
 
 <button
@@ -91,12 +91,12 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
 .c1 {
   overflow: hidden;
   border: 1px solid #A5B4FC;
-  background-image: linear-gradient(to bottom right,#FAF3F7,#EFF6FF) !important;
+  background-image: linear-gradient(to bottom right,#FAF3F7,EEF2FF) !important;
   box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
 }
 
 .c1:hover {
-  background-image: linear-gradient(to bottom right,#F3E5ED,#DBEAFE) !important;
+  background-image: linear-gradient(to bottom right,#F3E5ED,E0E7FF) !important;
 }
 
 <button

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -43,6 +43,13 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
   background-image: linear-gradient(to bottom right,#A61E69,#6366F1) !important;
 }
 
+@supports ((border-image:linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1) and (border-radius:3px)) {
+  .c1 {
+    border: none;
+    border-image: none;
+  }
+}
+
 <button
   aria-label="Fix with AI"
   aria-pressed={true}
@@ -97,6 +104,13 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
 
 .c1:hover {
   background-image: linear-gradient(to bottom right,#F3E5ED,#E0E7FF) !important;
+}
+
+@supports ((border-image:linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1) and (border-radius:3px)) {
+  .c1 {
+    border: 1px solid transparent;
+    border-image: linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1;
+  }
 }
 
 <button

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -35,12 +35,12 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
 .c1 {
   overflow: hidden;
   border: none;
-  background-image: linear-gradient(to bottom right,#A61E69,6366F1) !important;
+  background-image: linear-gradient(to bottom right,#A61E69,#6366F1) !important;
   box-shadow: inset 0 -2px 0 #B94986;
 }
 
 .c1:hover {
-  background-image: linear-gradient(to bottom right,#A61E69,6366F1) !important;
+  background-image: linear-gradient(to bottom right,#A61E69,#6366F1) !important;
 }
 
 <button
@@ -91,12 +91,12 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
 .c1 {
   overflow: hidden;
   border: 1px solid #A5B4FC;
-  background-image: linear-gradient(to bottom right,#FAF3F7,EEF2FF) !important;
+  background-image: linear-gradient(to bottom right,#FAF3F7,#EEF2FF) !important;
   box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
 }
 
 .c1:hover {
-  background-image: linear-gradient(to bottom right,#F3E5ED,E0E7FF) !important;
+  background-image: linear-gradient(to bottom right,#F3E5ED,#E0E7FF) !important;
 }
 
 <button

--- a/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
+++ b/packages/components/tests/__snapshots__/IconAIFixesButtonTest.js.snap
@@ -43,13 +43,6 @@ exports[`the pressed IconAIFixesButton matches the snapshot 1`] = `
   background-image: linear-gradient(to bottom right,#A61E69,#6366F1) !important;
 }
 
-@supports ((border-image:linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1) and (border-radius:3px)) {
-  .c1 {
-    border: none;
-    border-image: none;
-  }
-}
-
 <button
   aria-label="Fix with AI"
   aria-pressed={true}
@@ -104,13 +97,6 @@ exports[`the unpressed IconAIFixesButton matches the snapshot 1`] = `
 
 .c1:hover {
   background-image: linear-gradient(to bottom right,#F3E5ED,#E0E7FF) !important;
-}
-
-@supports ((border-image:linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1) and (border-radius:3px)) {
-  .c1 {
-    border: 1px solid transparent;
-    border-image: linear-gradient(to bottom right,#CD82AB,#A5B4FC) 1;
-  }
 }
 
 <button

--- a/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
+++ b/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
@@ -12,12 +12,15 @@ export const SparklesIcon = ( { pressed = false } ) => {
 				<path
 					d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
 					stroke={ pressed ? "white" : "url(#paint0_linear_1538_754)" } strokeWidth="1.33333" strokeLinecap="round"
-					strokeLinejoin="round"/>
+					strokeLinejoin="round"
+				/>
 				<defs>
-					<linearGradient id="paint0_linear_1538_754" x1="1.99951" y1="2.96991" x2="15.3308" y2="4.69764"
-									gradientUnits="userSpaceOnUse">
-						<stop stopColor="#A61E69"/>
-						<stop offset="1" stopColor="#6366F1"/>
+					<linearGradient
+						id="paint0_linear_1538_754" x1="1.99951" y1="2.96991" x2="15.3308" y2="4.69764"
+						gradientUnits="userSpaceOnUse"
+					>
+						<stop stopColor="#A61E69" />
+						<stop offset="1" stopColor="#6366F1" />
 					</linearGradient>
 				</defs>
 			</svg>

--- a/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
+++ b/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
@@ -8,15 +8,16 @@ import propTypes from "prop-types";
 export const SparklesIcon = ( { pressed = false } ) => {
 	return (
 		<>
-			<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path
-					d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
-					stroke={ pressed ? "white" : "url(#paint0_linear_1538_754)" } strokeWidth="1.33333" strokeLinecap="round"
+					d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
+					stroke={ pressed ? "white" : "url(#paint0_linear_1208_188)" } strokeWidth="1.33333"
+					strokeLinecap="round"
 					strokeLinejoin="round"
 				/>
 				<defs>
 					<linearGradient
-						id="paint0_linear_1538_754" x1="1.99951" y1="2.96991" x2="15.3308" y2="4.69764"
+						id="paint0_linear_1208_188" x1="0" y1="0" x2="16" y2="16"
 						gradientUnits="userSpaceOnUse"
 					>
 						<stop stopColor="#A61E69" />

--- a/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
+++ b/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
@@ -11,7 +11,7 @@ export const SparklesIcon = ( { pressed = false } ) => {
 			<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path
 					d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
-					stroke="url(#paint0_linear_1538_754)" strokeWidth="1.33333" strokeLinecap="round"
+					stroke={ pressed ? "white" : "url(#paint0_linear_1538_754)" } strokeWidth="1.33333" strokeLinecap="round"
 					strokeLinejoin="round"/>
 				<defs>
 					<linearGradient id="paint0_linear_1538_754" x1="1.99951" y1="2.96991" x2="15.3308" y2="4.69764"

--- a/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
+++ b/packages/js/src/ai-assessment-fixes/components/sparkles-icon.js
@@ -8,19 +8,16 @@ import propTypes from "prop-types";
 export const SparklesIcon = ( { pressed = false } ) => {
 	return (
 		<>
-			<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<path
-					d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
-					stroke={ pressed ? "white" : "url(#paint0_linear_1208_188)" } strokeWidth="1.33333" strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
+					d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
+					stroke="url(#paint0_linear_1538_754)" strokeWidth="1.33333" strokeLinecap="round"
+					strokeLinejoin="round"/>
 				<defs>
-					<linearGradient
-						id="paint0_linear_1208_188" x1="0" y1="0" x2="16" y2="16"
-						gradientUnits="userSpaceOnUse"
-					>
-						<stop stopColor="#A61E69" />
-						<stop offset="1" stopColor="#3B82F6" />
+					<linearGradient id="paint0_linear_1538_754" x1="1.99951" y1="2.96991" x2="15.3308" y2="4.69764"
+									gradientUnits="userSpaceOnUse">
+						<stop stopColor="#A61E69"/>
+						<stop offset="1" stopColor="#6366F1"/>
 					</linearGradient>
 				</defs>
 			</svg>

--- a/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
+++ b/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
@@ -4,14 +4,14 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is f
 <div>
   <svg
     fill="none"
-    height="17"
-    viewBox="0 0 16 17"
+    height="16"
+    viewBox="0 0 16 16"
     width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
-      stroke="url(#paint0_linear_1538_754)"
+      d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
+      stroke="url(#paint0_linear_1208_188)"
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="1.33333"
@@ -19,11 +19,11 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is f
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="paint0_linear_1538_754"
-        x1="1.99951"
-        x2="15.3308"
-        y1="2.96991"
-        y2="4.69764"
+        id="paint0_linear_1208_188"
+        x1="0"
+        x2="16"
+        y1="0"
+        y2="16"
       >
         <stop
           stop-color="#A61E69"
@@ -42,13 +42,13 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is t
 <div>
   <svg
     fill="none"
-    height="17"
-    viewBox="0 0 16 17"
+    height="16"
+    viewBox="0 0 16 16"
     width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
+      d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
       stroke="white"
       stroke-linecap="round"
       stroke-linejoin="round"
@@ -57,11 +57,11 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is t
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="paint0_linear_1538_754"
-        x1="1.99951"
-        x2="15.3308"
-        y1="2.96991"
-        y2="4.69764"
+        id="paint0_linear_1208_188"
+        x1="0"
+        x2="16"
+        y1="0"
+        y2="16"
       >
         <stop
           stop-color="#A61E69"

--- a/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
+++ b/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
@@ -49,7 +49,7 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is t
   >
     <path
       d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
-      stroke="url(#paint0_linear_1538_754)"
+      stroke="white"
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="1.33333"

--- a/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
+++ b/packages/js/tests/ai-assessment-fixes/components/__snapshots__/SparklesIcon.test.js.snap
@@ -4,14 +4,14 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is f
 <div>
   <svg
     fill="none"
-    height="16"
-    viewBox="0 0 16 16"
+    height="17"
+    viewBox="0 0 16 17"
     width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
-      stroke="url(#paint0_linear_1208_188)"
+      d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
+      stroke="url(#paint0_linear_1538_754)"
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="1.33333"
@@ -19,18 +19,18 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is f
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="paint0_linear_1208_188"
-        x1="0"
-        x2="16"
-        y1="0"
-        y2="16"
+        id="paint0_linear_1538_754"
+        x1="1.99951"
+        x2="15.3308"
+        y1="2.96991"
+        y2="4.69764"
       >
         <stop
           stop-color="#A61E69"
         />
         <stop
           offset="1"
-          stop-color="#3B82F6"
+          stop-color="#6366F1"
         />
       </lineargradient>
     </defs>
@@ -42,14 +42,14 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is t
 <div>
   <svg
     fill="none"
-    height="16"
-    viewBox="0 0 16 16"
+    height="17"
+    viewBox="0 0 16 17"
     width="16"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M3.33284 2V4.66667M1.99951 3.33333H4.66618M3.99951 11.3333V14M2.66618 12.6667H5.33284M8.66618 2L10.19 6.57143L13.9995 8L10.19 9.42857L8.66618 14L7.14237 9.42857L3.33284 8L7.14237 6.57143L8.66618 2Z"
-      stroke="white"
+      d="M3.33284 2.96991V5.63658M1.99951 4.30324H4.66618M3.99951 12.3032V14.9699M2.66618 13.6366H5.33284M8.66618 2.96991L10.19 7.54134L13.9995 8.96991L10.19 10.3985L8.66618 14.9699L7.14237 10.3985L3.33284 8.96991L7.14237 7.54134L8.66618 2.96991Z"
+      stroke="url(#paint0_linear_1538_754)"
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="1.33333"
@@ -57,18 +57,18 @@ exports[`SparklesIcon should render the SparklesIcon component when pressed is t
     <defs>
       <lineargradient
         gradientUnits="userSpaceOnUse"
-        id="paint0_linear_1208_188"
-        x1="0"
-        x2="16"
-        y1="0"
-        y2="16"
+        id="paint0_linear_1538_754"
+        x1="1.99951"
+        x2="15.3308"
+        y1="2.96991"
+        y2="4.69764"
       >
         <stop
           stop-color="#A61E69"
         />
         <stop
           offset="1"
-          stop-color="#3B82F6"
+          stop-color="#6366F1"
         />
       </lineargradient>
     </defs>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The AI assessment sparkle button color changed from 'blue' to 'indigo'.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the styling of AI assessments fixes buttons.

## Relevant technical choices:

* Just change color.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Yoast SEO and Yoast SEO Premium activated.
* Open or create a new post.
* Use the block editor. 
* Add enough content and also add a _focus keyphrase_. Ensure that the keyphrase is not included in the first paragraph/introduction and that it isn't used more than once in the content. 
* Open the Premium SEO analysis tab in the Yoast Premium SEO > SEO or in the Yoast SEO sidebar. 

<img width="1269" alt="SCR-20240604-oftc" src="https://github.com/Yoast/wordpress-seo/assets/152272313/fc628b0b-a887-419e-bf0b-4c81e1f966b3">

* Check that the __Keyphrase in introduction_ and _Keyphrase density_ and _Keyphrase distribution_ assessments aren't green and show the sparkle button of the AI assessments fixes project. 
* Check that  the __FIx with AI__ button background is fit  the [Design](https://www.figma.com/proto/3PU3tncELdnjvCTY1OSuWk/AI---Fix-individual-assessments?node-id=0-1503&starting-point-node-id=0%3A1555) and  'to-indigo-50 (#eef2ff)' color is used.
* Check that  the __FIx with AI__ button hover background is fit  the [Design](https://www.figma.com/proto/3PU3tncELdnjvCTY1OSuWk/AI---Fix-individual-assessments?node-id=0-1503&starting-point-node-id=0%3A1555) and  'to-indigo-100 (#e0e7ff)' color is used.
* Check that  the __FIx with AI__ button image is fit  the [Design](https://www.figma.com/proto/3PU3tncELdnjvCTY1OSuWk/AI---Fix-individual-assessments?node-id=0-1503&starting-point-node-id=0%3A1555).
* Click  the __FIx with AI__ button and make sure that active state background is fit  the [Design](https://www.figma.com/proto/3PU3tncELdnjvCTY1OSuWk/AI---Fix-individual-assessments?node-id=0-1503&starting-point-node-id=0%3A1555) and  'to-indigo-500 (#6366f1)' color is used.
* Check that  the __FIx with AI__ button active state image is fit  the [Design](https://www.figma.com/proto/3PU3tncELdnjvCTY1OSuWk/AI---Fix-individual-assessments?node-id=0-1503&starting-point-node-id=0%3A1555) and white color is used.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Please check any other Toast message that it still the same.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched of
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#1624](https://github.com/Yoast/plugins-automated-testing/issues/1624)
