### PR TITLE
Refactor meta fields

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -748,30 +748,20 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$data       = null;
 			$field_name = WPSEO_Meta::$form_prefix . $key;
 
-			if ( $meta_box['type'] === 'checkbox' ) {
-				$data = isset( $_POST[ $field_name ] ) ? 'on' : 'off';
-			}
-			else {
-				if ( isset( $_POST[ $field_name ] ) ) {
-					// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're preparing to do just that.
-					$data = wp_unslash( $_POST[ $field_name ] );
+			if ( isset( $_POST[ $field_name ] ) ) {
+				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're preparing to do just that.
+				$data = wp_unslash( $_POST[ $field_name ] );
 
-					// For multi-select.
-					if ( is_array( $data ) ) {
-						$data = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $data );
-					}
-
-					if ( is_string( $data ) ) {
-						$data = ( $key !== 'canonical' ) ? WPSEO_Utils::sanitize_text_field( $data ) : WPSEO_Utils::sanitize_url( $data );
-					}
+				// For multi-select.
+				if ( is_array( $data ) ) {
+					$data = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $data );
 				}
 
-				// Reset options when no entry is present with multiselect - only applies to `meta-robots-adv` currently.
-				if ( ! isset( $_POST[ $field_name ] ) && ( $meta_box['type'] === 'multiselect' ) ) {
-					$data = [];
+				if ( is_string( $data ) ) {
+					$data = ( $key !== 'canonical' ) ? WPSEO_Utils::sanitize_text_field( $data ) : WPSEO_Utils::sanitize_url( $data );
 				}
 			}
-
+			
 			if ( $data !== null ) {
 				WPSEO_Meta::set_value( $key, $data, $post_id );
 			}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -756,10 +756,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 				if ( is_array( $data ) ) {
 					$data = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $data );
 				}
