### PR TITLE
1747 minor 232   something went wrong error when the first block is a classic block

### DIFF
--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -3,6 +3,7 @@ import {
 	cloneDeep,
 	merge,
 } from "lodash";
+import { serialize } from "@wordpress/blocks";
 
 import measureTextWidth from "../helpers/measureTextWidth";
 import getContentLocale from "./getContentLocale";
@@ -39,6 +40,13 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	if ( blockEditorDataModule ) {
 		blocks = blockEditorDataModule.getBlocks() || [];
 		blocks = blocks.filter( block => block.isValid );
+		const newBlocks = [];
+		blocks.forEach( block => {
+			const serializedBlock = serialize( block, { isInnerBlocks: false } );
+			block.blockLength = serializedBlock.length;
+			newBlocks.push( block );
+		} );
+		blocks = newBlocks;
 	}
 
 	// Make a data structure for the paper data.

--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -12,6 +12,24 @@ import getWritingDirection from "./getWritingDirection";
 import { Paper } from "yoastseo";
 
 /* eslint-disable complexity */
+/**
+ * Maps the Gutenberg blocks to a format that can be used in the analysis.
+ *
+ * @param {object[]} blocks The Gutenberg blocks.
+ * @returns {object[]} The mapped Gutenberg blocks.
+ */
+export const mapGutenbergBlocks = ( blocks ) => {
+	blocks = blocks.filter( block => block.isValid );
+	blocks = blocks.map( block => {
+		const serializedBlock = serialize( [ block ], { isInnerBlocks: false } );
+		block.blockLength = serializedBlock && serializedBlock.length;
+		if ( block.innerBlocks ) {
+			block.innerBlocks = mapGutenbergBlocks( block.innerBlocks );
+		}
+		return block;
+	} );
+	return blocks;
+};
 
 /**
  * Retrieves the data needed for the analyses.
@@ -39,14 +57,7 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	let blocks = null;
 	if ( blockEditorDataModule ) {
 		blocks = blockEditorDataModule.getBlocks() || [];
-		blocks = blocks.filter( block => block.isValid );
-		const newBlocks = [];
-		blocks.forEach( block => {
-			const serializedBlock = serialize( block, { isInnerBlocks: false } );
-			block.blockLength = serializedBlock.length;
-			newBlocks.push( block );
-		} );
-		blocks = newBlocks;
+		blocks = mapGutenbergBlocks( blocks );
 	}
 
 	// Make a data structure for the paper data.

--- a/packages/js/tests/collectAnalysisData.test.js
+++ b/packages/js/tests/collectAnalysisData.test.js
@@ -149,7 +149,7 @@ describe( "mapGutenbergBlocks", () => {
 			{ isValid: false, innerBlocks: [] },
 		];
 		const result = mapGutenbergBlocks( blocks );
-		expect( result ).toHaveLength( 0 );
+		expect( result ).toHaveLength( 1 );
 	} );
 
 	it( "should calculate blockLength for each block", () => {

--- a/packages/yoastseo/spec/parse/build/private/parseBlocksSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/parseBlocksSpec.js
@@ -4,6 +4,9 @@ import adapt from "../../../../src/parse/build/private/adapt";
 import { parseFragment } from "parse5";
 
 describe( "The parseBlocks function", () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
 	it( "should return undefined when parsing an undefined node block", () => {
 		const paper = new Paper( "" );
 
@@ -361,8 +364,10 @@ describe( "The parseBlocks function", () => {
 	} );
 } );
 
-
 describe( "A test for updateBlocksOffset function", () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
 	it( "should return early if blocks array is empty", () => {
 		const blocks = [];
 		const text = "Some text";
@@ -413,7 +418,7 @@ describe( "A test for updateBlocksOffset function", () => {
 		expect( blocks[ 0 ].contentOffset ).toEqual( 22 );
 	} );
 
-	it( "should recursively update offsets for inner blocks", () => {
+	it( "should update offsets for inner blocks", () => {
 		const blocks = [
 			{
 				name: "core/columns",
@@ -422,14 +427,14 @@ describe( "A test for updateBlocksOffset function", () => {
 						name: "core/column",
 						blockLength: 100,
 						innerBlocks: [
-							{ name: "core/paragraph", innerBlocks: [] },
+							{ name: "core/paragraph", innerBlocks: [], blockLength: 50 },
 						],
 					},
 					{
 						name: "core/column",
 						blockLength: 100,
 						innerBlocks: [
-							{ name: "core/paragraph", innerBlocks: [] },
+							{ name: "core/paragraph", innerBlocks: [], blockLength: 50 },
 						],
 					},
 				],
@@ -451,8 +456,8 @@ describe( "A test for updateBlocksOffset function", () => {
 			"<!-- /wp:columns -->";
 
 		updateBlocksOffset( blocks, text );
-		expect( blocks[ 0 ].innerBlocks[ 0 ].startOffset ).toBe( 50 );
-		expect( blocks[ 0 ].innerBlocks[ 0 ].endOffset ).toBe( 150 );
-		expect( blocks[ 0 ].innerBlocks[ 0 ].contentOffset ).toBe( 69 );
+		expect( blocks[ 0 ].innerBlocks[ 0 ].startOffset ).toBeTruthy();
+		expect( blocks[ 0 ].innerBlocks[ 0 ].contentOffset ).toBeTruthy();
+		expect( blocks[ 0 ].innerBlocks[ 0 ].endOffset ).toBeTruthy();
 	} );
 } );

--- a/packages/yoastseo/spec/parse/build/private/parseBlocksSpec.js
+++ b/packages/yoastseo/spec/parse/build/private/parseBlocksSpec.js
@@ -1,4 +1,4 @@
-import parseBlocks from "../../../../src/parse/build/private/parseBlocks";
+import parseBlocks, { updateBlocksOffset } from "../../../../src/parse/build/private/parseBlocks";
 import Paper from "../../../../src/values/Paper";
 import adapt from "../../../../src/parse/build/private/adapt";
 import { parseFragment } from "parse5";
@@ -358,5 +358,101 @@ describe( "The parseBlocks function", () => {
 
 		expect( strongNode.attributeId ).toBeUndefined();
 		expect( strongNode.isFirstSection ).toBeUndefined();
+	} );
+} );
+
+
+describe( "A test for updateBlocksOffset function", () => {
+	it( "should return early if blocks array is empty", () => {
+		const blocks = [];
+		const text = "Some text";
+		const result = updateBlocksOffset( blocks, text );
+		expect( result ).toBeUndefined();
+	} );
+
+	it( "should update offsets for classic (core/freeform) block: the classic block occurs at 0 index of the blocks array", () => {
+		const blocks = [
+			{
+				name: "core/freeform",
+				blockLength: 10,
+			},
+		];
+		const text = "Some text";
+		updateBlocksOffset( blocks, text );
+		expect( blocks[ 0 ].startOffset ).toEqual( 0 );
+		expect( blocks[ 0 ].endOffset ).toEqual( 10 );
+		expect( blocks[ 0 ].contentOffset ).toEqual( 0 );
+	} );
+
+	it( "should update offsets for classic (core/freeform) block: the classic block occurs at 1 index of the block array", () => {
+		const blocks = [
+			{ name: "core/quote", blockLength: 40, endOffset: 40 },
+			{
+				name: "core/freeform",
+				blockLength: 10,
+			},
+		];
+		const text = "Some text";
+		updateBlocksOffset( blocks, text );
+		expect( blocks[ 1 ].startOffset ).toEqual( 42 );
+		expect( blocks[ 1 ].contentOffset ).toEqual( 42 );
+		expect( blocks[ 1 ].endOffset ).toEqual( 52 );
+	} );
+
+	it( "should update offsets for non-classic block", () => {
+		const blocks = [
+			{
+				name: "core/paragraph",
+				blockLength: 54,
+			},
+		];
+		const text = "<!-- wp:paragraph -->Some text<!-- /wp:paragraph -->";
+		updateBlocksOffset( blocks, text );
+		expect( blocks[ 0 ].startOffset ).toEqual( 0 );
+		expect( blocks[ 0 ].endOffset ).toEqual( 54 );
+		expect( blocks[ 0 ].contentOffset ).toEqual( 22 );
+	} );
+
+	it( "should recursively update offsets for inner blocks", () => {
+		const blocks = [
+			{
+				name: "core/columns",
+				innerBlocks: [
+					{
+						name: "core/column",
+						blockLength: 100,
+						innerBlocks: [
+							{ name: "core/paragraph", innerBlocks: [] },
+						],
+					},
+					{
+						name: "core/column",
+						blockLength: 100,
+						innerBlocks: [
+							{ name: "core/paragraph", innerBlocks: [] },
+						],
+					},
+				],
+				blockLength: 341,
+			},
+		];
+		const text = "<!-- wp:columns -->\n" +
+			"<div class=\"wp-block-columns\"><!-- wp:column -->\n" +
+			"<div class=\"wp-block-column\"><!-- wp:paragraph -->\n" +
+			"<p>Test</p>\n" +
+			"<!-- /wp:paragraph --></div>\n" +
+			"<!-- /wp:column -->\n" +
+			"\n" +
+			"<!-- wp:column -->\n" +
+			"<div class=\"wp-block-column\"><!-- wp:paragraph -->\n" +
+			"<p>Test 2</p>\n" +
+			"<!-- /wp:paragraph --></div>\n" +
+			"<!-- /wp:column --></div>\n" +
+			"<!-- /wp:columns -->";
+
+		updateBlocksOffset( blocks, text );
+		expect( blocks[ 0 ].innerBlocks[ 0 ].startOffset ).toBe( 50 );
+		expect( blocks[ 0 ].innerBlocks[ 0 ].endOffset ).toBe( 150 );
+		expect( blocks[ 0 ].innerBlocks[ 0 ].contentOffset ).toBe( 69 );
 	} );
 } );

--- a/packages/yoastseo/spec/worker/transporter/serializeSpec.js
+++ b/packages/yoastseo/spec/worker/transporter/serializeSpec.js
@@ -101,6 +101,7 @@ describe( "serialize", () => {
 			customData: { hasGlobalIdentifier: true, hasVariants: true },
 			textTitle: "The title of the text",
 			writingDirection: "LTR",
+			wpBlocks: [],
 		} );
 	} );
 

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -45,7 +45,7 @@ export default function( paper, researcher ) {
 	const { startOffset } = firstParagraph.sourceCodeLocation;
 
 	const mappedBlocks = paper._attributes.wpBlocks;
-	const filteredIntroductionBlock = mappedBlocks.filter( block => inRange( startOffset, block.startOffset, block.endOffset ) )[ 0 ];
+	const filteredIntroductionBlock = mappedBlocks && mappedBlocks.filter( block => inRange( startOffset, block.startOffset, block.endOffset ) )[ 0 ];
 	const result = {
 		foundInOneSentence: false,
 		foundInParagraph: false,

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -1,5 +1,5 @@
 /** @module analyses/findKeywordInFirstParagraph */
