### PR TITLE
Allows setting a reason for a disabled Yoast AI Optimize button

### DIFF
--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -32,7 +32,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const [ buttonClass, setButtonClass ] = useState( "" );
 
 	const defaultLabel = __( "Optimize with AI", "wordpress-seo" );
-	const tooLongLabel = __( "Your text is too long for the AI model to process.", "wordpress-seo" );
 	const htmlLabel = __( "Please switch to the visual editor to optimize with AI.", "wordpress-seo" );
 
 	// The button is pressed when the active AI button id is the same as the current button id.
@@ -44,7 +43,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	// (3) the editor is in visual mode.
 	// (4) all blocks are in visual mode.
 	const { isEnabled, ariaLabel } = useSelect( ( select ) => {
-		const disabledAIButtons = select( "yoast-seo/editor" ).getDisabledAIFixesButtons();
 		if ( activeAIButtonId !== null && ! isButtonPressed ) {
 			return {
 				isEnabled: false,
@@ -52,10 +50,11 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			};
 		}
 
-		if ( disabledAIButtons.includes( aiFixesId ) ) {
+		const disabledAIButtons = select( "yoast-seo/editor" ).getDisabledAIFixesButtons();
+		if ( Object.keys( disabledAIButtons ).includes( aiFixesId ) ) {
 			return {
 				isEnabled: false,
-				ariaLabel: tooLongLabel,
+				ariaLabel: disabledAIButtons[ aiFixesId ],
 			};
 		}
 

--- a/packages/js/src/redux/actions/AIButton.js
+++ b/packages/js/src/redux/actions/AIButton.js
@@ -15,7 +15,7 @@ export function setActiveAIFixesButton( activeAIButton ) {
 
 /**
  * Updates the disabled AI buttons.
- * @param {string[]} disabledAIButtons The disabled AI buttons.
+ * @param {Object.<string, string>} disabledAIButtons The disabled AI buttons along with their reasons.
  * @returns {Object} An action for redux.
  */
 export function setDisabledAIFixesButtons( disabledAIButtons ) {

--- a/packages/js/src/redux/reducers/AIButton.js
+++ b/packages/js/src/redux/reducers/AIButton.js
@@ -2,7 +2,7 @@ import { SET_ACTIVE_AI_FIXES_BUTTON, SET_DISABLED_AI_FIXES_BUTTONS } from "../ac
 
 const INITIAL_STATE = {
 	activeAIButton: null,
-	disabledAIButtons: [],
+	disabledAIButtons: {},
 };
 
 /**

--- a/packages/js/src/redux/selectors/AIButton.js
+++ b/packages/js/src/redux/selectors/AIButton.js
@@ -10,6 +10,6 @@ export const getActiveAIFixesButton = state => get( state, "AIButton.activeAIBut
 /**
  * Returns the disabled AI Fixes buttons.
  * @param {object} state The state.
- * @returns {string[]} The disabled buttons.
+ * @returns {object} The disabled buttons along with their reasons.
  */
-export const getDisabledAIFixesButtons = state => get( state, "AIButton.disabledAIButtons", [] );
+export const getDisabledAIFixesButtons = state => get( state, "AIButton.disabledAIButtons", {} );

--- a/packages/js/tests/ai-assessment-fixes/components/AIAssessmentFixesButton.test.js
+++ b/packages/js/tests/ai-assessment-fixes/components/AIAssessmentFixesButton.test.js
@@ -26,7 +26,7 @@ const mockSelect = ( activeAIButton, editorMode = "visual", blocks = [] ) =>
 	useSelect.mockImplementation( select => select( () => ( {
 		getActiveAIFixesButton: () => activeAIButton,
 		getActiveMarker: () => null,
-		getDisabledAIFixesButtons: () => [ "keyphraseDistributionAIFixes" ],
+		getDisabledAIFixesButtons: () => ( { keyphraseDistributionAIFixes: "Your text is too long." } ),
 		getBlocks: () => blocks,
 		getBlockMode: ( clientId ) => clientId === "htmlTest" ? "html" : "visual",
 		getEditorMode: () => editorMode,
@@ -81,7 +81,7 @@ describe( "AIAssessmentFixesButton", () => {
 		const button = screen.getByRole( "button" );
 		expect( button ).toBeInTheDocument();
 		expect( button ).toBeDisabled();
-		expect( button ).toHaveAttribute( "aria-label", "Your text is too long for the AI model to process." );
+		expect( button ).toHaveAttribute( "aria-label", "Your text is too long." );
 	} );
 
 	test( "should be disabled in HTML editing mode", () => {

--- a/packages/js/tests/redux/actions/AIButton.test.js
+++ b/packages/js/tests/redux/actions/AIButton.test.js
@@ -17,7 +17,7 @@ describe( "AIButton", () => {
 		expect( setActiveAIFixesButton( activeAIButton ) ).toEqual( expected );
 	} );
 	it( "setDisabledAIFixesButtons should return an action with the SET_DISABLED_AI_FIXES_BUTTONS type and the ids of the disabled buttons", () => {
-		const disabledAIButtons = [ "keyphraseInIntroductionAIFixes" ];
+		const disabledAIButtons = { keyphraseInIntroductionAIFixes: "Your text is too long." };
 
 		const expected = {
 			type: SET_DISABLED_AI_FIXES_BUTTONS,

--- a/packages/js/tests/redux/reducers/AIButton.test.js
+++ b/packages/js/tests/redux/reducers/AIButton.test.js
@@ -4,7 +4,7 @@ import AIButton from "../../../src/redux/reducers/AIButton";
 describe( "AIButton", () => {
 	const state = {
 		activeAIButton: null,
-		disabledAIButtons: [],
+		disabledAIButtons: {},
 	};
 
 	it( "should set the active AI fixes button on receiving the SET_ACTIVE_AI_FIXES_BUTTON action", () => {
@@ -14,7 +14,7 @@ describe( "AIButton", () => {
 		};
 		const expected = {
 			activeAIButton: "keyphraseDensityAIFixes",
-			disabledAIButtons: [],
+			disabledAIButtons: {},
 		};
 
 		// eslint-disable-next-line new-cap
@@ -23,11 +23,11 @@ describe( "AIButton", () => {
 	it( "should set the disabled AI fixes buttons on receiving the SET_DISABLED_AI_FIXES_BUTTONS action", () => {
 		const action = {
 			type: SET_DISABLED_AI_FIXES_BUTTONS,
-			disabledAIButtons: [ "keyphraseDensityAIFixes", "keyphraseDistributionAIFixes" ],
+			disabledAIButtons: { keyphraseDensityAIFixes: "too short", keyphraseDistributionAIFixes: "too long" },
 		};
 		const expected = {
 			activeAIButton: null,
-			disabledAIButtons: [ "keyphraseDensityAIFixes", "keyphraseDistributionAIFixes" ],
+			disabledAIButtons: { keyphraseDensityAIFixes: "too short", keyphraseDistributionAIFixes: "too long" },
 		};
 
 		// eslint-disable-next-line new-cap

--- a/packages/js/tests/redux/selectors/AIButton.test.js
+++ b/packages/js/tests/redux/selectors/AIButton.test.js
@@ -4,7 +4,7 @@ describe( "AIButton", () => {
 	const state = {
 		AIButton: {
 			activeAIButton: "keyphraseInSubheadingAIFixes",
-			disabledAIButtons: [ "keyphraseDensityAIFixes" ],
+			disabledAIButtons: { keyphraseDensityAIFixes: "Your text is too long." },
 		},
 	};
 
@@ -12,6 +12,6 @@ describe( "AIButton", () => {
 		expect( getActiveAIFixesButton( state ) ).toEqual( "keyphraseInSubheadingAIFixes" );
 	} );
 	it( "returns the ids of the disabled AI Assessment Fixes buttons", () => {
-		expect( getDisabledAIFixesButtons( state ) ).toEqual( [ "keyphraseDensityAIFixes" ] );
+		expect( getDisabledAIFixesButtons( state ) ).toEqual( { keyphraseDensityAIFixes: "Your text is too long." } );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With this PR with allow setting a reason for a disabled Yoast AI Optimize button through the Redux store. We basically change the list to an object, with the keys being the buttons that should be disabled, and the values being the reason why they should be disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows setting a reason for a disabled Yoast AI Optimize button.

## Relevant technical choices:

* We are not using a `Map` because Redux can not store non-serializable objects. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm all unit tests pass. 
* See the Premium PR for the remainder of the testing steps.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No other impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes github.com/Yoast/plugins-automated-testing/issues/1703
