### PR TITLE
Added Sitemap public url when home_url() != site_url().

### DIFF
--- a/inc/sitemaps/class-sitemaps-renderer.php
+++ b/inc/sitemaps/class-sitemaps-renderer.php
@@ -339,7 +339,8 @@ class WPSEO_Sitemaps_Renderer {
 	 */
 	protected function get_xsl_url() {
 		if ( home_url() !== site_url() ) {
-			return home_url( 'main-sitemap.xsl' );
+			$sitemap_public_url = home_url( 'main-sitemap.xsl' );
+			return apply_filter('sitemap_public_url', $sitemap_public_url);
 		}
 
 		/*


### PR DESCRIPTION
Note: This will help users who are using wordpress as headles. Their wp backend is hosted on another url/subdomain and frontend is installed on other server. that case home_url() which useually a frontend app url. the current will return 404 error for main-sitemap.xsl as this file won't exist on frontend app. I have added a filter which will help those users to overwrite with backend path. After that their backend will have the sitemap and they can write their code to download and store in their public directory. It will help them to keep their sitemap updated overtime.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
Overwrite the XML public path. 

## Summary
If someone are using WordPress as a headless CMS, where their backend is hosted on WordPress and the frontend is in Next.js/react or any other tech. In that scenario , the SITE_URL (backend URL) and Home URL (frontend URL) are different. let's say backend.example.com, and the frontend URL is example.com.
 
That user will struggle with the XML sitemap. Cause as per google they will require their xml site map like example.com/sitemap.xml or example.com/sitemap_index.xml but since WordPress is hosted on backend.example.com, the example.com/sitemap_index.xml does not work. Even backend.example.com/sitemap_index.xml will not work cause the current code which i had investigated found that home_url has preference over site_url. Due to that main-sitemap.xsl will return 404 or not found. 

I have added 1 filter which will help developers to overwrite the URL in case if they want. 

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
Fixes a bug on Sitemap URL. 
*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*
Simply keep Different Site URL and Home URL different. and then check sitemap_index.xml at any URL. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
