### PR TITLE
Add website information to the script data in Elementor

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -927,6 +927,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'isWooCommerceActive'        => $woocommerce_active,
 			'woocommerceUpsell'          => get_post_type( $post_id ) === 'product' && ! $woocommerce_seo_active && $woocommerce_active,
 		];
+
 		/**
 		 * The website information repository.
 		 *
@@ -936,6 +937,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$site_information = $repo->get_post_site_information();
 		$site_information->set_permalink( $this->get_permalink() );
 		$script_data = array_merge_recursive( $site_information->get_legacy_site_information(), $script_data );
+
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
 			$asset_manager->enqueue_style( 'featured-image' );
 

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -21,6 +21,7 @@ use WPSEO_Utils;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\Editors\Application\Site\Website_Information_Repository;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -457,10 +458,11 @@ class Elementor implements Integration_Interface {
 		$alert_dismissal_action  = \YoastSEO()->classes->get( Alert_Dismissal_Action::class );
 		$dismissed_alerts        = $alert_dismissal_action->all_dismissed();
 		$woocommerce_conditional = new WooCommerce_Conditional();
+		$permalink               = $this->get_permalink();
 
 		$script_data = [
 			'media'                     => [ 'choose_image' => \__( 'Use Image', 'wordpress-seo' ) ],
-			'metabox'                   => $this->get_metabox_script_data(),
+			'metabox'                   => $this->get_metabox_script_data( $permalink ),
 			'userLanguageCode'          => WPSEO_Language_Utils::get_language( \get_user_locale() ),
 			'isPost'                    => true,
 			'isBlockEditor'             => WP_Screen::get()->is_block_editor(),
@@ -480,6 +482,16 @@ class Elementor implements Integration_Interface {
 			'pluginUrl'                 => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission'     => \YoastSEO()->classes->get( Wistia_Embed_Permission_Repository::class )->get_value_for_user( \get_current_user_id() ),
 		];
+
+		/**
+		 * The website information repository.
+		 *
+		 * @var $repo Website_Information_Repository
+		 */
+		$repo             = \YoastSEO()->classes->get( Website_Information_Repository::class );
+		$site_information = $repo->get_post_site_information();
+		$site_information->set_permalink( $permalink );
+		$script_data = \array_merge_recursive( $site_information->get_legacy_site_information(), $script_data );
 
 		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {
 			$this->asset_manager->enqueue_style( 'featured-image' );
@@ -597,16 +609,11 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Passes variables to js for use with the post-scraper.
 	 *
+	 * @param string $permalink The permalink.
+	 *
 	 * @return array
 	 */
-	protected function get_metabox_script_data() {
-		$permalink = '';
-
-		if ( \is_object( $this->get_metabox_post() ) ) {
-			$permalink = \get_sample_permalink( $this->get_metabox_post()->ID );
-			$permalink = $permalink[0];
-		}
-
+	protected function get_metabox_script_data( $permalink ) {
 		$post_formatter = new WPSEO_Metabox_Formatter(
 			new WPSEO_Post_Metabox_Formatter( $this->get_metabox_post(), [], $permalink )
 		);
@@ -622,6 +629,22 @@ class Elementor implements Integration_Interface {
 		$values['elementorMarkerStatus'] = $this->is_highlighting_available() ? 'enabled' : 'hidden';
 
 		return $values;
+	}
+
+	/**
+	 * Gets the permalink.
+	 *
+	 * @return string
+	 */
+	protected function get_permalink(): string {
+		$permalink = '';
+
+		if ( \is_object( $this->get_metabox_post() ) ) {
+			$permalink = \get_sample_permalink( $this->get_metabox_post()->ID );
+			$permalink = $permalink[0];
+		}
+
+		return $permalink;
 	}
 
 	/**

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -18,14 +18,12 @@ use WPSEO_Post_Metabox_Formatter;
 use WPSEO_Replace_Vars;
 use WPSEO_Shortlinker;
 use WPSEO_Utils;
-use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Editors\Application\Site\Website_Information_Repository;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
-use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
 use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 
@@ -129,13 +127,11 @@ class Elementor implements Integration_Interface {
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Options_Helper $options,
-		Capability_Helper $capability,
-		Promotion_Manager $promotion_manager
+		Capability_Helper $capability
 	) {
 		$this->asset_manager     = $asset_manager;
 		$this->options           = $options;
 		$this->capability        = $capability;
-		$this->promotion_manager = $promotion_manager;
 
 		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();
@@ -455,8 +451,6 @@ class Elementor implements Integration_Interface {
 			'enabled_features'        => WPSEO_Utils::retrieve_enabled_features(),
 		];
 
-		$alert_dismissal_action  = \YoastSEO()->classes->get( Alert_Dismissal_Action::class );
-		$dismissed_alerts        = $alert_dismissal_action->all_dismissed();
 		$woocommerce_conditional = new WooCommerce_Conditional();
 		$permalink               = $this->get_permalink();
 
@@ -474,13 +468,8 @@ class Elementor implements Integration_Interface {
 				'plugins' => $plugins_script_data,
 				'worker'  => $worker_script_data,
 			],
-			'dismissedAlerts'           => $dismissed_alerts,
 			'webinarIntroElementorUrl'  => WPSEO_Shortlinker::get( 'https://yoa.st/webinar-intro-elementor' ),
-			'currentPromotions'         => $this->promotion_manager->get_current_promotions(),
 			'usedKeywordsNonce'         => \wp_create_nonce( 'wpseo-keyword-usage-and-post-types' ),
-			'linkParams'                => WPSEO_Shortlinker::get_query_params(),
-			'pluginUrl'                 => \plugins_url( '', \WPSEO_FILE ),
-			'wistiaEmbedPermission'     => \YoastSEO()->classes->get( Wistia_Embed_Permission_Repository::class )->get_value_for_user( \get_current_user_id() ),
 		];
 
 		/**

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -119,19 +119,18 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager     The asset manager.
-	 * @param Options_Helper            $options           The options helper.
-	 * @param Capability_Helper         $capability        The capability helper.
-	 * @param Promotion_Manager         $promotion_manager The promotion manager.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
+	 * @param Options_Helper            $options       The options helper.
+	 * @param Capability_Helper         $capability    The capability helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Options_Helper $options,
 		Capability_Helper $capability
 	) {
-		$this->asset_manager     = $asset_manager;
-		$this->options           = $options;
-		$this->capability        = $capability;
+		$this->asset_manager = $asset_manager;
+		$this->options       = $options;
+		$this->capability    = $capability;
 
 		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We forgot to add the removed script data back in Elementor in https://github.com/Yoast/wordpress-seo/pull/21368 😞 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the website information in the `wpseoScriptData` was no longer present in the Elementor editor.

## Relevant technical choices:

This PR is adjusting Elementor for:

The removed variables from the `wpseoScriptData.metabox` part:
* Defaults: https://github.com/Yoast/wordpress-seo/pull/21368/files#diff-e578f46d7b0ca259212c2d636041ca36a5de9e6f08d13733890a730354e3886aL56-L69
* Just for posts: https://github.com/Yoast/wordpress-seo/pull/21368/files#diff-3443072aee6094201d9f6c827bb3f27fd6570a9f7769a8cefa9fc8991feb66e8L59-L61

And the removed variables from the `wpseoScriptData` itself:
* https://github.com/Yoast/wordpress-seo/pull/21368/files#diff-0eb66e66763a2ba4315357e7002fe8abd99de6f36dcc73aa5fea0bb98e936a04L933-L944


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in the Elementor editor
* Open the Yoast SEO sidebar
* [ ] Verify you no longer get the error from the issue
* Open the browser console
* Run `wpseoScriptData.metabox` and verify that the following entries are there:
  * [ ] `base_url` and is your site domain
  * [ ] `contentLocale` and is your site locale (`en_US`?)
  * [ ] `isPremium` is `false` when you don't have Premium active
  * [ ] ` isRtl` is `false` when you are not using a right to left locale
  * [ ] `post_edit_url` is most likely your site domain plus `/wp-admin/post.php?post={id}&action=edit`
  * [ ] `search_url` is most likely your site domain plus `/wp-admin/edit.php?seo_kw_filter={keyword}`
  * [ ] `siteIconUrl` is empty or the site icon URL you entered
  * [ ] `site_name` is your site name
  * [ ] `userLocale` is your user locale (`en_US`?)
* Run `wpseoScriptData` and verify that the following entries are there:
  * [ ] `dismissedAlerts` is (most likely) an empty array
  * [ ] `currentPromotions` is (most likely) an empty array
  * [ ] `webinarIntroBlockEditorUrl` (though not needed due as `webinarIntroElementorUrl` is used) is `https://yoa.st/webinar-intro-block-editor` followed by the link params
  * [ ] `blackFridayBlockEditorUrl` is an empty string
  * [ ] `linkParams` is an array with the link params including for example `platform: "wordpress"`
  * [ ] `pluginUrl` is the url of Yoast SEO plugin, most likely your site domain plus `/wp-content/plugins/wordpress-seo`
  * [ ] `wistiaEmbedPermission` is either an empty string or 1 (as string)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1690
