### PR TITLE
Tweak SnippetPreview

### DIFF
--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "yarn clean && yarn build:js",
     "build:js": "babel src --out-dir build",
+    "watch": "yarn build:js --watch",
     "clean": "rm -rf build",
     "test": "jest",
     "lint": "eslint . --max-warnings=7"

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -112,12 +112,13 @@ export default class FixedWidthContainer extends Component {
 	render() {
 		const { width, padding, children, className, id } = this.props;
 
+		const klass = className || id;
 		const innerWidth = width - 2 * padding;
 
-		return <React.Fragment>
+		return <div className={ `${ klass }__wrapper` }>
 			<FixedWidth
 				id={ id }
-				className={ className }
+				className={ klass }
 				widthValue={ width }
 				paddingValue={ padding }
 				ref={ this.setContainerRef }
@@ -138,7 +139,7 @@ export default class FixedWidthContainer extends Component {
 					</ScrollHint>
 				</ScrollHintContainer>
 			}
-		</React.Fragment>;
+		</div>;
 	}
 }
 

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -19,7 +19,7 @@ const Inner = styled.div`
 
 const ScrollHintContainer = styled.div`
 	text-align: center;
-	margin: 1em 0 5px;
+	margin: 1em 0 0.5rem;
 `;
 
 const ScrollHint = styled.div`

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -5,6 +5,8 @@ import PropTypes from "prop-types";
 import debounce from "lodash/debounce";
 import { __ } from "@wordpress/i18n";
 
+const isMobileUserAgentRegExp = /mobi/i;
+
 const FixedWidth = styled.div`
 	overflow: auto;
 	width: ${ ( props ) => props.widthValue }px;
@@ -92,7 +94,7 @@ export default class FixedWidthContainer extends Component {
 	determineSize() {
 		this.setState( {
 			showScrollHint: this._container?.offsetWidth !== this._container?.scrollWidth,
-			isMobileUserAgent: window?.navigator?.userAgent?.includes( "Mobi" ),
+			isMobileUserAgent: isMobileUserAgentRegExp.test( window?.navigator?.userAgent ),
 		} );
 	}
 

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -58,7 +58,7 @@ export default class FixedWidthContainer extends Component {
 
 		this.state = {
 			showScrollHint: false,
-			isMobileUserAgent: window.navigator.userAgent.includes( "Mobi" ),
+			isMobileUserAgent: false,
 		};
 
 		this.setContainerRef = this.setContainerRef.bind( this );
@@ -94,6 +94,7 @@ export default class FixedWidthContainer extends Component {
 
 		this.setState( {
 			showScrollHint: width < this.props.width,
+			isMobileUserAgent: window?.navigator?.userAgent?.includes( "Mobi" ),
 		} );
 	}
 

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -30,7 +30,7 @@ const ScrollHint = styled.div`
 		display: inline-block;
 		margin-right: 10px;
 		font-size: 20px;
-		line-height: inherit;
+		line-height: 20px;
 		vertical-align: text-top;
 		content: "\\21c4";
 		box-sizing: border-box;

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -19,7 +19,7 @@ const Inner = styled.div`
 
 const ScrollHintContainer = styled.div`
 	text-align: center;
