### PR TITLE
Add learn more link to primary category picker

### DIFF
--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -1,14 +1,11 @@
-/* External dependencies */
-import { Component } from "@wordpress/element";
-import PropTypes from "prop-types";
-import { sprintf, __ } from "@wordpress/i18n";
 import apiFetch from "@wordpress/api-fetch";
 import { ExternalLink } from "@wordpress/components";
+import { Component } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
-import styled from "styled-components";
 import { difference, noop } from "lodash";
-
-/* Internal dependencies */
+import PropTypes from "prop-types";
+import styled from "styled-components";
 import TaxonomyPicker from "./TaxonomyPicker";
 
 const PrimaryTaxonomyPickerField = styled.div`
@@ -92,7 +89,7 @@ class PrimaryTaxonomyPicker extends Component {
 			/**
 			 * If the selected term is no longer available, set the primary term id to
 			 * the first term, and to -1 if no term is available.
- 			 */
+			 */
 			this.onChange( selectedTerms.length ? selectedTerms[ 0 ].id : -1 );
 		}
 	}

--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -3,6 +3,7 @@ import { Component } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { sprintf, __ } from "@wordpress/i18n";
 import apiFetch from "@wordpress/api-fetch";
+import { ExternalLink } from "@wordpress/components";
 import { addQueryArgs } from "@wordpress/url";
 import styled from "styled-components";
 import { difference, noop } from "lodash";
@@ -222,6 +223,7 @@ class PrimaryTaxonomyPicker extends Component {
 		const {
 			primaryTaxonomyId,
 			taxonomy,
+			learnMoreLink,
 		} = this.props;
 
 		if ( this.state.selectedTerms.length < 2 ) {
@@ -250,6 +252,12 @@ class PrimaryTaxonomyPicker extends Component {
 					id={ fieldId }
 					terms={ this.state.selectedTerms }
 				/>
+				<ExternalLink href={ learnMoreLink }>
+					{ __( "Learn more", "wordpress-seo" ) }
+					<span className="screen-reader-text">
+						{ __( "Learn more about the primary category.", "wordpress-seo" ) }
+					</span>
+				</ExternalLink>
 			</PrimaryTaxonomyPickerField>
 		);
 	}
@@ -266,6 +274,7 @@ PrimaryTaxonomyPicker.propTypes = {
 		restBase: PropTypes.string,
 		singularLabel: PropTypes.string,
 	} ),
+	learnMoreLink: PropTypes.string.isRequired,
 };
 
 PrimaryTaxonomyPicker.defaultProps = {

--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -234,19 +234,14 @@ class PrimaryTaxonomyPicker extends Component {
 
 		return (
 			<PrimaryTaxonomyPickerField className="components-base-control__field">
-				<label
-					htmlFor={ fieldId }
-					className="components-base-control__label"
-				>
-					{
+				<TaxonomyPicker
+					label={
 						sprintf(
 							/* translators: %s expands to the taxonomy name. */
 							__( "Select the primary %s", "wordpress-seo" ),
 							taxonomy.singularLabel.toLowerCase()
 						)
 					}
-				</label>
-				<TaxonomyPicker
 					value={ primaryTaxonomyId }
 					onChange={ this.onChange }
 					id={ fieldId }

--- a/packages/js/src/components/TaxonomyPicker.js
+++ b/packages/js/src/components/TaxonomyPicker.js
@@ -1,58 +1,37 @@
-/* External dependencies */
-import PropTypes from "prop-types";
-import styled from "styled-components";
-import { unescape } from "lodash";
+import { SelectControl } from "@wordpress/components";
 import { useCallback } from "@wordpress/element";
-
-const SelectContainer = styled.div`
-	padding-top: 6px;
-`;
+import { unescape } from "lodash";
+import PropTypes from "prop-types";
 
 /**
  * A select box for selecting a taxonomy.
  *
- * @param {Object} props The component's props.
+ * @param {string} id The ID of the select.
+ * @param {number} value The selected term.
+ * @param {{id: number, name: string}[]} terms The terms to choose from.
+ * @param {string} label The label for the select.
+ * @param {Function} onChange The function to call when the selected term changes.
  *
- * @returns {wp.Element} The rendered TaxonomyPicker component.
+ * @returns {JSX.Element} The rendered TaxonomyPicker component.
  */
-const TaxonomyPicker = ( props ) => {
-	const {
-		value,
-		id,
-		terms,
-		onChange,
-	} = props;
-
-	const handleChange = useCallback( ( e ) => {
-		onChange( parseInt( e.target.value, 10 ) );
+const TaxonomyPicker = ( { id, value, terms, label, onChange } ) => {
+	const handleChange = useCallback( ( newValue ) => {
+		onChange( parseInt( newValue, 10 ) );
 	}, [ onChange ] );
 
-	// Disable reason: UI needs to be re-designed.
-	/* eslint-disable jsx-a11y/no-onchange */
 	return (
-		<SelectContainer>
-			<select
-				className="components-select-control__input"
-				id={ id }
-				value={ value }
-				onChange={ handleChange }
-			>
-				{
-					terms.map( term => {
-						return (
-							<option
-								key={ term.id }
-								value={ term.id }
-							>
-								{ unescape( term.name ) }
-							</option>
-						);
-					} )
-				}
-			</select>
-		</SelectContainer>
+		<SelectControl
+			__next40pxDefaultSize={ true }
+			id={ id }
+			label={ label }
+			value={ value }
+			onChange={ handleChange }
+			options={ terms.map( term => ( {
+				label: unescape( term.name ),
+				value: term.id,
+			} ) ) }
+		/>
 	);
-	/* eslint-enable jsx-a11y/no-onchange */
 };
 
 TaxonomyPicker.propTypes = {
@@ -62,6 +41,7 @@ TaxonomyPicker.propTypes = {
 	} ) ),
 	onChange: PropTypes.func.isRequired,
 	id: PropTypes.string,
+	label: PropTypes.string,
 	value: PropTypes.number,
 };
 

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -17,6 +17,7 @@ export default compose( [
 		return {
 			selectedTermIds,
 			primaryTaxonomyId: yoastData.getPrimaryTaxonomyId( taxonomy.name ),
+			learnMoreLink: yoastData.selectLink( "https://yoa.st/primary-category-more" ),
 		};
 	} ),
 	withDispatch( dispatch => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Due to WP itself not handling `%category%` as flexible part in the permalink structure, we are leaving the original report unfixed. The hard part is to determine if and what part of the URL is in fact the replaced `%category%`. Depending on the post type different logic is used, there are different extra structs one could implement etc.
Note: if you save twice or save and refresh, you will get the proper URL showing up in the UI too.

Instead, we add a learn more link (relevant info should be added still). 
And as a bonus, the UI is updated to use WP component.

Slack threads [one](https://yoast.slack.com/archives/C03KU0EHCNQ/p1723108384702479?thread_ts=1723098145.210149&cid=C03KU0EHCNQ) and [two](https://yoast.slack.com/archives/C03KU0EHCNQ/p1723453869331269?thread_ts=1723447471.472969&cid=C03KU0EHCNQ)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a learn more link to the primary category picker.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Setup
* Change the permalink structure of your site to include `%category%`, e.g. `/%category%/%postname%/` on `/wp-admin/options-permalink.php`

#### User interface and link
* Edit a post in the block editor
* Enable more than 1 category
* [ ] Verify you see the `Select the primary category` and `Learn more` below in WordPress style
![image](https://github.com/user-attachments/assets/51b48a7f-c84c-47e0-9856-5242060af20a)
* [ ] Verify the `Learn more` link points to: `https://yoa.st/primary-category-more` and includes some link parameters
* [ ] Verify the `Learn more` ends up on `https://yoast.com/help/how-to-select-a-primary-category/`

#### Regression
* Change the primary category (to NOT the first, since that is WP default behavior)
* Save the post
* Refresh the page (or save again)
* [ ] Verify the link of the page is using the primary term in the URL
* Visit the frontend of the post
* [ ] Verify the canonical URL is using the primary term too

#### More regression
* Create a custom taxonomy and add it to a post (or other custom taxonomy) or use the Yoast test helper' books/movies
* [ ] Verify the UI looks similar
* [ ] Verify saving is persistent

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The primary taxonomy user interface in the block editor

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Related https://github.com/Yoast/wordpress-seo/issues/17260
