### PR TITLE
Add column-gap to each column inside the AnalysisList

### DIFF
--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -26,7 +26,7 @@ const AnalysisResultBase = styled.li`
 	display: flex;
 	align-items: flex-start;
 	position: relative;
-	column-gap: 12px;
+	gap: 12px;
 `;
 
 const ScoreIcon = styled( SvgIcon )`

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -26,14 +26,15 @@ const AnalysisResultBase = styled.li`
 	display: flex;
 	align-items: flex-start;
 	position: relative;
+	column-gap: 12px;
 `;
 
 const ScoreIcon = styled( SvgIcon )`
-	margin: 3px 11px 0 0; // icon 13 + 11 right margin = 24 for the 8px grid.
+	margin: 3px 0 0 0;
 `;
 
 const AnalysisResultText = styled.p`
-	margin: 0 16px 0 0;
+	margin: 0;
 	flex: 1 1 auto;
 	color: ${ props => props.suppressedText ? "rgba(30,30,30,0.5)" : "inherit" };
 `;

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -72,8 +72,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -212,8 +211,7 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -319,8 +317,7 @@ exports[`the AnalysisResult component with a beta badge label matches the snapsh
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -446,8 +443,7 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -550,8 +546,7 @@ exports[`the AnalysisResult component with hidden buttons matches the snapshot 1
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -672,8 +667,7 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {
@@ -776,8 +770,7 @@ exports[`the AnalysisResult component with suppressed text matches the snapshot 
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c2 {

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -72,14 +72,16 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -210,14 +212,16 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -315,14 +319,16 @@ exports[`the AnalysisResult component with a beta badge label matches the snapsh
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -440,14 +446,16 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -542,14 +550,16 @@ exports[`the AnalysisResult component with hidden buttons matches the snapshot 1
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -662,14 +672,16 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -764,14 +776,16 @@ exports[`the AnalysisResult component with suppressed text matches the snapshot 
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c2 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c3 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -194,8 +194,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -967,8 +966,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -1705,8 +1703,7 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -2428,8 +2425,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -3201,8 +3197,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -4014,8 +4009,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -4787,8 +4781,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -5357,8 +5350,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -5927,8 +5919,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {
@@ -6586,8 +6577,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
-  -webkit-column-gap: 12px;
-  column-gap: 12px;
+  gap: 12px;
 }
 
 .c18 {

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -194,14 +194,16 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -965,14 +967,16 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -1701,14 +1705,16 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -2422,14 +2428,16 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -3193,14 +3201,16 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -3208,7 +3218,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
 }
 
 .c22 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -4004,14 +4014,16 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -4775,14 +4787,16 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -5343,14 +5357,16 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -5911,14 +5927,16 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -6568,14 +6586,16 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
   -ms-flex-align: flex-start;
   align-items: flex-start;
   position: relative;
+  -webkit-column-gap: 12px;
+  column-gap: 12px;
 }
 
 .c18 {
-  margin: 3px 11px 0 0;
+  margin: 3px 0 0 0;
 }
 
 .c19 {
-  margin: 0 16px 0 0;
+  margin: 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When adding the AI optimize buttons, we introduced some styling changes to the analysis results to make it look nice when there are two buttons next to an assessment (e.g. highlight and AI buttons). However, this change resulted in very little space left between the assessment text and the buttons in Shopify.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [shopify-seo enhancement] Increases the spacing between the assessment copy and the highlight buttons.
* [analysis-report] Removes right margins from the `ScoreIcon` and `AnalysisResultText`components and adds a `column-gap` property to the `AnalysisResultBase` component.
* Refactors code related to the spacing between columns in the analysis results (score icon, assessment text, buttons).

## Relevant technical choices:

* We solved the issue by adding a column gap in between the analysis columns (score icon, assessment text, and button) and removing the right margin for the score icon and result text.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### In Shopify:
* Create a post and add some text
* If necessary, adjust the text to trigger some readability assessments to show the highlight button (e.g. add transition words or passive voice)
* Confirm that there is sufficient space in between the text and the highlight buttons, like this:
<img width="976" alt="Screenshot 2024-08-15 at 13 56 28" src="https://github.com/user-attachments/assets/8b46b6d1-8569-4b92-989d-0cad6fd3cc39">

* Inspect the list element for one of these assessments and confirm the `gap` property is `12px` (in the screenshot it's `column-gap`, we had since updated the name)
<img width="921" alt="Screenshot 2024-08-15 at 13 57 30" src="https://github.com/user-attachments/assets/d572c93e-5cbf-42f1-b2b8-d501fbb2ca45">

* Experiment with dragging the console tab to make it wider or narrower. Confirm there is always sufficient space between the text and the button.
* Confirm also that the space between the score icon and the text is the same as the screenshot above
* Inspect the `svg` child element of one of the list elements and confirm the top margin (second value of the `margin` property) is 0
<img width="999" alt="Screenshot 2024-08-15 at 14 00 26" src="https://github.com/user-attachments/assets/e5dc68fc-0a5c-4abf-bee1-246699f54c1e">

* Repeat these steps also for the SEO analysis and the inclusive language analysis

#### In WordPress:
* Repeat the same steps as for Shopify
* Add the keyphrase
* Confirm that when there is both a highlight button and an AI button, that there is sufficient space in between the two buttons, like this:
<img width="265" alt="Screenshot 2024-08-15 at 13 22 44" src="https://github.com/user-attachments/assets/f2cbd27f-5250-4637-bfa6-077a1df44570">

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [23.1 [Minor] - No room between assessment copy and highlight button](https://github.com/Yoast/shopify-seo/issues/1972)
