### PR TITLE
exclude image caption inside classic block from keyphrase in intro assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/findKeywordInFirstParagraphSpec.js
@@ -68,6 +68,25 @@ describe( "a test for excluded elements", function() {
 		} );
 		expect( firstParagraph( paper, researcher ).introduction.childNodes[ 0 ].value ).toEqual( "Some other text." );
 	} );
+	it( "should not recognize image captions as the introduction if it occurs at the beginning of the post (block editor: classic block)", function() {
+		// The keyphrase is 'the highland cow Braunvieh', where it is added to the image caption. The first paragraph after the image doesn't contain the keyphrase.
+		// Hence, this test should return that the keyphrase was not found in the first paragraph.
+		const paper = new Paper( "<p>[caption id=\"attachment_1425\" align=\"alignnone\" width=\"300\"]<img class=\"size-medium wp-image-1425\"" +
+			" src=\"https://basic.wordpress.test\" alt=\"\" width=\"300\" height=\"213\"> Braunvieh: the highland cow[/caption]</p>" +
+			"\n<p>The <b>Braunvieh</b> (German, \"brown cattle\") or <b>Swiss Brown</b> is a breed or group of breeds of domestic cattle originating in Switzerland" +
+			" and distributed throughout the Alpine region.</p>",
+		{ keyword: "the highland cow Braunvieh" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		buildTree( paper, researcher );
+
+		expect( firstParagraph( paper, researcher ) ).toMatchObject( {
+			foundInOneSentence: false,
+			foundInParagraph: false,
+			keyphraseOrSynonym: "",
+		} );
+		expect( firstParagraph( paper, researcher ).introduction.sentences[ 0 ].text ).toEqual( "The Braunvieh (German, \"brown cattle\") or Swiss Brown is a breed or group of breeds of domestic cattle originating in Switzerland and distributed throughout the Alpine region." );
+	} );
 } );
 
 describe( "checks for the content words from the keyphrase in the first paragraph (English)", function() {

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -32,7 +32,7 @@ export default function( paper, researcher ) {
 		const parentNode = getParentNode( paper, paragraph );
 		return ! ( paragraph.isImplicit && parentNode && parentNode.name === "figcaption" );
 	} );
-	// Filter captions from Classic editor.
+	// Filter captions from Classic editor and from classic block inside Block editor.
 	paragraphs = paragraphs.filter( paragraph => {
 		return ! ( paragraph.childNodes && paragraph.childNodes[ 0 ] &&
 			createShortcodeTagsRegex( [ "caption" ] ).test( paragraph.childNodes[ 0 ].value ) );

--- a/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
+++ b/packages/yoastseo/src/languageProcessing/researches/findKeywordInFirstParagraph.js
@@ -34,7 +34,7 @@ export default function( paper, researcher ) {
 	} );
 	// Filter captions from Classic editor.
 	paragraphs = paragraphs.filter( paragraph => {
-		return ! ( paragraph.isImplicit && paragraph.childNodes && paragraph.childNodes[ 0 ] &&
+		return ! ( paragraph.childNodes && paragraph.childNodes[ 0 ] &&
 			createShortcodeTagsRegex( [ "caption" ] ).test( paragraph.childNodes[ 0 ].value ) );
 	} );
 	 const firstParagraph = paragraphs[ 0 ];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* With this PR: https://github.com/Yoast/wordpress-seo/pull/21414 we excluded the image captions from the keyphrase in introduction assessment for all editors. However, the solution still doesn't exclude the image caption inside a classic block in Block editor. This PR is to fix that issue.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an image caption inside a classic block would be considered the introduction when using the _keyphrase in introduction_ assessment in the default editor.
* [yoastseo enhancement] Excludes the image caption inside a classic block from the _keyphrase in introduction_ assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### AI Optimize
* Test together with this accompanying PR in Premium: https://github.com/Yoast/wordpress-seo-premium/pull/4470

#### Block editor, classic block
* Create a post in Block editor
* Set a keyphrase
* Add one classic block
* To the classic block, add a text with more than 300 words, make sure to add the keyphrase in the first paragraph and don't add the keyphrase anywhere else
* Go to the keyphrase in introduction assessment
* Confirm that the assessment returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment recognizes one keyphrase occurrence
* Inside the classic block, before the first paragraph, add an image with a caption that doesn't include the keyphrase
* Confirm that the keyphrase in introduction assessment still returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment still recognizes **one** keyphrase occurrence
* Add the keyphrase to the image caption
* Confirm that the keyphrase in introduction assessment still returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment now recognizes **two** keyphrase occurrences

#### Classic editor
* Create a post in Classic editor
* Set a keyphrase
* Add a text with more than 300 words, make sure to add the keyphrase in the first paragraph and don't add the keyphrase anywhere else
* Go to the keyphrase in introduction assessment
* Confirm that the assessment returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment recognizes one keyphrase occurrence
* Before the first paragraph, add an image with a caption that doesn't include the keyphrase
* Confirm that the keyphrase in introduction assessment still returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment still recognizes **one** keyphrase occurrence
* Add the keyphrase to the image caption
* Confirm that the keyphrase in introduction assessment still returns with 🟢 green feedback
* Go to the keyphrase density assessment
* Confirm that the keyphrase density assessment now recognizes **two** keyphrase occurrences

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1814
