### PR TITLE
275 preprare backend to hook problems and notifications into alert center front end

### DIFF
--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -6,7 +6,7 @@
  */
 
 use Yoast\WP\SEO\Actions\Alert_Dismissal_Action;
-use Yoast\WP\SEO\Dashboard\User_Interface\New_Dashboard_Page_Integration;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Integrations\Academy_Integration;
 use Yoast\WP\SEO\Integrations\Settings_Integration;
 use Yoast\WP\SEO\Integrations\Support_Integration;
@@ -48,9 +48,10 @@ class WPSEO_Admin_Pages {
 	 * @return void
 	 */
 	public function init() {
+		$conditional = new New_Dashboard_Ui_Conditional();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		$page = isset( $_GET['page'] ) && is_string( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
-		if ( in_array( $page, [ Settings_Integration::PAGE, Academy_Integration::PAGE, Support_Integration::PAGE, New_Dashboard_Page_Integration::PAGE ], true ) ) {
+		if ( in_array( $page, [ Settings_Integration::PAGE, Academy_Integration::PAGE, Support_Integration::PAGE ], true ) || $conditional->is_met() ) {
 			// Bail, this is managed in the applicable integration.
 			return;
 		}

--- a/admin/class-config.php
+++ b/admin/class-config.php
@@ -50,7 +50,7 @@ class WPSEO_Admin_Pages {
 	public function init() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		$page = isset( $_GET['page'] ) && is_string( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
-		if ( in_array( $page, [ Settings_Integration::PAGE, Academy_Integration::PAGE, Support_Integration::PAGE ], true ) ) {
+		if ( in_array( $page, [ Settings_Integration::PAGE, Academy_Integration::PAGE, Support_Integration::PAGE, New_Dashboard_Page_Integration::PAGE ], true ) ) {
 			// Bail, this is managed in the applicable integration.
 			return;
 		}
@@ -104,7 +104,7 @@ class WPSEO_Admin_Pages {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		$page = isset( $_GET['page'] ) && is_string( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
 
-		if ( in_array( $page, [ WPSEO_Admin::PAGE_IDENTIFIER, New_Dashboard_Page_Integration::PAGE, 'wpseo_workouts' ], true ) ) {
+		if ( in_array( $page, [ WPSEO_Admin::PAGE_IDENTIFIER, 'wpseo_workouts' ], true ) ) {
 			wp_enqueue_media();
 
 			$script_data['userEditUrl'] = add_query_arg( 'user_id', '{user_id}', admin_url( 'user-edit.php' ) );

--- a/src/dashboard/user-interface/new-dashboard-page-integration.php
+++ b/src/dashboard/user-interface/new-dashboard-page-integration.php
@@ -172,6 +172,7 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 				],
 			],
 			'linkParams'    => $this->shortlink_helper->get_query_params(),
+			'userEditUrl'   => \add_query_arg( 'user_id', '{user_id}', \admin_url( 'user-edit.php' ) ),
 			'problems'      => $this->notification_helper->get_problems(),
 			'notifications' => $this->notification_helper->get_notifications(),
 		];

--- a/src/dashboard/user-interface/new-dashboard-page-integration.php
+++ b/src/dashboard/user-interface/new-dashboard-page-integration.php
@@ -6,6 +6,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -19,6 +20,13 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 	 * The page name.
 	 */
 	public const PAGE = 'wpseo_dashboard';
+
+	/**
+	 * The notification helper.
+	 *
+	 * @var Notification_Helper
+	 */
+	protected $notification_helper;
 
 	/**
 	 * Holds the WPSEO_Admin_Asset_Manager.
@@ -55,17 +63,20 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 	 * @param Current_Page_Helper       $current_page_helper The Current_Page_Helper.
 	 * @param Product_Helper            $product_helper      The Product_Helper.
 	 * @param Short_Link_Helper         $shortlink_helper    The Short_Link_Helper.
+	 * @param Notification_Helper       $notification_helper The Notification_Helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Current_Page_Helper $current_page_helper,
 		Product_Helper $product_helper,
-		Short_Link_Helper $shortlink_helper
+		Short_Link_Helper $shortlink_helper,
+		Notification_Helper $notification_helper
 	) {
 		$this->asset_manager       = $asset_manager;
 		$this->current_page_helper = $current_page_helper;
 		$this->product_helper      = $product_helper;
 		$this->shortlink_helper    = $shortlink_helper;
+		$this->notification_helper = $notification_helper;
 	}
 
 	/**
@@ -141,7 +152,7 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 		\wp_enqueue_media();
 		$this->asset_manager->enqueue_script( 'new-dashboard' );
 		$this->asset_manager->enqueue_style( 'new-dashboard' );
-		$this->asset_manager->localize_script( 'dashboard', 'wpseoScriptData', $this->get_script_data() );
+		$this->asset_manager->localize_script( 'new-dashboard', 'wpseoScriptData', $this->get_script_data() );
 	}
 
 	/**
@@ -151,7 +162,7 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 	 */
 	private function get_script_data() {
 		return [
-			'preferences' => [
+			'preferences'   => [
 				'isPremium'      => $this->product_helper->is_premium(),
 				'isRtl'          => \is_rtl(),
 				'pluginUrl'      => \plugins_url( '', \WPSEO_FILE ),
@@ -160,7 +171,9 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
 			],
-			'linkParams'  => $this->shortlink_helper->get_query_params(),
+			'linkParams'    => $this->shortlink_helper->get_query_params(),
+			'problems'      => $this->notification_helper->get_problems(),
+			'notifications' => $this->notification_helper->get_notifications(),
 		];
 	}
 }

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -22,4 +22,107 @@ class Notification_Helper {
 	public function restore_notification( Yoast_Notification $notification ) {
 		return Yoast_Notification_Center::restore_notification( $notification );
 	}
+
+	/**
+	 * Return the notifications sorted on type and priority. (wrapper function)
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return array|Yoast_Notification[] Sorted Notifications
+	 */
+	public function get_sorted_notifications() {
+		$notification_center = Yoast_Notification_Center::get();
+
+		return $notification_center->get_sorted_notifications();
+	}
+
+	/**
+	 * Check if the user has dismissed a notification. (wrapper function)
+	 *
+	 * @param Yoast_Notification $notification The notification to check for dismissal.
+	 * @param int|null           $user_id      User ID to check on.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool
+	 */
+	private function is_notification_dismissed( Yoast_Notification $notification, $user_id = null ) {
+		return Yoast_Notification_Center::is_notification_dismissed( $notification, $user_id );
+	}
+
+	/**
+	 * Parses all the notifications to an array with just warnings notifications, and splitting them between dismissed
+	 * and active.
+	 *
+	 * @return array<Yoast_Notification>
+	 */
+	public function get_notifications(): array {
+		$all_notifications       = $this->get_sorted_notifications();
+		$notifications           = \array_filter(
+			$all_notifications,
+			static function ( $notification ) {
+				return $notification->get_type() !== 'error';
+			}
+		);
+		$dismissed_notifications = \array_filter(
+			$notifications,
+			function ( $notification ) {
+				return $this->is_notification_dismissed( $notification );
+			}
+		);
+		$active_notifications    = \array_diff( $notifications, $dismissed_notifications );
+
+		return [
+			'dismissed' => \array_map(
+				static function ( $notification ) {
+					return $notification->to_array();
+				},
+				$dismissed_notifications
+			),
+			'active'    => \array_map(
+				static function ( $notification ) {
+					return $notification->to_array();
+				},
+				$active_notifications
+			),
+		];
+	}
+
+	/**
+	 * Parses all the notifications to an array with just error notifications, and splitting them between dismissed and
+	 * active.
+	 *
+	 * @return array<Yoast_Notification>
+	 */
+	public function get_problems(): array {
+		$all_notifications  = $this->get_sorted_notifications();
+		$problems           = \array_filter(
+			$all_notifications,
+			static function ( $notification ) {
+				return $notification->get_type() === 'error';
+			}
+		);
+		$dismissed_problems = \array_filter(
+			$problems,
+			function ( $notification ) {
+				return $this->is_notification_dismissed( $notification );
+			}
+		);
+		$active_problems    = \array_diff( $problems, $dismissed_problems );
+
+		return [
+			'dismissed' => \array_map(
+				static function ( $notification ) {
+					return $notification->to_array();
+				},
+				$dismissed_problems
+			),
+			'active'    => \array_map(
+				static function ( $notification ) {
+					return $notification->to_array();
+				},
+				$active_problems
+			),
+		];
+	}
 }

--- a/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
@@ -74,11 +74,11 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 	public function set_up() {
 		$this->stubTranslationFunctions();
 
-		$this->asset_manager       = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
-		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
-		$this->product_helper      = Mockery::mock( Product_Helper::class );
-		$this->shortlink_helper    = Mockery::mock( Short_Link_Helper::class );
-		$this->notifications_helper    = Mockery::mock( Notification_Helper::class );
+		$this->asset_manager        = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->current_page_helper  = Mockery::mock( Current_Page_Helper::class );
+		$this->product_helper       = Mockery::mock( Product_Helper::class );
+		$this->shortlink_helper     = Mockery::mock( Short_Link_Helper::class );
+		$this->notifications_helper = Mockery::mock( Notification_Helper::class );
 
 		$this->instance = new New_Dashboard_Page_Integration(
 			$this->asset_manager,
@@ -230,6 +230,8 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 			->once();
 
 		Monkey\Functions\expect( 'wp_enqueue_media' )->once();
+		Monkey\Functions\expect( 'add_query_arg' )->once();
+		Monkey\Functions\expect( 'admin_url' )->once();
 
 		$this->asset_manager
 			->expects( 'enqueue_script' )

--- a/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\New_Dashboard_Page_Integration;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Notification_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Academy_Integration;
@@ -52,6 +53,13 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 	private $shortlink_helper;
 
 	/**
+	 * Holds the Notification_Helper.
+	 *
+	 * @var Notification_Helper
+	 */
+	private $notifications_helper;
+
+	/**
 	 * The class under test.
 	 *
 	 * @var New_Dashboard_Page_Integration
@@ -70,12 +78,14 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$this->product_helper      = Mockery::mock( Product_Helper::class );
 		$this->shortlink_helper    = Mockery::mock( Short_Link_Helper::class );
+		$this->notifications_helper    = Mockery::mock( Notification_Helper::class );
 
 		$this->instance = new New_Dashboard_Page_Integration(
 			$this->asset_manager,
 			$this->current_page_helper,
 			$this->product_helper,
-			$this->shortlink_helper
+			$this->shortlink_helper,
+			$this->notifications_helper
 		);
 	}
 
@@ -271,6 +281,16 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 			->expects( 'get_query_params' )
 			->once()
 			->andReturn( $link_params );
+
+		$this->notifications_helper
+			->expects( 'get_problems' )
+			->once()
+			->andReturn( [] );
+
+		$this->notifications_helper
+			->expects( 'get_notifications' )
+			->once()
+			->andReturn( [] );
 
 		return $link_params;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add the data we need for the notification ui to the script data.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds notification and problem information to the script data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you see a notification in the old dashboard. You can make this happen by resetting your indexables.
* Add the following code to you project: `define( 'YOAST_SEO_NEW_DASHBOARD_UI', true );`
* Open the console on the new general page and type `window.wpseoScriptData.notifications.active` And make sure you see a notification. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
