### PR TITLE
Adds alert center redux store

### DIFF
--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -356,6 +356,15 @@ class Yoast_Notification {
 	}
 
 	/**
+	 * Get the message for the notification.
+	 *
+	 * @return string The message.
+	 */
+	public function get_message() {
+		return wpautop( $this->message );
+	}
+
+	/**
 	 * Wraps the message with a Yoast SEO icon.
 	 *
 	 * @param string $message The message to wrap.

--- a/packages/js/src/dashboard/components/alerts-list.js
+++ b/packages/js/src/dashboard/components/alerts-list.js
@@ -1,46 +1,81 @@
-import { useContext } from "@wordpress/element";
+import { useContext, useCallback } from "@wordpress/element";
+import { useDispatch } from "@wordpress/data";
 import PropTypes from "prop-types";
 import { Button } from "@yoast/ui-library";
 import { EyeOffIcon, EyeIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
 import { AlertsContext } from "../contexts/alerts-context";
 
+
+/**
+ * The alert item object.
+ *
+ * @param {string} id The alert id.
+ * @param {string} nonce The alert nonce.
+ * @param {boolean} dismissed Whether the alert is dismissed or not.
+ * @param {string} message The alert message.
+ *
+ * @returns {JSX.Element} The alert item component.
+ */
+const AlertItem = ( { id, nonce, dismissed, message  } ) => {
+	const { bulletClass = "" } = useContext( AlertsContext );
+	const { toggleAlertStatus } = useDispatch( "@yoast/dashboard" );
+	const Eye = dismissed ? EyeOffIcon : EyeIcon;
+
+	const toggleAlert = useCallback( () => {
+		toggleAlertStatus( id, nonce, dismissed );
+	}, [ id, nonce, dismissed, toggleAlertStatus ] );
+
+	return <li key={ id } className="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0">
+		<div className="yst-flex yst-justify-between yst-gap-5 yst-items-start">
+			<div className={ classNames( "yst-mt-1",  dismissed && "yst-opacity-50" ) }>
+				<svg width="11" height="11" className={ bulletClass }>
+					<circle cx="5.5" cy="5.5" r="5.5" />
+				</svg>
+			</div>
+			<div
+				className={ classNames(
+					"yst-text-sm yst-text-slate-600 yst-grow",
+					dismissed && "yst-opacity-50" ) }
+				dangerouslySetInnerHTML={ { __html: message } }
+			/>
+
+
+			<Button variant="secondary" size="small" className="yst-self-center yst-h-8" onClick={ toggleAlert }>
+				<Eye className="yst-w-4 yst-h-4 yst-text-neutral-700" />
+			</Button>
+		</div>
+	</li>;
+};
+
+AlertItem.propTypes = {
+	id: PropTypes.string,
+	nonce: PropTypes.string,
+	dismissed: PropTypes.bool,
+	message: PropTypes.string,
+};
+
 /**
  * @param {string} className The class name.
  * @param {Object[]} items The list of items.
- * @param {boolean} hidden Whether the items are hidden or not.
  *
  * @returns {JSX.Element} The list component.
  */
