### PR TITLE
Disable the AI buttons when the editor or blocks are in HTML mode

### DIFF
--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -12,6 +12,7 @@ import { Paper } from "yoastseo";
 /* Internal dependencies */
 import { ModalContent } from "./modal-content";
 import { SparklesIcon } from "./sparkles-icon";
+import { getAllBlocks } from "../../helpers/getAllBlocks";
 
 /**
  * The AI Assessment Fixes button component.
@@ -30,6 +31,14 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
 	const [ buttonClass, setButtonClass ] = useState( "" );
+
+	// Only enable the button when the editor is in visual mode and all blocks are in visual mode.
+	const allVisual = useSelect( ( select ) => {
+		const blocks = getAllBlocks( select( "core/block-editor" ).getBlocks() );
+		return blocks.every( block => select( "core/block-editor" ).getBlockMode( block.clientId ) === "visual" );
+	}, [] );
+	const editorMode = useSelect( select => select( "core/edit-post" ).getEditorMode(), [] );
+	const isEnabled = editorMode === "visual" && allVisual;
 
 	/**
 	 * Handles the button press state.
@@ -92,6 +101,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 				id={ aiFixesId }
 				className={ `ai-button ${buttonClass}` }
 				pressed={ isButtonPressed }
+				disabled={ ! isEnabled }
 			>
 				<SparklesIcon pressed={ isButtonPressed } />
 				{

--- a/packages/js/src/helpers/getAllBlocks.js
+++ b/packages/js/src/helpers/getAllBlocks.js
@@ -1,0 +1,16 @@
+/**
+ * Returns all Gutenberg blocks given the (current) top-level blocks.
+ * @param {object[]} blocks The (current) top-level blocks.
+ * @returns {object[]} All blocks.
+ */
+export const getAllBlocks = ( blocks ) => {
+	let allBlocks = [ ...blocks ];
+
+	blocks.forEach( block => {
+		if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+			allBlocks = [ ...allBlocks, ...getAllBlocks( block.innerBlocks ) ];
+		}
+	} );
+
+	return allBlocks;
+};

--- a/packages/ui-library/src/components/notifications/index.js
+++ b/packages/ui-library/src/components/notifications/index.js
@@ -93,7 +93,7 @@ Notification.propTypes = {
 	title: PropTypes.string,
 	description: PropTypes.oneOfType( [ PropTypes.node, PropTypes.arrayOf( PropTypes.node ) ] ),
 	onDismiss: PropTypes.func,
-	autoDismiss: PropTypes.oneOfType( [ PropTypes.number, null ] ),
+	autoDismiss: PropTypes.number,
 	dismissScreenReaderLabel: PropTypes.string.isRequired,
 };
 

--- a/packages/ui-library/src/elements/toast/index.js
+++ b/packages/ui-library/src/elements/toast/index.js
@@ -158,7 +158,7 @@ Toast.propTypes = {
 	className: PropTypes.string,
 	position: PropTypes.string,
 	onDismiss: PropTypes.func,
-	autoDismiss: PropTypes.oneOfType( [ PropTypes.number, null ] ),
+	autoDismiss: PropTypes.number,
 	isVisible: PropTypes.bool.isRequired,
 	setIsVisible: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to disable the AI buttons when the editor or any of the blocks are in HTML mode. 
* In this PR, we also fix a small issue with the props of the Toast and Notification in the UI library, that led to a console error. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the AI buttons when the editor or blocks are in HTML mode.
* [@yoast/ui-library 0.0.1] Fixes the `autoDismiss` prop on the _Toast_ element and _Notification_ component.

## Relevant technical choices:

* To retrieve and check the editing mode of all blocks, we need a helper function, because `getBlocks` from Gutenberg only retrieves the top-level blocks (see [docs](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-block-editor/#getblocks)).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post in the default editor.
* Add various blocks, also create some inner blocks through creating a columns block.
* Add some content to these blocks.
* Add a keyphrase, make sure it does not appear in the first block (that can be regarded as an introduction). 
* Confirm that the AI button next to the _keyphrase in introduction_ assessment is present and **active**. 
* Switch from visual mode to HTML mode for the editor as a whole -- click the three vertical dots on the top right and then click "Code editor".
* Confirm that the AI button next to the _keyphrase in introduction_ assessment is present but **disabled**.
* Switch back to visual mode -- click the three vertical dots on the top right and then click "Visual editor".
* Confirm that the AI button next to the _keyphrase in introduction_ assessment is present and **active**. 
* For one (or multiple of the) blocks, switch to HTML editing mode -- select a block, click the three vertical dots on the top right of the menu that opens, and then click "Edit as HTML".
* Confirm that the AI button next to the _keyphrase in introduction_ assessment is present but **disabled**.
* For all blocks, switch back to visual mode -- select a block in HTML editing mode and click "Edit visually".
* Confirm that the AI button next to the _keyphrase in introduction_ assessment is present and **active**. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR affects whether the AI button is enabled, no other impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1594