-	margin: 1em 0 0.5rem;
+	margin: 1rem 0 0.5rem;
 `;
 
 const ScrollHint = styled.div`

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -111,13 +111,13 @@ export default class FixedWidthContainer extends Component {
 	render() {
 		const { width, padding, children, className, id } = this.props;
 
-		const klass = className || id;
+		const classNameOrId = className || id;
 		const innerWidth = width - 2 * padding;
 
-		return <div className={ `${ klass }__wrapper` }>
+		return <div className={ `${ classNameOrId }__wrapper` }>
 			<FixedWidth
 				id={ id }
-				className={ klass }
+				className={ classNameOrId }
 				widthValue={ width }
 				paddingValue={ padding }
 				ref={ this.setContainerRef }

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -90,10 +90,8 @@ export default class FixedWidthContainer extends Component {
 	 * @returns {void}
 	 */
 	determineSize() {
-		const width = this._container.offsetWidth;
-
 		this.setState( {
-			showScrollHint: width < this.props.width,
+			showScrollHint: this._container?.offsetWidth !== this._container?.scrollWidth,
 			isMobileUserAgent: window?.navigator?.userAgent?.includes( "Mobi" ),
 		} );
 	}

--- a/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
+++ b/packages/search-metadata-previews/src/snippet-preview/FixedWidthContainer.js
@@ -58,6 +58,7 @@ export default class FixedWidthContainer extends Component {
 
 		this.state = {
 			showScrollHint: false,
+			isMobileUserAgent: window.navigator.userAgent.includes( "Mobi" ),
 		};
 
 		this.setContainerRef = this.setContainerRef.bind( this );
@@ -130,7 +131,10 @@ export default class FixedWidthContainer extends Component {
 			{ this.state.showScrollHint &&
 				<ScrollHintContainer>
 					<ScrollHint>
-						{ __( "Scroll to see the preview content.", "wordpress-seo" ) }
+						{ this.state.isMobileUserAgent
+							? __( "Drag to view the full preview.", "wordpress-seo" )
+							: __( "Scroll to see the preview content.", "wordpress-seo" )
+						}
 					</ScrollHint>
 				</ScrollHintContainer>
 			}

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -266,8 +266,8 @@ const MobilePartContainer = styled.div`
 `;
 
 const SiteName = styled.div`
-	line-height: 18x; 
-	font-size: 14px; 
+	line-height: 18x;
+	font-size: 14px;
 	color: black;
 	max-width: ${ props => props.screenMode === MODE_DESKTOP ? "100%" : MOBILE_SITENAME_LIMIT };
 	overflow: hidden;
@@ -891,9 +891,10 @@ export default class SnippetPreview extends PureComponent {
 		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 		return (
-			<section>
+			<section className="yoast-snippet-preview-section">
 				<Container
 					id="yoast-snippet-preview-container"
+					className="yoast-snippet-preview-container"
 					/*
 					 * MobileContainer doesn't use the width prop: avoid to
 					 * render an invalid `width` HTML attribute on the DOM node.

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -77,7 +77,7 @@ exports[`SnippetEditor Desktop mode and should switch to mobile 1`] = `
   align-self: center;
 }
 
-.c5 {
+.c6 {
   overflow: auto;
   width: 640px;
   padding: 0 20px;
@@ -89,7 +89,7 @@ exports[`SnippetEditor Desktop mode and should switch to mobile 1`] = `
   width: 600px;
 }
 
-.c6 {
+.c5 {
   background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
@@ -339,106 +339,112 @@ exports[`SnippetEditor Desktop mode and should switch to mobile 1`] = `
         Desktop result
       </label>
     </fieldset>
-    <section>
+    <section
+      class="yoast-snippet-preview-section"
+    >
       <div
-        class="c5 c6"
-        id="yoast-snippet-preview-container"
+        class="c5 yoast-snippet-preview-container__wrapper"
       >
         <div
-          class="c7"
+          class="c6 c5 yoast-snippet-preview-container"
+          id="yoast-snippet-preview-container"
         >
           <div
-            class="SnippetPreview__DesktopPartContainer-sc-1hxg8jo-20"
+            class="c7"
           >
-            <span
-              class="screen-reader-text"
-              style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
-            >
-              Url preview:
-            </span>
             <div
-              class="c8"
+              class="SnippetPreview__DesktopPartContainer-sc-1hxg8jo-20"
             >
+              <span
+                class="screen-reader-text"
+                style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
+              >
+                Url preview:
+              </span>
               <div
-                class="c8 c9"
+                class="c8"
               >
                 <div
-                  class="c10"
-                >
-                  <img
-                    alt=""
-                    class="c11"
-                    src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABs0lEQVR4AWL4//8/RRjO8Iucx+noO0MWUDo16FYABMGP6ZfUcRnWtm27jVPbtm3bttuH2t3eFPcY9pLz7NxiLjCyVd87pKnHyqXyxtCs8APd0rnyxiu4qSeA3QEDrAwBDrT1s1Rc/OrjLZwqVmOSu6+Lamcpp2KKMA9PH1BYXMe1mUP5qotvXTywsOEEYHXxrY+3cqk6TMkYpNr2FeoY3KIr0RPtn9wQ2unlA+GMkRw6+9TFw4YTwDUzx/JVvARj9KaedXRO8P5B1Du2S32smzqUrcKGEyA+uAgQjKX7zf0boWHGfn71jIKj2689gxp7OAGShNcBUmLMPVjZuiKcA2vuWHHDCQxMCz629kXAIU4ApY15QwggAFbfOP9DhgBJ+nWVJ1AZAfICAj1pAlY6hCADZnveQf7bQIwzVONGJonhLIlS9gr5mFg44Xd+4S3XHoGNPdJl1INIwKyEgHckEhgTe1bGiFY9GSFBYUwLh1IkiJUbY407E7syBSFxKTszEoiE/YdrgCEayDmtaJwCI9uu8TKMuZSVfSa4BpGgzvomBR/INhLGzrqDotp01ZR8pn/1L0JN9d9XNyx0AAAAAElFTkSuQmCC"
-                  />
-                </div>
-                <span
-                  class="c12"
+                  class="c8 c9"
                 >
                   <div
-                    class="c13"
+                    class="c10"
                   >
-                    Test site name
+                    <img
+                      alt=""
+                      class="c11"
+                      src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABs0lEQVR4AWL4//8/RRjO8Iucx+noO0MWUDo16FYABMGP6ZfUcRnWtm27jVPbtm3bttuH2t3eFPcY9pLz7NxiLjCyVd87pKnHyqXyxtCs8APd0rnyxiu4qSeA3QEDrAwBDrT1s1Rc/OrjLZwqVmOSu6+Lamcpp2KKMA9PH1BYXMe1mUP5qotvXTywsOEEYHXxrY+3cqk6TMkYpNr2FeoY3KIr0RPtn9wQ2unlA+GMkRw6+9TFw4YTwDUzx/JVvARj9KaedXRO8P5B1Du2S32smzqUrcKGEyA+uAgQjKX7zf0boWHGfn71jIKj2689gxp7OAGShNcBUmLMPVjZuiKcA2vuWHHDCQxMCz629kXAIU4ApY15QwggAFbfOP9DhgBJ+nWVJ1AZAfICAj1pAlY6hCADZnveQf7bQIwzVONGJonhLIlS9gr5mFg44Xd+4S3XHoGNPdJl1INIwKyEgHckEhgTe1bGiFY9GSFBYUwLh1IkiJUbY407E7syBSFxKTszEoiE/YdrgCEayDmtaJwCI9uu8TKMuZSVfSa4BpGgzvomBR/INhLGzrqDotp01ZR8pn/1L0JN9d9XNyx0AAAAAElFTkSuQmCC"
+                    />
                   </div>
                   <span
-                    class="c14"
+                    class="c12"
                   >
-                    example.org
-                  </span>
-                  <span
-                    class="c15"
-                  >
-                     › test-slug
-                  </span>
-                  <span
-                    class="c16"
-                  >
-                    <svg
-                      fill="#4d5156"
-                      style="width: 18px;"
-                      viewBox="0 0 24 24"
-                      xmlns="http://www.w3.org/2000/svg"
+                    <div
+                      class="c13"
                     >
-                      <path
-                        d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-                      />
-                    </svg>
+                      Test site name
+                    </div>
+                    <span
+                      class="c14"
+                    >
+                      example.org
+                    </span>
+                    <span
+                      class="c15"
+                    >
+                       › test-slug
+                    </span>
+                    <span
+                      class="c16"
+                    >
+                      <svg
+                        fill="#4d5156"
+                        style="width: 18px;"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                        />
+                      </svg>
+                    </span>
                   </span>
-                </span>
+                </div>
               </div>
-            </div>
-            <span
-              class="screen-reader-text"
-              style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
-            >
-              SEO title preview:
-            </span>
-            <div
-              class="c17"
-            >
-              <div
-                class="c18 c19"
+              <span
+                class="screen-reader-text"
+                style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
               >
-                <span
-                  class="c20"
+                SEO title preview:
+              </span>
+              <div
+                class="c17"
+              >
+                <div
+                  class="c18 c19"
                 >
-                  Test title
-                </span>
+                  <span
+                    class="c20"
+                  >
+                    Test title
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="SnippetPreview__DesktopPartContainer-sc-1hxg8jo-20"
-          >
-            <span
-              class="screen-reader-text"
-              style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
-            >
-              Meta description preview:
-            </span>
             <div
-              class="c21"
+              class="SnippetPreview__DesktopPartContainer-sc-1hxg8jo-20"
             >
-              Test description, %%replacement_variable%%
+              <span
+                class="screen-reader-text"
+                style="clip: rect(1px, 1px, 1px, 1px); position: absolute; height: 1px; width: 1px; overflow: hidden;"
+              >
+                Meta description preview:
+              </span>
+              <div
+                class="c21"
+              >
+                Test description, %%replacement_variable%%
+              </div>
             </div>
           </div>
         </div>
@@ -809,9 +815,11 @@ exports[`SnippetEditor Mobile mode 1`] = `
         Desktop result
       </label>
     </fieldset>
-    <section>
+    <section
+      class="yoast-snippet-preview-section"
+    >
       <div
-        class="c5"
+        class="c5 yoast-snippet-preview-container"
         id="yoast-snippet-preview-container"
       >
         <div


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Changes are needed for a Premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/4398

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews 0.1.0] Reads the user agent and shows a different desktop fixed width copy for mobile agents.
* [@yoast/search-metadata-previews 0.1.0] Adds an extra container to the SnippetPreview' FixedWidthContainer, allowing for better outside styling control.
* [@yoast/search-metadata-previews 0.1.0] Changes the FixedWidthContainer to show the scroll hint when a scrollbar is shown instead of whether the `width` prop is larger than the current `width`.
* [@yoast/search-metadata-previews 0.0.1 non-user-facing] Adds a `yarn watch` command for ease of development.

## Relevant technical choices:

* Using the navigator API to test for the user agent including `Mobi`, to determine if on a mobile device. Not sure what else to use when `userAgentData` is not fully supported (see https://caniuse.com/?search=navigator.userAgentData). I saw `maxTouchPoints` being suggested (see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints), I'm not sure.
* Change the scroll hint display logic to check for a scrollbar. Making it possible to change the padding via CSS by checking the offsetWidth and comparing it against the scrollWidth. This assumes the max-width and overflow remain in effect!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### New copy
* Edit a post on a mobile device, or in Chrome you can [simulate using the device-mode](https://developer.chrome.com/docs/devtools/device-mode)
* Go to the search appearance preview
* Switch to the desktop result
* [ ] Verify the copy is `Drag to view the full preview.`
* Go back to a non-mobile device
* [ ] Verify the copy is `Scroll to see the preview content.`

#### Regression tests
* Edit a post
* Check the search appearance preview
* [ ] Verify there is no visible difference using the mobile result
* [ ] Verify there is almost no visible difference using the desktop result, except:
  * When on a smaller screen than the content, you get a scroll hint
  * The spacing around the scroll hint is adapted to be 16px on the top and 8px on the bottom (though looking equal due to other factors)
  * [ ] Only possible in the sidebar' Search appearance modal: Change the width of the screen and verify the scroll hint comes into play at exactly the right times (when the scrollbar is active)
* You could check the same in the social previews

#### DEV only: yarn watch
* Do a normal build first for the dependencies installation (PHP and JS)
* Run `yarn workspace @yoast/search-metadata-previews watch`, or run `yarn watch` in the `packages/search-metadata-previews` folder
* Make a change in the code of `packages/search-metadata-previews`
* Verify the watcher picked it up (output + check/search in the build folder?)
* If you would build Free (or run `yarn start` in the root), you would see the change on refresh of the page

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The UI of the search appearance preview.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/ux/issues/140