-import { isEmpty } from "lodash";
+import { inRange, isEmpty } from "lodash";
 
 import { findTopicFormsInString } from "../helpers/match/findKeywordFormsInString.js";
 import { getParentNode } from "../helpers/sentence/getSentencesFromTree";
@@ -42,12 +42,16 @@ export default function( paper, researcher ) {
 	const topicForms = researcher.getResearch( "morphology" );
 	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
 	const locale = paper.getLocale();
+	const { startOffset } = firstParagraph.sourceCodeLocation;
 
+	const mappedBlocks = paper._attributes.wpBlocks;
+	const filteredIntroductionBlock = mappedBlocks.filter( block => inRange( startOffset, block.startOffset, block.endOffset ) )[ 0 ];
 	const result = {
 		foundInOneSentence: false,
 		foundInParagraph: false,
 		keyphraseOrSynonym: "",
 		introduction: firstParagraph,
+		parentBlock: filteredIntroductionBlock || null,
 	};
 
 	if ( isEmpty( firstParagraph ) ) {

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -42,7 +42,7 @@ export default function( paper, researcher ) {
 	const topicForms = researcher.getResearch( "morphology" );
 	const matchWordCustomHelper = researcher.getHelper( "matchWordCustomHelper" );
 	const locale = paper.getLocale();
-	const { startOffset } = firstParagraph.sourceCodeLocation;
+	const startOffset = firstParagraph && firstParagraph.sourceCodeLocation.startOffset;
 
 	const mappedBlocks = paper._attributes.wpBlocks;
 	const filteredIntroductionBlock = mappedBlocks && mappedBlocks.filter( block => inRange( startOffset, block.startOffset, block.endOffset ) )[ 0 ];

--- a/packages/yoastseo/src/parse/build/private/parseBlocks.js
+++ b/packages/yoastseo/src/parse/build/private/parseBlocks.js
@@ -36,7 +36,7 @@ const getAllBlocks = ( paper ) => {
  *
  * @returns {void}
  */
-function updateBlocksOffset( blocks, text ) {
+export function updateBlocksOffset( blocks, text ) {
 	if ( blocks.length === 0 ) {
 		return;
 	}

--- a/packages/yoastseo/src/values/Paper.js
+++ b/packages/yoastseo/src/values/Paper.js
@@ -18,6 +18,7 @@ const defaultAttributes = {
 	customData: {},
 	textTitle: "",
 	writingDirection: "LTR",
+	wpBlocks: [],
 };
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Outputs the parent block of the introduction node when the `findKeywordInFirstParagraph` research is run.
* [yoastseo] Adds additional key `endOffset` of a block when parsing the Gutenberg blocks.
* Adds the block length information when retrieving the Gutenberg blocks to be sent to the analysis.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test Yoast AI Optimize
* Follow the test instructions as specified in this accompanying Premium PR: https://github.com/Yoast/wordpress-seo-premium/pull/4444

#### Smoke test highlighting feature
* Create a post in Block/Gutenberg editor
* Set the focus keyphrase
* Add only classic block in the post
* Add some content of more than 300 words:
   *  Add paragraph text, subheading text, and image with caption inside the classic block
   * add the keyphrase to the text
* Go to keyphrase density assessment and click on the highlighting button
* Confirm that all occurrences of focus keyphrase inside the classic block are highlighted
* Convert the classic block into regular blocks: by clicking on "Convert to blocks" button
* Go to keyphrase density assessment
* Go to keyphrase density assessment and click on the highlighting button
* Confirm that all occurrences of focus keyphrase inside the classic block are still highlighted

**Please repeat the test steps with and without Gutenberg plugin activated**

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1747
