### PR TITLE
Only handle editor changes when on the document from our form

### DIFF
--- a/packages/js/src/elementor/helpers/is-form-id.js
+++ b/packages/js/src/elementor/helpers/is-form-id.js
@@ -14,4 +14,4 @@ export const isFormId = ( id ) => getFormPostId() === id;
 /**
  * @returns {boolean} True if the form ID is equal to the current document ID.
  */
-export const isFormIdEqualToDocumentId = () => isFormId( elementor.documents.getCurrent().id );
+export const isFormIdEqualToDocumentId = () => isFormId( elementor.documents.getCurrent()?.id );

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -179,7 +179,11 @@ const debouncedHandleEditorChange = debounce( handleEditorChange, refreshDelay )
  * @returns {void}
  */
 function observeChanges() {
-	const observer = new MutationObserver( debouncedHandleEditorChange );
+	const observer = new MutationObserver( () => {
+		if ( isFormIdEqualToDocumentId() ) {
+			debouncedHandleEditorChange();
+		}
+	} );
 	observer.observe( document, { attributes: true, childList: true, subtree: true, characterData: true } );
 }
 

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -115,6 +115,9 @@ function getEditorData( editorDocument ) {
  */
 function handleEditorChange() {
 	const currentDocument = elementor.documents.getCurrent();
+	if( ! currentDocument.$element ) {
+		return;
+	}
 
 	// Quit early if the change was caused by switching out of the wp-post/page document.
 	// This can happen when users go to Site Settings, for example.

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -115,7 +115,7 @@ function getEditorData( editorDocument ) {
  */
 function handleEditorChange() {
 	const currentDocument = elementor.documents.getCurrent();
-	if( ! currentDocument.$element ) {
+	if ( ! currentDocument.$element ) {
 		return;
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where slug would change when switching to draft post in elementor editor.

## Relevant technical choices:

* The check in the action is not enough because the mutatation observer won't turn off

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post with Elementor and keep it as a draft.
* Go back to WordPress admin pages and create another post with Elementor and publish it.
* Edit the published post and inspect the page for hidden field id yoast_wpseo_slug, remember the slug.
* Switch to the draft post within the Elementor editor and check the field with the id yoast_wpseo_slug stays the same.
* Switch back to the original post you published and check the field with the id yoast_wpseo_slug has the same slug and when editing search appearance you see the same slug.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The changes in https://github.com/Yoast/wordpress-seo/pull/21514 and https://github.com/Yoast/wordpress-seo/pull/21522 should be tested again for regressions

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
