### PR TITLE
Stop flushing cache aggressively when not needed

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -416,8 +416,8 @@ class WPSEO_Utils {
 	 * @return void
 	 */
 	public static function clear_cache() {
-		if ( function_exists( 'w3tc_pgcache_flush' ) ) {
-			w3tc_pgcache_flush();
+		if ( function_exists( 'w3tc_flush_posts' ) ) {
+			w3tc_flush_posts();
 		}
 		elseif ( function_exists( 'wp_cache_clear_cache' ) ) {
 			wp_cache_clear_cache();

--- a/src/analytics/user-interface/last-completed-indexation-integration.php
+++ b/src/analytics/user-interface/last-completed-indexation-integration.php
@@ -58,7 +58,10 @@ class Last_Completed_Indexation_Integration implements Integration_Interface {
 		if ( $count === 0 ) {
 			$no_index                    = $this->options_helper->get( 'last_known_no_unindexed', [] );
 			$no_index[ $indexable_name ] = \time();
+
+			\remove_action( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] );
 			$this->options_helper->set( 'last_known_no_unindexed', $no_index );
+			\add_action( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] );
 		}
 	}
 }

--- a/tests/Unit/Analytics/User_Interface/Last_Completed_Indexation_Integration_Test.php
+++ b/tests/Unit/Analytics/User_Interface/Last_Completed_Indexation_Integration_Test.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\Analytics\User_Interface;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Analytics\User_Interface\Last_Completed_Indexation_Integration;
 use Yoast\WP\SEO\Helpers\Options_Helper;
@@ -67,6 +68,14 @@ final class Last_Completed_Indexation_Integration_Test extends TestCase {
 		$this->options_helper_mock->expects()->get( 'last_known_no_unindexed', [] );
 		$this->options_helper_mock->expects()->set( 'last_known_no_unindexed', [ 'name' => \time() ] );
 
+		Monkey\Functions\expect( 'remove_action' )
+			->with( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] )
+			->once();
+
+		Monkey\Functions\expect( 'add_action' )
+			->with( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] )
+			->once();
+
 		$this->sut->maybe_set_indexables_unindexed_calculated( 'name', 0 );
 	}
 
@@ -79,6 +88,14 @@ final class Last_Completed_Indexation_Integration_Test extends TestCase {
 	 */
 	public function test_maybe_set_indexables_unindexed_calculated_with_many_indexables(): void {
 		$this->options_helper_mock->expects( 'set' )->never();
+
+		Monkey\Functions\expect( 'remove_action' )
+			->with( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] )
+			->never();
+
+		Monkey\Functions\expect( 'add_action' )
+			->with( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] )
+			->never();
 
 		$this->sut->maybe_set_indexables_unindexed_calculated( 'name', 100000 );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves our integration with cache plugins by preventing flushing their cache when not needed.
* [wordpress-seo non-user-facing] Stops using W3 Total cache's deprecated `w3tc_pgcache_flush` function in favor of the `w3tc_flush_posts` one.

## Relevant technical choices:

* Checked other usages of the `update_option_wpseo` hook to verify we're not breaking something
  * Found a couple of them in the `Option_Wpseo_Watcher` that won't run anymore when we store the logging option, but that's ok because they deal only with a different option.
 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Complete the SEOO
* Install WP Super Cache and select `Caching On` in **Settings->WP Super Cache** (or W3 Total cache and enable Page Cache in **Performance->General Settings->Page cache**)
* Visit a page as a non-logged-in user and verify that there was a folder for that page created in `\wp-content\cache\supercache\example.com` (or `wp-content\cache\page_enhanced\example.com\<category_name>\<post_name>` in the case of W3 Total cache)
* Now, delete all transients (`wp transient delete --all` in WP CLI) and visit the `Yoast->tools` page in the admin.
  * This is supposed to update all the `last_known_no_unindexed` elements in the `wpseo` option, which used to flush the cache.
* Check the `wpseo` option and verify that the timestamps saved in `last_known_no_unindexed` pinpoints to the time that you refreshed the admin page (you can use epochconverter.com to make the timestamp into human readable date)

**Before this fix**:
* Check the `\wp-content\cache\supercache\example.com` and confirm that there is no folder anymore for the page you had visited (or confirm that the `wp-content\cache\page_enhanced\example.com\<category_name>\<post_name>` folder now has a `_index_slash.html_old` file, which means that cache was invalidated)

**After this fix**:
* Check the `\wp-content\cache\supercache\example.com` and confirm that the folder for the page you had visited still exists. (or confirm that the `wp-content\cache\page_enhanced\example.com\<category_name>\<post_name>` folder still has the `_index_slash.html` file)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test that we still clear the cache when it's indeed necessary. A nice way to do that is:
  * In the Yoast->Settings->Posts->Meta description, set `DESCRIPTION 1` as the default
  * Install WP Super Cache and select `Caching On` in **Settings->WP Super Cache** (or W3 Total cache and enable Page Cache in **Performance->General Settings->Page cache**)
  * Visit a page as a non-logged-in user and take a note of the meta description where it should be the default, `DESCRIPTION 1`.
  * In the Yoast->Settings->Posts->Meta description, change the default to `DESCRIPTION 2`
  * Refresh the post you visit before and confirm that it now has the new `DESCRIPTION 2` meta description.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/261
