### PR TITLE
Elementor: stop editor watcher when switching the document

### DIFF
--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -119,6 +119,11 @@ function handleEditorChange() {
 		return;
 	}
 
+	// Don't update the editor data when the form ID is not equal to the document ID.
+	if ( ! isFormIdEqualToDocumentId() ) {
+		return;
+	}
+
 	// Quit early if the change was caused by switching out of the wp-post/page document.
 	// This can happen when users go to Site Settings, for example.
 	if ( ! [ "wp-post", "wp-page" ].includes( currentDocument.config.type ) ) {

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -1,7 +1,7 @@
 /* global elementor, YoastSEO */
 import { dispatch, select } from "@wordpress/data";
 import { cleanForSlug } from "@wordpress/url";
-import { debounce, get } from "lodash";
+import { debounce, get, noop } from "lodash";
 import { markers, Paper } from "yoastseo";
 import { refreshDelay } from "../../analysis/constants";
 import firstImageUrlInContent from "../../helpers/firstImageUrlInContent";
@@ -182,18 +182,32 @@ function resetMarks() {
 const debouncedHandleEditorChange = debounce( handleEditorChange, refreshDelay );
 
 /**
- * Observes changes to the whole document through a MutationObserver.
+ * Creates a MutationObserver to observe changes to the document.
  *
- * @returns {void}
+ * @param {function} callback The callback to execute when a change is detected.
+ *
+ * @returns {function} A function to disconnect the observer.
  */
-function observeChanges() {
-	const observer = new MutationObserver( () => {
-		if ( isFormIdEqualToDocumentId() ) {
-			debouncedHandleEditorChange();
-		}
-	} );
-	observer.observe( document, { attributes: true, childList: true, subtree: true, characterData: true } );
-}
+const createMutationObserver = ( callback ) => {
+	const observer = new MutationObserver( callback );
+
+	/**
+	 * Observes changes in the document.
+	 *
+	 * @param {Node} [target=document] A DOM Node (which may be an Element) within the DOM tree to watch for changes.
+	 *
+	 * @returns {function} The disconnect function.
+	 */
+	return ( target = document ) => {
+		observer.observe( target, { attributes: true, childList: true, subtree: true, characterData: true } );
+
+		/**
+		 * Disconnects the observer.
+		 * @returns {void}
+		 */
+		return () => observer.disconnect();
+	};
+};
 
 /**
  * Initializes the watcher by coupling the change handlers to the change events.
@@ -206,9 +220,31 @@ export default function initialize() {
 	// This hook will fire just before the document is saved.
 	registerElementorUIHookBefore( "document/save/save", "yoast-seo/marks/reset-on-save", resetMarks, ( { document } ) => isFormId( document?.id || elementor.documents.getCurrent().id ) );
 
+	const startObserver = createMutationObserver( debouncedHandleEditorChange );
+	let stopObserver = noop;
+
+	/**
+	 * Stops the observer and cancels any pending changes.
+	 * @returns {void}
+	 */
+	const stopObserverAndPendingChanges = () => {
+		// Stop listening to the document.
+		stopObserver();
+		stopObserver = noop;
+		// Stop any pending debounced editor change calls.
+		debouncedHandleEditorChange.cancel();
+	};
+
+	registerElementorUIHookAfter(
+		"editor/documents/close",
+		"yoast-seo/content-scraper/stop",
+		stopObserverAndPendingChanges,
+		( { id } ) => isFormId( id )
+	);
 	// This hook will fire when the Elementor preview becomes available.
-	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo/content-scraper/initial", debouncedHandleEditorChange, isFormIdEqualToDocumentId );
-	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo/content-scraper", debounce( observeChanges, refreshDelay ), isFormIdEqualToDocumentId );
+	registerElementorUIHookAfter( "editor/documents/attach-preview", "yoast-seo/content-scraper/start", () => {
+		stopObserver = startObserver();
+	}, isFormIdEqualToDocumentId );
 
 	// This hook will fire when the contents of the editor are modified.
 	registerElementorUIHookAfter( "document/save/set-is-modified", "yoast-seo/content-scraper/on-modified", debouncedHandleEditorChange, ( { document } ) => isFormId( document?.id || elementor.documents.getCurrent().id ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The editor watcher would still be able to run on a document that is not our form due to our debounce timing. When this document is a draft it would update the slug still! Which should never happen.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where switching from a page to a draft post would cause a slug change.

## Relevant technical choices:

Preventing the update is already done by comparing the document ID to the form ID in `handleEditorChange`. However, I refactored the whole mutation observer to be stopped when the document changes. And the extra important bit there: also cancelling pending editor changes (i.e. stopping the debounce from triggering later) should be the proper prevention. 
It made sense to then change the mutation observer code to just have 1 active and start it on attaching the preview and stopping on switching the document. The previous method seemed hazardous with the switching of documents.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Issue
* Create a post with Elementor and keep it as a draft
* Create a PAGE with Elementor and publish it
* Make some changes in the published page (do NOT save it yet)
* Via the top bar, switch to the draft post
* Within the popup, DO save the changes (for the published page)
* Via the top bar, switch back to the published post
* Make some changes in the published page
* Via the top bar, switch to the draft post
* Verify you do NOT get a Premium redirect popup or verify the slug of the page without Premium
* Repeat the switching and editing more times to ensure it never happens anymore

#### Regression
The mutation observer was originally implemented in the following PR: https://github.com/Yoast/wordpress-seo/pull/20910
Where a comment mentions
> some problems with detecting changes to images, that should be better when watching the whole DOM

Test the highlighting in Elementor still works properly:
* Edit the published page
* Switch to the draft post
* Switch back to the published page
* Please follow the steps in 1.1.1, 1.1.2, 1.2.1 and 1.2.2 in the [Elementor highlighting ATP](https://docs.google.com/document/d/19X5RJr5WaDzxYKU6j3vxzdBa7eK-TKrCUP0OCQj_VEQ). Only for English is enough.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Elementor editor change watcher

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1818
