### PR TITLE
Elementor: fix timing issue after save and before closing the document

### DIFF
--- a/packages/js/src/elementor/initializers/editor-integration.js
+++ b/packages/js/src/elementor/initializers/editor-integration.js
@@ -45,9 +45,9 @@ const sendFormData = ( form ) => new Promise( ( resolve ) => {
 		return result;
 	}, {} );
 
-	jQuery.post( form.getAttribute( "action" ), formData, ( { success, data }, status, xhr ) => {
-		resolve( { success, formData, data, xhr } );
-	} );
+	jQuery.post( form.getAttribute( "action" ), formData )
+		.done( ( { success, data }, status, xhr ) => resolve( { success, formData, data, xhr } ) )
+		.fail( ( xhr ) => resolve( { success: false, formData, xhr } ) );
 } );
 
 /**
@@ -127,10 +127,12 @@ export const initializeElementEditorIntegration = () => {
 			doAction( "yoast.elementor.toggleFreeze", { isFreeze: true, isDiscard: mode === "discard" } );
 
 			removeAction( "yoast.elementor.save.success", "yoast/yoast-seo/finishClosingDocument" );
+			removeAction( "yoast.elementor.save.failure", "yoast/yoast-seo/finishClosingDocument" );
 		};
 
 		if ( isSaving ) {
 			addAction( "yoast.elementor.save.success", "yoast/yoast-seo/finishClosingDocument", finishClosingDocument );
+			addAction( "yoast.elementor.save.failure", "yoast/yoast-seo/finishClosingDocument", finishClosingDocument );
 			return;
 		}
 		finishClosingDocument();
@@ -177,6 +179,8 @@ export const initializeElementEditorIntegration = () => {
 		if ( ! success ) {
 			// Revert false assumption, see above.
 			hasUnsavedSeoChanges = true;
+			isSaving = false;
+			doAction( "yoast.elementor.save.failure" );
 			return;
 		}
 

--- a/packages/js/src/elementor/initializers/editor-integration.js
+++ b/packages/js/src/elementor/initializers/editor-integration.js
@@ -1,6 +1,6 @@
 /* global $e, elementor, YoastSEO */
 import { dispatch } from "@wordpress/data";
-import { doAction } from "@wordpress/hooks";
+import { addAction, doAction, removeAction } from "@wordpress/hooks";
 import { debounce, throttle } from "lodash";
 import { registerReactComponent } from "../../helpers/reactRoot";
 import { registerElementorDataHookAfter, registerElementorUIHookAfter, registerElementorUIHookBefore } from "../helpers/hooks";
@@ -14,6 +14,12 @@ import { initializeTab } from "./tab";
 
 // Keep track of unsaved SEO setting changes.
 let hasUnsavedSeoChanges = false;
+
+/**
+ * The save takes longer than the closing of the document, due to the async nature of the save.
+ * This flag is used to prevent freezing the store before the save is done.
+ */
+let isSaving = false;
 
 /**
  * Wraps the callback in a trailing debounce.
@@ -102,11 +108,32 @@ export const initializeElementEditorIntegration = () => {
 			updateSaveAsDraftWarning( hasUnsavedSeoChanges );
 		}
 
-		// Disable our integration for the form document.
-		YoastSEO.store._freeze( true );
+		/**
+		 * Runs the final actions we want to do when the user closes a document.
+		 *
+		 * 1. Freeze the store.
+		 * 2. Notify other plugins the document is no longer relevant.
+		 * 3. Remove the action to prevent multiple calls.
+		 *
+		 * This function is called after the save is done. As to not freeze the store while saving!
+		 *
+		 * @returns {void}
+		 */
+		const finishClosingDocument = () => {
+			// Disable our integration for the form document.
+			YoastSEO.store._freeze( true );
 
-		// Notify other plugins the document is no longer relevant.
-		doAction( "yoast.elementor.toggleFreeze", { isFreeze: true, isDiscard: mode === "discard" } );
+			// Notify other plugins the document is no longer relevant.
+			doAction( "yoast.elementor.toggleFreeze", { isFreeze: true, isDiscard: mode === "discard" } );
+
+			removeAction( "yoast.elementor.save.success", "yoast/yoast-seo/finishClosingDocument" );
+		};
+
+		if ( isSaving ) {
+			addAction( "yoast.elementor.save.success", "yoast/yoast-seo/finishClosingDocument", finishClosingDocument );
+			return;
+		}
+		finishClosingDocument();
 	};
 
 	/**
@@ -117,6 +144,8 @@ export const initializeElementEditorIntegration = () => {
 	 * @returns {Promise<void>} The promise that resolves when the save is done.
 	 */
 	const handleSaveDocument = async( { document } ) => {
+		isSaving = true;
+
 		/**
 		 * Ensure we only save to the (HTML) form document.
 		 *
@@ -165,6 +194,8 @@ export const initializeElementEditorIntegration = () => {
 		// Take a snapshot, to restore from here when discarding.
 		YoastSEO.store._takeSnapshot();
 		formWatcher.takeSnapshot();
+
+		isSaving = false;
 	};
 
 	registerElementorUIHookBefore(

--- a/packages/js/src/elementor/initializers/editor-integration.js
+++ b/packages/js/src/elementor/initializers/editor-integration.js
@@ -39,7 +39,7 @@ const sendFormData = ( form ) => new Promise( ( resolve ) => {
 		return result;
 	}, {} );
 
-	jQuery.post( form.getAttribute( "action" ), formData, ( { success, data }, xhr ) => {
+	jQuery.post( form.getAttribute( "action" ), formData, ( { success, data }, status, xhr ) => {
 		resolve( { success, formData, data, xhr } );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Fixes two issues coming from: https://github.com/Yoast/wordpress-seo/pull/21514
* timing issue when saving while switching to another post/page
* save action not sending the same data (which broke our Premium redirect notification)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where our save action would not send the same data anymore.
* Fixes an unreleased bug where saving while switching a document would result in a timing issue.

## Relevant technical choices:

* Added one more "module" variable to keep track of if currently saving or not. Re-used the save hook to get a call when done
* Adapted the AJAX request to always resolve, no longer ignoring errors so we can't get stuck in a frozen state 🧊 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate the top bar of elementor from: Elementor > Settings > Features (If not active)

#### Test that the timing issue is fixed
* Edit any post/page in Elementor
* Go to the Yoast tab
* Change the focus keyphrase (or anything we save)
* Switch to another page/page from the top bar
* Save the Changes in the popup
* Switch back to the post/page you are editing
* Go to the Yoast tab
* [ ] Verify you no longer see the update notice

#### Test Premium redirect
* Activate Premium (latest 23.3-RC)
* Edit any post/page in Elementor
* Go to the Yoast tab
* Change the focus keyphrase (or anything we save)
* Switch to another page/page from the top bar
* Save the Changes in the popup
* [ ] Verify you do not see a JS `xhr` error in the console (`TypeError: xhr.getResponseHeader is not a function`)

#### Test save error still unfreezes
* Add the following PHP to make the save error:
```php
add_action( 'wp_ajax_wpseo_elementor_save', function() {
	wp_send_json_error( 'foo', 400 );
}, 1 );
```
* Edit any post/page in Elementor
* Go to the Yoast tab
* Change the focus keyphrase (or anything we save)
* Switch to another page/page from the top bar
* Save the Changes in the popup
* Switch back to the post/page you are editing
* Go to the Yoast tab
* [ ] Verify you still see the update notice
* [ ] Verify you can still edit the focus keyphrase
* Note: we don't properly handle save errors, this is just testing we unfreeze our store properly

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1781
