### PR TITLE
Fix SelectControl deprecation warning

### DIFF
--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -244,7 +244,7 @@ class PrimaryTaxonomyPicker extends Component {
 					id={ fieldId }
 					terms={ this.state.selectedTerms }
 				/>
-				<ExternalLink href={ learnMoreLink }>
+				<ExternalLink className="yst-inline-block yst-mt-2" href={ learnMoreLink }>
 					{ __( "Learn more", "wordpress-seo" ) }
 					<span className="screen-reader-text">
 						{ __( "Learn more about the primary category.", "wordpress-seo" ) }

--- a/packages/js/src/components/TaxonomyPicker.js
+++ b/packages/js/src/components/TaxonomyPicker.js
@@ -21,6 +21,7 @@ const TaxonomyPicker = ( { id, value, terms, label, onChange } ) => {
 
 	return (
 		<SelectControl
+			__nextHasNoMarginBottom={ true }
 			__next40pxDefaultSize={ true }
 			id={ id }
 			label={ label }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Gutenberg 19.1 added a deprecation warning for SelectControl via https://github.com/WordPress/gutenberg/issues/38730 This opts in to that behavior and adds the margin top to the ExternalLink below (therefor needing block layout to get the margin to take effect)
The `__nextHasNoMarginBottom` prop is available since Gutenberg 13.4, included in WP 6.0. So it should be safe to use.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevents a deprecation warning when editing a post with Gutenberg version 19.1.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post
* Open the settings panel
* Add multiple categories
* Verify the Primary Taxonomy picker still has the same spacing between the select and the external link below:
![image](https://github.com/user-attachments/assets/8f2ab737-eace-4bb2-a6a7-1073e5fdd3d2)
* Install and activate Gutenberg 19.1 or higher
* Check again and confirm you dont get the `Bottom margin styles for wp.components.SelectControl is deprecated since version 6.7 and will be removed in version 7.0.` notice in console. The margins should stay the same.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The primary taxonomy picker's distance between the select and the link below

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
