### PR TITLE
Updates BF banners and sets the correct date.

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -97,7 +97,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		$class = $this->get_html_class();
 
 		/* translators: %s expands to Yoast SEO Premium */
-		$button_text = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ? esc_html__( 'Claim your 30% off now!', 'wordpress-seo' ) : sprintf( esc_html__( 'Explore %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' );
+		$button_text = YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ? esc_html__( 'Upgrade now', 'wordpress-seo' ) : sprintf( esc_html__( 'Explore %s now!', 'wordpress-seo' ), 'Yoast SEO Premium' );
 		/* translators: Hidden accessibility text. */
 		$button_text .= '<span class="screen-reader-text">' . esc_html__( '(Opens in a new browser tab)', 'wordpress-seo' ) . '</span>'
 			. '<span aria-hidden="true" class="yoast-button-upsell__caret"></span>';
@@ -111,11 +111,10 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		echo '<div class="' . esc_attr( $class ) . '">';
 
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
-			$bf_label   = esc_html__( 'BLACK FRIDAY', 'wordpress-seo' );
-			$sale_label = esc_html__( '30% OFF', 'wordpress-seo' );
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+			$bf_label   = esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
-			echo "<div class='black-friday-container'><span>$bf_label</span> <span style='margin-left: auto;'>$sale_label</span> </div>";
+			echo "<div class='black-friday-container'><span>$bf_label</span></div>";
 		}
 
 		echo '<div class="' . esc_attr( $class . '--container' ) . '">';

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -112,7 +112,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		echo '<div class="' . esc_attr( $class ) . '">';
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
-			$bf_label   = esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' );
+			$bf_label = esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
 			echo "<div class='black-friday-container'><span>$bf_label</span></div>";
 		}

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -260,7 +260,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 			$title = __( 'Upgrades', 'wordpress-seo' );
 		}
 
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
 			$title = __( 'Upgrades', 'wordpress-seo' ) . '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';
 		}
 

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -133,9 +133,9 @@ $new_tab_message         = sprintf(
 $sale_badge         = '';
 $premium_sale_badge = '';
 
-if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 	/* translators: %1$s expands to opening span, %2$s expands to closing span */
-	$sale_badge_span = sprintf( esc_html__( '%1$sSALE 30%% OFF!%2$s', 'wordpress-seo' ), '<span>', '</span>' );
+	$sale_badge_span = sprintf( esc_html__( '%1$s30%% OFF | Use code: BF2024%2$s', 'wordpress-seo' ), '<span>', '</span>' );
 
 	$sale_badge = '<div class="yoast-seo-premium-extension-sale-badge">' . $sale_badge_span . '</div>';
 

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -871,6 +871,7 @@ body.folded .wpseo-admin-submit-fixed {
 
 #black-friday-2024-promotion-sidebar .notice-yoast__header {
 	margin-bottom: 2px;
+    padding-right: 20px;
 }
 
 #black-friday-2024-promotion-metabox.notice-yoast {

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -856,7 +856,7 @@ body.folded .wpseo-admin-submit-fixed {
 	color: #dba617;
 }
 
-#black-friday-2023-promotion-sidebar.notice-yoast {
+#black-friday-2024-promotion-sidebar.notice-yoast {
 	border-color: #fcd34d;
 	border-width: 2px;
 	border-radius: 8px;
@@ -869,11 +869,11 @@ body.folded .wpseo-admin-submit-fixed {
 	margin-top: 20px;
 }
 
-#black-friday-2023-promotion-sidebar .notice-yoast__header {
+#black-friday-2024-promotion-sidebar .notice-yoast__header {
 	margin-bottom: 2px;
 }
 
-#black-friday-2023-promotion-metabox.notice-yoast {
+#black-friday-2024-promotion-metabox.notice-yoast {
 	border-color: #fcd34d;
 	border-width: 2px;
 	border-radius: 8px;
@@ -882,23 +882,23 @@ body.folded .wpseo-admin-submit-fixed {
 	margin: 20px;
 }
 
-#black-friday-2023-promotion-metabox h2.notice-yoast__header-heading {
+#black-friday-2024-promotion-metabox h2.notice-yoast__header-heading {
 	padding: 0px;
 }
 
