### PR TITLE
Improve storybook documentation toast element

### DIFF
--- a/packages/ui-library/src/elements/toast/docs/complex-layout.md
+++ b/packages/ui-library/src/elements/toast/docs/complex-layout.md
@@ -1,0 +1,2 @@
+The content of the `Toast` element can be provided a complex structure. Here `Toast.Title`, `Toast.Description`
+and `Toast.Close` are combined with several other elements like `Button` and `ValidationIcon` in a flex-based structure.

--- a/packages/ui-library/src/elements/toast/docs/component.md
+++ b/packages/ui-library/src/elements/toast/docs/component.md
@@ -1,1 +1,1 @@
-The `Toast` element is a versatile toast component that can be used to implement custom notifications.
+Toasts are versatile elements that can include multiple subcomponents for implementing custom notifications.

--- a/packages/ui-library/src/elements/toast/docs/index.js
+++ b/packages/ui-library/src/elements/toast/docs/index.js
@@ -3,3 +3,4 @@ export { default as close } from "./close.md";
 export { default as description } from "./description.md";
 export { default as title } from "./title.md";
 export { default as useToastContext } from "./use-toast-context.md";
+export { default as complexLayout } from "./complex-layout.md";

--- a/packages/ui-library/src/elements/toast/docs/index.js
+++ b/packages/ui-library/src/elements/toast/docs/index.js
@@ -2,4 +2,4 @@ export { default as component } from "./component.md";
 export { default as close } from "./close.md";
 export { default as description } from "./description.md";
 export { default as title } from "./title.md";
-
+export { default as useToastContext } from "./use-toast-context.md";

--- a/packages/ui-library/src/elements/toast/docs/use-toast-context.md
+++ b/packages/ui-library/src/elements/toast/docs/use-toast-context.md
@@ -4,7 +4,7 @@ a different kind of action.
 
 With help of the `handleDismiss` callback, the `Toast.Close` subcomponent could be replaced with below `ConfirmButton`.
 
