### PR TITLE
Remove no longer used `add_settings_error`

### DIFF
--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -168,24 +168,10 @@ class WPSEO_Option_Social extends WPSEO_Option {
 						if ( $twitter_id ) {
 							$clean[ $key ] = $twitter_id;
 						}
-						else {
-							if ( isset( $old[ $key ] ) && $old[ $key ] !== '' ) {
+						elseif ( isset( $old[ $key ] ) && $old[ $key ] !== '' ) {
 								$twitter_id = sanitize_text_field( ltrim( $old[ $key ], '@' ) );
-								if ( preg_match( '`^[A-Za-z0-9_]{1,25}$`', $twitter_id ) ) {
-									$clean[ $key ] = $twitter_id;
-								}
-							}
-							if ( function_exists( 'add_settings_error' ) ) {
-								add_settings_error(
-									$this->group_name, // Slug title of the setting.
-									$key, // Suffix-ID for the error message box.
-									sprintf(
-										/* translators: %s expands to a twitter user name. */
-										__( '%s does not seem to be a valid Twitter Username. Please correct.', 'wordpress-seo' ),
-										'<strong>' . esc_html( sanitize_text_field( $dirty[ $key ] ) ) . '</strong>'
-									), // The error message.
-									'error' // Message type.
-								);
+							if ( preg_match( '`^[A-Za-z0-9_]{1,25}$`', $twitter_id ) ) {
+								$clean[ $key ] = $twitter_id;
 							}
 						}
 						unset( $twitter_id );

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -311,29 +311,16 @@ abstract class WPSEO_Option {
 			$meta = sanitize_text_field( $meta );
 			if ( $meta !== '' ) {
 				$regex   = '`^[A-Fa-f0-9_-]+$`';
-				$service = '';
 
 				switch ( $key ) {
+					case 'googleverify':
 					case 'baiduverify':
 						$regex   = '`^[A-Za-z0-9_-]+$`';
-						$service = 'Baidu Webmaster tools';
-						break;
-
-					case 'googleverify':
-						$regex   = '`^[A-Za-z0-9_-]+$`';
-						$service = 'Google Webmaster tools';
 						break;
 
 					case 'msverify':
-						$service = 'Bing Webmaster tools';
-						break;
-
 					case 'pinterestverify':
-						$service = 'Pinterest';
-						break;
-
 					case 'yandexverify':
-						$service = 'Yandex Webmaster tools';
 						break;
 				}
 
@@ -344,16 +331,6 @@ abstract class WPSEO_Option {
 					// Restore the previous value, if any.
 					if ( isset( $old[ $key ] ) && preg_match( $regex, $old[ $key ] ) ) {
 						$clean[ $key ] = $old[ $key ];
-					}
-
-					if ( function_exists( 'add_settings_error' ) ) {
-						add_settings_error(
-							$this->group_name, // Slug title of the setting.
-							$key, // Suffix-ID for the error message box. WordPress prepends `setting-error-`.
-							/* translators: 1: Verification string from user input; 2: Service name. */
-							sprintf( __( '%1$s does not seem to be a valid %2$s verification string. Please correct.', 'wordpress-seo' ), '<strong>' . esc_html( $meta ) . '</strong>', $service ), // The error message.
-							'error' // CSS class for the WP notice, either the legacy 'error' / 'updated' or the new `notice-*` ones.
-						);
 					}
 
 					Yoast_Input_Validation::add_dirty_value_to_settings_errors( $key, $meta );
@@ -380,23 +357,6 @@ abstract class WPSEO_Option {
 			$validated_url = filter_var( WPSEO_Utils::sanitize_url( $submitted_url ), FILTER_VALIDATE_URL );
 
 			if ( $validated_url === false ) {
-				if ( function_exists( 'add_settings_error' ) ) {
-					add_settings_error(
-						// Slug title of the setting.
-						$this->group_name,
-						// Suffix-ID for the error message box. WordPress prepends `setting-error-`.
-						$key,
-						// The error message.
-						sprintf(
-							/* translators: %s expands to an invalid URL. */
-							__( '%s does not seem to be a valid url. Please correct.', 'wordpress-seo' ),
-							'<strong>' . esc_url( $submitted_url ) . '</strong>'
-						),
-						// Message type.
-						'error'
-					);
-				}
-
 				// Restore the previous URL value, if any.
 				if ( isset( $old[ $key ] ) && $old[ $key ] !== '' ) {
 					$url = WPSEO_Utils::sanitize_url( $old[ $key ] );

--- a/inc/options/class-wpseo-option.php
+++ b/inc/options/class-wpseo-option.php
@@ -310,12 +310,12 @@ abstract class WPSEO_Option {
 
 			$meta = sanitize_text_field( $meta );
 			if ( $meta !== '' ) {
-				$regex   = '`^[A-Fa-f0-9_-]+$`';
+				$regex = '`^[A-Fa-f0-9_-]+$`';
 
 				switch ( $key ) {
 					case 'googleverify':
 					case 'baiduverify':
-						$regex   = '`^[A-Za-z0-9_-]+$`';
+						$regex = '`^[A-Za-z0-9_-]+$`';
 						break;
 
 					case 'msverify':

--- a/tests/Unit/Inc/Options/Option_Social_Test.php
+++ b/tests/Unit/Inc/Options/Option_Social_Test.php
@@ -81,10 +81,6 @@ final class Option_Social_Test extends TestCase {
 			]
 		);
 
-		Monkey\Functions\expect( 'add_settings_error' )
-			->once()
-			->with( 'yoast_wpseo_social_options', $slug_name, $message, 'error' );
-
 		$instance = new Option_Social_Double();
 
 		$GLOBALS['wp_settings_errors'] = [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to clean up some unused code in the options handler.
 
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unused `add_settings_error` function.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to wp-admin/admin.php?page=wpseo_page_settings#/site-representation and fill in valid and invalid url's in the Other profiles section to make sure it still validates with the right messages.
* Go to wp-admin/admin.php?page=wpseo_page_settings#/site-connections and fill in valid and invalid connection keys. This can be done by using strings for `Pinterest` to make sure it validates with the right messages.
* 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
