### PR TITLE
21555 remove featured image notice translation from wpseoscriptdata

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -938,7 +938,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$site_information->set_permalink( $this->get_permalink() );
 		$script_data = array_merge_recursive( $site_information->get_legacy_site_information(), $script_data );
 
-		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
+		if ( ! $is_block_editor && post_type_supports( get_post_type(), 'thumbnail' ) ) {
 			$asset_manager->enqueue_style( 'featured-image' );
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -940,11 +940,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		if ( post_type_supports( get_post_type(), 'thumbnail' ) ) {
 			$asset_manager->enqueue_style( 'featured-image' );
-
-			// @todo replace this translation with JavaScript translations.
-			$script_data['featuredImage'] = [
-				'featured_image_notice' => __( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' ),
-			];
 		}
 
 		$asset_manager->localize_script( $post_edit_handle, 'wpseoScriptData', $script_data );

--- a/packages/js/src/initializers/featured-image.js
+++ b/packages/js/src/initializers/featured-image.js
@@ -6,6 +6,7 @@
 import { select, subscribe } from "@wordpress/data";
 import a11ySpeak from "a11y-speak";
 import isBlockEditor from "../helpers/isBlockEditor";
+import { __ } from "@wordpress/i18n";
 
 /**
  * @summary Initializes the featured image integration.
@@ -109,19 +110,20 @@ export default function initFeaturedImageIntegration( $ ) {
 	 */
 	function checkFeaturedImage( featuredImage ) {
 		var attachment = featuredImage.state().get( "selection" ).first().toJSON();
+		const featuredImageNotice = __( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' );
 
 		if ( attachment.width < 200 || attachment.height < 200 ) {
 			// Show warning to user and do not add image to OG
 			if ( 0 === $( "#yst_opengraph_image_warning" ).length ) {
 				// Create a warning using native WordPress notices styling.
 				$( '<div id="yst_opengraph_image_warning" class="notice notice-error notice-alt"><p>' +
-					wpseoScriptData.featuredImage.featured_image_notice +
+					featuredImageNotice +
 					"</p></div>" )
 					.insertAfter( $postImageDivHeading );
 
 				$postImageDiv.addClass( "yoast-opengraph-image-notice" );
 
-				a11ySpeak( wpseoScriptData.featuredImage.featured_image_notice, "assertive" );
+				a11ySpeak( featuredImageNotice, "assertive" );
 			}
 		} else {
 			// Force reset warning
@@ -188,13 +190,11 @@ export default function initFeaturedImageIntegration( $ ) {
 	let previousImageData;
 	subscribe( () => {
 		const featuredImageId = select( "core/editor" ).getEditedPostAttribute( "featured_media" );
-
 		if ( ! isValidMediaId( featuredImageId ) ) {
 			return;
 		}
 
 		imageData = select( "core" ).getMedia( featuredImageId );
-
 		if ( typeof imageData === "undefined" ) {
 			return;
 		}

--- a/packages/js/src/initializers/featured-image.js
+++ b/packages/js/src/initializers/featured-image.js
@@ -1,5 +1,4 @@
 /* global wp */
-/* global wpseoScriptData */
 /* global YoastSEO */
 /* jshint -W097 */
 /* jshint -W003 */
@@ -110,7 +109,7 @@ export default function initFeaturedImageIntegration( $ ) {
 	 */
 	function checkFeaturedImage( featuredImage ) {
 		var attachment = featuredImage.state().get( "selection" ).first().toJSON();
-		const featuredImageNotice = __( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' );
+		const featuredImageNotice = __( "SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.", "wordpress-seo" );
 
 		if ( attachment.width < 200 || attachment.height < 200 ) {
 			// Show warning to user and do not add image to OG

--- a/packages/js/src/initializers/featured-image.js
+++ b/packages/js/src/initializers/featured-image.js
@@ -189,11 +189,13 @@ export default function initFeaturedImageIntegration( $ ) {
 	let previousImageData;
 	subscribe( () => {
 		const featuredImageId = select( "core/editor" ).getEditedPostAttribute( "featured_media" );
+
 		if ( ! isValidMediaId( featuredImageId ) ) {
 			return;
 		}
 
 		imageData = select( "core" ).getMedia( featuredImageId );
+
 		if ( typeof imageData === "undefined" ) {
 			return;
 		}

--- a/packages/js/src/post-edit.js
+++ b/packages/js/src/post-edit.js
@@ -41,8 +41,8 @@ domReady( () => {
 	// Initialize the post scraper.
 	initPostScraper( jQuery, store, editorData );
 
-	// Initialize the featured image integration.
-	if ( window.wpseoScriptData && typeof window.wpseoScriptData.featuredImage !== "undefined" ) {
+	// Initialize the featured image integration for classic editor and block editor only.
+	if ( ! window.wpseoScriptData?.isElementorEditor ) {
 		initFeaturedImageIntegration( jQuery );
 	}
 

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -441,14 +441,6 @@ class Elementor implements Integration_Interface {
 		$site_information->set_permalink( $permalink );
 		$script_data = \array_merge_recursive( $site_information->get_legacy_site_information(), $script_data );
 
-		if ( \post_type_supports( $this->get_metabox_post()->post_type, 'thumbnail' ) ) {
-			$this->asset_manager->enqueue_style( 'featured-image' );
-
-			$script_data['featuredImage'] = [
-				'featured_image_notice' => \__( 'SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.', 'wordpress-seo' ),
-			];
-		}
-
 		$this->asset_manager->localize_script( 'elementor', 'wpseoScriptData', $script_data );
 		$this->asset_manager->enqueue_user_language_script();
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove the feature image notice translation from the script data.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the translation for featured image notice to the feature image integration.

## Relevant technical choices:

* The featured image integration is supported only by classic editor and block editor. In the block editor we don't have the notice but we are adding the image to the analysis data.
* No support for elementor yet.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in classic editor and try to upload a tinny featured image ( under width and height of 200px).
* Check that you see a red notice: 
> SEO issue: The featured image should be at least 200 by 200 pixels to be picked up by Facebook and other social media sites.
* Upload the same featured image to a post edited by block editor, you should not see the notice and the image is previewed and saved as before.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21555 