-
-				if ( is_string( $data ) ) {
-					$data = ( $key !== 'canonical' ) ? WPSEO_Utils::sanitize_text_field( $data ) : WPSEO_Utils::sanitize_url( $data );
-				}
 			}
 			
 			if ( $data !== null ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -500,6 +500,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 	/**
 	 * Adds a line in the meta box.
+	 * 
+	 * @deprecated 23.5
+	 * @codeCoverageIgnore
 	 *
 	 * @todo [JRF] Check if $class is added appropriately everywhere.
 	 *
@@ -509,6 +512,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return string
 	 */
 	public function do_meta_box( $meta_field_def, $key = '' ) {
+		_deprecated_function( __METHOD__, 'Yoast SEO 23.5', 'WPSEO_Metabox::do_meta_box' );
+		
 		$content      = '';
 		$esc_form_key = esc_attr( WPSEO_Meta::$form_prefix . $key );
 		$meta_value   = WPSEO_Meta::get_value( $key, $this->get_metabox_post()->ID );

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -751,11 +751,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			if ( isset( $_POST[ $field_name ] ) ) {
 				// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We're preparing to do just that.
 				$data = wp_unslash( $_POST[ $field_name ] );
-
-				// For multi-select.
-				if ( is_array( $data ) ) {
-					$data = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $data );
-				}
 			}
 			
 			if ( $data !== null ) {

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -69,15 +69,10 @@ class WPSEO_Meta {
 	 * Meta box field definitions for the meta box form.
 	 *
 	 * {@internal
-	 * - Titles, help texts, description text and option labels are added via a translate_meta_boxes() method
-	 *   in the relevant child classes (WPSEO_Metabox and WPSEO_Social_admin) as they are only needed there.
 	 * - Beware: even though the meta keys are divided into subsets, they still have to be uniquely named!}}
 	 *
 	 * @var array
 	 *            Array format:
-	 *                (required)       'type'          => (string) field type. i.e. text / textarea / checkbox /
-	 *                                                    radio / select / multiselect / upload etc.
-	 *                (required)       'title'         => (string) table row title.
 	 *                (recommended)    'default_value' => (string|array) default value for the field.
 	 *                                                    IMPORTANT:
 	 *                                                    - if the field has options, the default has to be the
@@ -91,125 +86,72 @@ class WPSEO_Meta {
 	 *                                                    fields, required if that's the field type.
 	 *                                                    key = (string) value which will be saved to db.
 	 *                                                    value = (string) text label for the option.
-	 *                (optional)        'autocomplete' => (bool) whether autocomplete is on for text fields,
-	 *                                                    defaults to true.
-	 *                (optional)        'class'        => (string) classname(s) to add to the actual <input> tag.
-	 *                (optional)        'description'  => (string) description to show underneath the field.
-	 *                (optional)        'expl'         => (string) label for a checkbox.
-	 *                (optional)        'help'         => (string) help text to show on mouse over ? image.
-	 *                (optional)        'rows'         => (int) number of rows for a textarea, defaults to 3.
-	 *                (optional)        'placeholder'  => (string) Currently only used by add-on plugins.
 	 *                (optional)        'serialized'   => (bool) whether the value is expected to be serialized,
 	 *                                                     i.e. an array or object, defaults to false.
 	 *                                                     Currently only used by add-on plugins.
 	 */
 	public static $meta_fields = [
 		'general'  => [
-			'focuskw' => [
-				'type'  => 'hidden',
-				'title' => '',
-			],
-			'title' => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
+			'focuskw'                  => [],
+			'title'                    => [
 				'default_value' => '',
-				'description'   => '', // Translation added later.
-				'help'          => '', // Translation added later.
 			],
-			'metadesc' => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
+			'metadesc'                 => [
 				'default_value' => '',
-				'class'         => 'metadesc',
-				'rows'          => 2,
-				'description'   => '', // Translation added later.
-				'help'          => '', // Translation added later.
 			],
-			'linkdex' => [
-				'type'          => 'hidden',
-				'title'         => 'linkdex',
+			'linkdex'                  => [
 				'default_value' => '0',
-				'description'   => '',
 			],
-			'content_score' => [
-				'type'          => 'hidden',
-				'title'         => 'content_score',
+			'content_score'            => [
 				'default_value' => '0',
-				'description'   => '',
 			],
 			'inclusive_language_score' => [
-				'type'          => 'hidden',
-				'title'         => 'inclusive_language_score',
 				'default_value' => '0',
-				'description'   => '',
 			],
-			'is_cornerstone' => [
-				'type'          => 'hidden',
-				'title'         => 'is_cornerstone',
+			'is_cornerstone'           => [
 				'default_value' => 'false',
-				'description'   => '',
 			],
 		],
 		'advanced' => [
 			'meta-robots-noindex'  => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
 				'default_value' => '0', // = post-type default.
 				'options'       => [
-					'0' => '', // Post type default - translation added later.
-					'2' => '', // Index - translation added later.
-					'1' => '', // No-index - translation added later.
+					'0' => '',
+					'2' => '',
+					'1' => '',
 				],
 			],
 			'meta-robots-nofollow' => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
 				'default_value' => '0', // = follow.
 				'options'       => [
-					'0' => '', // Follow - translation added later.
-					'1' => '', // No-follow - translation added later.
+					'0' => '', // Follow.
+					'1' => '', // No-follow .
 				],
 			],
 			'meta-robots-adv'      => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
 				'default_value' => '',
-				'description'   => '', // Translation added later.
 				'options'       => [
-					'noimageindex' => '', // Translation added later.
-					'noarchive'    => '', // Translation added later.
-					'nosnippet'    => '', // Translation added later.
+					'noimageindex' => '',
+					'noarchive'    => '',
+					'nosnippet'    => '',
 				],
 			],
 			'bctitle'              => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
 				'default_value' => '',
-				'description'   => '', // Translation added later.
 			],
 			'canonical'            => [
-				'type'          => 'hidden',
-				'title'         => '', // Translation added later.
 				'default_value' => '',
-				'description'   => '', // Translation added later.
 			],
 			'redirect'             => [
-				'type'          => 'url',
-				'title'         => '', // Translation added later.
 				'default_value' => '',
-				'description'   => '', // Translation added later.
 			],
 		],
 		'social'   => [],
 		'schema'   => [
 			'schema_page_type'    => [
-				'type'    => 'hidden',
-				'title'   => '',
 				'options' => Schema_Types::PAGE_TYPES,
 			],
 			'schema_article_type' => [
-				'type'          => 'hidden',
-				'title'         => '',
 				'hide_on_pages' => true,
 				'options'       => Schema_Types::ARTICLE_TYPES,
 			],
@@ -217,7 +159,6 @@ class WPSEO_Meta {
 		/* Fields we should validate & save, but not show on any form. */
 		'non_form' => [
 			'linkdex' => [
-				'type'          => null,
 				'default_value' => '0',
 			],
 		],
@@ -258,10 +199,10 @@ class WPSEO_Meta {
 	 * @var array
 	 */
 	private static $social_fields = [
-		'title'       => 'hidden',
-		'description' => 'hidden',
-		'image'       => 'hidden',
-		'image-id'    => 'hidden',
+		'title',
+		'description',
+		'image',
+		'image-id',
 	];
 
 	/**
@@ -272,17 +213,14 @@ class WPSEO_Meta {
 	public static function init() {
 		foreach ( self::$social_networks as $option => $network ) {
 			if ( WPSEO_Options::get( $option, false ) === true ) {
-				foreach ( self::$social_fields as $box => $type ) {
-					self::$meta_fields['social'][ $network . '-' . $box ] = [
-						'type'          => $type,
-						'title'         => '', // Translation added later.
+				foreach ( self::$social_fields as $key ) {
+					self::$meta_fields['social'][ $network . '-' . $key ] = [
 						'default_value' => '',
-						'description'   => '', // Translation added later.
 					];
 				}
 			}
 		}
-		unset( $option, $network, $box, $type );
+		unset( $option, $network, $key );
 
 		/**
 		 * Allow add-on plugins to register their meta fields for management by this class.
@@ -367,13 +305,6 @@ class WPSEO_Meta {
 					return [];
 				}
 
-				/* Adjust the no-index text strings based on the post type. */
-				$post_type_object = get_post_type_object( $post_type );
-
-				$field_defs['meta-robots-noindex']['title']        = sprintf( $field_defs['meta-robots-noindex']['title'], $post_type_object->labels->singular_name );
-				$field_defs['meta-robots-noindex']['options']['0'] = sprintf( $field_defs['meta-robots-noindex']['options']['0'], ( ( WPSEO_Options::get( 'noindex-' . $post_type, false ) === true ) ? $field_defs['meta-robots-noindex']['options']['1'] : $field_defs['meta-robots-noindex']['options']['2'] ), $post_type_object->label );
-				$field_defs['meta-robots-nofollow']['title']       = sprintf( $field_defs['meta-robots-nofollow']['title'], $post_type_object->labels->singular_name );
-
 				/* Don't show the breadcrumb title field if breadcrumbs aren't enabled. */
 				if ( WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ) ) {
 					unset( $field_defs['bctitle'] );
@@ -434,33 +365,22 @@ class WPSEO_Meta {
 		$field_def = self::$meta_fields[ self::$fields_index[ $meta_key ]['subset'] ][ self::$fields_index[ $meta_key ]['key'] ];
 		$clean     = self::$defaults[ $meta_key ];
 
-		switch ( true ) {
-			case ( $meta_key === self::$meta_prefix . 'linkdex' ):
+		$key = str_replace( self::$meta_prefix, '', $meta_key );
+
+		switch ( $key ) {
+			case 'linkdex':
 				$int = WPSEO_Utils::validate_int( $meta_value );
 				if ( $int !== false && $int >= 0 ) {
 					$clean = strval( $int ); // Convert to string to make sure default check works.
 				}
 				break;
 
-			case ( $field_def['type'] === 'checkbox' ):
-				// Only allow value if it's one of the predefined options.
-				if ( in_array( $meta_value, [ 'on', 'off' ], true ) ) {
-					$clean = $meta_value;
-				}
-				break;
-
-			case ( $field_def['type'] === 'select' || $field_def['type'] === 'radio' ):
-				// Only allow value if it's one of the predefined options.
-				if ( isset( $field_def['options'][ $meta_value ] ) ) {
-					$clean = $meta_value;
-				}
-				break;
-
-			case ( $field_def['type'] === 'hidden' && $meta_key === self::$meta_prefix . 'meta-robots-adv' ):
+			case 'meta-robots-adv':
 				$clean = self::validate_meta_robots_adv( $meta_value );
 				break;
 
-			case ( $field_def['type'] === 'url' || $meta_key === self::$meta_prefix . 'canonical' ):
+			case 'redirect':
+			case 'canonical':
 				// Validate as url(-part).
 				$url = WPSEO_Utils::sanitize_url( $meta_value );
 				if ( $url !== '' ) {
@@ -468,7 +388,8 @@ class WPSEO_Meta {
 				}
 				break;
 
-			case ( $field_def['type'] === 'upload' && in_array( $meta_key, [ self::$meta_prefix . 'opengraph-image', self::$meta_prefix . 'twitter-image' ], true ) ):
+			case 'opengraph-image':
+			case 'twitter-image':
 				// Validate as url.
 				$url = WPSEO_Utils::sanitize_url( $meta_value, [ 'http', 'https', 'ftp', 'ftps' ] );
 				if ( $url !== '' ) {
@@ -476,8 +397,10 @@ class WPSEO_Meta {
 				}
 				break;
 
-			case ( $field_def['type'] === 'hidden' && $meta_key === self::$meta_prefix . 'is_cornerstone' ):
-				$clean = $meta_value;
+			case 'is_cornerstone':
+				if ( in_array( $meta_value, [ '1', '0' ], true ) ) {
+					$clean = $meta_value;
+				}
 
 				/*
 				 * This used to be a checkbox, then became a hidden input.
@@ -488,27 +411,16 @@ class WPSEO_Meta {
 				}
 				break;
 
-			case ( $field_def['type'] === 'hidden' && isset( $field_def['options'] ) ):
+			case 'meta-robots-noindex':
+			case 'meta-robots-nofollow':
+			case 'schema_page_type':
+			case 'schema_article_type':
 				// Only allow value if it's one of the predefined options.
 				if ( isset( $field_def['options'][ $meta_value ] ) ) {
 					$clean = $meta_value;
 				}
 				break;
 
-			case ( $field_def['type'] === 'textarea' ):
-				if ( is_string( $meta_value ) ) {
-					// Remove line breaks and tabs.
-					// @todo [JRF => Yoast] Verify that line breaks and the likes aren't allowed/recommended in meta header fields.
-					$meta_value = str_replace( [ "\n", "\r", "\t", '  ' ], ' ', $meta_value );
-					$clean      = WPSEO_Utils::sanitize_text_field( trim( $meta_value ) );
-				}
-				break;
-
-			case ( $field_def['type'] === 'multiselect' ):
-				$clean = $meta_value;
-				break;
-
-			case ( $field_def['type'] === 'text' ):
 			default:
 				if ( is_string( $meta_value ) ) {
 					$clean = WPSEO_Utils::sanitize_text_field( trim( $meta_value ) );

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -70,6 +70,8 @@ class WPSEO_Meta {
 	 *
 	 * {@internal
 	 * - Beware: even though the meta keys are divided into subsets, they still have to be uniquely named!}}
+	 * - The properties for the field translations and configuration (all the properties except 'default_value', 'options') 
+	 *   are not used anymore because the fields rendered hidden by the Meta_Fields_Presenter and otherwise the fields are configured on the client side.
 	 *
 	 * @var array
 	 *            Array format:
@@ -77,11 +79,7 @@ class WPSEO_Meta {
 	 *                                                    IMPORTANT:
 	 *                                                    - if the field has options, the default has to be the
 	 *                                                      key of one of the options.
-	 *                                                    - if the field is a text field, the default **has** to be
-	 *                                                      an empty string as otherwise the user can't save
-	 *                                                      an empty value/delete the meta value.
-	 *                                                    - if the field is a checkbox, the only valid values
-	 *                                                      are 'on' or 'off'.
+	 *                                                    - default will be an empty string.
 	 *                (semi-required)   'options'      => (array) options for used with (multi-)select and radio
 	 *                                                    fields, required if that's the field type.
 	 *                                                    key = (string) value which will be saved to db.
@@ -93,12 +91,8 @@ class WPSEO_Meta {
 	public static $meta_fields = [
 		'general'  => [
 			'focuskw'                  => [],
-			'title'                    => [
-				'default_value' => '',
-			],
-			'metadesc'                 => [
-				'default_value' => '',
-			],
+			'title'                    => [],
+			'metadesc'                 => [],
 			'linkdex'                  => [
 				'default_value' => '0',
 			],
@@ -129,22 +123,15 @@ class WPSEO_Meta {
 				],
 			],
 			'meta-robots-adv'      => [
-				'default_value' => '',
 				'options'       => [
 					'noimageindex' => '',
 					'noarchive'    => '',
 					'nosnippet'    => '',
 				],
 			],
-			'bctitle'              => [
-				'default_value' => '',
-			],
-			'canonical'            => [
-				'default_value' => '',
-			],
-			'redirect'             => [
-				'default_value' => '',
-			],
+			'bctitle'              => [],
+			'canonical'            => [],
+			'redirect'             => [],
 		],
 		'social'   => [],
 		'schema'   => [

--- a/tests/WP/Admin/Metabox/Metabox_Test.php
+++ b/tests/WP/Admin/Metabox/Metabox_Test.php
@@ -278,7 +278,7 @@ final class Metabox_Test extends TestCase {
 			],
 			[
 				'field_name'     => 'meta-robots-adv',
-				'field_value'    => [ '<strong>noimageindex</strong>', 'dingdong' ],
+				'field_value'    => 'noimageindex',
 				'expected_value' => 'noimageindex',
 				'message'        => 'Test multiselect field with invalid values given.',
 			],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove outdated properties and code from the wpseo meta class.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove outdated properties from the wpseo meta class for meta fields.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
