### PR TITLE
21630 refactor sitewide social image preference

### DIFF
--- a/admin/formatter/class-metabox-formatter.php
+++ b/admin/formatter/class-metabox-formatter.php
@@ -52,7 +52,6 @@ class WPSEO_Metabox_Formatter {
 
 		$defaults = [
 			'author_name'                        => get_the_author_meta( 'display_name' ),
-			'sitewide_social_image'              => WPSEO_Options::get( 'og_default_image' ),
 			'keyword_usage'                      => [],
 			'title_template'                     => '',
 			'metadesc_template'                  => '',

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -25,7 +25,7 @@ const populateStore = store => {
 	store.dispatch(
 		actions.setSettings( {
 			socialPreviews: {
-				sitewideImage: window.wpseoScriptData.metabox.sitewide_social_image,
+				sitewideImage: window.wpseoScriptData.sitewideSocialImage,
 				siteName: window.wpseoScriptData.metabox.site_name,
 				contentImage: window.wpseoScriptData.metabox.first_content_image,
 				twitterCardType: window.wpseoScriptData.metabox.twitterCardType,

--- a/packages/js/src/initializers/editor-store.js
+++ b/packages/js/src/initializers/editor-store.js
@@ -14,7 +14,7 @@ const populateStore = store => {
 	store.dispatch(
 		actions.setSettings( {
 			socialPreviews: {
-				sitewideImage: window.wpseoScriptData.metabox.sitewide_social_image,
+				sitewideImage: window.wpseoScriptData.sitewideSocialImage,
 				siteName: window.wpseoScriptData.metabox.site_name,
 				contentImage: window.wpseoScriptData.metabox.first_content_image,
 				twitterCardType: window.wpseoScriptData.metabox.twitterCardType,

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -3,7 +3,7 @@
 namespace Yoast\WP\SEO\Editors\Framework\Site;
 
 use Exception;
-use WPSEO_Options;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
@@ -43,6 +43,13 @@ abstract class Base_Site_Information {
 	protected $product_helper;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper $options_helper
+	 */
+	protected $optios_helper;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param Short_Link_Helper                  $short_link_helper                  The short link helper.
@@ -50,17 +57,20 @@ abstract class Base_Site_Information {
 	 *                                                                               repository.
 	 * @param Meta_Surface                       $meta                               The meta surface.
 	 * @param Product_Helper                     $product_helper                     The product helper.
+	 * @param Options_Helper                     $options_helper                     The options helper.
 	 */
 	public function __construct(
 		Short_Link_Helper $short_link_helper,
 		Wistia_Embed_Permission_Repository $wistia_embed_permission_repository,
 		Meta_Surface $meta,
-		Product_Helper $product_helper
+		Product_Helper $product_helper,
+		Options_Helper $options_helper
 	) {
 		$this->short_link_helper                  = $short_link_helper;
 		$this->wistia_embed_permission_repository = $wistia_embed_permission_repository;
 		$this->meta                               = $meta;
 		$this->product_helper                     = $product_helper;
+		$this->options_helper                     = $options_helper;
 	}
 
 	/**

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -91,7 +91,7 @@ abstract class Base_Site_Information {
 			'isRtl'                 => \is_rtl(),
 			'isPremium'             => $this->product_helper->is_premium(),
 			'siteIconUrl'           => \get_site_icon_url(),
-			'sitewideSocialImage'   => WPSEO_Options::get( 'og_default_image' ),
+			'sitewideSocialImage'   => $this->options_helper->get( 'og_default_image' ),
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
 			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
 		];
@@ -109,7 +109,7 @@ abstract class Base_Site_Information {
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
-			'sitewideSocialImage'   => WPSEO_Options::get( 'og_default_image' ),
+			'sitewideSocialImage'   => $this->options_helper->get( 'og_default_image' ),
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
 			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
 			'metabox'               => [

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -47,7 +47,7 @@ abstract class Base_Site_Information {
 	 *
 	 * @var Options_Helper $options_helper
 	 */
-	protected $optios_helper;
+	protected $options_helper;
 
 	/**
 	 * The constructor.

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Editors\Framework\Site;
 
 use Exception;
+use WPSEO_Options;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
@@ -80,6 +81,7 @@ abstract class Base_Site_Information {
 			'isRtl'                 => \is_rtl(),
 			'isPremium'             => $this->product_helper->is_premium(),
 			'siteIconUrl'           => \get_site_icon_url(),
+			'sitewideSocialImage'   => WPSEO_Options::get( 'og_default_image' ),
 		];
 	}
 
@@ -95,6 +97,7 @@ abstract class Base_Site_Information {
 			'linkParams'            => $this->short_link_helper->get_query_params(),
 			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
 			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
+			'sitewideSocialImage'   => WPSEO_Options::get( 'og_default_image' ),
 			'metabox'               => [
 				'site_name'     => $this->meta->for_current_page()->site_name,
 				'contentLocale' => \get_locale(),

--- a/src/editors/framework/site/post-site-information.php
+++ b/src/editors/framework/site/post-site-information.php
@@ -37,13 +37,6 @@ class Post_Site_Information extends Base_Site_Information {
 	private $promotion_manager;
 
 	/**
-	 * The options helper.
-	 *
-	 * @var Options_Helper $options_helper
-	 */
-	protected $options_helper;
-
-	/**
 	 * Constructs the class.
 	 *
 	 * @param Promotion_Manager                  $promotion_manager                  The promotion manager.

--- a/src/editors/framework/site/post-site-information.php
+++ b/src/editors/framework/site/post-site-information.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Editors\Framework\Site;
 
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
@@ -36,6 +37,13 @@ class Post_Site_Information extends Base_Site_Information {
 	private $promotion_manager;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper $options_helper
+	 */
+	protected $options_helper;
+
+	/**
 	 * Constructs the class.
 	 *
 	 * @param Promotion_Manager                  $promotion_manager                  The promotion manager.
@@ -45,6 +53,7 @@ class Post_Site_Information extends Base_Site_Information {
 	 * @param Meta_Surface                       $meta                               The meta surface.
 	 * @param Product_Helper                     $product_helper                     The product helper.
 	 * @param Alert_Dismissal_Action             $alert_dismissal_action             The alert dismissal action.
+	 * @param Options_Helper                     $options_helper                     The options helper.
 	 *
 	 * @return void
 	 */
@@ -54,9 +63,10 @@ class Post_Site_Information extends Base_Site_Information {
 		Wistia_Embed_Permission_Repository $wistia_embed_permission_repository,
 		Meta_Surface $meta,
 		Product_Helper $product_helper,
-		Alert_Dismissal_Action $alert_dismissal_action
+		Alert_Dismissal_Action $alert_dismissal_action,
+		Options_Helper $options_helper
 	) {
-		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper );
+		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper, $options_helper );
 		$this->promotion_manager      = $promotion_manager;
 		$this->alert_dismissal_action = $alert_dismissal_action;
 	}

--- a/src/editors/framework/site/term-site-information.php
+++ b/src/editors/framework/site/term-site-information.php
@@ -4,23 +4,11 @@ namespace Yoast\WP\SEO\Editors\Framework\Site;
 
 use WP_Taxonomy;
 use WP_Term;
-use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Product_Helper;
-use Yoast\WP\SEO\Helpers\Short_Link_Helper;
-use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
-use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
 /**
  * The Term_Site_Information class.
  */
 class Term_Site_Information extends Base_Site_Information {
-
-	/**
-	 * The options helper.
-	 *
-	 * @var Options_Helper
-	 */
-	protected $options_helper;
 
 	/**
 	 * The taxonomy.
@@ -35,27 +23,6 @@ class Term_Site_Information extends Base_Site_Information {
 	 * @var WP_Term|string|false
 	 */
 	private $term;
-
-	/**
-	 * The constructor.
-	 *
-	 * @param Options_Helper                     $options_helper                     The options helper.
-	 * @param Short_Link_Helper                  $short_link_helper                  The short link helper.
-	 * @param Wistia_Embed_Permission_Repository $wistia_embed_permission_repository The wistia embed permission
-	 *                                                                               repository.
-	 * @param Meta_Surface                       $meta                               The meta surface.
-	 * @param Product_Helper                     $product_helper                     The product helper.
-	 */
-	public function __construct(
-		Options_Helper $options_helper,
-		Short_Link_Helper $short_link_helper,
-		Wistia_Embed_Permission_Repository $wistia_embed_permission_repository,
-		Meta_Surface $meta,
-		Product_Helper $product_helper
-	) {
-		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper, $options_helper );
-		$this->options_helper = $options_helper;
-	}
 
 	/**
 	 *  Sets the term for the information object and retrieves its taxonomy.

--- a/src/editors/framework/site/term-site-information.php
+++ b/src/editors/framework/site/term-site-information.php
@@ -20,7 +20,7 @@ class Term_Site_Information extends Base_Site_Information {
 	 *
 	 * @var Options_Helper
 	 */
-	private $options_helper;
+	protected $options_helper;
 
 	/**
 	 * The taxonomy.
@@ -53,7 +53,7 @@ class Term_Site_Information extends Base_Site_Information {
 		Meta_Surface $meta,
 		Product_Helper $product_helper
 	) {
-		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper );
+		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper, $options_helper );
 		$this->options_helper = $options_helper;
 	}
 

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -7,6 +7,7 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Editors\Framework\Site\Post_Site_Information;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
@@ -69,6 +70,13 @@ final class Post_Site_Information_Test extends TestCase {
 	private $product_helper;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper $options_helper
+	 */
+	private $options_helper;
+
+	/**
 	 * The Post_Site_Information container.
 	 *
 	 * @var Post_Site_Information
@@ -88,8 +96,9 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->meta_surface           = Mockery::mock( Meta_Surface::class );
 		$this->product_helper         = Mockery::mock( Product_Helper::class );
 		$this->alert_dismissal_action = Mockery::mock( Alert_Dismissal_Action::class );
+		$this->options_helper         = Mockery::mock( Options_Helper::class );
 
-		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action );
+		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper );
 		$this->instance->set_permalink( 'perma' );
 		$this->set_mocks();
 	}

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -136,7 +136,7 @@ final class Post_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'                  => '/location',
 			'wistiaEmbedPermission'      => true,
-
+			'sitewideSocialImage'        => null,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
@@ -191,7 +191,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'isRtl'                          => false,
 			'isPremium'                      => true,
 			'siteIconUrl'                    => 'https://example.org',
-
+			'sitewideSocialImage'            => null,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -157,6 +157,7 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->promotion_manager->expects( 'get_current_promotions' )->andReturn( [ 'the promotion', 'another one' ] );
 		$this->promotion_manager->expects( 'is' )->andReturnFalse();
 		$this->short_link_helper->expects( 'get' )->andReturn( 'https://expl.c' );
+		$this->options_helper->expects( 'get' )->with( 'og_default_image' )->andReturn( null );
 
 		$this->assertSame( $expected, $this->instance->get_legacy_site_information() );
 	}
@@ -217,6 +218,7 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->promotion_manager->expects( 'get_current_promotions' )->andReturn( [ 'the promotion', 'another one' ] );
 		$this->promotion_manager->expects( 'is' )->andReturnFalse();
 		$this->short_link_helper->expects( 'get' )->andReturn( 'https://expl.c' );
+		$this->options_helper->expects( 'get' )->with( 'og_default_image' )->andReturn( null );
 
 		$this->assertSame( $expected, $this->instance->get_site_information() );
 	}

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -82,7 +82,7 @@ final class Term_Site_Information_Test extends TestCase {
 		$this->meta_surface      = Mockery::mock( Meta_Surface::class );
 		$this->product_helper    = Mockery::mock( Product_Helper::class );
 
-		$this->instance      = new Term_Site_Information( $this->options_helper, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper );
+		$this->instance      = new Term_Site_Information( $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->options_helper );
 		$taxonomy            = Mockery::mock( WP_Taxonomy::class )->makePartial();
 		$taxonomy->rewrite   = false;
 		$mock_term           = Mockery::mock( WP_Term::class )->makePartial();

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -127,6 +127,7 @@ final class Term_Site_Information_Test extends TestCase {
 			'isRtl'                 => false,
 			'isPremium'             => true,
 			'siteIconUrl'           => 'https://example.org',
+			'sitewideSocialImage'   => null,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
@@ -168,7 +169,7 @@ final class Term_Site_Information_Test extends TestCase {
 			],
 			'pluginUrl'             => '/location',
 			'wistiaEmbedPermission' => true,
-
+			'sitewideSocialImage'   => null,
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -93,6 +93,7 @@ final class Term_Site_Information_Test extends TestCase {
 
 		$this->instance->set_term( $mock_term );
 		$this->options_helper->expects( 'get' )->with( 'stripcategorybase', false )->andReturnFalse();
+		$this->options_helper->expects( 'get' )->with( 'og_default_image' )->andReturn( null );
 
 		$this->set_mocks();
 	}

--- a/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\WP\Editors\Framework\Site;
 use Mockery;
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
 use Yoast\WP\SEO\Editors\Framework\Site\Post_Site_Information;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
@@ -65,6 +66,13 @@ final class Post_Site_Information_Test extends TestCase {
 	private $product_helper;
 
 	/**
+	 * The options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper $options_helper
+	 */
+	private $options_helper;
+
+	/**
 	 * The Post_Site_Information container.
 	 *
 	 * @var Post_Site_Information
@@ -84,9 +92,10 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->wistia_embed_repo->expects( 'get_value_for_user' )->with( 0 )->andReturnTrue();
 		$this->meta_surface           = \YoastSEO()->meta;
 		$this->product_helper         = \YoastSEO()->helpers->product;
+		$this->options_helper         = \YoastSEO()->helpers->options;
 		$this->alert_dismissal_action = \YoastSEO()->classes->get( Alert_Dismissal_Action::class );
 
-		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action );
+		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper );
 		$this->instance->set_permalink( 'perma' );
 	}
 

--- a/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -124,6 +124,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'linkParams'                 => $this->short_link_helper->get_query_params(),
 			'pluginUrl'                  => 'http://example.org/wp-content/plugins/wordpress-seo',
 			'wistiaEmbedPermission'      => true,
+			'sitewideSocialImage'        => '',
 		];
 
 		$this->assertSame( $expected, $this->instance->get_legacy_site_information() );
@@ -160,7 +161,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'isRtl'                      => false,
 			'isPremium'                  => false,
 			'siteIconUrl'                => '',
-
+			'sitewideSocialImage'        => '',
 		];
 
 		$this->assertSame( $expected, $this->instance->get_site_information() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor sitewide Social image property.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast Premium
* Go to Yoast SEO->Settings->Site Basics
* Add site image
* Leave the settings and edit a post
* Go to social appearance
* [ ] Check that you can see the site image.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21630
