### PR TITLE
Fixes the previously used keywords in terms not expecting script data

### DIFF
--- a/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
+++ b/packages/yoastseo/src/bundledPlugins/previouslyUsedKeywords.js
@@ -154,7 +154,7 @@ PreviouslyUsedKeyword.prototype.researchPreviouslyUsedKeywords = function( paper
 
 	if ( ! isUndefined( this.usedKeywords[ keyword ] ) && this.usedKeywords[ keyword ].length > 0 ) {
 		count = this.usedKeywords[ keyword ].length;
-		if ( this.usedKeywordsPostTypes ) {
+		if ( keyword in this.usedKeywordsPostTypes ) {
 			postTypeToDisplay = this.usedKeywordsPostTypes[ keyword ][ 0 ];
 		}
 		id = this.usedKeywords[ keyword ][ 0 ];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

With the refactor of the script data in https://github.com/Yoast/wordpress-seo/pull/21339 we had one change in the data: for terms we now do output a value in `wpseoScriptData.metabox.keyword_usage_post_types`. Before we did not. Unfortunately I missed the console error that produced. This PR is to fix that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the previously used keywords was not expecting empty script data.

## Relevant technical choices:

* [Add safety check](https://github.com/Yoast/wordpress-seo/commit/dd8e71f759d8907bb32200c747afd682c4a6472c) 
We now include an empty array value for terms.
This code will handle an empty array the same as an object with a keyword as key.
Why is it a JS array and not object? It starts as an empty PHP array (I suppose not specifically asoc), and is localized as a JS array instead of an object.
 * I did doubt whether to do this or change the script data to not output like we did before. Some elaboration on those thoughts on Slack: https://yoast.slack.com/archives/C03PRESAXMJ/p1720080190109539

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create/edit a term and add a focus keyphrase
* Create/edit another term and add the same focus keyphrase
* Reload the page (saving already does)
* [ ] Verify the error as described in the issue is not there anymore in the browser console
* [ ] Verify that `wpseoScriptData.metabox.keyword_usage_post_types` contains an empty array (type in your browser console)
* [ ] Verify the SEO analysis contains the improvement: `Previously used keyphrase: You've used this keyphrase once before. Do not use your keyphrase more than once.`
* Change the focus keyphrase
* [ ] Verify the SEO analysis assessment result changed to a good result: `Previously used keyphrase: You've not used this keyphrase before, very good.`

After that, verify the same SEO analysis assessment still works the same for a post:
* Create/edit a post and add a focus keyphrase
* Create/edit another post and add the same focus keyphrase
* Reload the page
* [x] Verify the SEO analysis contains the improvement: `Previously used keyphrase: You've used this keyphrase once before. Do not use your keyphrase more than once.`
* Change the focus keyphrase
* [x] Verify the SEO analysis assessment result changed to a good result: `Previously used keyphrase: You've not used this keyphrase before, very good.`


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1687
