### PR TITLE
Refactor filter_input and remove dependency.

### DIFF
--- a/src/helpers/first-time-configuration-notice-helper.php
+++ b/src/helpers/first-time-configuration-notice-helper.php
@@ -55,7 +55,6 @@ class First_Time_Configuration_Notice_Helper {
 		if ( ! $this->on_wpseo_admin_page_or_dashboard() ) {
 			return false;
 		}
-
 		return $this->first_time_configuration_not_finished();
 	}
 
@@ -121,17 +120,21 @@ class First_Time_Configuration_Notice_Helper {
 			return true;
 		}
 
-		$page_from_get = \filter_input( \INPUT_GET, 'page' );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information and only comparing the variable in a condition.
+			$page_from_get = \wp_unslash( $_GET['page'] );
 
-		// Show on Yoast SEO pages, with some exceptions.
-		if ( $pagenow === 'admin.php' && \strpos( $page_from_get, 'wpseo' ) === 0 ) {
-			$exceptions = [
-				'wpseo_installation_successful',
-				'wpseo_installation_successful_free',
-			];
+			// Show on Yoast SEO pages, with some exceptions.
+			if ( $pagenow === 'admin.php' && \strpos( $page_from_get, 'wpseo' ) === 0 ) {
+				$exceptions = [
+					'wpseo_installation_successful',
+					'wpseo_installation_successful_free',
+				];
 
-			if ( ! \in_array( $page_from_get, $exceptions, true ) ) {
-				return true;
+				if ( ! \in_array( $page_from_get, $exceptions, true ) ) {
+					return true;
+				}
 			}
 		}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -261,14 +261,14 @@ class Settings_Integration implements Integration_Interface {
 			$post_action = '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
 			if ( isset( $_POST['action'] ) && \is_string( $_POST['action'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
-				$post_action = \sanitize_text_field( \wp_unslash( $_POST['action'] ) );
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information.
+				$post_action = \wp_unslash( $_POST['action'] );
 			}
 			$option_page = '';
 			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
 			if ( isset( $_POST['option_page'] ) && \is_string( $_POST['option_page'] ) ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
-				$option_page = \sanitize_text_field( \wp_unslash( $_POST['option_page'] ) );
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information.
+				$option_page = \wp_unslash( $_POST['option_page'] );
 			}
 
 			if ( $post_action === 'update' && $option_page === self::PAGE ) {

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -258,10 +258,18 @@ class Settings_Integration implements Integration_Interface {
 
 		// Are we saving the settings?
 		if ( $this->current_page_helper->get_current_admin_page() === 'options.php' ) {
-			// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- This deprecation will be addressed later.
-			$post_action = \filter_input( \INPUT_POST, 'action', @\FILTER_SANITIZE_STRING );
-			$option_page = \filter_input( \INPUT_POST, 'option_page', @\FILTER_SANITIZE_STRING );
-			// phpcs:enable
+			$post_action = '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
+			if ( isset( $_POST['action'] ) && \is_string( $_POST['action'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
+				$post_action = \sanitize_text_field( \wp_unslash( $_POST['action'] ) );
+			}
+			$option_page = '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
+			if ( isset( $_POST['option_page'] ) && \is_string( $_POST['option_page'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Reason: We are not processing form information.
+				$option_page = \sanitize_text_field( \wp_unslash( $_POST['option_page'] ) );
+			}
 
 			if ( $post_action === 'update' && $option_page === self::PAGE ) {
 				\add_action( 'admin_init', [ $this, 'register_setting' ] );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -534,25 +534,25 @@ function yoast_wpseo_missing_autoload_notice() {
  * Throw an error if the filter extension is disabled (prevent white screens) and self-deactivate plugin.
  *
  * @since 2.0
+ * @deprecated 23.3
+ * @codeCoverageIgnore
  *
  * @return void
  */
 function yoast_wpseo_missing_filter() {
-	if ( is_admin() ) {
-		add_action( 'admin_notices', 'yoast_wpseo_missing_filter_notice' );
-
-		yoast_wpseo_self_deactivate();
-	}
+	_deprecated_function( __FUNCTION__, 'Yoast SEO 23.3' );
 }
 
 /**
  * Returns the notice in case of missing filter extension.
  *
+ * @deprecated 23.3
+ * @codeCoverageIgnore
+ *
  * @return void
  */
 function yoast_wpseo_missing_filter_notice() {
-	$message = esc_html__( 'The filter extension seem to be unavailable. Please ask your web host to enable it.', 'wordpress-seo' );
-	yoast_wpseo_activation_failed_notice( $message );
+	_deprecated_function( __FUNCTION__, 'Yoast SEO 23.3' );
 }
 
 /**

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -410,7 +410,7 @@ if ( ! $spl_autoload_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_spl', 1 );
 }
 
-if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {
+if ( ! wp_installing() && ( $spl_autoload_exists ) ) {
 	add_action( 'plugins_loaded', 'wpseo_init', 14 );
 	add_action( 'setup_theme', [ 'Yoast_Dynamic_Rewrites', 'instance' ], 1 );
 	add_action( 'rest_api_init', 'wpseo_init_rest_api' );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -405,14 +405,9 @@ function wpseo_admin_init() {
 
 /* ***************************** BOOTSTRAP / HOOK INTO WP *************************** */
 $spl_autoload_exists = function_exists( 'spl_autoload_register' );
-$filter_exists       = function_exists( 'filter_input' );
 
 if ( ! $spl_autoload_exists ) {
 	add_action( 'admin_init', 'yoast_wpseo_missing_spl', 1 );
-}
-
-if ( ! $filter_exists ) {
-	add_action( 'admin_init', 'yoast_wpseo_missing_filter', 1 );
 }
 
 if ( ! wp_installing() && ( $spl_autoload_exists && $filter_exists ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->


* We want to replace all `filter_input` calls in our codebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor filter_input calls in `first-time-configuration-notice-helper.php`.
* Refactor filter_input calls in `settings-integration.php`.
* Removes dependancy on the `filter_input` function

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* The test the settings, smoke test the settings and see if they still save.
* To check the FTC message. Use the test helper to reset your options and FTC progress.
* Go to any yoastSEO page and see that there is a notification to complete the FTC.
![Screenshot 2024-08-13 at 14 10 10](https://github.com/user-attachments/assets/b850bd27-a025-4068-8f70-34f1093eb1cb)
* Remove the notification and refresh and make sure it stays gone.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
