### PR TITLE
Remove unnecessary inclusive language feedback string variables

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
@@ -1,4 +1,4 @@
-import { potentiallyHarmful, potentiallyHarmfulUnless, harmfulNonInclusive } from "./feedbackStrings";
+import { potentiallyHarmful, potentiallyHarmfulUnless } from "./feedbackStrings";
 import { isNotPrecededByException } from "../helpers/isPrecededByException";
 import { isNotFollowedByException } from "../helpers/isFollowedByException";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
@@ -11,13 +11,6 @@ import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
  * "Or, if possible, be specific about the group you are referring to (e.g. %3$s)."
  */
 const specificAgeGroup = "Or, if possible, be specific about the group you are referring to (e.g. %3$s).";
-/*
- * Used to suggest an alternative for 'senile'.
- *
- * "Consider using an alternative, such as a specific characteristic or experience if it is known (e.g. <i>has Alzheimer's</i>)."
- */
-const characteristicIfKnown = "Consider using an alternative, such as a specific characteristic or experience if it is known" +
-	" (e.g. <i>has Alzheimer's</i>).";
 
 const ageAssessments = [
 	{
@@ -51,9 +44,9 @@ const ageAssessments = [
 	{
 		identifier: "senile",
 		nonInclusivePhrases: [ "senile" ],
-		inclusiveAlternatives: "",
+		inclusiveAlternatives: "a specific characteristic or experience if it is known (e.g. <i>has Alzheimer's</i>)",
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: [ harmfulNonInclusive, characteristicIfKnown ].join( " " ),
+		feedbackFormat: potentiallyHarmful,
 	},
 	{
 		identifier: "senility",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -2,6 +2,7 @@ import {
 	potentiallyHarmful,
 	potentiallyHarmfulUnless,
 	harmfulPotentiallyNonInclusive,
+	harmfulNonInclusive,
 	alternative,
 } from "./feedbackStrings";
 import { isPrecededByException, isNotPrecededByException } from "../helpers/isPrecededByException";
@@ -38,14 +39,6 @@ const derogatory = "Avoid using <i>%1$s</i> as it is derogatory. Consider using 
  */
 const medicalCondition = harmfulPotentiallyNonInclusive +
 	" Unless you are referencing the specific medical condition, consider using another alternative to describe the trait or behavior, such as %2$s.";
-/*
- * Used for the term 'special needs'.
- *
- * "Avoid using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, such as %2$s when referring to someone's needs,
- * or %3$s when referring to a person."
- */
-const potentiallyHarmfulTwoAlternatives = "Avoid using <i>%1$s</i> as it is potentially harmful. " +
-	"Consider using an alternative, such as %2$s when referring to someone's needs, or %3$s when referring to a person.";
 
 const disabilityAssessments = [
 	{
@@ -191,7 +184,8 @@ const disabilityAssessments = [
 		nonInclusivePhrases: [ "special needs" ],
 		inclusiveAlternatives: [ "<i>functional needs, support needs</i>", "<i>disabled, person with a disability</i>" ],
 		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: potentiallyHarmfulTwoAlternatives,
+		feedbackFormat: [ harmfulNonInclusive, "Consider using an alternative, such as %2$s when referring to someone's" +
+		" needs, or %3$s when referring to a person." ].join( " " ),
 	},
 	{
 		identifier: "hardOfHearing",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We can get rid off feedback string variables that are very specific and only used for one phrase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes unnecessary inclusive language feedback string variables.
* [shopify-seo] Removes unnecessary inclusive language feedback string variables.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post
* Add the non-inclusive phrases 'senile' and 'special needs' to the text
* Confirm that you get the following feedback in the inclusive language analysis:
     * 🔴  Avoid using senile as it is potentially harmful. Consider using an alternative, such as a specific characteristic or experience if it is known (e.g. has Alzheimer's). [Learn more.](https://yoa.st/inclusive-language-age?php_version=8.1&platform=wordpress&platform_version=6.6.1&software=free&software_version=23.3-RC2&days_active=469&user_language=en_US)
     * 🔴  Avoid using special needs as it is potentially harmful. Consider using an alternative, such as functional needs, support needs when referring to someone's needs, or disabled, person with a disability when referring to a person. [Learn more.](https://yoa.st/inclusive-language-disability?php_version=8.1&platform=wordpress&platform_version=6.6.1&software=free&software_version=23.3-RC2&days_active=469&user_language=en_US)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No other impact

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Inclusive language: Remove feedback string variables that are very specific and used for only one phrase](https://github.com/Yoast/lingo-other-tasks/issues/152)
