### PR TITLE
21619 refactor is news seo active

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -865,7 +865,6 @@ class WPSEO_Utils {
 			'isBreadcrumbsDisabled' => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
 			'isPrivateBlog'         => ( (string) get_option( 'blog_public' ) ) === '0',
-			'news_seo_is_active'    => ( defined( 'WPSEO_NEWS_FILE' ) ),
 			'isAiFeatureActive'     => (bool) WPSEO_Options::get( 'enable_ai_generator' ),
 		];
 

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -32,7 +32,7 @@ function getDefaultState() {
 		useTwitterData: window.wpseoScriptData.metabox.showSocial.twitter,
 		isWincherIntegrationActive: isWincherIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
-		isNewsEnabled: ! ! window.wpseoAdminL10n.news_seo_is_active,
+		isNewsEnabled: get( window, "wpseoScriptData.metabox.isNewsSEOActive", false ),
 		isAiFeatureActive: Boolean( window.wpseoAdminL10n.isAiFeatureActive ),
 	};
 }

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -32,7 +32,7 @@ function getDefaultState() {
 		useTwitterData: window.wpseoScriptData.metabox.showSocial.twitter,
 		isWincherIntegrationActive: isWincherIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
-		isNewsEnabled: get( window, "wpseoScriptData.metabox.isNewsSEOActive", false ),
+		isNewsEnabled: get( window, "wpseoScriptData.metabox.isNewsSeoActive", false ),
 		isAiFeatureActive: Boolean( window.wpseoAdminL10n.isAiFeatureActive ),
 	};
 }

