### PR TITLE
disable AI button when other ai button is pressed.

### DIFF
--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -114,7 +114,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 
 	// Add tooltip classes on mouse enter and remove them on mouse leave.
 	const handleMouseEnter = useCallback( () => {
-		if( ariaLabel ){
+		if ( ariaLabel ) {
 			const direction = isEnabled ? "yoast-tooltip-w" : "yoast-tooltip-nw";
 			setButtonClass( `yoast-tooltip yoast-tooltip-multiline ${ direction }` );
 		}

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -48,7 +48,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 		if ( activeAIButtonId !== null && ! isButtonPressed ) {
 			return {
 				isEnabled: false,
-				ariaLabel: defaultLabel,
+				ariaLabel: null,
 			};
 		}
 
@@ -114,8 +114,10 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 
 	// Add tooltip classes on mouse enter and remove them on mouse leave.
 	const handleMouseEnter = useCallback( () => {
-		const direction = isEnabled ? "yoast-tooltip-w" : "yoast-tooltip-nw";
-		setButtonClass( `yoast-tooltip yoast-tooltip-multiline ${ direction }` );
+		if( ariaLabel ){
+			const direction = isEnabled ? "yoast-tooltip-w" : "yoast-tooltip-nw";
+			setButtonClass( `yoast-tooltip yoast-tooltip-multiline ${ direction }` );
+		}
 	}, [ isEnabled ] );
 
 	const handleMouseLeave = useCallback( () => {

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -50,6 +50,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 				ariaLabel: defaultLabel,
 			};
 		}
+		
 		if ( disabledAIButtons.includes( aiFixesId ) ) {
 			return {
 				isEnabled: false,

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -35,6 +35,9 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const tooLongLabel = __( "Your text is too long for the AI model to process.", "wordpress-seo" );
 	const htmlLabel = __( "Please switch to the visual editor to optimize with AI.", "wordpress-seo" );
 
+	// The button is pressed when the active AI button id is the same as the current button id.
+	const isButtonPressed = activeAIButtonId === aiFixesId;
+
 	// Enable the button when:
 	// (1) other AI buttons are not pressed.
 	// (2) the AI button is not disabled.
@@ -42,8 +45,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	// (4) all blocks are in visual mode.
 	const { isEnabled, ariaLabel } = useSelect( ( select ) => {
 		const disabledAIButtons = select( "yoast-seo/editor" ).getDisabledAIFixesButtons();
-		const activeAIButtonId = select( "yoast-seo/editor" ).getActiveAIFixesButton();
-		const isButtonPressed = activeAIButtonId === aiFixesId;
 		if ( activeAIButtonId !== null && ! isButtonPressed ) {
 			return {
 				isEnabled: false,
@@ -72,7 +73,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			isEnabled: allVisual,
 			ariaLabel: allVisual ? defaultLabel : htmlLabel,
 		};
-	}, [] );
+	}, [ isButtonPressed, activeAIButtonId ] );
 
 	/**
 	 * Handles the button press state.
@@ -110,9 +111,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			setIsModalOpenTrue();
 		}
 	}, [ handlePressedButton, setIsModalOpenTrue ] );
-
-	// The button is pressed when the active AI button id is the same as the current button id.
-	const isButtonPressed = activeAIButtonId === aiFixesId;
 
 	// Add tooltip classes on mouse enter and remove them on mouse leave.
 	const handleMouseEnter = useCallback( () => {

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -36,11 +36,20 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const htmlLabel = __( "Please switch to the visual editor to optimize with AI.", "wordpress-seo" );
 
 	// Enable the button when:
-	// (1) the AI button is not disabled.
-	// (2) the editor is in visual mode.
-	// (3) all blocks are in visual mode.
+	// (1) other AI buttons are not pressed.
+	// (2) the AI button is not disabled.
+	// (3) the editor is in visual mode.
+	// (4) all blocks are in visual mode.
 	const { isEnabled, ariaLabel } = useSelect( ( select ) => {
 		const disabledAIButtons = select( "yoast-seo/editor" ).getDisabledAIFixesButtons();
+		const activeAIButtonId = select( "yoast-seo/editor" ).getActiveAIFixesButton();
+		const isButtonPressed = activeAIButtonId === aiFixesId;
+		if( activeAIButtonId !== null && ! isButtonPressed ){
+			return {
+				isEnabled: false,
+				ariaLabel: defaultLabel,
+			};
+		}
 		if ( disabledAIButtons.includes( aiFixesId ) ) {
 			return {
 				isEnabled: false,

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -118,7 +118,7 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			const direction = isEnabled ? "yoast-tooltip-w" : "yoast-tooltip-nw";
 			setButtonClass( `yoast-tooltip yoast-tooltip-multiline ${ direction }` );
 		}
-	}, [ isEnabled ] );
+	}, [ isEnabled, ariaLabel ] );
 
 	const handleMouseLeave = useCallback( () => {
 		// Remove tooltip classes on mouse leave

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -44,13 +44,13 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 		const disabledAIButtons = select( "yoast-seo/editor" ).getDisabledAIFixesButtons();
 		const activeAIButtonId = select( "yoast-seo/editor" ).getActiveAIFixesButton();
 		const isButtonPressed = activeAIButtonId === aiFixesId;
-		if( activeAIButtonId !== null && ! isButtonPressed ){
+		if ( activeAIButtonId !== null && ! isButtonPressed ) {
 			return {
 				isEnabled: false,
 				ariaLabel: defaultLabel,
 			};
 		}
-		
+
 		if ( disabledAIButtons.includes( aiFixesId ) ) {
 			return {
 				isEnabled: false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to disable other AI buttons when one is pressed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the rest of the AI buttons when one AI button is pressed. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions in https://github.com/Yoast/wordpress-seo-premium/pull/4383.
* Create a post where all the AI buttons are enabled, You can consider [text 3 from the AI test set](https://docs.google.com/spreadsheets/d/1ZHax02aXgjphmhyBe1d7CQN4gcLV-K0u7aeaZdrctAE/edit?gid=333444527#gid=333444527).
* Click on one of them and check the rest are disabled as long as the notification and suggestion are rendered. 
* Check that in this case there is no tooltip on hover.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Disable all AI buttons other than the one currently in use](https://github.com/Yoast/wordpress-seo/issues/21481)
