### PR TITLE
Deprecate old introduction and fix deprecation messages

### DIFF
--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -28,17 +28,19 @@ use Yoast\WP\SEO\Integrations\Admin\Old_Premium_Integration;
 use Yoast\WP\SEO\Integrations\Third_Party\Wincher;
 use Yoast\WP\SEO\Integrations\Third_Party\Wordproof;
 use Yoast\WP\SEO\Integrations\Third_Party\Wordproof_Integration_Toggle;
+use Yoast\WP\SEO\Introductions\Application\Ai_Generate_Titles_And_Descriptions_Introduction_Upsell;
 
 $deprecated_classes = [
-	Old_Premium_Integration::class                  => '20.10',
-	Wincher::class                                  => '21.6',
-	Wordproof_Integration_Toggle::class             => '21.6',
-	Wordproof::class                                => '22.10',
-	Wordproof_Integration_Active_Conditional::class => '22.10',
-	Wordproof_Plugin_Inactive_Conditional::class    => '22.10',
-	Wordproof_App_Config::class                     => '22.10',
-	Wordproof_Translations::class                   => '22.10',
-	Wordproof_Helper::class                         => '22.10',
+	Old_Premium_Integration::class                                 => '20.10',
+	Wincher::class                                                 => '21.6',
+	Wordproof_Integration_Toggle::class                            => '21.6',
+	Wordproof::class                                               => '22.10',
+	Wordproof_Integration_Active_Conditional::class                => '22.10',
+	Wordproof_Plugin_Inactive_Conditional::class                   => '22.10',
+	Wordproof_App_Config::class                                    => '22.10',
+	Wordproof_Translations::class                                  => '22.10',
+	Wordproof_Helper::class                                        => '22.10',
+	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => '23.2',
 ];
 
 foreach ( $deprecated_classes as $original_class => $version ) {

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -22,7 +22,7 @@ use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
 use Yoast\WP\SEO\Introductions\Application\Ai_Generate_Titles_And_Descriptions_Introduction_Upsell;
 
 $renamed_classes = [
-	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => [ Ai_Fix_Assessments_Upsell::class, '23.1' ],
+	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => [ Ai_Fix_Assessments_Upsell::class, '23.2' ],
 ];
 
 foreach ( $renamed_classes as $original_class => $replacement ) {

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -18,12 +18,7 @@
  * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
  */
 
-use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
-use Yoast\WP\SEO\Introductions\Application\Ai_Generate_Titles_And_Descriptions_Introduction_Upsell;
-
-$renamed_classes = [
-	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => [ Ai_Fix_Assessments_Upsell::class, '23.2' ],
-];
+$renamed_classes = [];
 
 foreach ( $renamed_classes as $original_class => $replacement ) {
 	list( $renamed_class, $version ) = $replacement;

--- a/config/dependency-injection/renamed-classes.php
+++ b/config/dependency-injection/renamed-classes.php
@@ -18,7 +18,12 @@
  * @var $container \Symfony\Component\DependencyInjection\ContainerBuilder
  */
 
-$renamed_classes = [];
+use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
+use Yoast\WP\SEO\Introductions\Application\Ai_Generate_Titles_And_Descriptions_Introduction_Upsell;
+
+$renamed_classes = [
+	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => [ Ai_Fix_Assessments_Upsell::class, '23.1' ],
+];
 
 foreach ( $renamed_classes as $original_class => $replacement ) {
 	list( $renamed_class, $version ) = $replacement;

--- a/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -5,10 +5,10 @@
  * {@internal As this file is just (temporarily) put in place to warn extending
  * plugins about the class name changes, it is exempt from select CS standards.}
  *
- * @package Yoast\WP\SEO
- *
  * @since      23.2
  * @deprecated 23.2
+ *
+ * @codeCoverageIgnore
  *
  * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound

--- a/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -5,7 +5,6 @@
  * {@internal As this file is just (temporarily) put in place to warn extending
  * plugins about the class name changes, it is exempt from select CS standards.}
  *
- * @since      23.2
  * @deprecated 23.2
  *
  * @codeCoverageIgnore

--- a/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -7,8 +7,8 @@
  *
  * @package Yoast\WP\SEO
  *
- * @since      23.1
- * @deprecated 23.1
+ * @since      23.2
+ * @deprecated 23.2
  *
  * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
@@ -25,7 +25,7 @@ use Yoast\WP\SEO\Helpers\Product_Helper;
 /**
  * Represents the introduction for the AI generate titles and introduction upsell.
  *
- * @deprecated 23.1 Use {@see \Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell} instead.
+ * @deprecated 23.2 Use {@see \Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell} instead.
  */
 class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell extends Ai_Fix_Assessments_Upsell {
 
@@ -50,7 +50,7 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell extends Ai_Fix_Ass
 	/**
 	 * Constructs the introduction.
 	 *
-	 * @deprecated 23.1
+	 * @deprecated 23.2
 	 *
 	 * @param Product_Helper $product_helper The product helper.
 	 * @param Options_Helper $options_helper The options' helper.
@@ -66,13 +66,13 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell extends Ai_Fix_Ass
 	/**
 	 * Returns the ID.
 	 *
-	 * @deprecated 23.1
+	 * @deprecated 23.2
 	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
 	public function get_id() {
-		\_deprecated_function( __METHOD__, 'Yoast SEO 23.0' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 23.2' );
 		return 'ai-generate-titles-and-descriptions-upsell';
 	}
 
@@ -93,26 +93,26 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell extends Ai_Fix_Ass
 	/**
 	 * Returns the requested pagination priority. Lower means earlier.
 	 *
-	 * @deprecated 23.1
+	 * @deprecated 23.2
 	 * @codeCoverageIgnore
 	 *
 	 * @return int
 	 */
 	public function get_priority() {
-		\_deprecated_function( __METHOD__, 'Yoast SEO 23.0' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 23.2' );
 		return 10;
 	}
 
 	/**
 	 * Returns whether this introduction should show.
 	 *
-	 * @deprecated 23.1
+	 * @deprecated 23.2
 	 * @codeCoverageIgnore
 	 *
 	 * @return bool
 	 */
 	public function should_show() {
-		\_deprecated_function( __METHOD__, 'Yoast SEO 23.0' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 23.2' );
 		// Outdated feature introduction.
 		return false;
 	}

--- a/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Graceful deprecation of various classes which were renamed.
+ * Graceful deprecation of the Ai_Generate_Titles_And_Descriptions_Introduction_Upsell class.
  *
  * {@internal As this file is just (temporarily) put in place to warn extending
  * plugins about the class name changes, it is exempt from select CS standards.}

--- a/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
+++ b/src/deprecated/src/introductions/application/ai-generate-titles-and-descriptions-introduction-upsell.php
@@ -1,17 +1,33 @@
 <?php
+/**
+ * Graceful deprecation of various classes which were renamed.
+ *
+ * {@internal As this file is just (temporarily) put in place to warn extending
+ * plugins about the class name changes, it is exempt from select CS standards.}
+ *
+ * @package Yoast\WP\SEO
+ *
+ * @since      23.1
+ * @deprecated 23.1
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ * @phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedNamespaceFound
+ * @phpcs:disable Yoast.Commenting.CodeCoverageIgnoreDeprecated
+ * @phpcs:disable Yoast.Commenting.FileComment.Unnecessary
+ * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
+ */
 
 namespace Yoast\WP\SEO\Introductions\Application;
 
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
-use Yoast\WP\SEO\Introductions\Domain\Introduction_Interface;
 
 /**
  * Represents the introduction for the AI generate titles and introduction upsell.
  *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @deprecated 23.1 Use {@see \Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell} instead.
  */
-class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introduction_Interface {
+class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell extends Ai_Fix_Assessments_Upsell {
 
 	use Current_Page_Trait;
 	use User_Allowed_Trait;
@@ -34,6 +50,8 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 	/**
 	 * Constructs the introduction.
 	 *
+	 * @deprecated 23.1
+	 *
 	 * @param Product_Helper $product_helper The product helper.
 	 * @param Options_Helper $options_helper The options' helper.
 	 */
@@ -48,7 +66,7 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 	/**
 	 * Returns the ID.
 	 *
-	 * @deprecated 23.0
+	 * @deprecated 23.1
 	 * @codeCoverageIgnore
 	 *
 	 * @return string
@@ -75,7 +93,7 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 	/**
 	 * Returns the requested pagination priority. Lower means earlier.
 	 *
-	 * @deprecated 23.0
+	 * @deprecated 23.1
 	 * @codeCoverageIgnore
 	 *
 	 * @return int
@@ -88,7 +106,7 @@ class Ai_Generate_Titles_And_Descriptions_Introduction_Upsell implements Introdu
 	/**
 	 * Returns whether this introduction should show.
 	 *
-	 * @deprecated 23.0
+	 * @deprecated 23.1
 	 * @codeCoverageIgnore
 	 *
 	 * @return bool

--- a/src/introductions/application/ai-fix-assessments-upsell.php
+++ b/src/introductions/application/ai-fix-assessments-upsell.php
@@ -46,7 +46,7 @@ class Ai_Fix_Assessments_Upsell implements Introduction_Interface {
 	 *
 	 * @return string The ID.
 	 */
-	public function get_id(): string {
+	public function get_id() {
 		return self::ID;
 	}
 
@@ -55,7 +55,7 @@ class Ai_Fix_Assessments_Upsell implements Introduction_Interface {
 	 *
 	 * @return string The name.
 	 */
-	public function get_name(): string {
+	public function get_name() {
 		\_deprecated_function( __METHOD__, 'Yoast SEO Premium 21.6', 'Please use get_id() instead' );
 
 		return self::ID;
@@ -66,7 +66,7 @@ class Ai_Fix_Assessments_Upsell implements Introduction_Interface {
 	 *
 	 * @return int The priority.
 	 */
-	public function get_priority(): int {
+	public function get_priority() {
 		return 10;
 	}
 
@@ -75,7 +75,7 @@ class Ai_Fix_Assessments_Upsell implements Introduction_Interface {
 	 *
 	 * @return bool Whether this introduction should show.
 	 */
-	public function should_show(): bool {
+	public function should_show() {
 
 		if ( $this->product_helper->is_premium() ) {
 			return false;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove deprecation message from admin pages. To do that we need to properly deprecate the whole introduction upsell class and replace it with the new one.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove deprecation message for ai generator for titles and descriptions on Yoast admin pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to one of yoast admin pages with Premium disabled
* Check you do not see the deprecation message for the `Ai_Generate_Titles_And_Descriptions_Introduction::should_show()` method
* Also smoke test the new upsell appearing properly.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
