### PR TITLE
Add the phrase "dumb down" and improve feedback for the word "lame" in the Inclusive language assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -154,6 +154,16 @@ describe( "A test for Disability assessments", function() {
 		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
 	} );
 
+	it( "should not target 'dumb' if followed by 'down'.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "dumb" ) );
+
+		const testSentence = "They're not used to dumbing down their articles.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+	} );
+
 	it( "correctly identifies 'the disabled' which is only recognized when followed by participle or simple past tense", () => {
 		const mockPaper = new Paper( "the disabled worked, the better they are." );
 		const mockResearcher = Factory.buildMockResearcher( [ "The disabled worked, the better they are." ] );
@@ -550,26 +560,29 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			{
 				identifier: "lame",
 				text: "Such a lame excuse!",
-				expectedFeedback: "Avoid using <i>lame</i> as it is potentially harmful. Consider using an alternative, such as <i>boring, lousy, " +
-					"unimpressive, sad, corny</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
+				expectedFeedback: "Be careful when using <i>lame</i> as it is potentially harmful. Unless you are " +
+					"referring to an object, considering using an alternative. For example, <i>boring, lousy, " +
+					"unimpressive, sad, corny</i>. If referring to someone's disability, use an alternative such " +
+					"as <i>person with a disability, person who has difficulty with walking</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
 			},
 			{
 				identifier: "lamer",
 				text: "It is a lamer excuse compared to the previous one.",
-				expectedFeedback: "Avoid using <i>lamer</i> as it is potentially harmful. Consider using an alternative, such as <i>more boring, " +
-					"lousier, more unimpressive, sadder, cornier</i>. <a href='https://yoa.st/inclusive-language-disability' " +
-					"target='_blank'>Learn more.</a>",
-				expectedScore: 3,
+				expectedFeedback: "Be careful when using <i>lame</i> as it is potentially harmful. Unless you are " +
+					"referring to an object, considering using an alternative. For example, <i>boring, lousy, " +
+					"unimpressive, sad, corny</i>. If referring to someone's disability, use an alternative such " +
+					"as <i>person with a disability, person who has difficulty with walking</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
 			},
 			{
 				identifier: "lamest",
 				text: "This is the lamest excuse by far!",
-				expectedFeedback:
-					"Avoid using <i>lamest</i> as it is potentially harmful. Consider using an alternative, such as <i>most boring, " +
-					"lousiest, most unimpressive, saddest, corniest</i>. <a href='https://yoa.st/inclusive-language-disability'" +
-					" target='_blank'>Learn more.</a>",
-				expectedScore: 3,
+				expectedFeedback: "Be careful when using <i>lame</i> as it is potentially harmful. Unless you are " +
+					"referring to an object, considering using an alternative. For example, <i>boring, lousy, " +
+					"unimpressive, sad, corny</i>. If referring to someone's disability, use an alternative such " +
+					"as <i>person with a disability, person who has difficulty with walking</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
 			},
 		];
 
@@ -1123,6 +1136,55 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				expectedFeedback: "Avoid using <i>psychopathic</i> as it is potentially harmful. Consider using an alternative, such as <i>toxic, " +
 					"manipulative, unpredictable, impulsive, reckless, out of control</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+		];
+
+		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should return the appropriate score and feedback string for: 'dumb down' and its other forms", () => {
+		// The different forms of "dumb down" is one entry under the same identifier.
+		const testData = [
+			{
+				identifier: "dumbDown",
+				text: "They had to dumb it down for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbDown",
+				text: "They dumbed it down for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbDown",
+				text: "They are dumbing it down for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbDown",
+				text: "They had to dumb down the reasoning for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbDown",
+				text: "They dumbed down the reasoning for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbDown",
+				text: "They are dumbing down the reasoning for him.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
 		];

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -215,9 +215,10 @@ const disabilityAssessments = [
 	{
 		identifier: "lame",
 		nonInclusivePhrases: [ "lame" ],
-		inclusiveAlternatives: "<i>boring, lousy, unimpressive, sad, corny</i>",
-		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: redHarmful,
+		inclusiveAlternatives: "<i>boring, lousy, unimpressive, sad, corny</i>, <i>person with a disability, person who has difficulty with walking</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: [ "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
+		"Unless you are referring to an object, considering using an alternative. For example, %1$s. If referring to someone's disability, use an alternative such as %2$s." ],
 	},
 	{
 		identifier: "lamer",
@@ -314,6 +315,14 @@ const disabilityAssessments = [
 		identifier: "stupid",
 		nonInclusivePhrases: [ "stupid" ],
 		inclusiveAlternatives: [ "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbDown",
+		nonInclusivePhrases: [ "dumb down", "dumbing down", "dumbed down", "dumb it down", "dumbing it down",
+			"dumbed it down" ],
+		inclusiveAlternatives: "<i>oversimplify</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: redHarmful,
 	},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the phrase "dumb down" to the _inclusive language assessment_.
* Improves the feedback for "lame" in the _inclusive language assessment_.
* [shopify-seo] Adds the phrase "dumb down" to the _inclusive language assessment_.
* [shopify-seo] Improves the feedback for "lame" in the _inclusive language assessment_.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Active Yoast SEO Free
* Activate the Inclusive language assessment in the settings
* Add a text of at least 300 words
* Add the phrase "dumb" to the text
* Confirm that the inclusive language assessment shows red with the following feedback:
"Avoid using dumb as it is potentially harmful. Consider using an alternative, such as uninformed, ignorant, foolish, inconsiderate, irrational, reckless. Learn more.".
* Add the phrase "dumb down" to the text
* Confirm that a second feedback appears under the inclusive language assessment with a red bullet ""Avoid using dumb down as it is potentially harmful. Consider using an alternative, such as oversimplify. Learn more."
* Change the form of the phrase "dumb down" to "dumbed down"
* Confirm that the previous score disappeared and this similar feedback string appeared instead: "Avoid using dumbed down as it is potentially harmful. Consider using an alternative, such as oversimplify. Learn more."
* Remove the previous text and add a new text of at least 300 words
* Add the phrase "dumbing down"
* Confirm that the Inclusive language feedback shows red with the following feedback: "Avoid using dumbing down as it is potentially harmful. Consider using an alternative, such as oversimplify. Learn more."
* Add the phrase "lame"
* Confirm that a second feedback appears under the inclusive language assessment with an orange bullet and the following feedback: "Be careful when using lame as it is potentially harmful. Unless you are referring to an object, considering using an alternative. For example, boring, lousy, unimpressive, sad, corny. If referring to someone's disability, use an alternative such as person with a disability, person who has difficulty with walking. Learn more.".

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
