### PR TITLE
fixed webinar link in settings

### DIFF
--- a/packages/js/src/initializers/settings-header.js
+++ b/packages/js/src/initializers/settings-header.js
@@ -1,6 +1,7 @@
 import { get } from "lodash";
 import { select } from "@wordpress/data";
 import { render } from "@wordpress/element";
+import { addQueryArgs } from "@wordpress/url";
 import { ThemeProvider } from "styled-components";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
 import { BlackFridaySidebarChecklistPromotion } from "../components/BlackFridaySidebarChecklistPromotion";
@@ -14,7 +15,8 @@ import { shouldShowWebinarPromotionNotificationInDashboard } from "../helpers/sh
 const initSettingsHeader = () => {
 	const reactRoot = document.getElementById( "yst-settings-header-root" );
 	const isRtl = Boolean( get( window, "wpseoScriptData.isRtl", false ) );
-	const webinarIntroSettingsUrl = select( "yoast-seo/settings" ).selectLinkParams( "https://yoa.st/webinar-intro-settings" );
+	const linkParams = select( "yoast-seo/settings" ).selectLinkParams();
+	const webinarIntroSettingsUrl = addQueryArgs( "https://yoa.st/webinar-intro-settings", linkParams );
 	const isWooCommerce = get( window, "wpseoScriptData.isWooCommerceActive", "" );
 
 	if ( reactRoot ) {

--- a/packages/js/src/initializers/settings-header.js
+++ b/packages/js/src/initializers/settings-header.js
@@ -1,5 +1,5 @@
 import { get } from "lodash";
-import { useSelect } from "@wordpress/data";
+import { select } from "@wordpress/data";
 import { render } from "@wordpress/element";
 import { ThemeProvider } from "styled-components";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
@@ -14,7 +14,7 @@ import { shouldShowWebinarPromotionNotificationInDashboard } from "../helpers/sh
 const initSettingsHeader = () => {
 	const reactRoot = document.getElementById( "yst-settings-header-root" );
 	const isRtl = Boolean( get( window, "wpseoScriptData.isRtl", false ) );
-	const webinarIntroSettingsUrl = useSelect( select => select( "yoast-seo/editor" ).selectLink( "https://yoa.st/webinar-intro-settings" ), [] );
+	const webinarIntroSettingsUrl = select( "yoast-seo/settings" ).selectLinkParams( "https://yoa.st/webinar-intro-settings" );
 	const isWooCommerce = get( window, "wpseoScriptData.isWooCommerceActive", "" );
 
 	if ( reactRoot ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Missed test instructions for webinar link in settings https://github.com/Yoast/wordpress-seo/pull/21582, and added the link with the editor store by mistake.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where webinar link would be missing when on settings page.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to one of the Yoast settings page.
* Check you don't see a console error:
![Screenshot 2024-09-06 at 16 10 41](https://github.com/user-attachments/assets/c4cbbe2f-90ba-4e0b-aaeb-5ffd55c2f638)
* Go to Yoast SEO -> General 
* Check you see the webinar link, if you don't go to your user meta `_yoast_alerts_dismissed` and resent the webinar promo notification.
* Check the link in the notification has the params like this:
> https://yoast.com/how-to-do-seo-webinar/#utm_medium=software&utm_source=yoast-seo&utm_campaign=ad&utm_term=free-weekly-webinar&utm_content=settings&php_version=8.1&platform=wordpress&platform_version=6.6.1&software=free&software_version=23.5-RC1&days_active=35&screen=wpseo_dashboard&shortlink=webinar-intro-settings
![Screenshot 2024-09-06 at 16 39 10](https://github.com/user-attachments/assets/c97cd0b6-66b8-4c32-8f1f-43380b985587)



#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21580
