### PR TITLE
Hides AI buttons when the AI feature is disabled

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -866,6 +866,7 @@ class WPSEO_Utils {
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
 			'isPrivateBlog'         => ( (string) get_option( 'blog_public' ) ) === '0',
 			'news_seo_is_active'    => ( defined( 'WPSEO_NEWS_FILE' ) ),
+			'isAiFeatureActive'     => (bool) WPSEO_Options::get( 'enable_ai_generator' ),
 		];
 
 		$additional_entries = apply_filters( 'wpseo_admin_l10n', [] );

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cd ../.. && wp-scripts build --config config/webpack/webpack.config.js",
     "test": "jest",
-    "lint": "eslint src tests --max-warnings=73"
+    "lint": "eslint src tests --max-warnings=69"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,5 +1,5 @@
 /* global wpseoAdminL10n */
-import { withSelect, select } from "@wordpress/data";
+import { withSelect } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
@@ -40,7 +40,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 * @param {string} locationContext In which editor this component is rendered.
 	 *
-	 * @returns {wp.Element} A modalButtonContainer component with the modal for a keyword synonyms upsell.
+	 * @returns {JSX.Element} A modalButtonContainer component with the modal for a keyword synonyms upsell.
 	 */
 	renderSynonymsUpsell( location, locationContext ) {
 		const modalProps = {
@@ -76,7 +76,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location The location of the upsell component. Used to determine the shortlinks in the component.
 	 * @param {string} locationContext In which editor this component is rendered.
 	 *
-	 * @returns {wp.Element} A modalButtonContainer component with the modal for a multiple keywords upsell.
+	 * @returns {JSX.Element} A modalButtonContainer component with the modal for a multiple keywords upsell.
 	 */
 	renderMultipleKeywordsUpsell( location, locationContext ) {
 		const modalProps = {
@@ -112,7 +112,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location The location of the upsell component. Used to determine the shortlink in the component.
 	 * @param {string} locationContext In which editor this component is rendered.
 	 *
-	 * @returns {wp.Element} The AnalysisUpsell component.
+	 * @returns {JSX.Element} The AnalysisUpsell component.
 	 */
 	renderWordFormsUpsell( location, locationContext ) {
 		let url = location === "sidebar"
@@ -133,7 +133,7 @@ class SeoAnalysis extends Component {
 	 * @param {string} location       Where this component is rendered.
 	 * @param {string} scoreIndicator String indicating the score.
 	 *
-	 * @returns {wp.Element} The rendered score icon portal element.
+	 * @returns {JSX.Element} The rendered score icon portal element.
 	 */
 	renderTabIcon( location, scoreIndicator ) {
 		// The tab icon should only be rendered for the metabox.
@@ -191,31 +191,40 @@ class SeoAnalysis extends Component {
 		];
 	}
 
+	/* eslint-disable complexity */
 	/**
-	 * Renders the AI Assessment Fixes button.
+	 * Renders the Yoast AI Optimize button.
+	 * The button is shown when:
+	 * - The assessment can be fixed through Yoast AI Optimize.
+	 * - The AI feature is enabled (for Yoast SEO Premium users; for Free users, the button is shown with an upsell).
+	 * - We are in the block editor.
+	 * - We are not in the Elementor editor, nor in the Elementor in-between screen.
 	 *
-	 * @param {boolean} hasAIFixes Whether the assessment has AI fixes or not.
-	 * @param {string} id The assessment ID for which the AI fixes should be applied to.
+	 * @param {boolean} hasAIFixes Whether the assessment can be fixed through Yoast AI Optimize.
+	 * @param {string} id The assessment ID.
 	 *
-	 * @returns {JSX.Element} The AI Assessment Fixes button.
+	 * @returns {void|JSX.Element} The AI Optimize button, or nothing if the button should not be shown.
 	 */
 	renderAIFixesButton = ( hasAIFixes, id ) => {
 		const isPremium = getL10nObject().isPremium;
-		const isAiFeatureEnabled = select( "yoast-seo/editor" ).getPreference( "isAiFeatureActive", false );
-		if ( ! isAiFeatureEnabled && isPremium ) {
+
+		// Don't show the button if the AI feature is not enabled for Yoast SEO Premium users.
+		if ( isPremium && ! this.props.isAiFeatureEnabled ) {
 			return;
 		}
+
 		// The reason of adding the check if Elementor is active or not is because `isBlockEditor` method also returns `true` for Elementor.
 		// The reason of adding the check if the Elementor editor is active, is to stop showing the buttons in the in-between screen.
 		return hasAIFixes && isBlockEditor() && ! this.props.isElementor && ! document.body.classList.contains( "elementor-editor-active" ) && (
 			<AIAssessmentFixesButton id={ id } isPremium={ isPremium } />
 		);
 	};
+	/* eslint-enable complexity */
 
 	/**
 	 * Renders the SEO Analysis component.
 	 *
-	 * @returns {wp.Element} The SEO Analysis component.
+	 * @returns {JSX.Element} The SEO Analysis component.
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
@@ -294,6 +303,7 @@ SeoAnalysis.propTypes = {
 	overallScore: PropTypes.number,
 	shouldUpsellHighlighting: PropTypes.bool,
 	isElementor: PropTypes.bool,
+	isAiFeatureEnabled: PropTypes.bool,
 };
 
 SeoAnalysis.defaultProps = {
@@ -305,6 +315,7 @@ SeoAnalysis.defaultProps = {
 	overallScore: null,
 	shouldUpsellHighlighting: false,
 	isElementor: false,
+	isAiFeatureEnabled: false,
 };
 
 export default withSelect( ( select, ownProps ) => {
@@ -313,6 +324,7 @@ export default withSelect( ( select, ownProps ) => {
 		getMarksButtonStatus,
 		getResultsForKeyword,
 		getIsElementorEditor,
+		getPreference,
 	} = select( "yoast-seo/editor" );
 
 	const keyword = getFocusKeyphrase();
@@ -322,5 +334,6 @@ export default withSelect( ( select, ownProps ) => {
 		marksButtonStatus: ownProps.hideMarksButtons ? "disabled" : getMarksButtonStatus(),
 		keyword,
 		isElementor: getIsElementorEditor(),
+		isAiFeatureEnabled: getPreference( "isAiFeatureActive", false ),
 	};
 } )( SeoAnalysis );

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -1,5 +1,5 @@
 /* global wpseoAdminL10n */
-import { withSelect } from "@wordpress/data";
+import { withSelect, select } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
@@ -202,6 +202,11 @@ class SeoAnalysis extends Component {
 	renderAIFixesButton = ( hasAIFixes, id ) => {
 		const isPremium = getL10nObject().isPremium;
 
+		const isAiFeatureEnabled = select( "yoast-seo/editor" ).getPreference( "isAiFeatureActive", false );
+		
+		if( ! isAiFeatureEnabled ) {
+			return;
+		}
 		// The reason of adding the check if Elementor is active or not is because `isBlockEditor` method also returns `true` for Elementor.
 		// The reason of adding the check if the Elementor editor is active, is to stop showing the buttons in the in-between screen.
 		return hasAIFixes && isBlockEditor() && ! this.props.isElementor && ! document.body.classList.contains( "elementor-editor-active" ) && (

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -201,10 +201,8 @@ class SeoAnalysis extends Component {
 	 */
 	renderAIFixesButton = ( hasAIFixes, id ) => {
 		const isPremium = getL10nObject().isPremium;
-
 		const isAiFeatureEnabled = select( "yoast-seo/editor" ).getPreference( "isAiFeatureActive", false );
-		
-		if( ! isAiFeatureEnabled ) {
+		if ( ! isAiFeatureEnabled && isPremium ) {
 			return;
 		}
 		// The reason of adding the check if Elementor is active or not is because `isBlockEditor` method also returns `true` for Elementor.

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -37,6 +37,7 @@ function getDefaultState() {
 		isWincherIntegrationActive: isWincherIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
 		isNewsEnabled: ! ! window.wpseoAdminL10n.news_seo_is_active,
+		isAiFeatureActive: Boolean( window.wpseoAdminL10n.isAiFeatureActive ),
 	};
 }
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We do not want to display the AI Optimize buttons when the AI feature as a whole has been disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the AI buttons would be shown when the AI feature as a whole was disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Yoast SEO premium.
* Go to the Yoast SEO settings and disable the AI feature.
* Edit a post with focus keyphrase and content that doesn't contain it.
* Go to the Premium SEO analysis.
* Check you don't see the Sparkle AI button.
* Go back to Yoast SEO settings and enable to the AI feature.
* Edit the same post and check you see the AI sparkle button.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact than disabling the buttons.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Major-AI-Sparkle buttons display even if AI feature is off in Yoast Settings](https://github.com/Yoast/plugins-automated-testing/issues/1739)