-export const AlertsList = ( { className = "", items = [], hidden = false } ) => {
-	const { bulletClass = "" } = useContext( AlertsContext );
-
-	const Eye = hidden ? EyeIcon : EyeOffIcon;
-
+export const AlertsList = ( { className = "", items = [] } ) => {
 	if ( items.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<ul className={ className }>
-			{ items.map( ( item, index ) => (
-				<li key={ index } className="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0">
-					<div className="yst-flex yst-justify-between yst-gap-5 yst-items-start">
-						<div className={ classNames( "yst-mt-1",  hidden && "yst-opacity-50" ) }>
-							<svg width="11" height="11" className={ bulletClass }>
-								<circle cx="5.5" cy="5.5" r="5.5" />
-							</svg>
-						</div>
-						<p
-							className={ classNames(
-								"yst-text-sm yst-text-slate-600 yst-grow",
-								hidden && "yst-opacity-50" ) }
-						>{ item.message }</p>
-						<Button variant="secondary" size="small" className="yst-self-center yst-h-8">
-							<Eye className="yst-w-4 yst-h-4 yst-text-neutral-700" />
-						</Button>
-					</div>
-				</li>
+			{ items.map( ( item ) => (
+				<AlertItem
+					key={ item.id }
+					id={ item.id }
+					nonce={ item.nonce }
+					dismissed={ item.dismissed }
+					message={ item.message }
+				/>
 			) ) }
 		</ul>
 	);
@@ -51,5 +86,4 @@ AlertsList.propTypes = {
 	items: PropTypes.arrayOf( PropTypes.shape( {
 		message: PropTypes.string,
 	} ) ),
-	hidden: PropTypes.bool,
 };

--- a/packages/js/src/dashboard/components/alerts-title.js
+++ b/packages/js/src/dashboard/components/alerts-title.js
@@ -13,7 +13,7 @@ import { AlertsContext } from "../contexts/alerts-context";
  *
  * @returns {JSX.Element} The alert title element.
  */
-export const AlertTitle = ( {
+export const AlertsTitle = ( {
 	title,
 	counts = 0,
 	children = null,
@@ -31,7 +31,7 @@ export const AlertTitle = ( {
 	);
 };
 
-AlertTitle.propTypes = {
+AlertsTitle.propTypes = {
 	title: PropTypes.string,
 	counts: PropTypes.number,
 	children: PropTypes.node,

--- a/packages/js/src/dashboard/components/index.js
+++ b/packages/js/src/dashboard/components/index.js
@@ -2,5 +2,5 @@ export { default as RouteLayout } from "./route-layout";
 export { Notifications } from "./notifications";
 export { Problems } from "./problems";
 export { AlertsList } from "./alerts-list";
-export { AlertTitle } from "./alert-title";
+export { AlertsTitle } from "./alerts-title";
 export { Collapsible } from "./collapsible";

--- a/packages/js/src/dashboard/components/notifications.js
+++ b/packages/js/src/dashboard/components/notifications.js
@@ -3,7 +3,7 @@ import { useSelect } from "@wordpress/data";
 import { BellIcon } from "@heroicons/react/outline";
 import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
-import { AlertTitle } from "./alert-title";
+import { AlertsTitle } from "./alerts-title";
 import { Collapsible } from "./collapsible";
 import { AlertsContext } from "../contexts/alerts-context";
 
@@ -32,9 +32,9 @@ export const Notifications = () => {
 		<Paper>
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ notificationsTheme }>
-					<AlertTitle counts={ notificationsAlertsList.length } title={ __( "Notifications", "wordpress-seo" ) }>
+					<AlertsTitle counts={ notificationsAlertsList.length } title={ __( "Notifications", "wordpress-seo" ) }>
 						{ notificationsAlertsList.length === 0 && <p className="yst-mt-2 yst-text-sm">{ __( "No new notifications.", "wordpress-seo" ) }</p> }
-					</AlertTitle>
+					</AlertsTitle>
 					<AlertsList items={ notificationsAlertsList } />
 
 					{ hiddenNotifications > 0 && (

--- a/packages/js/src/dashboard/components/notifications.js
+++ b/packages/js/src/dashboard/components/notifications.js
@@ -1,4 +1,5 @@
 import { __, _n } from "@wordpress/i18n";
+import { useSelect } from "@wordpress/data";
 import { BellIcon } from "@heroicons/react/outline";
 import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
@@ -10,24 +11,8 @@ import { AlertsContext } from "../contexts/alerts-context";
  * @returns {JSX.Element} The notifications component.
  */
 export const Notifications = () => {
-	const notificationsAlertsList = [
-		{
-			message: "Your site is not connected to your MyYoast account. Connect your site to get access to all the features.",
-		},
-		{
-			message: "You have a new notification from Yoast SEO. Click here to read it.",
-		},
-	];
-
-	const hiddenNotificationsAlertsList = [
-		{
-			message: "Your site is not connected to your MyYoast account. Connect your site to get access to all the features.",
-		},
-		{
-			message: "You have a new notification from Yoast SEO. Click here to read it.",
-		},
-	];
-
+	const notificationsAlertsList = useSelect( ( select ) => select( "@yoast/dashboard" ).selectActiveNotifications(), [] );
+	const hiddenNotificationsAlertsList = useSelect( ( select ) => select( "@yoast/dashboard" ).selectDismissedNotifications(), [] );
 	const hiddenNotifications = hiddenNotificationsAlertsList.length;
 
 	const hiddenNotificationLabel = _n(
@@ -47,12 +32,14 @@ export const Notifications = () => {
 		<Paper>
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ notificationsTheme }>
-					<AlertTitle counts={ 2 } title={ __( "Notifications", "wordpress-seo" ) } />
-					<AlertsList items={ notificationsAlertsList } hidden={ false } />
+					<AlertTitle counts={ notificationsAlertsList.length } title={ __( "Notifications", "wordpress-seo" ) }>
+						{ notificationsAlertsList.length === 0 && <p className="yst-mt-2 yst-text-sm">{ __( "No new notifications.", "wordpress-seo" ) }</p> }
+					</AlertTitle>
+					<AlertsList items={ notificationsAlertsList } />
 
 					{ hiddenNotifications > 0 && (
 						<Collapsible label={ `${ hiddenNotifications } ${ hiddenNotificationLabel }` }>
-							<AlertsList className="yst-pb-6" items={ hiddenNotificationsAlertsList } hidden={ true } />
+							<AlertsList className="yst-pb-6" items={ hiddenNotificationsAlertsList } />
 						</Collapsible>
 					) }
 				</AlertsContext.Provider>

--- a/packages/js/src/dashboard/components/problems.js
+++ b/packages/js/src/dashboard/components/problems.js
@@ -3,7 +3,7 @@ import { useSelect } from "@wordpress/data";
 import { ExclamationCircleIcon } from "@heroicons/react/outline";
 import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
-import { AlertTitle } from "./alert-title";
+import { AlertsTitle } from "./alerts-title";
 import { Collapsible } from "./collapsible";
 import { AlertsContext } from "../contexts/alerts-context";
 
@@ -33,9 +33,9 @@ export const Problems = () => {
 		<Paper>
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ problemsTheme }>
-					<AlertTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
+					<AlertsTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
 						<p className="yst-mt-2 yst-text-sm">{ __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" ) }</p>
-					</AlertTitle>
+					</AlertsTitle>
 					<AlertsList items={ problemsList } />
 
 					{ dismissedProblems > 0 && (

--- a/packages/js/src/dashboard/components/problems.js
+++ b/packages/js/src/dashboard/components/problems.js
@@ -1,4 +1,5 @@
 import { __, _n } from "@wordpress/i18n";
+import { useSelect } from "@wordpress/data";
 import { ExclamationCircleIcon } from "@heroicons/react/outline";
 import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
@@ -10,30 +11,15 @@ import { AlertsContext } from "../contexts/alerts-context";
  * @returns {JSX.Element} The problems component.
  */
 export const Problems = () => {
-	const problemsList = [
-		{
-			message: "Huge SEO issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.",
-		},
-		{
-			message: "You still have the default WordPress tagline, even an empty one is probably better. You can fix this in the customizer.",
-		},
-	];
+	const problemsList = useSelect( ( select ) => select( "@yoast/dashboard" ).selectActiveProblems(), [] );
+	const dismissedProblemsList = useSelect( ( select ) => select( "@yoast/dashboard" ).selectDismissedProblems(), [] );
 
-	const hiddenProblemsList = [
-		{
-			message: "Huge SEO issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.",
-		},
-		{
-			message: "You still have the default WordPress tagline, even an empty one is probably better. You can fix this in the customizer.",
-		},
-	];
+	const dismissedProblems = dismissedProblemsList.length;
 
-	const hiddenProblems = hiddenProblemsList.length;
-
-	const hiddenProblemsLabel = _n(
+	const dismissedProblemsLabel = _n(
 		"hidden problem",
 		"hidden problems",
-		hiddenProblems,
+		dismissedProblems,
 		"wordpress-seo"
 	);
 
@@ -47,14 +33,14 @@ export const Problems = () => {
 		<Paper>
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ problemsTheme }>
-					<AlertTitle title={ __( "Problems", "wordpress-seo" ) } counts={ 2 }>
+					<AlertTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
 						<p className="yst-mt-2 yst-text-sm">{ __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" ) }</p>
 					</AlertTitle>
-					<AlertsList items={ problemsList } hidden={ false } />
+					<AlertsList items={ problemsList } />
 
-					{ hiddenProblems > 0 && (
-						<Collapsible label={ `${ hiddenProblems } ${ hiddenProblemsLabel }` }>
-							<AlertsList className="yst-pb-6" items={ hiddenProblemsList } hidden={ true } />
+					{ dismissedProblems > 0 && (
+						<Collapsible label={ `${ dismissedProblems } ${ dismissedProblemsLabel }` }>
+							<AlertsList className="yst-pb-6" items={ dismissedProblemsList } />
 						</Collapsible>
 					) }
 				</AlertsContext.Provider>

--- a/packages/js/src/dashboard/initialize.js
+++ b/packages/js/src/dashboard/initialize.js
@@ -5,6 +5,7 @@ import { render } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import { get } from "lodash";
 import { LINK_PARAMS_NAME } from "../shared-admin/store";
+import { ALERT_CENTER_NAME } from "./store/alert-center";
 import { HashRouter } from "react-router-dom";
 import App from "./app";
 import { STORE_NAME } from "./constants";
@@ -18,6 +19,7 @@ domReady( () => {
 	registerStore( {
 		initialState: {
 			[ LINK_PARAMS_NAME ]: get( window, "wpseoScriptData.linkParams", {} ),
+			[ ALERT_CENTER_NAME ]: { alerts: get( window, "wpseoScriptData.alerts", [] ) },
 		},
 	} );
 	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -1,22 +1,27 @@
+/* global ajaxurl */
 import { createSlice } from "@reduxjs/toolkit";
-import apiFetch from "@wordpress/api-fetch";
 import { get } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+
 
 const TOGGLE_ALERT_VISIBILITY = "TOGGLE_ALERT_VISIBILITY";
 
 /**
  * @param {string} id The id of the alert.
+ * @param {string} nonce The nonce of the alert.
+ * @param {boolean} hidden The hidden state of the alert.
  * @returns {Object} Success or error action object.
  */
-export function* toggleAlertStatus( id ) {
+export function* toggleAlertStatus( id, nonce, hidden = false ) {
 	try {
-		const data = yield { type: TOGGLE_ALERT_VISIBILITY,
-                payload: {
-                    id,
-                },
+		yield{ type: TOGGLE_ALERT_VISIBILITY,
+			payload: {
+				id,
+				nonce,
+				hidden,
+			},
 		    };
-		return { type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.success }`, payload: data };
+		return { type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.success }`, payload: { id, hidden } };
 	} catch ( error ) {
 		return { type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.error }`, payload: error };
 	}
@@ -40,31 +45,30 @@ export const createInitialAlertCenterState = () => ( {
  * Change alert visability.
  *
  * @param {object} state The state.
- * @param {string} type The type of the alert.
- * @param {string} target The target visability of the alert.
+ * @param {boolean} hidden The hidden state of the alert.
  * @param {string} id The id of the alert to hide.
  *
  * @returns {void}
  */
-const changeAlertVisibility = ( state, type, target, id ) => {
-	const statuses = [ "active", "dismissed" ];
-	const source = statuses.find( ( status ) => status !== target );
-
+const changeAlertVisibility = ( state, hidden, id ) => {
+	const target = hidden ? "active" : "dismissed";
+	const source = hidden ? "dismissed" : "active";
+	const type = state.problems[ source ].find( ( alert ) => alert.id === id ) ? "problems" : "notifications";
 	const alertToShow = state[ type ][ source ].find( ( alert ) => alert.id === id );
 	if ( alertToShow ) {
-		state[ type ][ source ] = state[ type ].active.filter( ( alert ) => alert.id !== id );
-		state[ type ][ target ].push( alertToShow );
+		state[ type ][ source ] = state[ type ][ source ].filter( ( alert ) => alert.id !== id );
+		state[ type ][ target ] = [ ...state[ type ][ target ], alertToShow ];
 	}
 };
 
 const slice = createSlice( {
 	name: "alertCenter",
 	initialState: createInitialAlertCenterState(),
-    extraReducers: ( builder ) => {
-        builder.addCase( `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_STATUS.success }`, ( state, { payload: { id, type, target } } ) => {
-			changeAlertVisibility( state, type, target, id );
+	extraReducers: ( builder ) => {
+		builder.addCase( `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_STATUS.success }`, ( state, { payload: { id, hidden } } ) => {
+			changeAlertVisibility( state, hidden, id );
 		} );
-    },
+	},
 } );
 
 export const alertCenterSelectors = {
@@ -75,18 +79,27 @@ export const alertCenterSelectors = {
 };
 
 export const alertCenterActions = {
-    ...slice.actions,
-    toggleAlertStatus,
+	...slice.actions,
+	toggleAlertStatus,
 };
 
 export const alertCenterControls = {
-	[ TOGGLE_ALERT_VISIBILITY ]: async( { payload } ) => apiFetch( {
-		path: "/yoast/v1/toggle-alert-status",
-		method: "POST",
-		data: {
-            id: payload.id,
-        }
-	} ),
+	[ TOGGLE_ALERT_VISIBILITY ]: async( { payload } ) => {
+		const formData = new URLSearchParams();
+		formData.append( "action", payload.hidden ? "yoast_restore_notification" : "yoast_dismiss_notification" );
+		formData.append( "notification", payload.id );
+		formData.append( "nonce", payload.nonce );
+
+		fetch( ajaxurl, {
+			method: "POST",
+			headers: {
+				"X-WP-Nonce": payload.nonce,
+				"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+			},
+			credentials: "same-origin",
+			body: formData.toString(),
+		} );
+	},
 };
 
 export default slice.reducer;

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -1,0 +1,67 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+/**
+ * @returns {Object} The initial state.
+ */
+export const createInitialAlertCenterState = () => ( {
+	notifications: {
+		active: get( window, "wpseoScriptData.notifications.active", [] ),
+		dismissed: get( window, "wpseoScriptData.notifications.dismissed", [] ),
+	},
+	problems: {
+		active: get( window, "wpseoScriptData.problems.active", [] ),
+		dismissed: get( window, "wpseoScriptData.problems.dismissed", [] ),
+	},
+} );
+
+/**
+ * Change alert visability.
+ *
+ * @param {object} state The state.
+ * @param {string} type The type of the alert.
+ * @param {string} target The target visability of the alert.
+ * @param {string} id The id of the alert to hide.
+ *
+ * @returns {void}
+ */
+const changeAlertVisibility = ( state, type, target, id ) => {
+	const statuses = [ "active", "dismissed" ];
+	const source = statuses.find( ( status ) => status !== target );
+
+	const alertToShow = state[ type ][ source ].find( ( alert ) => alert.id === id );
+	if ( alertToShow ) {
+		state[ type ][ source ] = state[ type ].active.filter( ( alert ) => alert.id !== id );
+		state[ type ][ target ].push( alertToShow );
+	}
+};
+
+const slice = createSlice( {
+	name: "alertCenter",
+	initialState: createInitialAlertCenterState(),
+	reducers: {
+		hideNotification: ( state, action ) => {
+			changeAlertVisibility( state, "notifications", "dismissed", action.payload );
+		},
+		hideProblem: ( state, action ) => {
+			changeAlertVisibility( state, "problems", "dismissed", action.payload );
+		},
+		showNotification: ( state, action ) => {
+			changeAlertVisibility( state, "notifications", "active", action.payload );
+		},
+		showProblem: ( state, action ) => {
+			changeAlertVisibility( state, "problems", "active", action.payload );
+		},
+	},
+} );
+
+export const alertCenterSelectors = {
+	selectActiveProblems: ( state ) => get( state, "alertCenter.problems.active", [] ),
+	selectDismissedProblems: ( state ) => get( state, "alertCenter.problems.dismissed", [] ),
+	selectActiveNotifications: ( state ) => get( state, "alertCenter.notifications.active", [] ),
+	selectDismissedNotifications: ( state ) => get( state, "alertCenter.notifications.dismissed", [] ),
+};
+
+export const alertCenterActions = slice.actions;
+
+export default slice.reducer;

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -60,7 +60,7 @@ const slice = createSlice( {
 /**
  * @returns {Object} The initial state.
  */
-export const createInitialAlertCenterState = slice.getInitialState;
+export const getInitialAlertCenterState = slice.getInitialState;
 
 /**
  * Base selector to get the alerts from the state.
@@ -95,7 +95,7 @@ export const alertCenterActions = {
 };
 
 export const alertCenterControls = {
-	[ TOGGLE_ALERT_VISIBILITY ]: async( { payload } ) => {
+	[ TOGGLE_ALERT_VISIBILITY ]: ( { payload } ) => {
 		const formData = new URLSearchParams();
 		formData.append( "action", payload.hidden ? "yoast_restore_notification" : "yoast_dismiss_notification" );
 		formData.append( "notification", payload.id );

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -1,7 +1,8 @@
-/* global ajaxurl */
 import { createSlice, createSelector } from "@reduxjs/toolkit";
 import { get } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+import { select } from "@wordpress/data";
+import { STORE_NAME } from "../constants";
 
 export const ALERT_CENTER_NAME = "alertCenter";
 
@@ -101,7 +102,9 @@ export const alertCenterControls = {
 		formData.append( "notification", payload.id );
 		formData.append( "nonce", payload.nonce );
 
-		fetch( ajaxurl, {
+		const ajaxUrl = select( STORE_NAME ).selectPreference( "ajaxUrl" );
+
+		fetch( ajaxUrl, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -30,7 +30,7 @@ export function* toggleAlertStatus( id, nonce, hidden = false ) {
 }
 
 /**
- * Toggle alert visability.
+ * Toggle alert visibility.
  *
  * @param {object} state The state.
  * @param {string} id The id of the alert to hide.

--- a/packages/js/src/dashboard/store/alert-center.js
+++ b/packages/js/src/dashboard/store/alert-center.js
@@ -38,12 +38,10 @@ export function* toggleAlertStatus( id, nonce, hidden = false ) {
  * @returns {void}
  */
 const toggleAlert = ( state, id ) => {
-	state.alerts = state.alerts.map( ( alert ) => {
-		if ( alert.id === id ) {
-			return { ...alert, dismissed: ! alert.dismissed };
-		}
-		return alert;
-	} );
+	const index = state.alerts.findIndex( ( alert ) => alert.id === id );
+	if ( index !== -1 ) {
+		state.alerts[ index ].dismissed = ! state.alerts[ index ].dismissed;
+	}
 };
 
 const slice = createSlice( {

--- a/packages/js/src/dashboard/store/index.js
+++ b/packages/js/src/dashboard/store/index.js
@@ -29,7 +29,7 @@ const createStore = ( { initialState } ) => {
 			{
 				[ LINK_PARAMS_NAME ]: getInitialLinkParamsState(),
 				preferences: createInitialPreferencesState(),
-				alertCenter: createInitialAlertCenterState(),
+				[ ALERT_CENTER_NAME ]: createInitialAlertCenterState(),
 			},
 			initialState
 		),

--- a/packages/js/src/dashboard/store/index.js
+++ b/packages/js/src/dashboard/store/index.js
@@ -4,7 +4,7 @@ import { merge } from "lodash";
 import { getInitialLinkParamsState, LINK_PARAMS_NAME, linkParamsActions, linkParamsReducer, linkParamsSelectors } from "../../shared-admin/store";
 import { STORE_NAME } from "../constants";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
-import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState, alertCenterControls } from "./alert-center";
+import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState, alertCenterControls, ALERT_CENTER_NAME } from "./alert-center";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -36,7 +36,7 @@ const createStore = ( { initialState } ) => {
 		reducer: combineReducers( {
 			[ LINK_PARAMS_NAME ]: linkParamsReducer,
 			preferences,
-			alertCenter,
+			[ ALERT_CENTER_NAME ]: alertCenter,
 		} ),
 		controls: {
 			...alertCenterControls,

--- a/packages/js/src/dashboard/store/index.js
+++ b/packages/js/src/dashboard/store/index.js
@@ -4,7 +4,7 @@ import { merge } from "lodash";
 import { getInitialLinkParamsState, LINK_PARAMS_NAME, linkParamsActions, linkParamsReducer, linkParamsSelectors } from "../../shared-admin/store";
 import { STORE_NAME } from "../constants";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
-import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState, alertCenterControls, ALERT_CENTER_NAME } from "./alert-center";
+import alertCenter, { alertCenterActions, alertCenterSelectors, getInitialAlertCenterState, alertCenterControls, ALERT_CENTER_NAME } from "./alert-center";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -29,7 +29,7 @@ const createStore = ( { initialState } ) => {
 			{
 				[ LINK_PARAMS_NAME ]: getInitialLinkParamsState(),
 				preferences: createInitialPreferencesState(),
-				[ ALERT_CENTER_NAME ]: createInitialAlertCenterState(),
+				[ ALERT_CENTER_NAME ]: getInitialAlertCenterState(),
 			},
 			initialState
 		),

--- a/packages/js/src/dashboard/store/index.js
+++ b/packages/js/src/dashboard/store/index.js
@@ -4,6 +4,7 @@ import { merge } from "lodash";
 import { getInitialLinkParamsState, LINK_PARAMS_NAME, linkParamsActions, linkParamsReducer, linkParamsSelectors } from "../../shared-admin/store";
 import { STORE_NAME } from "../constants";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
+import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState } from "./alert-center";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -16,22 +17,26 @@ const createStore = ( { initialState } ) => {
 		actions: {
 			...linkParamsActions,
 			...preferencesActions,
+			...alertCenterActions,
 		},
 		selectors: {
 			...linkParamsSelectors,
 			...preferencesSelectors,
+			...alertCenterSelectors,
 		},
 		initialState: merge(
 			{},
 			{
 				[ LINK_PARAMS_NAME ]: getInitialLinkParamsState(),
 				preferences: createInitialPreferencesState(),
+				alertCenter: createInitialAlertCenterState(),
 			},
 			initialState
 		),
 		reducer: combineReducers( {
 			[ LINK_PARAMS_NAME ]: linkParamsReducer,
 			preferences,
+			alertCenter,
 		} ),
 
 	} );

--- a/packages/js/src/dashboard/store/index.js
+++ b/packages/js/src/dashboard/store/index.js
@@ -4,7 +4,7 @@ import { merge } from "lodash";
 import { getInitialLinkParamsState, LINK_PARAMS_NAME, linkParamsActions, linkParamsReducer, linkParamsSelectors } from "../../shared-admin/store";
 import { STORE_NAME } from "../constants";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
-import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState } from "./alert-center";
+import alertCenter, { alertCenterActions, alertCenterSelectors, createInitialAlertCenterState, alertCenterControls } from "./alert-center";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -38,7 +38,9 @@ const createStore = ( { initialState } ) => {
 			preferences,
 			alertCenter,
 		} ),
-
+		controls: {
+			...alertCenterControls,
+		},
 	} );
 };
 

--- a/packages/js/src/dashboard/store/preferences.js
+++ b/packages/js/src/dashboard/store/preferences.js
@@ -6,6 +6,7 @@ import { get } from "lodash";
  */
 export const createInitialPreferencesState = () => ( {
 	...get( window, "wpseoScriptData.preferences", {} ),
+	ajaxUrl: get( window, "ajaxurl", "" ),
 } );
 
 const slice = createSlice( {

--- a/packages/js/tests/dashboard/components/__snapshots__/alerts-list.test.js.snap
+++ b/packages/js/tests/dashboard/components/__snapshots__/alerts-list.test.js.snap
@@ -1,0 +1,212 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertsList should match snapshot 1`] = `
+<div>
+  <ul
+    class=""
+  >
+    <li
+      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+    >
+      <div
+        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+      >
+        <div
+          class="yst-mt-1"
+        >
+          <svg
+            class="yst-fill-blue-500"
+            height="11"
+            width="11"
+          >
+            <circle
+              cx="5.5"
+              cy="5.5"
+              r="5.5"
+            />
+          </svg>
+        </div>
+        <div
+          class="yst-text-sm yst-text-slate-600 yst-grow"
+        >
+          You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+        </div>
+        <button
+          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-4 yst-h-4 yst-text-neutral-700"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+    <li
+      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+    >
+      <div
+        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+      >
+        <div
+          class="yst-mt-1"
+        >
+          <svg
+            class="yst-fill-blue-500"
+            height="11"
+            width="11"
+          >
+            <circle
+              cx="5.5"
+              cy="5.5"
+              r="5.5"
+            />
+          </svg>
+        </div>
+        <div
+          class="yst-text-sm yst-text-slate-600 yst-grow"
+        >
+          We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+        </div>
+        <button
+          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-4 yst-h-4 yst-text-neutral-700"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+    <li
+      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+    >
+      <div
+        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+      >
+        <div
+          class="yst-mt-1 yst-opacity-50"
+        >
+          <svg
+            class="yst-fill-blue-500"
+            height="11"
+            width="11"
+          >
+            <circle
+              cx="5.5"
+              cy="5.5"
+              r="5.5"
+            />
+          </svg>
+        </div>
+        <div
+          class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
+        >
+          Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+        </div>
+        <button
+          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-4 yst-h-4 yst-text-neutral-700"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+    <li
+      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+    >
+      <div
+        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+      >
+        <div
+          class="yst-mt-1 yst-opacity-50"
+        >
+          <svg
+            class="yst-fill-blue-500"
+            height="11"
+            width="11"
+          >
+            <circle
+              cx="5.5"
+              cy="5.5"
+              r="5.5"
+            />
+          </svg>
+        </div>
+        <div
+          class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
+        >
+          We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+        </div>
+        <button
+          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-4 yst-h-4 yst-text-neutral-700"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/js/tests/dashboard/components/__snapshots__/alerts-title.test.js.snap
+++ b/packages/js/tests/dashboard/components/__snapshots__/alerts-title.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertsTitle should match snapshot 1`] = `
+<div>
+  <div>
+    <div
+      class="yst-flex yst-justify-between yst-gap-2 yst-items-center"
+    >
+      <svg
+        aria-hidden="true"
+        class="yst-w-6 yst-h-6 yst-text-blue-500"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <h2
+        class="yst-title yst-title--2 yst-grow"
+      >
+        Test Title
+         
+        (5)
+      </h2>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/js/tests/dashboard/components/__snapshots__/notifications.test.js.snap
+++ b/packages/js/tests/dashboard/components/__snapshots__/notifications.test.js.snap
@@ -1,0 +1,290 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertsList should match snapshot 1`] = `
+<div>
+  <div
+    class="yst-paper"
+  >
+    <div
+      class="yst-paper__content yst-flex yst-flex-col yst-gap-y-6"
+    >
+      <div>
+        <div
+          class="yst-flex yst-justify-between yst-gap-2 yst-items-center"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-6 yst-h-6 yst-text-blue-500"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <h2
+            class="yst-title yst-title--2 yst-grow"
+          >
+            Notifications
+             
+            (4)
+          </h2>
+        </div>
+      </div>
+      <ul
+        class=""
+      >
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-blue-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-blue-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-blue-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-blue-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+      </ul>
+      <div
+        class="yst-shadow-sm yst-border-slate-300 yst-rounded-md yst-border"
+      >
+        <button
+          aria-expanded="false"
+          class="yst-w-full yst-flex yst-justify-between yst-py-4 yst-pr-4 yst-pl-6 yst-items-center"
+          data-headlessui-state=""
+          id="headlessui-disclosure-button-:r0:"
+          type="button"
+        >
+          <div
+            class="yst-font-medium"
+          >
+            4 hidden notifications
+          </div>
+          <svg
+            aria-hidden="true"
+            class="yst-h-5 yst-w-5 flex-shrink-0 yst-text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 9l-7 7-7-7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/js/tests/dashboard/components/__snapshots__/problems.test.js.snap
+++ b/packages/js/tests/dashboard/components/__snapshots__/problems.test.js.snap
@@ -1,0 +1,298 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AlertsList should match snapshot 1`] = `
+<div>
+  <div
+    class="yst-paper"
+  >
+    <div
+      class="yst-paper__content yst-flex yst-flex-col yst-gap-y-6"
+    >
+      <div>
+        <div
+          class="yst-flex yst-justify-between yst-gap-2 yst-items-center"
+        >
+          <svg
+            aria-hidden="true"
+            class="yst-w-6 yst-h-6 yst-text-red-500"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <h2
+            class="yst-title yst-title--2 yst-grow"
+          >
+            Problems
+             
+            (4)
+          </h2>
+        </div>
+        <p
+          class="yst-mt-2 yst-text-sm"
+        >
+          We have detected the following issues that affect the SEO of your site.
+        </p>
+      </div>
+      <ul
+        class=""
+      >
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-red-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-red-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-red-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              <b>
+                Huge SEO Issue:
+              </b>
+               You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+        <li
+          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+        >
+          <div
+            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+          >
+            <div
+              class="yst-mt-1"
+            >
+              <svg
+                class="yst-fill-red-500"
+                height="11"
+                width="11"
+              >
+                <circle
+                  cx="5.5"
+                  cy="5.5"
+                  r="5.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="yst-text-sm yst-text-slate-600 yst-grow"
+            >
+              We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+            </div>
+            <button
+              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="yst-w-4 yst-h-4 yst-text-neutral-700"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </div>
+        </li>
+      </ul>
+      <div
+        class="yst-shadow-sm yst-border-slate-300 yst-rounded-md yst-border"
+      >
+        <button
+          aria-expanded="false"
+          class="yst-w-full yst-flex yst-justify-between yst-py-4 yst-pr-4 yst-pl-6 yst-items-center"
+          data-headlessui-state=""
+          id="headlessui-disclosure-button-:r0:"
+          type="button"
+        >
+          <div
+            class="yst-font-medium"
+          >
+            4 hidden problems
+          </div>
+          <svg
+            aria-hidden="true"
+            class="yst-h-5 yst-w-5 flex-shrink-0 yst-text-slate-400"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 9l-7 7-7-7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/js/tests/dashboard/components/alerts-list.test.js
+++ b/packages/js/tests/dashboard/components/alerts-list.test.js
@@ -1,0 +1,46 @@
+import { render } from "../../test-utils";
+import { AlertsList } from "../../../src/dashboard/components/alerts-list";
+import { AlertsContext } from "../../../src/dashboard/contexts/alerts-context";
+
+const notificationsTheme = {
+	bulletClass: "yst-fill-blue-500",
+};
+
+jest.mock( "@wordpress/data", () => ( {
+	useDispatch: jest.fn( () => ( { toggleAlertStatus: jest.fn() } ) ),
+} ) );
+
+describe( "AlertsList", () => {
+	it( "should match snapshot", () => {
+		const items = [
+			{
+				id: "test-id-1",
+				message: "You've added a new type of content. We recommend that you review the corresponding Search appearance settings.",
+				type: "warning",
+				dismissed: false,
+			},
+			{
+				id: "test-id-2",
+				message: "We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!",
+				type: "warning",
+				dismissed: false,
+			},
+			{
+				id: "test-id-3",
+				message: "Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.",
+				type: "warning",
+				dismissed: true,
+			},
+			{
+				id: "test-id-4",
+				message: "We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.",
+				type: "warning",
+				dismissed: true,
+			},
+		];
+		const { container } = render( <AlertsContext.Provider value={ notificationsTheme }>
+			<AlertsList items={ items } />
+		</AlertsContext.Provider> );
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/packages/js/tests/dashboard/components/alerts-title.test.js
+++ b/packages/js/tests/dashboard/components/alerts-title.test.js
@@ -1,0 +1,36 @@
+import { render } from "../../test-utils";
+import { AlertsTitle } from "../../../src/dashboard/components/alerts-title";
+import { AlertsContext } from "../../../src/dashboard/contexts/alerts-context";
+import { BellIcon } from "@heroicons/react/outline";
+
+const notificationsTheme = {
+	Icon: BellIcon,
+	bulletClass: "yst-fill-blue-500",
+	iconClass: "yst-text-blue-500",
+};
+
+describe( "AlertsTitle", () => {
+	it( "should match snapshot", () => {
+		const title = "Test Title";
+		const counts = 5;
+		const { container } = render( <AlertsContext.Provider value={ notificationsTheme }>
+			<AlertsTitle title={ title } counts={ counts } />
+		</AlertsContext.Provider> );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( "renders the children correctly", () => {
+		const children = <div>Test Children</div>;
+
+		const { getByText } = render(
+			<AlertsContext.Provider value={ notificationsTheme }>
+				<AlertsTitle title="Test Title" counts={ 0 }>
+					{ children }
+				</AlertsTitle>
+			</AlertsContext.Provider>
+		);
+
+		const childrenElement = getByText( "Test Children" );
+		expect( childrenElement ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/tests/dashboard/components/collapsible.test.js
+++ b/packages/js/tests/dashboard/components/collapsible.test.js
@@ -1,0 +1,24 @@
+import { render, fireEvent } from "../../test-utils";
+import { Collapsible } from "../../../src/dashboard/components/collapsible";
+
+describe( "Collapsible", () => {
+	it( "should hide children when collapsible is closed", () => {
+		const { queryByText } = render( <Collapsible label="5 hidden notificaions">
+			<div>Test Children</div>
+		</Collapsible> );
+
+		const childrenElement = queryByText( "Test Children" );
+		expect( childrenElement ).not.toBeInTheDocument();
+	} );
+	it( "should show children when collapsible is open", () => {
+		const { queryByText, getByRole } = render( <Collapsible label="5 hidden notificaions">
+			<div>Test Children</div>
+		</Collapsible> );
+
+		const buttonElement = getByRole( "button" );
+		fireEvent.click( buttonElement );
+
+		const childrenElement = queryByText( "Test Children" );
+		expect( childrenElement ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/tests/dashboard/components/notifications.test.js
+++ b/packages/js/tests/dashboard/components/notifications.test.js
@@ -1,0 +1,41 @@
+import { render } from "../../test-utils";
+import { Notifications } from "../../../src/dashboard/components/notifications";
+
+const items = [
+	{
+		id: "test-id-1",
+		message: "You've added a new type of content. We recommend that you review the corresponding Search appearance settings.",
+		type: "warning",
+		dismissed: false,
+	},
+	{
+		id: "test-id-2",
+		message: "We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!",
+		type: "warning",
+		dismissed: false,
+	},
+	{
+		id: "test-id-3",
+		message: "Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.",
+		type: "warning",
+		dismissed: false,
+	},
+	{
+		id: "test-id-4",
+		message: "We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.",
+		type: "warning",
+		dismissed: false,
+	},
+];
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn( () =>  items ),
+	useDispatch: jest.fn( () => ( { toggleAlertStatus: jest.fn() } ) ),
+} ) );
+
+describe( "AlertsList", () => {
+	it( "should match snapshot", () => {
+		const { container } = render( <Notifications /> );
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/packages/js/tests/dashboard/components/problems.test.js
+++ b/packages/js/tests/dashboard/components/problems.test.js
@@ -1,0 +1,41 @@
+import { render } from "../../test-utils";
+import { Problems } from "../../../src/dashboard/components/problems";
+
+const items = [
+	{
+		id: "test-id-1",
+		message: "You've added a new type of content. We recommend that you review the corresponding Search appearance settings.",
+		type: "error",
+		dismissed: false,
+	},
+	{
+		id: "test-id-2",
+		message: "We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!",
+		type: "error",
+		dismissed: false,
+	},
+	{
+		id: "test-id-3",
+		message: "<b>Huge SEO Issue:</b> You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.",
+		type: "error",
+		dismissed: false,
+	},
+	{
+		id: "test-id-4",
+		message: "We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.",
+		type: "error",
+		dismissed: false,
+	},
+];
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn( () =>  items ),
+	useDispatch: jest.fn( () => ( { toggleAlertStatus: jest.fn() } ) ),
+} ) );
+
+describe( "AlertsList", () => {
+	it( "should match snapshot", () => {
+		const { container } = render( <Problems /> );
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/packages/js/tests/dashboard/store/alert-center.test.js
+++ b/packages/js/tests/dashboard/store/alert-center.test.js
@@ -1,0 +1,59 @@
+import { toggleAlertStatus, alertCenterActions, alertCenterSelectors } from "../../../src/dashboard/store/alert-center";
+
+describe( "toggleAlertStatus", () => {
+	it( "should dispatch the request action", () => {
+		const id = "alertId";
+		const nonce = "alertNonce";
+		const hidden = false;
+
+		const generator = toggleAlertStatus( id, nonce, hidden );
+
+		expect( generator.next().value ).toEqual( {
+			type: "toggleAlertVisibility/request",
+		} );
+	} );
+
+	it( "should dispatch the success action with the correct payload", () => {
+		const id = "alertId";
+		const nonce = "alertNonce";
+		const hidden = false;
+
+		const generator = toggleAlertStatus( id, nonce, hidden );
+
+		generator.next();
+
+		const successAction = generator.next().value;
+
+		expect( successAction.type ).toEqual( "toggleAlertVisibility" );
+		expect( successAction.payload.id ).toEqual( id );
+		expect( successAction.payload.nonce ).toEqual( nonce );
+		expect( successAction.payload.hidden ).toEqual( hidden );
+	} );
+} );
+
+describe( "alertCenterActions", () => {
+	it( "should have the toggleAlert action", () => {
+		expect( alertCenterActions.toggleAlert ).toBeDefined();
+		expect( alertCenterActions.toggleAlertStatus ).toBeDefined();
+	} );
+} );
+
+describe( "alertCenterSelectors", () => {
+	it( "should have the selectActiveNotifications selector", () => {
+		expect( alertCenterSelectors.selectActiveNotifications ).toBeDefined();
+	} );
+
+	it( "should have the selectDismissedNotifications selector", () => {
+		expect( alertCenterSelectors.selectDismissedNotifications ).toBeDefined();
+	} );
+
+	it( "should have the selectActiveProblems selector", () => {
+		expect( alertCenterSelectors.selectActiveProblems ).toBeDefined();
+	} );
+
+	it( "should have the selectDismissedProblems selector", () => {
+		expect( alertCenterSelectors.selectDismissedProblems ).toBeDefined();
+	} );
+} );
+
+

--- a/src/dashboard/user-interface/new-dashboard-page-integration.php
+++ b/src/dashboard/user-interface/new-dashboard-page-integration.php
@@ -173,8 +173,7 @@ class New_Dashboard_Page_Integration implements Integration_Interface {
 			],
 			'linkParams'    => $this->shortlink_helper->get_query_params(),
 			'userEditUrl'   => \add_query_arg( 'user_id', '{user_id}', \admin_url( 'user-edit.php' ) ),
-			'problems'      => $this->notification_helper->get_problems(),
-			'notifications' => $this->notification_helper->get_notifications(),
+			'alerts'        => $this->notification_helper->get_alerts(),
 		];
 	}
 }

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -75,13 +75,19 @@ class Notification_Helper {
 		return [
 			'dismissed' => \array_map(
 				static function ( $notification ) {
-					return $notification->to_array();
+					return [
+						'id'      => $notification->get_id(),
+						'message' => $notification->get_message(),
+					];
 				},
 				$dismissed_notifications
 			),
 			'active'    => \array_map(
 				static function ( $notification ) {
-					return $notification->to_array();
+					return [
+						'id'      => $notification->get_id(),
+						'message' => $notification->get_message(),
+					];
 				},
 				$active_notifications
 			),
@@ -113,13 +119,19 @@ class Notification_Helper {
 		return [
 			'dismissed' => \array_map(
 				static function ( $notification ) {
-					return $notification->to_array();
+					return [
+						'id'      => $notification->get_id(),
+						'message' => $notification->get_message(),
+					];
 				},
 				$dismissed_problems
 			),
 			'active'    => \array_map(
 				static function ( $notification ) {
-					return $notification->to_array();
+					return [
+						'id'      => $notification->get_id(),
+						'message' => $notification->get_message(),
+					];
 				},
 				$active_problems
 			),

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -78,6 +78,7 @@ class Notification_Helper {
 					return [
 						'id'      => $notification->get_id(),
 						'message' => $notification->get_message(),
+						'nonce'   => $notification->get_nonce(),
 					];
 				},
 				$dismissed_notifications
@@ -87,6 +88,7 @@ class Notification_Helper {
 					return [
 						'id'      => $notification->get_id(),
 						'message' => $notification->get_message(),
+						'nonce'   => $notification->get_nonce(),
 					];
 				},
 				$active_notifications
@@ -122,6 +124,7 @@ class Notification_Helper {
 					return [
 						'id'      => $notification->get_id(),
 						'message' => $notification->get_message(),
+						'nonce'   => $notification->get_nonce(),
 					];
 				},
 				$dismissed_problems
@@ -131,6 +134,7 @@ class Notification_Helper {
 					return [
 						'id'      => $notification->get_id(),
 						'message' => $notification->get_message(),
+						'nonce'   => $notification->get_nonce(),
 					];
 				},
 				$active_problems

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -51,94 +51,24 @@ class Notification_Helper {
 	}
 
 	/**
-	 * Parses all the notifications to an array with just warnings notifications, and splitting them between dismissed
-	 * and active.
+	 * Parses all the notifications to an array with just id, message, nonce, type and dismissed.
 	 *
-	 * @return array<Yoast_Notification>
+	 * @return array<string,string|bool>
 	 */
-	public function get_notifications(): array {
-		$all_notifications       = $this->get_sorted_notifications();
-		$notifications           = \array_filter(
-			$all_notifications,
-			static function ( $notification ) {
-				return $notification->get_type() !== 'error';
-			}
-		);
-		$dismissed_notifications = \array_filter(
-			$notifications,
+	public function get_alerts(): array {
+		$all_notifications = $this->get_sorted_notifications();
+
+		return \array_map(
 			function ( $notification ) {
-				return $this->is_notification_dismissed( $notification );
-			}
+				return [
+					'id'        => $notification->get_id(),
+					'message'   => $notification->get_message(),
+					'nonce'     => $notification->get_nonce(),
+					'type'      => $notification->get_type(),
+					'dismissed' => $this->is_notification_dismissed( $notification ),
+				];
+			},
+			$all_notifications
 		);
-		$active_notifications    = \array_diff( $notifications, $dismissed_notifications );
-
-		return [
-			'dismissed' => \array_map(
-				static function ( $notification ) {
-					return [
-						'id'      => $notification->get_id(),
-						'message' => $notification->get_message(),
-						'nonce'   => $notification->get_nonce(),
-					];
-				},
-				$dismissed_notifications
-			),
-			'active'    => \array_map(
-				static function ( $notification ) {
-					return [
-						'id'      => $notification->get_id(),
-						'message' => $notification->get_message(),
-						'nonce'   => $notification->get_nonce(),
-					];
-				},
-				$active_notifications
-			),
-		];
-	}
-
-	/**
-	 * Parses all the notifications to an array with just error notifications, and splitting them between dismissed and
-	 * active.
-	 *
-	 * @return array<Yoast_Notification>
-	 */
-	public function get_problems(): array {
-		$all_notifications  = $this->get_sorted_notifications();
-		$problems           = \array_filter(
-			$all_notifications,
-			static function ( $notification ) {
-				return $notification->get_type() === 'error';
-			}
-		);
-		$dismissed_problems = \array_filter(
-			$problems,
-			function ( $notification ) {
-				return $this->is_notification_dismissed( $notification );
-			}
-		);
-		$active_problems    = \array_diff( $problems, $dismissed_problems );
-
-		return [
-			'dismissed' => \array_map(
-				static function ( $notification ) {
-					return [
-						'id'      => $notification->get_id(),
-						'message' => $notification->get_message(),
-						'nonce'   => $notification->get_nonce(),
-					];
-				},
-				$dismissed_problems
-			),
-			'active'    => \array_map(
-				static function ( $notification ) {
-					return [
-						'id'      => $notification->get_id(),
-						'message' => $notification->get_message(),
-						'nonce'   => $notification->get_nonce(),
-					];
-				},
-				$active_problems
-			),
-		];
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/New_Dashboard_Page_Integration_Test.php
@@ -285,12 +285,7 @@ final class New_Dashboard_Page_Integration_Test extends TestCase {
 			->andReturn( $link_params );
 
 		$this->notifications_helper
-			->expects( 'get_problems' )
-			->once()
-			->andReturn( [] );
-
-		$this->notifications_helper
-			->expects( 'get_notifications' )
+			->expects( 'get_alerts' )
 			->once()
 			->andReturn( [] );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds alert center to dashboard redux store.

## Relevant technical choices:

* I added a method to get the message from the notification object for the paragraphs. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO -> General page and check you notifications and problems. ( You can trigger notification by adding new content types and resetting the indexables in the yoast test helper, you can trigger problems by disabling `Search engine visibility` in the Settings->Reading)
* Add the following line in `wp-config.php` or snippets plugin: 
```php
define( 'YOAST_SEO_NEW_DASHBOARD_UI', true );
```  
* Go to Yoast SEO -> General page
* [x] Check you see the same problems and notifications.
* [x] Check the number in the title of the problems and notifications matched the number of active alerts.
* [x] Hide notifications and check the number has changed in the title, the notification has moved to the hidden Collapsible and the hidden Collapsible has the right number of hidden notifications.
* [x] Hide more than one notification and check the translation has changed to plural (e.g. hidden notifications, hidden problems) in the Collapsible.
* [x] Restore notifications and problems from the hidden Collapsible and check the Collapsible disappears.
* [x] Hide only one notification/problem and check the label is singular (e.g hidden problem, hidden notification.
* [x] Hide all notification and check a text appears under the title: "No new notifications."
* [x] Refresh and check changes were saved.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Add Notifications to Alert center](https://github.com/Yoast/reserved-tasks/issues/272)