-```jsx
+```jsx dark
 import { Button, useToastContext } from "@yoast/ui-library";
 
 const ConfirmButton = () => {

--- a/packages/ui-library/src/elements/toast/docs/use-toast-context.md
+++ b/packages/ui-library/src/elements/toast/docs/use-toast-context.md
@@ -1,0 +1,14 @@
+The `useToastContext` hook returns the toast context. It provides an object with a `handleDismiss` callback, which can be used
+to close the toast from other actions inside the modal. This is useful when you want to close the toast from a custom button or
+a different kind of action.
+
+With help of the `handleDismiss` callback, the `Toast.Close` subcomponent could be replaced with below `ConfirmButton`.
+
+```jsx
+import { Button, useToastContext } from "@yoast/ui-library";
+
+const ConfirmButton = () => {
+	const { handleDismiss } = useToastContext();
+	return <Button size="small" onClick={ handleDismiss }>Confirm</Button>;
+};
+```

--- a/packages/ui-library/src/elements/toast/index.js
+++ b/packages/ui-library/src/elements/toast/index.js
@@ -8,6 +8,11 @@ import React, { createContext, useCallback, useContext, useEffect } from "react"
 
 const ToastContext = createContext( { handleDismiss: noop } );
 
+/**
+ * @returns {Object} The toast context.
+ */
+export const useToastContext = () => useContext( ToastContext );
+
 export const toastClassNameMap = {
 	position: {
 		"bottom-center": "yst-translate-y-full",
@@ -23,7 +28,7 @@ export const toastClassNameMap = {
 const Close = ( {
 	dismissScreenReaderLabel,
 } ) => {
-	const { handleDismiss } = useContext( ToastContext );
+	const { handleDismiss } = useToastContext();
 	return (
 		<div className="yst-flex-shrink-0 yst-flex">
 			<button

--- a/packages/ui-library/src/elements/toast/stories.js
+++ b/packages/ui-library/src/elements/toast/stories.js
@@ -90,12 +90,14 @@ export const withClose = {
 	name: "With close button",
 	args: {
 		children: (
-			<>
-				<div className="yst-flex yst-flex-row-reverse">
+			<div className="yst-flex">
+				<div className="yst-flex-1">
+					<p>Hello everyone!</p>
+				</div>
+				<div>
 					<Toast.Close dismissScreenReaderLabel="Dismiss" />
 				</div>
-				<p>Hello everyone!</p>
-			</>
+			</div>
 		),
 	},
 	parameters: {

--- a/packages/ui-library/src/elements/toast/stories.js
+++ b/packages/ui-library/src/elements/toast/stories.js
@@ -1,10 +1,10 @@
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
-import Toast  from ".";
+import Toast, { useToastContext } from ".";
 import Button from "../../elements/button";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
-import { description, component, close, title } from "./docs";
+import { description, component, close, title, useToastContext as useToastContextDocs } from "./docs";
 import classNames from "classnames";
 import { useToggleState } from "../../hooks";
 
@@ -105,6 +105,32 @@ export const withClose = {
 	},
 };
 
+const ConfirmButton = () => {
+	const { handleDismiss } = useToastContext();
+
+	return <Button size="small" onClick={ handleDismiss }>Confirm</Button>;
+};
+
+export const useToastContextHook = {
+	name: "useToastContext",
+	args: {
+		children: (
+			<div className="yst-flex">
+				<div className="yst-flex-1">
+					<p>Hello everyone!</p>
+				</div>
+				<div>
+					<ConfirmButton />
+				</div>
+			</div>
+		),
+	},
+	parameters: {
+		controls: { disable: true },
+		docs: { description: { story: useToastContextDocs } },
+	},
+};
+
 export default {
 	title: "1) Elements/Toast",
 	component: Template,
@@ -160,7 +186,7 @@ export default {
 			description: {
 				component,
 			},
-			page: () => <InteractiveDocsPage stories={ [ withTitle, withDescription, withClose ] } />,
+			page: () => <InteractiveDocsPage stories={ [ withTitle, withDescription, withClose, useToastContextHook ] } />,
 		},
 	},
 	decorators: [

--- a/packages/ui-library/src/elements/toast/stories.js
+++ b/packages/ui-library/src/elements/toast/stories.js
@@ -1,11 +1,12 @@
 import { noop } from "lodash";
 import PropTypes from "prop-types";
-import React, { useCallback, useState } from "react";
+import React from "react";
 import Toast  from ".";
 import Button from "../../elements/button";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
 import { description, component, close, title } from "./docs";
 import classNames from "classnames";
+import { useToggleState } from "../../hooks";
 
 const positionClassNameMap = {
 	position: {
@@ -15,9 +16,7 @@ const positionClassNameMap = {
 	},
 };
 const Template = ( { isVisible: initialVisible, setIsVisible: _, position, children, ...props } ) => {
-	const [ isVisible, setIsVisible ] = useState( initialVisible );
-	const toggleToast = useCallback( () => setIsVisible( ! isVisible ), [ isVisible ] );
-	const openToast = useCallback( () => setIsVisible( true ), [] );
+	const [ isVisible, toggleToast, , openToast ] = useToggleState( initialVisible );
 
 	return (
 		<>

--- a/packages/ui-library/src/elements/toast/stories.js
+++ b/packages/ui-library/src/elements/toast/stories.js
@@ -4,8 +4,9 @@ import React from "react";
 import Toast, { useToastContext } from ".";
 import Button from "../../elements/button";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
-import { description, component, close, title, useToastContext as useToastContextDocs } from "./docs";
+import { description, component, close, title, useToastContext as useToastContextDocs, complexLayout } from "./docs";
 import classNames from "classnames";
+import { ValidationIcon } from "../validation";
 import { useToggleState } from "../../hooks";
 
 const positionClassNameMap = {
@@ -131,6 +132,48 @@ export const useToastContextHook = {
 	},
 };
 
+const DismissButton = () => {
+	const { handleDismiss } = useToastContext();
+	return <Button size="small" variant="tertiary" onClick={ handleDismiss }>Dismiss</Button>;
+};
+
+export const asComplexLayout = {
+	name: "Complex layout",
+	args: {
+		children: (
+			<>
+				<div className="yst-flex yst-gap-3">
+					<div className="yst-flex-shrink-0">
+						<ValidationIcon className="yst-w-5 yst-h-5" />
+					</div>
+					<div className="yst-flex-1">
+						<Toast.Title title="Perform an action?" />
+						<p>An optional action can be performed. Please confirm this action. Otherwise, feel free to dismiss this suggestion.</p>
+					</div>
+					<div>
+						<Toast.Close dismissScreenReaderLabel="Dismiss" />
+					</div>
+				</div>
+				<div className="yst-flex yst-gap-3 yst-justify-end yst-mt-3">
+					<DismissButton />
+					<ConfirmButton />
+				</div>
+			</>
+		),
+	},
+	parameters: {
+		controls: { disable: true },
+		docs: { description: { story: complexLayout } },
+	},
+	decorators: [
+		( Story ) => (
+			<div className="yst-min-h-[21rem]">
+				<Story />
+			</div>
+		),
+	],
+};
+
 export default {
 	title: "1) Elements/Toast",
 	component: Template,
@@ -186,7 +229,7 @@ export default {
 			description: {
 				component,
 			},
-			page: () => <InteractiveDocsPage stories={ [ withTitle, withDescription, withClose, useToastContextHook ] } />,
+			page: () => <InteractiveDocsPage stories={ [ withTitle, withDescription, withClose, useToastContextHook, asComplexLayout ] } />,
 		},
 	},
 	decorators: [

--- a/packages/ui-library/src/elements/toast/stories.js
+++ b/packages/ui-library/src/elements/toast/stories.js
@@ -159,7 +159,7 @@ export default {
 			description: {
 				component,
 			},
-			page: () => <InteractiveDocsPage stories={ [ withClose, withDescription, withTitle ] } />,
+			page: () => <InteractiveDocsPage stories={ [ withTitle, withDescription, withClose ] } />,
 		},
 	},
 	decorators: [

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -18,7 +18,7 @@ export { default as TagInput } from "./elements/tag-input";
 export { default as TextInput } from "./elements/text-input";
 export { default as Textarea } from "./elements/textarea";
 export { default as Title } from "./elements/title";
-export { default as Toast } from "./elements/toast";
+export { default as Toast, useToastContext } from "./elements/toast";
 export { default as Toggle } from "./elements/toggle";
 export { default as Tooltip } from "./elements/tooltip";
 export { ValidationIcon, ValidationInput, ValidationMessage } from "./elements/validation";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Improve the Storybook documentation of our toast element:
    * Improve the alignment of the `with close button` story to better resemble real world usage.
    * Add an additional story to showcase a more advanced toast element, using more different components

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library 0.1.0] Exports the `useToastContext` hook to allow dismissing a `Toast` element from a child node.

## Relevant technical choices:

* Switched ordering of stories to align with the navigation menu
* Reduced boilerplate by using `useToggleState` hook, instead of a combination of `useState` + `useCallback` hooks.
* Exposed the `useToastContext` hook to allow dismissing toasts from child buttons in stories.
    * There are already use cases where this can be leveraged.
    * Added a (dark mode) code block showing the  `ConfirmButton`, because Storybook's own code example does not show the insides, and this demonstrates using the `useToastContext`.
* Improved the main component description in consultation with @uxkai.
* Assigned the `non-user-facing` changelog since the `Toast` element has not been released yet.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Start the Storybook
* Visit the Toast page
* Compare the order of the stories in the "Docs" page with the order of the navigation
* Check the alignment in the "with close button" story to have the description beside the button
* Check the 2 new stories
    * Double check the descriptions and examples make sense
    * Test the buttons to dismiss the toast in similar fashion as the close button does (150ms timeout applied)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