-#black-friday-2023-promotion-metabox .notice-yoast__container {
+#black-friday-2024-promotion-metabox .notice-yoast__container {
 	padding-bottom: 0px;
 }
 
-#black-friday-2023-promotion-metabox .notice-yoast__container p {
+#black-friday-2024-promotion-metabox .notice-yoast__container p {
 	display: inline;
 }
 
-#black-friday-2023-promotion-metabox .notice-yoast__header {
+#black-friday-2024-promotion-metabox .notice-yoast__header {
 	margin-bottom: 8px;
 }
 
-#black-friday-2023-promotion-metabox .notice-yoast__header a {
+#black-friday-2024-promotion-metabox .notice-yoast__header a {
 	font-weight: 400;
 	margin-left: 13px;
 }

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -928,5 +928,6 @@ body.folded .wpseo-admin-submit-fixed {
 	font-size: 10px;
 	font-weight: 600;
 	line-height: normal;
+	text-wrap: nowrap;
 }
 /*# sourceMappingURL=admin-global.css.map */

--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -31,16 +31,17 @@
 	border-radius: 14px;
 }
 
-#wpadminbar .yoast-menu-bf-sale-badge{
-    margin-left: 5px;
-    border-radius: 8px;
-    border: 1px solid #FCD34D;
-    background-color: #1F2937;
-    color: #FCD34D;
-    padding: 2px 8px;
-    font-size: 10px;
-    font-weight: 600;
-    line-height: normal;
+#wpadminbar .yoast-menu-bf-sale-badge {
+	margin-left: 5px;
+	border-radius: 8px;
+	border: 1px solid #fcd34d;
+	background-color: #1f2937;
+	color: #fcd34d;
+	padding: 2px 8px;
+	font-size: 10px;
+	font-weight: 600;
+	line-height: normal;
+	text-wrap: nowrap;
 }
 
 #wpadminbar .quicklinks #wp-admin-bar-wpseo-menu .wpseo-focus-keyword {

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -587,10 +587,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 */
 	protected function add_premium_link( WP_Admin_Bar $wp_admin_bar ) {
 		$sale_percentage = '';
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 			$sale_percentage = sprintf(
 				'<span class="admin-bar-premium-promotion">%1$s</span>',
-				esc_html__( '-30%', 'wordpress-seo' )
+				esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' )
 			);
 		}
 		$wp_admin_bar->add_menu(

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -24,14 +24,14 @@ export const BlackFridayPromotion = ( {
 	const title = location === "sidebar"
 		? sprintf(
 			/* translators: %1$s expands to YOAST SEO PREMIUM */
-			__( "BLACK FRIDAY SALE: %1$s", "wordpress-seo" ),
-			"YOAST SEO PREMIUM"
+			__( "30%% OFF %1$s | Use code: BF2024", "wordpress-seo" ),
+			"Yoast SEO Premium"
 		)
 		: createInterpolateElement(
 			sprintf(
 				/* translators: %1$s expands to YOAST SEO PREMIUM, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
-				__( "BLACK FRIDAY SALE: %1$s %2$sBuy now!%3$s", "wordpress-seo" ),
-				"YOAST SEO PREMIUM",
+				__( "30%% OFF %1$s | Use code: BF2024 %2$sBuy now!%3$s", "wordpress-seo" ),
+				"Yoast SEO Premium",
 				"<a>",
 				"</a>"
 			),
@@ -42,15 +42,15 @@ export const BlackFridayPromotion = ( {
 		);
 	return isPremium ? null : (
 		<TimeConstrainedNotification
-			id={ `black-friday-2023-promotion-${ location }` }
-			promoId="black-friday-2023-promotion"
-			alertKey="black-friday-2023-promotion"
+			id={ `black-friday-2024-promotion-${ location }` }
+			promoId="black-friday-2024-promotion"
+			alertKey="black-friday-2024-promotion"
 			store={ store }
 			title={ title }
-			image={ Image }
+			image={ null }
 			{ ...props }
 		>
-			<span className="yoast-bf-sale-badge">{ __( "30% OFF!", "wordpress-seo" ) } </span>
+			<span className="yoast-bf-sale-badge">{ __( "Black Friday", "wordpress-seo" ) } </span>
 			{ location === "sidebar" && <a
 				// Styling is to counteract the WP paragraph margin-bottom.
 				className="yst-block yst--mb-[1em]"

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -47,7 +47,6 @@ export const BlackFridayPromotion = ( {
 			alertKey="black-friday-2024-promotion"
 			store={ store }
 			title={ title }
-			image={ null }
 			{ ...props }
 		>
 			<span className="yoast-bf-sale-badge">{ __( "Black Friday", "wordpress-seo" ) } </span>

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -108,16 +108,15 @@ class UpsellBox extends Component {
 	 * @returns {wp.Element} The rendered UpsellBox component.
 	 */
 	render() {
-		const isBlackFriday = select( "yoast-seo/editor" ).isPromotionActive( "black-friday-2023-promotion" );
+		const isBlackFriday = select( "yoast-seo/editor" ).isPromotionActive( "black-friday-2024-promotion" );
 		const { defaultPrice } = this.state;
 		const newPrice = isBlackFriday ? "69.30" : null;
 		const price = newPrice ? newPrice : defaultPrice;
 		return (
 			<Fragment>
 				{ isBlackFriday &&
-				<div className="yst-flex yst-justify-between yst-items-center yst-text-lg yst-content-between yst-bg-black yst-text-amber-300 yst-h-9 yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-px-6">
-					<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
-					<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
+				<div className="yst-flex  yst-items-center yst-text-lg yst-content-between yst-bg-black yst-text-amber-300 yst-h-9 yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-px-6">
+					<div className="yst-mx-auto">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
 				</div> }
 				<Container>
 					<Heading>{ this.props.title }</Heading>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -54,7 +54,11 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 			<Fill name="YoastElementor">
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
-					{ FirstEligibleNotification && <FirstEligibleNotification /> }
+					{ FirstEligibleNotification && (
+						<div className="yst-inline-block yst-px-1.5">
+							<FirstEligibleNotification />
+						</div>
+					) }
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/helpers/shouldShowWebinarPromotionNotification.js
+++ b/packages/js/src/helpers/shouldShowWebinarPromotionNotification.js
@@ -26,8 +26,8 @@ const shouldShowWebinarPromotionNotificationInDashboard = ( store = "yoast-seo/e
 	 * @returns {boolean} Whether the Webinar promotion should be shown.
 	 */
 const shouldShowWebinarPromotionNotificationInSidebar = ( store = "yoast-seo/editor" ) => {
-	const isBlackFridayPromotionActive = select( store ).isPromotionActive( "black-friday-2023-promotion" );
-	const isBlackFridayPromotionAlertDismissed = select( store ).isAlertDismissed( "black-friday-2023-promotion" );
+	const isBlackFridayPromotionActive = select( store ).isPromotionActive( "black-friday-2024-promotion" );
+	const isBlackFridayPromotionAlertDismissed = select( store ).isAlertDismissed( "black-friday-2024-promotion" );
 
 	if ( isBlackFridayPromotionActive ) {
 		return isBlackFridayPromotionAlertDismissed;

--- a/packages/js/src/hooks/use-first-eligible-notification.js
+++ b/packages/js/src/hooks/use-first-eligible-notification.js
@@ -1,8 +1,6 @@
 import { BlackFridayPromotion } from "../components/BlackFridayPromotion";
-import { BlackFridaySidebarChecklistPromotion } from "../components/BlackFridaySidebarChecklistPromotion";
 import { TrustpilotReviewNotification, useTrustpilotReviewNotification } from "../components/trustpilot-review-notification";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
-import { isWooCommerceActive } from "../helpers/isWooCommerceActive";
 import { shouldShowWebinarPromotionNotificationInSidebar } from "../helpers/shouldShowWebinarPromotionNotification";
 
 /**
@@ -42,10 +40,6 @@ export const useFirstEligibleNotification = ( { webinarIntroUrl } ) => {
 		{
 			getIsEligible: shouldShowWebinarPromotionNotificationInSidebar,
 			component: () => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } />,
-		},
-		{
-			getIsEligible: isWooCommerceActive,
-			component: () => <BlackFridaySidebarChecklistPromotion hasIcon={ false } />,
 		},
 		{
 			getIsEligible: () => true,

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -165,7 +165,7 @@ const PremiumUpsellList = () => {
 	const premiumLink = useSelectSettings( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectSettings( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectSettings( "selectPreference", [], "promotions", [] );
-	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
+	const isBlackFriday = promotions.includes( "black-friday-2024-promotion" );
 
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -169,9 +169,8 @@ const PremiumUpsellList = () => {
 
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
-			{ isBlackFriday && <div className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold">
-				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
-				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
+			{ isBlackFriday && <div className="yst-rounded-t-lg yst-h-9 yst-flex yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold">
+				<div>{ __( "30% OFF | Code: BF2024", "wordpress-seo" ) }</div>
 			</div> }
 			<div className="yst-p-6 yst-flex yst-flex-col">
 				<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -16,8 +16,9 @@ import { ReactComponent as G2Logo } from "./g2-logo-white.svg";
  * @returns {JSX.Element} The premium upsell card.
  */
 export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
-	const info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support, and much, much more!", "wordpress-seo" ), [] );
-	const getPremium = createInterpolateElement(
+	let info = useMemo( () => __( "Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support, and much, much more!", "wordpress-seo" ), [] );
+	const isBlackFriday = promotions.includes( "black-friday-2024-promotion" );
+	let getPremium = createInterpolateElement(
 		sprintf(
 			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
 			__( "%1$sGet%2$s %3$s", "wordpress-seo" ),
@@ -29,19 +30,21 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			nowrap: <span className="yst-whitespace-nowrap" />,
 		}
 	);
-	const isBlackFriday = promotions.includes( "black-friday-2023-promotion" );
-	const saveMoneyText = createInterpolateElement(
-		sprintf(
-			/* translators: %1$s and %2$s expand to strong tags. */
-			__( "%1$sSAVE 30%%%2$s on your 12 month subscription", "wordpress-seo" ),
-			"<strong>",
-			"</strong>"
-		),
-		{
-			strong: <strong />,
-		}
-	);
+	if ( isBlackFriday ) {
+		info = useMemo( () => __( "If you were thinking about upgrading, now's the time! 30% OFF ends 3rd Dec 11am (CET)", "wordpress-seo" ), [] );
 
+		getPremium = createInterpolateElement(
+			sprintf(
+				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+				__( "%1$sAll annual plans incl. %2$s", "wordpress-seo" ),
+				"<nowrap>",
+				"</nowrap>"
+			),
+			{
+				nowrap: <span className="yst-whitespace-nowrap" />,
+			}
+		);
+	}
 	return (
 		<div className="yst-p-6 yst-rounded-lg yst-text-white yst-bg-primary-500 yst-shadow">
 			<figure
@@ -51,18 +54,13 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			</figure>
 			{ isBlackFriday && <div className="sidebar__sale_banner_container">
 				<div className="sidebar__sale_banner">
-					<span className="banner_text">{ __( "BLACK FRIDAY - 30% OFF", "wordpress-seo" ) }</span>
+					<span className="banner_text">{ __( "30% OFF | Code: BF2024", "wordpress-seo" ) }</span>
 				</div>
 			</div> }
 			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">
 				{ getPremium }
 			</Title>
 			<p className="yst-mt-2">{ info }</p>
-			{ isBlackFriday && <div className="yst-text-center yst-border-t-[1px] yst-border-white yst-italic yst-mt-3">
-				<p className="yst-text-[10px] yst-my-3 yst-mx-0">
-					{ saveMoneyText }
-				</p>
-			</div> }
 			<Button
 				as="a"
 				variant="upsell"
@@ -72,7 +70,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...linkProps }
 			>
-				<span>{ isBlackFriday ? __( "Claim your 30% off now!", "wordpress-seo" ) : getPremium }</span>
+				<span>{ isBlackFriday ? __( "Buy now", "wordpress-seo" ) : getPremium }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
 			<p className="yst-text-center yst-text-xs yst-mx-2 yst-font-light yst-leading-5 yst-mt-2">

--- a/src/integrations/alerts/black-friday-promotion-notification.php
+++ b/src/integrations/alerts/black-friday-promotion-notification.php
@@ -12,5 +12,5 @@ class Black_Friday_Promotion_Notification extends Abstract_Dismissable_Alert {
 	 *
 	 * @var string
 	 */
-	protected $alert_identifier = 'black-friday-2023-promotion';
+	protected $alert_identifier = 'black-friday-2024-promotion';
 }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -378,7 +378,7 @@ class Settings_Integration implements Integration_Interface {
 		\wp_enqueue_media();
 		$this->asset_manager->enqueue_script( 'new-settings' );
 		$this->asset_manager->enqueue_style( 'new-settings' );
-		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 			$this->asset_manager->enqueue_style( 'black-friday-banner' );
 		}
 		$this->asset_manager->localize_script( 'new-settings', 'wpseoScriptData', $this->get_script_data() );

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -133,7 +133,7 @@ class Support_Integration implements Integration_Interface {
 		\remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 		$this->asset_manager->enqueue_script( 'support' );
 		$this->asset_manager->enqueue_style( 'support' );
-		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 			$this->asset_manager->enqueue_style( 'black-friday-banner' );
 		}
 		$this->asset_manager->localize_script( 'support', 'wpseoScriptData', $this->get_script_data() );

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -17,7 +17,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
-		$title = \__( 'BLACK FRIDAY - 30% OFF', 'wordpress-seo' );
+		$title = \__( '30% OFF | Code: BF2024', 'wordpress-seo' );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( \WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );
@@ -45,7 +45,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 									sizes="(min-width: 1321px) 75px">
 							</figure>
 						</figure>
-						<?php if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) : ?>
+						<?php if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) : ?>
 							<div class="sidebar__sale_banner_container">
 								<div class="sidebar__sale_banner">
 										<span class="banner_text"><?php echo \esc_html( $title ); ?></span>
@@ -54,30 +54,29 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php endif; ?>
 						<h2 class="yoast-get-premium-title">
 							<?php
-							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
+							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ){
+								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. */
+								\printf( \esc_html__( '%1$sAll annual plans incl.%2$s', 'wordpress-seo' ), '<span>', '</span>' );
+							}else {
+								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+								\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
+							}
 							?>
 						</h2>
 						<p>
 							<?php
-							echo \esc_html__( 'Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support, and much, much more!', 'wordpress-seo' );
+							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ){
+								echo \esc_html__( 'If you were thinking about upgrading, now\'s the time! 30% OFF ends 3rd Dec 11am (CET)', 'wordpress-seo' );
+							}else {
+								echo \esc_html__( 'Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support, and much, much more!', 'wordpress-seo' );
+							}
 							?>
 						</p>
-						<?php if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) : ?>
-							<div class="sidebar__sale_text">
-								<p>
-									<?php
-									/* translators: %1$s expands to an opening strong tag, %2$s expands to a closing strong tag */
-									\printf( \esc_html__( '%1$s SAVE 30%% %2$s on your 12 month subscription', 'wordpress-seo' ), '<strong>', '</strong>' );
-									?>
-								</p>
-							</div>
-						<?php endif; ?>
 						<p class="plugin-buy-button">
 							<a class="yoast-button-upsell" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" target="_blank" href="<?php echo \esc_url( $buy_yoast_seo_shortlink ); ?>">
 								<?php
-								if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
-									echo \esc_html__( 'Claim your 30% off now!', 'wordpress-seo' );
+								if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+									echo \esc_html__( 'Buy now', 'wordpress-seo' );
 								}
 								else {
 									/* translators: %s expands to Yoast SEO Premium */

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -54,10 +54,11 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php endif; ?>
 						<h2 class="yoast-get-premium-title">
 							<?php
-							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ){
+							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. */
 								\printf( \esc_html__( '%1$sAll annual plans incl.%2$s', 'wordpress-seo' ), '<span>', '</span>' );
-							}else {
+							}
+							else {
 								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
 								\printf( \esc_html__( '%1$sGet%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
 							}
@@ -65,9 +66,10 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						</h2>
 						<p>
 							<?php
-							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ){
+							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 								echo \esc_html__( 'If you were thinking about upgrading, now\'s the time! 30% OFF ends 3rd Dec 11am (CET)', 'wordpress-seo' );
-							}else {
+							}
+							else {
 								echo \esc_html__( 'Use AI to generate titles and meta descriptions, automatically redirect deleted pages, get 24/7 support, and much, much more!', 'wordpress-seo' );
 							}
 							?>

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -13,7 +13,7 @@ class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Int
 	public function __construct() {
 		parent::__construct(
 			'black-friday-2024-promotion',
-			new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2024 ), \gmmktime( 12, 00, 00, 12, 3, 2024) )
+			new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2024 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
 		);
 	}
 }

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -12,8 +12,8 @@ class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Int
 	 */
 	public function __construct() {
 		parent::__construct(
-			'black-friday-2023-promotion',
-			new Time_Interval( \gmmktime( 11, 00, 00, 11, 23, 2023 ), \gmmktime( 11, 00, 00, 11, 28, 2023 ) )
+			'black-friday-2024-promotion',
+			new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2024 ), \gmmktime( 12, 00, 00, 12, 3, 2024) )
 		);
 	}
 }

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -287,7 +287,7 @@ final class Support_Integration_Test extends TestCase {
 
 		// In enqueue_assets method.
 		$this->promotion_manager->expects( 'is' )
-			->with( 'black-friday-2023-promotion' )
+			->with( 'black-friday-2024-promotion' )
 			->once()
 			->andReturn( $is_black_friday );
 
@@ -369,7 +369,7 @@ final class Support_Integration_Test extends TestCase {
 			'preferences'   => [
 				'isPremium'      => false,
 				'isRtl'          => false,
-				'promotions'     => [ 'black-friday-2023-promotion' ],
+				'promotions'     => [ 'black-friday-2024-promotion' ],
 				'pluginUrl'      => 'http://basic.wordpress.test/wp-content/worspress-seo',
 				'upsellSettings' => [
 					'actionId'     => 'load-nfd-ctb',
@@ -390,7 +390,7 @@ final class Support_Integration_Test extends TestCase {
 	protected function assert_promotions() {
 		$this->promotion_manager->expects( 'get_current_promotions' )
 			->once()
-			->andReturn( [ 'black-friday-2023-promotion' ] );
+			->andReturn( [ 'black-friday-2024-promotion' ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
 			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $this->container ) ] );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds black friday promotion dates and content.

## Relevant technical choices:

* I chose to rename the promotion instead of making it global to make sure all dismissed notifications show up again.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preliminary steps
* Disable Yoast SEO Premium
* Make sure you don't have any dismissed notification
  * go to the db of your installation
  * in the table `wp_usermeta` search for the line where `user_id` is your user id and `meta_hey` is `_yoast_alerts_dismissed` 
  * remove the content of `meta_value` of that line

#### Test the removal of the Black Friday ads
* Copy the following in that file:
```
 <?php

namespace Yoast\WP\SEO\Promotions\Domain;

/**
 * Class to manage the Black Friday promotion.
 */
class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Interface {

	/**
	 * Class constructor.
	 */
	public function __construct() {
		parent::__construct(
			'black-friday-2024-promotion',
			new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2023 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
		);
	}
}

```

* Go to `Yoast SEO` -> `Dashboard` and verify that:
  <img width="154" alt="Screenshot 2023-12-06 at 14 31 40" src="https://github.com/Yoast/wordpress-seo/assets/68744851/ec3c1954-d9f9-4704-af85-e91a5957efb2">

  * the side and bottom ads are as follows:
  
![image](https://github.com/user-attachments/assets/bb4964c0-ecfd-4a5d-b538-0badd9586174)

![image](https://github.com/user-attachments/assets/04f82f37-a996-4330-a2eb-be5a621f0d1c)


* Go to the Yoast admin bar menu and verify
![image](https://github.com/user-attachments/assets/700ce54b-edda-4f8d-8abc-228e3135403a)

* Edit a post and verify that:
  * appears in the metabox:
![image](https://github.com/user-attachments/assets/32af6bad-b89d-4b22-bbf2-ce21da51d881)


  * the following notice appears in the sidebar:
![image](https://github.com/user-attachments/assets/51558506-dd30-4b8a-a6b9-2748bdc9a42c)


* Edit a post in classic and Elementor editor and verify the same as above

* Go to `Yoast SEO` -> `Premium` and verify `30% OFF | Use code: BF2024` badges are shown as below
![image](https://github.com/user-attachments/assets/95af0695-e17f-4536-ad4e-071457204bf9)



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
