### PR TITLE
Fix hardcoded `wp-admin` path

### DIFF
--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -106,14 +106,15 @@ const footerText = ( postTypeName ) => sprintf(
  * Interpolates the footerText string with an actual link component.
  *
  * @param {string} postTypeName  The name of the current post type.
+ * @param {string} href          The href for the link.
  *
  * @returns {string} A link to the Search Appearance settings.
  */
-const footerWithLink = ( postTypeName ) => interpolateComponents(
+const footerWithLink = ( postTypeName, href ) => interpolateComponents(
 	{
 		mixedString: footerText( postTypeName ),
 		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		components: { link: <a href="/wp-admin/admin.php?page=wpseo_page_settings" target="_blank" /> },
+		components: { link: <a href={ href } target="_blank" rel="noreferrer" /> },
 	}
 );
 
@@ -172,6 +173,7 @@ const Content = ( props ) => {
 	const woocommerceUpsellText = __( "Want your products stand out in search results with rich results like price, reviews and more?", "wordpress-seo" );
 	const isProduct = useSelect( ( select ) => select( STORE ).getIsProduct(), [] );
 	const isWooSeoActive = useSelect( select => select( STORE ).getIsWooSeoActive(), [] );
+	const settingsLink = useSelect( select => select( STORE ).selectAdminLink( "?page=wpseo_page_settings" ), [] );
 
 	const disablePageTypeSelect = isProduct && isWooSeoActive;
 
@@ -217,7 +219,7 @@ const Content = ( props ) => {
 				location={ props.location }
 				show={ ! props.isNewsEnabled && isNewsArticleType( focusedArticleType, props.defaultArticleType ) }
 			/>
-			{ props.displayFooter && ! disablePageTypeSelect && <p>{ footerWithLink( props.postTypeName ) }</p> }
+			{ props.displayFooter && ! disablePageTypeSelect && <p>{ footerWithLink( props.postTypeName, settingsLink ) }</p> }
 			{ disablePageTypeSelect && <p>
 				{ sprintf(
 					/* translators: %1$s expands to Yoast WooCommerce SEO. */

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -57,6 +57,7 @@ const populateStore = store => {
 
 	store.dispatch( actions.setIsPremium( Boolean( get( window, "wpseoScriptData.metabox.isPremium", false ) ) ) );
 
+	store.dispatch( actions.setAdminUrl( get( window, "wpseoScriptData.adminUrl", "" ) ) );
 	store.dispatch( actions.setLinkParams( get( window, "wpseoScriptData.linkParams", {} ) ) );
 	store.dispatch( actions.setPluginUrl( get( window, "wpseoScriptData.pluginUrl", "" ) ) );
 	store.dispatch( actions.setWistiaEmbedPermissionValue( get( window, "wpseoScriptData.wistiaEmbedPermission", false ) === "1" ) );

--- a/packages/js/src/initializers/editor-store.js
+++ b/packages/js/src/initializers/editor-store.js
@@ -39,6 +39,7 @@ const populateStore = store => {
 	store.dispatch( actions.setIsPremium( Boolean( get( window, "wpseoScriptData.metabox.isPremium", false ) ) ) );
 	store.dispatch( actions.setPostId( Number( get( window, "wpseoScriptData.postId", null ) ) ) );
 
+	store.dispatch( actions.setAdminUrl( get( window, "wpseoScriptData.adminUrl", "" ) ) );
 	store.dispatch( actions.setLinkParams( get( window, "wpseoScriptData.linkParams", {} ) ) );
 	store.dispatch( actions.setPluginUrl( get( window, "wpseoScriptData.pluginUrl", "" ) ) );
 	store.dispatch( actions.setWistiaEmbedPermissionValue( get( window, "wpseoScriptData.wistiaEmbedPermission", false ) === "1" ) );

--- a/packages/js/src/installation-success.js
+++ b/packages/js/src/installation-success.js
@@ -95,7 +95,7 @@ function InstallationSuccessPage() {
 					<a
 						id="installation-success-skip-link"
 						className="yst-bottom-12 yst-right-0 yst-mr-5 yst-self-end yst-text-base md:yst-absolute"
-						href={ "/wp-admin/admin.php?page=wpseo_dashboard" }
+						href={ window.wpseoInstallationSuccess.dashboardUrl }
 						data-hiive-event-name="clicked_skip_button | installation successful screen"
 					>
 						{

--- a/packages/js/src/redux/actions/index.js
+++ b/packages/js/src/redux/actions/index.js
@@ -1,5 +1,6 @@
-import { linkParamsActions, pluginUrlActions, wistiaEmbedPermissionActions } from "../../shared-admin/store";
+import { adminUrlActions, linkParamsActions, pluginUrlActions, wistiaEmbedPermissionActions } from "../../shared-admin/store";
 
+export const { setAdminUrl } = adminUrlActions;
 export const { setLinkParams } = linkParamsActions;
 export const { setPluginUrl } = pluginUrlActions;
 export const { setWistiaEmbedPermission, setWistiaEmbedPermissionValue } = wistiaEmbedPermissionActions;

--- a/packages/js/src/redux/reducers/index.js
+++ b/packages/js/src/redux/reducers/index.js
@@ -1,5 +1,7 @@
 import insights from "../../insights/redux/reducer";
 import {
+	ADMIN_URL_NAME,
+	adminUrlReducer,
 	LINK_PARAMS_NAME,
 	linkParamsReducer,
 	PLUGIN_URL_NAME,
@@ -13,8 +15,8 @@ import advancedSettings from "./advancedSettings";
 import AIButton from "./AIButton";
 import analysisData from "./analysisData";
 import checklist from "./checklist";
-import currentPromotions from "./currentPromotions";
 import isCornerstone from "./cornerstoneContent";
+import currentPromotions from "./currentPromotions";
 import dismissedAlerts from "./dismissedAlerts";
 import editorContext from "./editorContext";
 import editorData from "./editorData";
@@ -41,6 +43,7 @@ import WincherSEOPerformance from "./WincherSEOPerformance";
 
 export default {
 	activeMarker,
+	[ ADMIN_URL_NAME ]: adminUrlReducer,
 	advancedSettings,
 	AIButton,
 	analysis,

--- a/packages/js/src/redux/selectors/index.js
+++ b/packages/js/src/redux/selectors/index.js
@@ -1,5 +1,6 @@
-import { linkParamsSelectors, pluginUrlSelectors, wistiaEmbedPermissionSelectors } from "../../shared-admin/store";
+import { adminUrlSelectors, linkParamsSelectors, pluginUrlSelectors, wistiaEmbedPermissionSelectors } from "../../shared-admin/store";
 
+export const { selectAdminUrl, selectAdminLink } = adminUrlSelectors;
 export const { selectLinkParams, selectLinkParam, selectLink } = linkParamsSelectors;
 export const { selectPluginUrl, selectImageLink } = pluginUrlSelectors;
 export const {

--- a/packages/js/src/shared-admin/store/admin-url.js
+++ b/packages/js/src/shared-admin/store/admin-url.js
@@ -1,0 +1,36 @@
+import { createSelector, createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+export const ADMIN_URL_NAME = "adminUrl";
+
+const slice = createSlice( {
+	name: ADMIN_URL_NAME,
+	initialState: "",
+	reducers: {
+		setAdminUrl: ( state, { payload } ) => payload,
+	},
+} );
+
+export const getInitialAdminUrlState = slice.getInitialState;
+
+export const adminUrlSelectors = {
+	selectAdminUrl: state => get( state, ADMIN_URL_NAME, "" ),
+};
+adminUrlSelectors.selectAdminLink = createSelector(
+	[
+		adminUrlSelectors.selectAdminUrl,
+		( state, link ) => link,
+	],
+	( adminUrl, link = "" ) => {
+		try {
+			const url = new URL( link, adminUrl );
+			return url.href;
+		} catch ( e ) {
+			return adminUrl;
+		}
+	}
+);
+
+export const adminUrlActions = slice.actions;
+
+export const adminUrlReducer = slice.reducer;

--- a/packages/js/src/shared-admin/store/index.js
+++ b/packages/js/src/shared-admin/store/index.js
@@ -1,3 +1,4 @@
+export * from "./admin-url";
 export * from "./link-params";
 export * from "./notifications";
 export * from "./plugin-url";

--- a/packages/js/tests/shared-admin/store/admin-url.test.js
+++ b/packages/js/tests/shared-admin/store/admin-url.test.js
@@ -1,0 +1,104 @@
+import { describe, expect, it, test } from "@jest/globals";
+import { ADMIN_URL_NAME, adminUrlActions, adminUrlReducer, adminUrlSelectors, getInitialAdminUrlState } from "../../../src/shared-admin/store";
+
+describe( "adminUrl", () => {
+	it( "ADMIN_URL_NAME is adminUrl", () => {
+		expect( ADMIN_URL_NAME ).toBe( "adminUrl" );
+	} );
+
+	describe( "actions", () => {
+		describe( "setAdminUrl", () => {
+			it( "exists", () => {
+				expect( adminUrlActions.setAdminUrl ).toBeTruthy();
+			} );
+
+			it( "is a function", () => {
+				expect( typeof adminUrlActions.setAdminUrl ).toBe( "function" );
+			} );
+
+			it( "returns an action object", () => {
+				expect( adminUrlActions.setAdminUrl( "https://example.com" ) ).toEqual( {
+					type: "adminUrl/setAdminUrl",
+					payload: "https://example.com",
+				} );
+			} );
+
+			it( "sets the state", () => {
+				const actual = adminUrlReducer( "", adminUrlActions.setAdminUrl( "https://example.com" ) );
+				expect( actual ).toBe( "https://example.com" );
+			} );
+		} );
+	} );
+
+	describe( "initial state", () => {
+		it( "has an empty default state", () => {
+			expect( getInitialAdminUrlState() ).toBe( "" );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		it( "has an empty default state", () => {
+			expect( adminUrlReducer( undefined, { type: "" } ) ).toBe( "" );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		const state = {
+			[ ADMIN_URL_NAME ]: "https://example.com/",
+		};
+
+		describe( "selectAdminUrl", () => {
+			it( "exists", () => {
+				expect( adminUrlSelectors.selectAdminUrl ).toBeTruthy();
+			} );
+
+			it( "returns an empty string by default", () => {
+				expect( adminUrlSelectors.selectAdminUrl( {} ) ).toBe( "" );
+			} );
+
+			it( "returns the admin URL", () => {
+				expect( adminUrlSelectors.selectAdminUrl( state ) ).toBe( "https://example.com/" );
+			} );
+		} );
+
+		describe( "selectAdminLink", () => {
+			it( "exists", () => {
+				expect( adminUrlSelectors.selectAdminLink ).toBeTruthy();
+			} );
+
+			it( "returns the admin URL without parameters", () => {
+				expect( adminUrlSelectors.selectAdminLink( state ) ).toBe( "https://example.com/" );
+			} );
+
+			test.each( [
+				[ "foo", "https://example.com/foo" ],
+				// Takes just the base from the current admin URL.
+				[ "plugin.php", "https://example.com/plugin.php", "https://example.com/admin.php" ],
+				// Can handle query parameters.
+				[ "?page=foo", "https://example.com/admin.php?page=foo", "https://example.com/admin.php" ],
+				// Can handle hash parameters.
+				[ "#foo", "https://example.com/admin.php#foo", "https://example.com/admin.php" ],
+				// Can handle query and hash parameters.
+				[ "?page=foo#bar", "https://example.com/admin.php?page=foo#bar", "https://example.com/admin.php" ],
+				// Can handle full URLs: overriding the admin URL.
+				[ "https://other.com/foo", "https://other.com/foo" ],
+			] )( "returns a combined URL when passing %p", ( link, expected, adminUrl = "https://example.com/" ) => {
+				expect( adminUrlSelectors.selectAdminLink( { [ ADMIN_URL_NAME ]: adminUrl }, link ) ).toBe( expected );
+			} );
+
+			it( "returns the admin URL if not able to combine", () => {
+				/**
+				 * Fake class to throw an error when calling toString.
+				 */
+				class Test {
+					// eslint-disable-next-line require-jsdoc
+					toString() {
+						throw new Error( "Test error" );
+					}
+				}
+
+				expect( adminUrlSelectors.selectAdminLink( state, new Test() ) ).toBe( "https://example.com/" );
+			} );
+		} );
+	} );
+} );

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -70,6 +70,7 @@ abstract class Base_Site_Information {
 	 */
 	public function get_site_information(): array {
 		return [
+			'adminUrl'              => \admin_url( 'admin.php' ),
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
@@ -90,6 +91,7 @@ abstract class Base_Site_Information {
 	 */
 	public function get_legacy_site_information(): array {
 		return [
+			'adminUrl'              => \admin_url( 'admin.php' ),
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -133,6 +133,7 @@ class Installation_Success_Integration implements Integration_Interface {
 			[
 				'pluginUrl'                 => \esc_url( \plugins_url( '', \WPSEO_FILE ) ),
 				'firstTimeConfigurationUrl' => \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ),
+				'dashboardUrl'              => \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard' ) ),
 			]
 		);
 	}

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -128,6 +128,8 @@ final class Post_Site_Information_Test extends TestCase {
 				'isPremium'     => true,
 				'siteIconUrl'   => 'https://example.org',
 			],
+
+			'adminUrl'                   => 'https://example.org',
 			'linkParams'                 => [
 				'param',
 				'param2',
@@ -176,6 +178,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'post_edit_url'                  => 'https://example.org',
 			'base_url'                       => 'https://example.org',
 
+			'adminUrl'                       => 'https://example.org',
 			'linkParams'                     => [
 				'param',
 				'param2',

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -114,6 +114,7 @@ final class Term_Site_Information_Test extends TestCase {
 			'search_url'            => 'https://example.org',
 			'post_edit_url'         => 'https://example.org',
 			'base_url'              => 'https://example.org',
+			'adminUrl'              => 'https://example.org',
 			'linkParams'            => [
 				'param',
 				'param2',
@@ -160,6 +161,7 @@ final class Term_Site_Information_Test extends TestCase {
 				'isPremium'     => true,
 				'siteIconUrl'   => 'https://example.org',
 			],
+			'adminUrl'              => 'https://example.org',
 			'linkParams'            => [
 				'param',
 				'param2',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Lets use `admin_url()` instead of hardcoding to `/wp-admin/`

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where two of our admin links would not support a possible custom admin URL.

## Relevant technical choices:

* Add adminUrl slice, copied from Premium (but added tests here) and used script data abstraction to pass the data.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `/wp-admin/admin.php?page=wpseo_installation_successful_free`
* [x] Verify the `Skip` link at the bottom right still goes to our dashboard
* Edit a post in the block editor
* Open the schema tab
* [x] Verify the `Settings` link still goes to our settings
* Edit a post in Elementor
* Open the schema tab
* [ ] Verify the `Settings` link still goes to our settings

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
