### PR TITLE
21588 remove woocommerceupsell from wpseoscriptdata

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -901,7 +901,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			'isJetpackBoostNotPremium'   => ( $is_block_editor ) ? YoastSEO()->classes->get( Jetpack_Boost_Not_Premium_Conditional::class )->is_met() : false,
 			'isWooCommerceSeoActive'     => $woocommerce_seo_active,
 			'isWooCommerceActive'        => $woocommerce_active,
-			'woocommerceUpsell'          => get_post_type( $post_id ) === 'product' && ! $woocommerce_seo_active && $woocommerce_active,
 		];
 
 		/**

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -168,7 +168,7 @@ const Content = ( props ) => {
 	const schemaPageTypeOptions = getSchemaTypeOptions( props.pageTypeOptions, props.defaultPageType, props.postTypeName );
 	const schemaArticleTypeOptions = getSchemaTypeOptions( props.articleTypeOptions, props.defaultArticleType, props.postTypeName );
 	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellSchemaLink", "" );
-	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
+	const woocommerceUpsell = useSelect( ( select ) => select( STORE ).getIsWooSeoUpsell(), [] );
 	const [ focusedArticleType, setFocusedArticleType ] = useState( props.schemaArticleTypeSelected );
 	const woocommerceUpsellText = __( "Want your products stand out in search results with rich results like price, reviews and more?", "wordpress-seo" );
 	const isProduct = useSelect( ( select ) => select( STORE ).getIsProduct(), [] );

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -1,5 +1,5 @@
 import { compose } from "@wordpress/compose";
-import { withDispatch, withSelect } from "@wordpress/data";
+import { withDispatch, withSelect, useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
@@ -51,7 +51,7 @@ export const mapEditorDataToPreview = function( data, context ) {
  */
 const SnippetEditorWrapper = ( props ) => {
 	const woocommerceUpsellLink = get( window, "wpseoScriptData.metabox.woocommerceUpsellGooglePreviewLink", "" );
-	const woocommerceUpsell = get( window, "wpseoScriptData.woocommerceUpsell", "" );
+	const woocommerceUpsell = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsWooSeoUpsell(), [] );
 	const woocommerceUpsellText = __( "Want an enhanced Google preview of how your WooCommerce products look in the search results?", "wordpress-seo" );
 
 	return <LocationConsumer>

--- a/packages/js/src/redux/selectors/editorContext.js
+++ b/packages/js/src/redux/selectors/editorContext.js
@@ -27,7 +27,7 @@ export function getPostOrPageString( state ) {
  *
  * @param {Object} state The state.
  *
- * @returns {string} Whether you're editing a produc.
+ * @returns {string} Whether you're editing a product.
  */
 export function getIsProduct( state ) {
 	return get( state, "editorContext.postTypeNameSingular" ) === "Product";

--- a/packages/js/src/redux/selectors/isWooSEO.js
+++ b/packages/js/src/redux/selectors/isWooSEO.js
@@ -1,17 +1,10 @@
 import { get } from "lodash";
-
-/**
- * Determines whether the WooCommerce SEO addon is not active in a product page.
- *
- * @returns {Boolean}       Whether the plugin is WooCommerce SEO or not.
- */
-export const getIsWooSeoUpsell = () => get( window, "wpseoScriptData.woocommerceUpsell", false );
-
+import { getIsProduct } from "./editorContext";
 
 /**
  * Determines whether the WooCommerce SEO addon is active.
  *
- * @returns {Boolean}       Whether the plugin is WooCommerce SEO or not.
+ * @returns {Boolean} Whether the plugin is WooCommerce SEO or not.
  */
 export const getIsWooSeoActive = () => Boolean( get( window, "wpseoScriptData.isWooCommerceSeoActive", false ) );
 
@@ -21,3 +14,17 @@ export const getIsWooSeoActive = () => Boolean( get( window, "wpseoScriptData.is
  * @returns {boolean} True if WooCommerce is active.
  */
 export const getIsWooCommerceActive = () => Boolean( get( window, "wpseoScriptData.isWooCommerceActive", false ) );
+
+/**
+ * Determines whether the WooCommerce SEO addon is not active in a product page.
+ *
+ * @param {Object} state The state.
+ * @returns {Boolean} Whether the plugin is WooCommerce SEO or not.
+ */
+export const getIsWooSeoUpsell = ( state ) => {
+	const isWooSeoActive = getIsWooSeoActive();
+	const isWooCommerceActive = getIsWooCommerceActive();
+	const isProductPage = getIsProduct( state );
+
+	return ! isWooSeoActive && isWooCommerceActive && isProductPage;
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove `woocommerceUpsell` property from `wpseoScriptData` to slim down the scriptData as part of a process to decouple it from the global post.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the `woocommerceUpsell` property from `wpseoScriptData`.

## Relevant technical choices:

* In a the PR [Move links from wpseoScriptData to JS](https://github.com/Yoast/wordpress-seo/issues/21580) I removed the links from the sciptData. If that Pr will be merged before this PR, we will need to remove the import of `get` from `lodash`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Woocommerce.
* Make sure you don't have Woo SEO installed.
* Edit a post and check you get the the upsell ad on the search preview and schema tab.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21588 
