### PR TITLE
21628 refactor isprivateblog preference

### DIFF
--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -863,8 +863,6 @@ class WPSEO_Utils {
 			'postTypeNamePlural'    => ( $page_type === 'post' ) ? $label_object->label : $label_object->name,
 			'postTypeNameSingular'  => ( $page_type === 'post' ) ? $label_object->labels->singular_name : $label_object->singular_name,
 			'isBreadcrumbsDisabled' => WPSEO_Options::get( 'breadcrumbs-enable', false ) !== true && ! current_theme_supports( 'yoast-seo-breadcrumbs' ),
-			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
-			'isPrivateBlog'         => ( (string) get_option( 'blog_public' ) ) === '0',
 			'isAiFeatureActive'     => (bool) WPSEO_Options::get( 'enable_ai_generator' ),
 		];
 

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -22,7 +22,7 @@ function getDefaultState() {
 		isWordFormRecognitionActive: isUndefined( window.wpseoPremiumMetaboxData ) && isWordFormRecognitionActive(),
 		isCornerstoneActive: isCornerstoneActive(),
 		isBreadcrumbsDisabled: ! ! window.wpseoAdminL10n.isBreadcrumbsDisabled,
-		isPrivateBlog: ! ! window.wpseoAdminL10n.isPrivateBlog,
+		isPrivateBlog: ! ! window.wpseoScriptData.isPrivateBlog,
 		isSEMrushIntegrationActive: isSEMrushIntegrationActive(),
 		shouldUpsell: isUndefined( window.wpseoPremiumMetaboxData ),
 		displayAdvancedTab: displayAdvancedTab,

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -80,6 +80,7 @@ abstract class Base_Site_Information {
 			'isRtl'                 => \is_rtl(),
 			'isPremium'             => $this->product_helper->is_premium(),
 			'siteIconUrl'           => \get_site_icon_url(),
+			'isPrivateBlog'         => ! \get_option( 'blog_public' ),
 		];
 	}
 
@@ -95,6 +96,7 @@ abstract class Base_Site_Information {
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
+			'isPrivateBlog'         => ! \get_option( 'blog_public' ),
 			'metabox'               => [
 				'site_name'     => $this->meta->for_current_page()->site_name,
 				'contentLocale' => \get_locale(),

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -80,7 +80,8 @@ abstract class Base_Site_Information {
 			'isRtl'                 => \is_rtl(),
 			'isPremium'             => $this->product_helper->is_premium(),
 			'siteIconUrl'           => \get_site_icon_url(),
-			'isPrivateBlog'         => ! \get_option( 'blog_public' ),
+			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
+			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
 		];
 	}
 
@@ -96,7 +97,8 @@ abstract class Base_Site_Information {
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
-			'isPrivateBlog'         => ! \get_option( 'blog_public' ),
+			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
+			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
 			'metabox'               => [
 				'site_name'     => $this->meta->for_current_page()->site_name,
 				'contentLocale' => \get_locale(),

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -136,7 +136,7 @@ final class Post_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'                  => '/location',
 			'wistiaEmbedPermission'      => true,
-
+			'isPrivateBlog'              => true,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
@@ -191,11 +191,15 @@ final class Post_Site_Information_Test extends TestCase {
 			'isRtl'                          => false,
 			'isPremium'                      => true,
 			'siteIconUrl'                    => 'https://example.org',
-
+			'isPrivateBlog'                  => false,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
 		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://example.org' );
+		Monkey\Functions\expect( 'get_option' )
+				->once()
+				->with( 'blog_public' )
+				->andReturn( '1' );
 
 		$this->alert_dismissal_action->expects( 'all_dismissed' )->andReturn( [ 'the alert' ] );
 		$this->promotion_manager->expects( 'get_current_promotions' )->andReturn( [ 'the promotion', 'another one' ] );

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -136,7 +136,7 @@ final class Post_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'                  => '/location',
 			'wistiaEmbedPermission'      => true,
-			'isPrivateBlog'              => true,
+			'isPrivateBlog'              => false,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -127,10 +127,15 @@ final class Term_Site_Information_Test extends TestCase {
 			'isRtl'                 => false,
 			'isPremium'             => true,
 			'siteIconUrl'           => 'https://example.org',
+			'isPrivateBlog'         => true,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
 		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://example.org' );
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'blog_public' )
+			->andReturn( '0' );
 
 		$this->assertSame( $expected, $this->instance->get_site_information() );
 	}
@@ -168,7 +173,7 @@ final class Term_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'             => '/location',
 			'wistiaEmbedPermission' => true,
-
+			'isPrivateBlog'         => true,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -173,7 +173,7 @@ final class Term_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'             => '/location',
 			'wistiaEmbedPermission' => true,
-			'isPrivateBlog'         => true,
+			'isPrivateBlog'         => false,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -124,6 +124,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'linkParams'                 => $this->short_link_helper->get_query_params(),
 			'pluginUrl'                  => 'http://example.org/wp-content/plugins/wordpress-seo',
 			'wistiaEmbedPermission'      => true,
+			'isPrivateBlog'              => false,
 		];
 
 		$this->assertSame( $expected, $this->instance->get_legacy_site_information() );
@@ -142,6 +143,8 @@ final class Post_Site_Information_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_site_information() {
+		\update_option( 'blog_public', '0' );
+
 		$expected = [
 			'dismissedAlerts'            => false,
 			'currentPromotions'          => [],
@@ -160,9 +163,14 @@ final class Post_Site_Information_Test extends TestCase {
 			'isRtl'                      => false,
 			'isPremium'                  => false,
 			'siteIconUrl'                => '',
-
+			'isPrivateBlog'              => true,
 		];
 
-		$this->assertSame( $expected, $this->instance->get_site_information() );
+		$site_info = $this->instance->get_site_information();
+
+		// Reset the blog_public option before the next test.
+		\update_option( 'blog_public', '1' );
+
+		$this->assertSame( $expected, $site_info );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Refactor isPrivatBlog preference.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors isPrivateBlog preference.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings->Reading and tick the checkbox for `Search engine visibility`
* Edit a post and go to Advanced tab
* [ ] Check you see the following warnings:
![Screenshot 2024-09-12 at 13 58 29](https://github.com/user-attachments/assets/2e8dd7b8-d68e-4c26-ae7a-7d42d626117a)
* Go to Settings->Reading and uncheck the checkbox for `Search engine visibility` 
* Edit a post and go to Advanced tab
* [ ] Check you don't see the warning anymore.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21628