--- a/src/editors/framework/integrations/news-seo.php
+++ b/src/editors/framework/integrations/news-seo.php
@@ -19,7 +19,7 @@ class News_SEO implements Integration_Data_Provider_Interface {
 
 	/**
 	 * The constructor.
-	 * 
+	 *
 	 * @param WPSEO_Addon_Manager $addon_manager The addon manager.
 	 */
 	public function __construct( WPSEO_Addon_Manager $addon_manager ) {

--- a/src/editors/framework/integrations/news-seo.php
+++ b/src/editors/framework/integrations/news-seo.php
@@ -1,0 +1,53 @@
+<?php
+// @phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the original class.
+namespace Yoast\WP\SEO\Editors\Framework\Integrations;
+
+use WPSEO_Addon_Manager;
+use Yoast\WP\SEO\Editors\Domain\Integrations\Integration_Data_Provider_Interface;
+
+/**
+ * Describes if the News SEO plugin is enabled.
+ */
+class News_SEO implements Integration_Data_Provider_Interface {
+
+	/**
+	 * The addon manager.
+	 *
+	 * @var WPSEO_Addon_Manager
+	 */
+	private $addon_manager;
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		$this->addon_manager = new WPSEO_Addon_Manager();
+	}
+
+	/**
+	 * If the plugin is activated.
+	 *
+	 * @return bool If the plugin is activated.
+	 */
+	public function is_enabled(): bool {
+		return \is_plugin_active( $this->addon_manager->get_plugin_file( WPSEO_Addon_Manager::NEWS_SLUG ) );
+	}
+
+	/**
+	 * Return this object represented by a key value array.
+	 *
+	 * @return array<string,bool> Returns the name and if the feature is enabled.
+	 */
+	public function to_array(): array {
+		return [ 'isNewsSEOActive' => $this->is_enabled() ];
+	}
+
+	/**
+	 * Returns this object represented by a key value structure that is compliant with the script data array.
+	 *
+	 * @return array<string,bool> Returns the legacy key and if the feature is enabled.
+	 */
+	public function to_legacy_array(): array {
+		return [ 'isNewsSEOActive' => $this->is_enabled() ];
+	}
+}

--- a/src/editors/framework/integrations/news-seo.php
+++ b/src/editors/framework/integrations/news-seo.php
@@ -19,9 +19,11 @@ class News_SEO implements Integration_Data_Provider_Interface {
 
 	/**
 	 * The constructor.
+	 * 
+	 * @param WPSEO_Addon_Manager $addon_manager The addon manager.
 	 */
-	public function __construct() {
-		$this->addon_manager = new WPSEO_Addon_Manager();
+	public function __construct( WPSEO_Addon_Manager $addon_manager ) {
+		$this->addon_manager = $addon_manager;
 	}
 
 	/**
@@ -39,7 +41,7 @@ class News_SEO implements Integration_Data_Provider_Interface {
 	 * @return array<string,bool> Returns the name and if the feature is enabled.
 	 */
 	public function to_array(): array {
-		return [ 'isNewsSEOActive' => $this->is_enabled() ];
+		return [ 'isNewsSeoActive' => $this->is_enabled() ];
 	}
 
 	/**
@@ -48,6 +50,6 @@ class News_SEO implements Integration_Data_Provider_Interface {
 	 * @return array<string,bool> Returns the legacy key and if the feature is enabled.
 	 */
 	public function to_legacy_array(): array {
-		return [ 'isNewsSEOActive' => $this->is_enabled() ];
+		return [ 'isNewsSeoActive' => $this->is_enabled() ];
 	}
 }

--- a/tests/Unit/Editors/Framework/Integrations/News_SEO_Test.php
+++ b/tests/Unit/Editors/Framework/Integrations/News_SEO_Test.php
@@ -1,0 +1,95 @@
+<?php
+// @phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the original class.
+namespace Yoast\WP\SEO\Tests\Unit\Editors\Framework\Integrations;
+
+use Brain\Monkey;
+use Mockery;
+use WPSEO_Addon_Manager;
+use Yoast\WP\SEO\Editors\Framework\Integrations\News_SEO;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class News_SEO_Test
+ *
+ * @group editors
+ *
+ * @covers \Yoast\WP\SEO\Editors\Framework\Integrations\News_SEO
+ */
+final class News_SEO_Test extends TestCase {
+
+	/**
+	 * Holds the WPSEO_Addon_Manager mock.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Addon_Manager
+	 */
+	protected $addon_manager;
+
+	/**
+	 * The News_SEO feature.
+	 *
+	 * @var News_SEO
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->addon_manager = Mockery::mock( WPSEO_Addon_Manager::class );
+		$this->instance      = new News_SEO( $this->addon_manager );
+	}
+
+	/**
+	 * Tests the is_enabled method.
+	 *
+	 * @dataProvider data_provider_is_enabled
+	 *
+	 * @param bool $news_seo_enabled If the news plugin is enabled.
+	 * @param bool $expected         The expected outcome.
+	 *
+	 * @return void
+	 */
+	public function test_is_enabled(
+		bool $news_seo_enabled,
+		bool $expected
+	) {
+
+		$this->addon_manager
+			->expects( 'get_plugin_file' )
+			->times( 3 )
+			->with( 'yoast-seo-news' )
+			->andReturn( 'wpseo-news/wpseo-news.php' );
+
+		Monkey\Functions\expect( 'is_plugin_active' )
+			->times( 3 )
+			->with( 'wpseo-news/wpseo-news.php' )
+			->andReturn( $news_seo_enabled );
+
+		$is_woo_seo_active = $this->instance->is_enabled();
+
+		$this->assertSame( $expected, $is_woo_seo_active );
+		$this->assertSame( [ 'isNewsSeoActive' => $is_woo_seo_active ], $this->instance->to_legacy_array() );
+		$this->assertSame( [ 'isNewsSeoActive' => $is_woo_seo_active ], $this->instance->to_array() );
+	}
+
+	/**
+	 * Data provider for test_is_enabled.
+	 *
+	 * @return array<array<string,bool>>
+	 */
+	public static function data_provider_is_enabled() {
+		return [
+			'Enabled' => [
+				'news_seo_enabled' => true,
+				'expected'         => true,
+			],
+			'Disabled' => [
+				'news_seo_enabled' => false,
+				'expected'         => false,
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor check for news SEO add-on.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate News SEO
* Edit a post
* Open console and execute:
```js
wp.data.select( "yoast-seo/editor" ).getPreference( "isNewsEnabled" );
```
* [ ] Check you are getting `true`.
* Deactivte News SEO
* Edit a post 
* Open console and execute:
```js
wp.data.select( "yoast-seo/editor" ).getPreference( "isNewsEnabled" );
```
* [ ] Check you are getting `false`.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Refactor is news SEO active](https://github.com/Yoast/wordpress-seo/issues/21619)
