### PR TITLE
Make new dashboard page the root of the Yoast SEO menu

### DIFF
--- a/admin/menu/class-admin-menu.php
+++ b/admin/menu/class-admin-menu.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Admin\Menu
  */
 
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 /**
  * Registers the admin menu on the left of the admin area.
  */
@@ -88,7 +89,6 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 
 		// Submenu pages.
 		$submenu_pages = [
-			$this->get_submenu_page( __( 'General', 'wordpress-seo' ), $this->get_page_identifier() ),
 			$this->get_submenu_page(
 				__( 'Search Console', 'wordpress-seo' ),
 				'wpseo_search_console',
@@ -97,6 +97,10 @@ class WPSEO_Admin_Menu extends WPSEO_Base_Menu {
 			$this->get_submenu_page( __( 'Tools', 'wordpress-seo' ), 'wpseo_tools' ),
 			$this->get_submenu_page( $this->get_license_page_title(), 'wpseo_licenses' ),
 		];
+
+		if ( ! ( new New_Dashboard_Ui_Conditional() )->is_met() ) {
+			array_unshift( $submenu_pages, $this->get_submenu_page( __( 'General', 'wordpress-seo' ), $this->get_page_identifier() ) );
+		}
 
 		/**
 		 * Filter: 'wpseo_submenu_pages' - Collects all submenus that need to be shown.

--- a/css/src/new-dashboard.css
+++ b/css/src/new-dashboard.css
@@ -1,4 +1,4 @@
-body.seo_page_wpseo_page_new_dashboard {
+body.toplevel_page_wpseo_dashboard {
 	@apply yst-bg-slate-100;
 
 	/* Move WP footer behind our content. */

--- a/src/dashboard/user-interface/new-dashboard-page-integration.php
+++ b/src/dashboard/user-interface/new-dashboard-page-integration.php
@@ -17,10 +17,8 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 
 	/**
 	 * The page name.
-	 *
-	 * @TODO RENAME THIS TO SOMETHING SENSIBLE AFTER FEATURE FLAG PERIOD
 	 */
-	public const PAGE = 'wpseo_page_new_dashboard';
+	public const PAGE = 'wpseo_dashboard';
 
 	/**
 	 * Holds the WPSEO_Admin_Asset_Manager.
@@ -106,13 +104,13 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 	public function add_page( $pages ) {
 		\array_splice(
 			$pages,
-			3,
+			0,
 			0,
 			[
 				[
-					'wpseo_dashboard',
+					self::PAGE,
 					'',
-					\__( 'New dashboard', 'wordpress-seo' ),
+					\__( 'General', 'wordpress-seo' ),
 					'wpseo_manage_options',
 					self::PAGE,
 					[ $this, 'display_page' ],

--- a/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
@@ -127,7 +127,7 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 				'action_times' => 0,
 			],
 			'On dashboard page' => [
-				'current_page' => 'wpseo_page_new_dashboard',
+				'current_page' => 'wpseo_dashboard',
 				'action_times' => 1,
 			],
 		];
@@ -173,19 +173,25 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 	public function test_add_page() {
 		$pages = $this->instance->add_page(
 			[
-				[ 'page1', '', 'Page 1', 'manage_options', 'page1', [ $this, 'display_page' ] ],
-				[ 'page2', '', 'Page 2', 'manage_options', 'page2', [ $this, 'display_page' ] ],
-				[ 'page3', '', 'Page 3', 'manage_options', 'page3', [ $this, 'display_page' ] ],
+				[ 'page1', '', 'Page 1', 'manage_options', 'page1', [ 'custom_display_page' ] ],
+				[ 'page2', '', 'Page 2', 'manage_options', 'page2', [ 'custom_display_page' ] ],
+				[ 'page3', '', 'Page 3', 'manage_options', 'page3', [ 'custom_display_page' ] ],
 			]
 		);
 
-		// Assert that the new page was added at index 3.
-		$this->assertEquals( 'wpseo_dashboard', $pages[3][0] );
+		// Assert that the new page was added at index 0.
+		$this->assertEquals( 'wpseo_dashboard', $pages[0][0] );
+		$this->assertEquals( 'page3', $pages[3][0] );
+		$this->assertEquals( '', $pages[0][1] );
 		$this->assertEquals( '', $pages[3][1] );
-		$this->assertEquals( 'New dashboard', $pages[3][2] );
-		$this->assertEquals( 'wpseo_manage_options', $pages[3][3] );
-		$this->assertEquals( 'wpseo_page_new_dashboard', $pages[3][4] );
-		$this->assertEquals( [ $this->instance, 'display_page' ], $pages[3][5] );
+		$this->assertEquals( 'General', $pages[0][2] );
+		$this->assertEquals( 'Page 3', $pages[3][2] );
+		$this->assertEquals( 'wpseo_manage_options', $pages[0][3] );
+		$this->assertEquals( 'manage_options', $pages[3][3] );
+		$this->assertEquals( 'wpseo_dashboard', $pages[0][4] );
+		$this->assertEquals( 'page3', $pages[3][4] );
+		$this->assertEquals( [ $this->instance, 'display_page' ], $pages[0][5] );
+		$this->assertEquals( [ 'custom_display_page' ], $pages[3][5] );
 	}
 
 	/**

--- a/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
@@ -21,7 +21,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  */
 final class New_Dashboard_Page_Integration_Test extends TestCase {
 
-	public const PAGE = 'wpseo_page_new_dashboard';
+	public const PAGE = 'wpseo_dashboard';
 
 	/**
 	 * Holds the WPSEO_Admin_Asset_Manager.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the new dashboard page to the root of the Yoast SEO menu

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the `define( 'YOAST_SEO_NEW_DASHBOARD_UI', true );` define
* Go to the `Yoast SEO` menu item or to the `Yoast SEO->General` menu item 
* Confirm that you see the new dashboard design
* Remove the define and refresh
* Confirm that you see the old page

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Regression test the Yoast menu item in all scenarios, both with the define enabled and disabled (the only difference should be that with the define enabled, you see the new dashboard when expected)
  * In multisite
  * When not an admin but with other user roles
  * With all add-ons enabled.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
