### PR TITLE
Improve disabled state of UI library field components

### DIFF
--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -10,6 +10,7 @@ import { useDescribedBy } from "../../hooks";
  * @param {Object} validation The validation state.
  * @param {string} [className] Optional CSS class.
  * @param {string} label Label.
+ * @param {Boolean} [disabled] Disabled state.
  * @param {JSX.node} [description] Optional description.
  * @param {Object} [props] Any extra props.
  * @returns {JSX.Element} AutocompleteField component.
@@ -17,6 +18,7 @@ import { useDescribedBy } from "../../hooks";
 const AutocompleteField = forwardRef( ( {
 	id,
 	label,
+	disabled,
 	description,
 	validation,
 	className,
@@ -25,7 +27,7 @@ const AutocompleteField = forwardRef( ( {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
 
 	return (
-		<div className={ classNames( "yst-autocomplete-field", className ) }>
+		<div className={ classNames( "yst-autocomplete-field", disabled && "yst-autocomplete-field--disabled", className ) }>
 			<Autocomplete
 				ref={ ref }
 				id={ id }
@@ -37,6 +39,7 @@ const AutocompleteField = forwardRef( ( {
 				validation={ validation }
 				className="yst-autocomplete-field__select"
 				buttonProps={ { "aria-describedby": describedBy } }
+				disabled={ disabled }
 				{ ...props }
 			/>
 			{ validation?.message && (
@@ -55,6 +58,7 @@ AutocompleteField.displayName = "AutocompleteField";
 AutocompleteField.propTypes = {
 	id: PropTypes.string.isRequired,
 	label: PropTypes.string.isRequired,
+	disabled: PropTypes.bool,
 	description: PropTypes.node,
 	validation: PropTypes.shape( {
 		variant: PropTypes.string,
@@ -63,6 +67,7 @@ AutocompleteField.propTypes = {
 	className: PropTypes.string,
 };
 AutocompleteField.defaultProps = {
+	disabled: false,
 	description: null,
 	validation: {},
 	className: "",

--- a/packages/ui-library/src/components/autocomplete-field/style.css
+++ b/packages/ui-library/src/components/autocomplete-field/style.css
@@ -1,5 +1,16 @@
 @layer components {
 	.yst-root {
+		.yst-autocomplete-field--disabled {
+			.yst-autocomplete-field__label,
+			.yst-autocomplete-field__description {
+				@apply yst-opacity-50;
+			}
+
+			.yst-autocomplete-field__label {
+				@apply yst-cursor-not-allowed;
+			}
+		}
+
 		.yst-autocomplete-field__description {
 			@apply yst-mt-2;
 		}

--- a/packages/ui-library/src/components/tag-field/style.css
+++ b/packages/ui-library/src/components/tag-field/style.css
@@ -3,7 +3,11 @@
 		.yst-tag-field--disabled {
 			.yst-tag-field__label,
 			.yst-tag-field__description {
-				@apply yst-opacity-50 yst-cursor-not-allowed;
+				@apply yst-opacity-50;
+			}
+
+			.yst-tag-field__label {
+				@apply yst-cursor-not-allowed;
 			}
 		}
 

--- a/packages/ui-library/src/components/toggle-field/style.css
+++ b/packages/ui-library/src/components/toggle-field/style.css
@@ -14,8 +14,7 @@
 			}
 
 			.yst-toggle-field__label,
-			.yst-toggle-field__label-wrapper,
-			.yst-toggle-field__description {
+			.yst-toggle-field__label-wrapper {
 				@apply yst-cursor-not-allowed;
 			}
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The autocomplete fields for the policy configurations don't have their descriptions grayed out under the upsell section. This change ensures those descriptions will have the correct opacity.
* As a side effect, this ensures all descriptions in a disabled `AutocompleteField` receive this same opacity.
* This also aligns the disabled behavior between Field components in regards of the used cursor on the disabled description.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the description of a disabled AutocompleteField would not become grayed out.
* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the description of a disabled TagField showed a "not-allowed" cursor.
* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the description of a disabled ToggleField showed a "not-allowed" cursor.
* Fixes a visual inconsistency where the descriptions of the disabled Premium policy settings would look enabled, when they are not enabled. 

## Relevant technical choices:

* Aligned disabled behavior for UI library Field components after discussion with @uxkai on the look and cursor behavior, which cascades into the policy fields in the plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test the UI library standalone**

* Start the Storybook (`$ yarn workspace @yoast/ui-library storybook`)
* For the AutocompleteField, TagField, TextField, TextareaField and ToggleField:
   1. Fill a description
   2. Disable the component
   3. Check the label, the element, and the description all look grayed out
   4. Check the label and the element have a not-allowed cursor
   5. Check the description DOES NOT have a not-allowed cursor

**Test the plugin**

* DEV: Build the JS and CSS (`$ grunt build`)
* In the WP Admin go to Yoast SEO > Settings > Site basics
* Scroll to Website policies (near the bottom)
* Check all policy fields have a disabled description

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The disabled state of pretty much all input fields in the settings admin page.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes a concern raised by @uxkai.
