### PR TITLE
Fix SidebarNavigation menu and submenu items

### DIFF
--- a/packages/js/src/dashboard/app.js
+++ b/packages/js/src/dashboard/app.js
@@ -31,11 +31,23 @@ const Menu = ( { idSuffix = "" } ) => {
 		</header>
 		<div className="yst-px-0.5 yst-space-y-6">
 			<ul className="yst-mt-1 yst-space-y-1">
-				<MenuItemLink icon={ BellIcon } to="/" label={ __( "Alert center", "wordpress-seo" ) } idSuffix={ idSuffix } />
 				<MenuItemLink
-					icon={ AdjustmentsIcon } to="/first-time-configuration"
-					label={ __( "First-time configuration", "wordpress-seo" ) }
+					to="/"
+					label={ <>
+						<BellIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
+						{ __( "Alert center", "wordpress-seo" ) }
+					</> }
 					idSuffix={ idSuffix }
+					className="yst-gap-3"
+				/>
+				<MenuItemLink
+					to="/first-time-configuration"
+					label={ <>
+						<AdjustmentsIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
+						{ __( "First-time configuration", "wordpress-seo" ) }
+					</> }
+					idSuffix={ idSuffix }
+					className="yst-gap-3"
 				/>
 			</ul>
 		</div>

--- a/packages/ui-library/src/components/sidebar-navigation/collapsible.js
+++ b/packages/ui-library/src/components/sidebar-navigation/collapsible.js
@@ -1,0 +1,51 @@
+import { ChevronDownIcon } from "@heroicons/react/outline";
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+import { useToggleState } from "../../hooks";
+import { Icon } from "./icon";
+
+/**
+ * @param {JSX.ElementClass} [as="div"] The component.
+ * @param {string} label The label.
+ * @param {?JSX.ElementClass} [icon=null] Optional icon to put before the label.
+ * @param {?JSX.node} [children=null] The content.
+ * @param {boolean} [defaultOpen] Whether the sub menu starts opened.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The element.
+ */
+export const Collapsible = ( { as: Component = "div", label, icon = null, children = null, defaultOpen = true, ...props } ) => {
+	const [ isOpen, toggleOpen ] = useToggleState( defaultOpen );
+
+	return (
+		<Component className="yst-sidebar-navigation__collapsible">
+			<button
+				type="button"
+				className="yst-sidebar-navigation__collapsible-button yst-group"
+				onClick={ toggleOpen }
+				aria-expanded={ isOpen }
+				{ ...props }
+			>
+				{ icon && <Icon as={ icon } className="yst-h-6 yst-w-6" /> }
+				{ label }
+				<Icon
+					as={ ChevronDownIcon }
+					className={ classNames(
+						"yst-ml-auto yst-h-4 yst-w-4 yst-stroke-3",
+						isOpen && "yst-rotate-180",
+					) }
+				/>
+			</button>
+			{ isOpen && children }
+		</Component>
+	);
+};
+
+Collapsible.displayName = "SidebarNavigation.Collapsible";
+Collapsible.propTypes = {
+	as: PropTypes.elementType,
+	icon: PropTypes.elementType,
+	label: PropTypes.string.isRequired,
+	defaultOpen: PropTypes.bool,
+	children: PropTypes.node,
+};

--- a/packages/ui-library/src/components/sidebar-navigation/collapsible.js
+++ b/packages/ui-library/src/components/sidebar-navigation/collapsible.js
@@ -8,13 +8,13 @@ import { Icon } from "./icon";
 /**
  * @param {JSX.ElementClass} [as="div"] The component.
  * @param {string} label The label.
- * @param {?JSX.ElementClass} [icon=null] Optional icon to put before the label.
- * @param {?JSX.node} [children=null] The content.
+ * @param {JSX.ElementClass} [icon] Optional icon to put before the label.
+ * @param {JSX.node} [children] The content.
  * @param {boolean} [defaultOpen] Whether the sub menu starts opened.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The element.
  */
-export const Collapsible = ( { as: Component = "div", label, icon = null, children = null, defaultOpen = true, ...props } ) => {
+export const Collapsible = ( { as: Component = "div", label, icon, children, defaultOpen = true, ...props } ) => {
 	const [ isOpen, toggleOpen ] = useToggleState( defaultOpen );
 
 	return (

--- a/packages/ui-library/src/components/sidebar-navigation/icon.js
+++ b/packages/ui-library/src/components/sidebar-navigation/icon.js
@@ -4,12 +4,12 @@ import React from "react";
 
 /**
  * @param {JSX.ElementClass} [as="span"] The component.
- * @param {?JSX.node} [children=null] The content.
+ * @param {JSX.node} [children] The content.
  * @param {string} [className] The classname.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The element.
  */
-export const Icon = ( { as: Component = "span", children = null, className, ...props } ) => {
+export const Icon = ( { as: Component = "span", children, className, ...props } ) => {
 	return (
 		<Component
 			className={ classNames( "yst-sidebar-navigation__icon", className ) }

--- a/packages/ui-library/src/components/sidebar-navigation/icon.js
+++ b/packages/ui-library/src/components/sidebar-navigation/icon.js
@@ -1,0 +1,28 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * @param {JSX.ElementClass} [as="span"] The component.
+ * @param {?JSX.node} [children=null] The content.
+ * @param {string} [className] The classname.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The element.
+ */
+export const Icon = ( { as: Component = "span", children = null, className, ...props } ) => {
+	return (
+		<Component
+			className={ classNames( "yst-sidebar-navigation__icon", className ) }
+			{ ...props }
+		>
+			{ children }
+		</Component>
+	);
+};
+
+Icon.displayName = "SidebarNavigation.Icon";
+Icon.propTypes = {
+	as: PropTypes.elementType,
+	children: PropTypes.node,
+	className: PropTypes.string,
+};

--- a/packages/ui-library/src/components/sidebar-navigation/index.js
+++ b/packages/ui-library/src/components/sidebar-navigation/index.js
@@ -1,6 +1,11 @@
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React, { createContext, useContext, useState } from "react";
+import { Collapsible } from "./collapsible";
+import { Icon } from "./icon";
+import { Item } from "./item";
+import { Link } from "./link";
+import { List } from "./list";
 import MenuItem from "./menu-item";
 import Mobile from "./mobile";
 import Sidebar from "./sidebar";
@@ -37,13 +42,23 @@ SidebarNavigation.propTypes = {
 	children: PropTypes.node.isRequired,
 };
 
+// Different types of navigation.
 SidebarNavigation.Sidebar = Sidebar;
 SidebarNavigation.Sidebar.displayName = "SidebarNavigation.Sidebar";
 SidebarNavigation.Mobile = Mobile;
 SidebarNavigation.Mobile.displayName = "SidebarNavigation.Mobile";
+
+// "V1" components.
 SidebarNavigation.MenuItem = MenuItem;
 SidebarNavigation.MenuItem.displayName = "SidebarNavigation.MenuItem";
 SidebarNavigation.SubmenuItem = SubmenuItem;
 SidebarNavigation.SubmenuItem.displayName = "SidebarNavigation.SubmenuItem";
+
+// "V2" building blocks.
+SidebarNavigation.List = List;
+SidebarNavigation.Item = Item;
+SidebarNavigation.Collapsible = Collapsible;
+SidebarNavigation.Link = Link;
+SidebarNavigation.Icon = Icon;
 
 export default SidebarNavigation;

--- a/packages/ui-library/src/components/sidebar-navigation/item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/item.js
@@ -6,12 +6,12 @@ import React from "react";
  * Represents a Menu Item.
  *
  * @param {JSX.ElementClass} [as="li"] The component.
- * @param {?JSX.node} [children=null] The content.
+ * @param {JSX.node} [children] The content.
  * @param {string} [className] The classname.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The menu.
  */
-export const Item = ( { as: Component = "li", children = null, className, ...props } ) => {
+export const Item = ( { as: Component = "li", children, className, ...props } ) => {
 	return (
 		<Component
 			className={ classNames( "yst-sidebar-navigation__item", className ) }

--- a/packages/ui-library/src/components/sidebar-navigation/item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/item.js
@@ -1,0 +1,30 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * Represents a Menu Item.
+ *
+ * @param {JSX.ElementClass} [as="li"] The component.
+ * @param {?JSX.node} [children=null] The content.
+ * @param {string} [className] The classname.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The menu.
+ */
+export const Item = ( { as: Component = "li", children = null, className, ...props } ) => {
+	return (
+		<Component
+			className={ classNames( "yst-sidebar-navigation__item", className ) }
+			{ ...props }
+		>
+			{ children }
+		</Component>
+	);
+};
+
+Item.displayName = "SidebarNavigation.Item";
+Item.propTypes = {
+	as: PropTypes.elementType,
+	children: PropTypes.node,
+	className: PropTypes.string,
+};

--- a/packages/ui-library/src/components/sidebar-navigation/link.js
+++ b/packages/ui-library/src/components/sidebar-navigation/link.js
@@ -6,12 +6,12 @@ import { useNavigationContext } from "./index";
 /**
  * @param {JSX.ElementClass} [as="a"] The component.
  * @param {string} [pathProp="href"] The key of the path in the props.
- * @param {?JSX.node} [children=null] The content.
+ * @param {JSX.node} [children] The content.
  * @param {string} [className] The classname.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The element.
  */
-export const Link = ( { as: Component = "a", pathProp = "href", children = null, className, ...props } ) => {
+export const Link = ( { as: Component = "a", pathProp = "href", children, className, ...props } ) => {
 	const { activePath, setMobileMenuOpen } = useNavigationContext();
 
 	const handleClick = useCallback( () => {

--- a/packages/ui-library/src/components/sidebar-navigation/link.js
+++ b/packages/ui-library/src/components/sidebar-navigation/link.js
@@ -1,0 +1,48 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React, { useCallback } from "react";
+import { useNavigationContext } from "./index";
+
+/**
+ * @param {JSX.ElementClass} [as="a"] The component.
+ * @param {string} [pathProp="href"] The key of the path in the props.
+ * @param {?JSX.node} [children=null] The content.
+ * @param {string} [className] The classname.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The element.
+ */
+export const Link = ( { as: Component = "a", pathProp = "href", children = null, className, ...props } ) => {
+	const { activePath, setMobileMenuOpen } = useNavigationContext();
+
+	const handleClick = useCallback( () => {
+		setMobileMenuOpen( false );
+		// eslint-disable-next-line react/prop-types
+		if ( typeof props?.onClick === "function" ) {
+			// eslint-disable-next-line react/prop-types
+			props.onClick();
+		}
+	}, [ setMobileMenuOpen ] );
+
+	return (
+		<Component
+			className={ classNames(
+				"yst-sidebar-navigation__link yst-group",
+				activePath === props?.[ pathProp ] && "yst-sidebar-navigation__item--active",
+				className,
+			) }
+			aria-current={ activePath === props?.[ pathProp ] ? "page" : null }
+			{ ...props }
+			onClick={ handleClick }
+		>
+			{ children }
+		</Component>
+	);
+};
+
+Link.displayName = "SidebarNavigation.Link";
+Link.propTypes = {
+	as: PropTypes.elementType,
+	pathProp: PropTypes.string,
+	children: PropTypes.node,
+	className: PropTypes.string,
+};

--- a/packages/ui-library/src/components/sidebar-navigation/link.js
+++ b/packages/ui-library/src/components/sidebar-navigation/link.js
@@ -8,19 +8,16 @@ import { useNavigationContext } from "./index";
  * @param {string} [pathProp="href"] The key of the path in the props.
  * @param {JSX.node} [children] The content.
  * @param {string} [className] The classname.
+ * @param {Function} [onClick] The click handler. We wrap this to close the mobile menu on click.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The element.
  */
-export const Link = ( { as: Component = "a", pathProp = "href", children, className, ...props } ) => {
+export const Link = ( { as: Component = "a", pathProp = "href", children, className, onClick, ...props } ) => {
 	const { activePath, setMobileMenuOpen } = useNavigationContext();
 
 	const handleClick = useCallback( () => {
 		setMobileMenuOpen( false );
-		// eslint-disable-next-line react/prop-types
-		if ( typeof props?.onClick === "function" ) {
-			// eslint-disable-next-line react/prop-types
-			props.onClick();
-		}
+		onClick?.();
 	}, [ setMobileMenuOpen ] );
 
 	return (
@@ -45,4 +42,5 @@ Link.propTypes = {
 	pathProp: PropTypes.string,
 	children: PropTypes.node,
 	className: PropTypes.string,
+	onClick: PropTypes.func,
 };

--- a/packages/ui-library/src/components/sidebar-navigation/list.js
+++ b/packages/ui-library/src/components/sidebar-navigation/list.js
@@ -4,13 +4,13 @@ import React from "react";
 
 /**
  * @param {JSX.ElementClass} [as="ul"] The component.
- * @param {?JSX.node} [children=null] The content.
+ * @param {JSX.node} [children] The content.
  * @param {boolean} [isIndented=false] Whether the list is indented.
  * @param {string} [className] The classname.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The element.
  */
-export const List = ( { as: Component = "ul", children = null, isIndented = false, className, ...props } ) => {
+export const List = ( { as: Component = "ul", children, isIndented = false, className, ...props } ) => {
 	return (
 		<Component
 			role="list"

--- a/packages/ui-library/src/components/sidebar-navigation/list.js
+++ b/packages/ui-library/src/components/sidebar-navigation/list.js
@@ -1,0 +1,35 @@
+import classNames from "classnames";
+import PropTypes from "prop-types";
+import React from "react";
+
+/**
+ * @param {JSX.ElementClass} [as="ul"] The component.
+ * @param {?JSX.node} [children=null] The content.
+ * @param {boolean} [isIndented=false] Whether the list is indented.
+ * @param {string} [className] The classname.
+ * @param {Object} [props] Extra props.
+ * @returns {JSX.Element} The element.
+ */
+export const List = ( { as: Component = "ul", children = null, isIndented = false, className, ...props } ) => {
+	return (
+		<Component
+			role="list"
+			className={ classNames(
+				"yst-sidebar-navigation__list",
+				isIndented && "yst-sidebar-navigation__list--indented",
+				className,
+			) }
+			{ ...props }
+		>
+			{ children }
+		</Component>
+	);
+};
+
+List.displayName = "SidebarNavigation.List";
+List.propTypes = {
+	as: PropTypes.elementType,
+	children: PropTypes.node,
+	isIndented: PropTypes.bool,
+	className: PropTypes.string,
+};

--- a/packages/ui-library/src/components/sidebar-navigation/menu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/menu-item.js
@@ -1,7 +1,7 @@
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/outline";
 import PropTypes from "prop-types";
 import React from "react";
-import { useToggleState } from "../../hooks";
+import { Collapsible } from "./collapsible";
+import { List } from "./list";
 
 /**
  * @param {string} label The label.
@@ -9,33 +9,15 @@ import { useToggleState } from "../../hooks";
  * @param {JSX.node} [children] Optional sub menu.
  * @param {boolean} [defaultOpen] Whether the sub menu starts opened.
  * @param {Object} [props] Extra props.
- * @returns {JSX.Element} The menu item element.
+ * @returns {JSX.Element} The element.
  */
 const MenuItem = ( { label, icon: Icon = null, children = null, defaultOpen = true, ...props } ) => {
-	const [ isOpen, toggleOpen ] = useToggleState( defaultOpen );
-	const ChevronIcon = isOpen ? ChevronUpIcon : ChevronDownIcon;
-
 	return (
-		<div>
-			<button
-				type="button"
-				className="yst-group yst-flex yst-w-full yst-items-center yst-justify-between yst-gap-3 yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-text-slate-800 yst-rounded-md yst-no-underline hover:yst-text-slate-900 hover:yst-bg-slate-50 focus:yst-outline-none focus:yst-ring-2 focus:yst-ring-primary-500"
-				onClick={ toggleOpen }
-				aria-expanded={ isOpen }
-				{ ...props }
-			>
-				<span className="yst-flex yst-items-center yst-gap-3">
-					{ Icon &&
-						<Icon className="yst-flex-shrink-0 yst--ml-1 yst-h-6 yst-w-6 yst-text-slate-400 group-hover:yst-text-slate-500" />
-					}
-					{ label }
-				</span>
-				<ChevronIcon className="yst-h-4 yst-w-4 yst-text-slate-400 group-hover:yst-text-slate-500 yst-stroke-3" />
-			</button>
-			{ isOpen && children && <ul className="yst-ml-8 yst-mt-1 yst-space-y-1">
+		<Collapsible label={ label } icon={ Icon } defaultOpen={ defaultOpen } { ...props }>
+			<List isIndented={ true }>
 				{ children }
-			</ul> }
-		</div>
+			</List>
+		</Collapsible>
 	);
 };
 

--- a/packages/ui-library/src/components/sidebar-navigation/sidebar.js
+++ b/packages/ui-library/src/components/sidebar-navigation/sidebar.js
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -7,7 +8,7 @@ import React from "react";
  * @returns {JSX.Element} The sidebar element.
  */
 const Sidebar = ( { children, className = "" } ) => (
-	<nav className={ className }>{ children }</nav>
+	<nav className={ classNames( "yst-sidebar-navigation__sidebar", className ) }>{ children }</nav>
 );
 
 Sidebar.propTypes = {

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -1,54 +1,67 @@
 import { AdjustmentsIcon, ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
-import React from "react";
+import { useArgs } from "@storybook/preview-api";
+import React, { useCallback, useEffect } from "react";
 import SidebarNavigation from ".";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
 import Table from "../../elements/table";
 
-const Template = ( { children, activePath } ) => {
-	return (
-		<SidebarNavigation activePath={ activePath }>
-			{ children }
-		</SidebarNavigation> );
+const Template = ( args ) => {
+	const [ , updateArgs ] = useArgs();
+
+	const hashChangeHandler = useCallback( () => updateArgs( { activePath: document.location.hash } ), [ updateArgs ] );
+
+	useEffect( () => {
+		window.addEventListener( "hashchange", hashChangeHandler );
+		hashChangeHandler();
+
+		return () => window.removeEventListener( "hashchange", hashChangeHandler );
+	}, [ hashChangeHandler ] );
+
+	return <SidebarNavigation { ...args } />;
 };
 
 export const Factory = {
 	render: Template.bind( {} ),
 	args: {
 		children: <SidebarNavigation.Sidebar className="yst-w-1/3">
-
-			<SidebarNavigation.MenuItem
-				id={ "menu-item-default-1" }
-				icon={ DesktopComputerIcon }
-				label="MenuItem 1 label"
-			>
-				<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
-				<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
-				<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
-			</SidebarNavigation.MenuItem>
-			<SidebarNavigation.MenuItem
-				id={ "menu-item-default-2" }
-				icon={ AdjustmentsIcon }
-				label="MenuItem 2 label"
-				defaultOpen={ false }
-			>
-				<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
-				<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
-				<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
-
-			</SidebarNavigation.MenuItem>
-			<SidebarNavigation.MenuItem
-				id={ "menu-item-default-3" }
-				icon={ NewspaperIcon }
-				label="MenuItem 3 label"
-				defaultOpen={ false }
-			>
-				<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
-				<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
-				<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
-
-			</SidebarNavigation.MenuItem>
-			<ul className="yst-mt-1 yst-space-y-1">
-				<SidebarNavigation.SubmenuItem icon={ NewspaperIcon } to="#sub3" label="SubmenuItem 3 label" />
+			<ul className="yst-sidebar-navigation__list">
+				<SidebarNavigation.MenuItem
+					id={ "menu-item-default-1" }
+					icon={ DesktopComputerIcon }
+					label="MenuItem 1 label"
+				>
+					<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+					<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+					<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+				</SidebarNavigation.MenuItem>
+				<SidebarNavigation.MenuItem
+					id={ "menu-item-default-2" }
+					icon={ AdjustmentsIcon }
+					label="MenuItem 2 label"
+					defaultOpen={ false }
+				>
+					<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+					<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+					<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+				</SidebarNavigation.MenuItem>
+				<SidebarNavigation.MenuItem
+					id={ "menu-item-default-3" }
+					icon={ NewspaperIcon }
+					label="MenuItem 3 label"
+					defaultOpen={ false }
+				>
+					<SidebarNavigation.SubmenuItem to="#sub1" label="SubmenuItem 1 label" />
+					<SidebarNavigation.SubmenuItem to="#sub2" label="SubmenuItem 2 label" />
+					<SidebarNavigation.SubmenuItem to="#sub3" label="SubmenuItem 3 label" />
+				</SidebarNavigation.MenuItem>
+				<SidebarNavigation.SubmenuItem
+					to="#item1"
+					label={ <>
+						<DesktopComputerIcon className="yst-sidebar-navigation__icon yst-h-6 yst-w-6" />
+						Item 1 label
+					</> }
+					className="yst-gap-3"
+				/>
 			</ul>
 		</SidebarNavigation.Sidebar>,
 	},
@@ -120,7 +133,6 @@ export const Sidebar = {
 	},
 };
 
-
 export const Mobile = {
 	render: Template.bind( {} ),
 	parameters: {
@@ -136,17 +148,36 @@ export const Mobile = {
 			closeButtonScreenReaderText="Close sidebar"
 		>
 			<div className="yst-m-4">Mobile menu</div>
-			<SidebarNavigation.MenuItem
-				id={ "submenuitem-mobile" }
-				icon={ AdjustmentsIcon }
-				label="MenuItem label"
-				defaultOpen={ true }
-			>
-				<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
-				<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
-				<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
-
-			</SidebarNavigation.MenuItem>
+			<ul className="yst-sidebar-navigation__list">
+				<SidebarNavigation.MenuItem
+					id="submenuitem-mobile-1"
+					icon={ AdjustmentsIcon }
+					label="MenuItem 1 label"
+					defaultOpen={ true }
+				>
+					<SidebarNavigation.SubmenuItem to="#1" label="SubmenuItem 1" />
+					<SidebarNavigation.SubmenuItem to="#2" label="SubmenuItem 2" />
+					<SidebarNavigation.SubmenuItem to="#3" label="SubmenuItem 3" />
+				</SidebarNavigation.MenuItem>
+				<SidebarNavigation.MenuItem
+					id="submenuitem-mobile-2"
+					icon={ ColorSwatchIcon }
+					label="MenuItem 2 label"
+					defaultOpen={ false }
+				>
+					<SidebarNavigation.SubmenuItem to="#4" label="SubmenuItem 4" />
+					<SidebarNavigation.SubmenuItem to="#5" label="SubmenuItem 5" />
+					<SidebarNavigation.SubmenuItem to="#6" label="SubmenuItem 6" />
+				</SidebarNavigation.MenuItem>
+				<SidebarNavigation.SubmenuItem
+					to="#item1"
+					label={ <>
+						<DesktopComputerIcon className="yst-sidebar-navigation__icon yst-h-6 yst-w-6" />
+						Item 1 label
+					</> }
+					className="yst-gap-3"
+				/>
+			</ul>
 		</SidebarNavigation.Mobile> ),
 	},
 };
@@ -188,6 +219,96 @@ export const NavigationContext = {
 				</Table.Row>
 			</Table.Body>
 		</Table>,
+	},
+};
+
+export const UsingBuildingBlocks = {
+	render: Template.bind( {} ),
+	name: "Using the smaller building blocks",
+	parameters: {
+		docs: {
+			description: {
+				story: "To allow for more flexibility, we provide `SidebarNavigation.List`, `SidebarNavigation.Item`, `SidebarNavigation.Collapsible`, `SidebarNavigation.Link` and `SidebarNavigation.Icon` to create your own combinations.",
+			},
+		},
+	},
+	args: {
+		children: (
+			<SidebarNavigation.Sidebar className="yst-w-1/3">
+				<SidebarNavigation.List>
+					<SidebarNavigation.Collapsible label="Collapsible 1" icon={ NewspaperIcon }>
+						<SidebarNavigation.List isIndented={ true }>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#1">Link 1</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#2">Link 2</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#3">Link 3</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+						</SidebarNavigation.List>
+					</SidebarNavigation.Collapsible>
+					<SidebarNavigation.Collapsible label="Collapsible 2">
+						<SidebarNavigation.List isIndented={ true }>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#4">Link 4</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#5">Link 5</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+							<SidebarNavigation.Item>
+								<SidebarNavigation.Link href="#6">Link 6</SidebarNavigation.Link>
+							</SidebarNavigation.Item>
+						</SidebarNavigation.List>
+					</SidebarNavigation.Collapsible>
+					<SidebarNavigation.Item>
+						<SidebarNavigation.Link href="#7" className="yst-flex yst-gap-x-3">
+							<SidebarNavigation.Icon as={ NewspaperIcon } className="yst-h-6 yst-w-6" />
+							Link 7
+						</SidebarNavigation.Link>
+					</SidebarNavigation.Item>
+				</SidebarNavigation.List>
+			</SidebarNavigation.Sidebar>
+		),
+	},
+};
+
+export const NotUsingBuildingBlocks = {
+	render: Template.bind( {} ),
+	name: "Not using the smaller building blocks",
+	parameters: {
+		docs: {
+			description: {
+				story: "Here is the same example as the previous one, but without using the smaller building blocks. The `MenuItem` is a `Collapsible` with a `List`. The `SubmenuItem` is an `Item` with a `Link`.",
+			},
+		},
+	},
+	args: {
+		children: (
+			<SidebarNavigation.Sidebar className="yst-w-1/3">
+				<ul className="yst-sidebar-navigation__list">
+					<SidebarNavigation.MenuItem label="Collapsible 1" icon={ NewspaperIcon }>
+						<SidebarNavigation.SubmenuItem href="#n1" label={ "Link 1" } />
+						<SidebarNavigation.SubmenuItem href="#n2" label={ "Link 2" } />
+						<SidebarNavigation.SubmenuItem href="#n3" label={ "Link 3" } />
+					</SidebarNavigation.MenuItem>
+					<SidebarNavigation.MenuItem label="Collapsible 2">
+						<SidebarNavigation.SubmenuItem href="#n4" label={ "Link 4" } />
+						<SidebarNavigation.SubmenuItem href="#n5" label={ "Link 5" } />
+						<SidebarNavigation.SubmenuItem href="#n6" label={ "Link 6" } />
+					</SidebarNavigation.MenuItem>
+					<SidebarNavigation.SubmenuItem
+						href="#n7"
+						label={ <>
+							<NewspaperIcon className="yst-sidebar-navigation__icon yst-h-6 yst-w-6" />
+							Link 7
+						</> }
+						className="yst-flex yst-gap-x-3"
+					/>
+				</ul>
+			</SidebarNavigation.Sidebar>
+		),
 	},
 };
 
@@ -253,7 +374,16 @@ export default {
 			description: {
 				component: "A sidebar navigation component. Contains the subcomponents `Sidebar`, `Mobile`, `MenuItem` and `SubmenuItem` and contains the hook `useNavigationContext`.",
 			},
-			page: () => <InteractiveDocsPage stories={ [ MenuItem, Sidebar, Mobile, NavigationContext ] } />,
+			page: () => <InteractiveDocsPage
+				stories={ [
+					MenuItem,
+					Sidebar,
+					Mobile,
+					UsingBuildingBlocks,
+					NotUsingBuildingBlocks,
+					NavigationContext,
+				] }
+			/>,
 		},
 	},
 };

--- a/packages/ui-library/src/components/sidebar-navigation/style.css
+++ b/packages/ui-library/src/components/sidebar-navigation/style.css
@@ -7,5 +7,107 @@
 		.yst-mobile-navigation__dialog {
 			@apply yst-fixed yst-inset-0 yst-flex yst-z-50;
 		}
+
+		.yst-sidebar-navigation__sidebar, .yst-mobile-navigation__dialog {
+			/* Initializing the variable here instead of on the list, as one of these should always exist. */
+			--yst-menu-text-color: theme('colors.slate.800');
+		}
+
+		.yst-sidebar-navigation__list {
+			/* Due to the ring falling outside of the size, we need some spacing. */
+			@apply yst-space-y-0.5;
+
+		}
+
+		.yst-sidebar-navigation__list--indented {
+			@apply yst-ml-8;
+			--yst-menu-text-color: theme('colors.slate.600');
+		}
+
+		.yst-sidebar-navigation__item--active {
+			&.yst-sidebar-navigation__link, &.yst-sidebar-navigation__collapsible-button {
+				@apply yst-text-slate-900 yst-bg-slate-200 !important;
+			}
+
+			.yst-sidebar-navigation__icon {
+				@apply yst-text-slate-500;
+			}
+		}
+
+		.yst-sidebar-navigation__item {
+			@apply yst-list-none;
+
+			/* Due to the ring falling outside of the size, we need some spacing. */
+			@apply yst-space-y-0.5;
+
+			&:first-child {
+				@apply yst-mt-0.5;
+			}
+		}
+
+		.yst-sidebar-navigation__collapsible ~ .yst-sidebar-navigation__collapsible {
+			/* Due to the ring falling outside of the size, we need some spacing. This is the fallback for if not nested in a list. */
+			@apply yst-mt-1;
+		}
+
+		.yst-sidebar-navigation__collapsible-button {
+			@apply
+			yst-flex
+			yst-w-full
+			yst-justify-center
+			yst-items-center
+			yst-gap-x-3
+			yst-py-2
+			yst-px-3
+			yst-no-underline
+			yst-cursor-pointer
+			yst-rounded-md
+			yst-text-sm
+			yst-font-medium
+			yst-text-[var(--yst-menu-text-color)]
+
+			hover:yst-text-slate-900
+			hover:yst-bg-slate-50
+
+			focus:yst-outline-none
+			focus:yst-ring-2
+			focus:yst-ring-primary-500
+			;
+		}
+
+		.yst-sidebar-navigation__link {
+			@apply
+			yst-flex
+			yst-py-2
+			yst-px-3
+			yst-items-center
+			yst-no-underline
+			yst-text-sm
+			yst-font-medium
+			yst-rounded-md
+			yst-text-[var(--yst-menu-text-color)]
+
+			hover:yst-text-slate-900
+			hover:yst-bg-slate-50
+
+			focus:yst-outline-none
+			focus:yst-ring-1
+			focus:yst-ring-offset-1
+			focus:yst-ring-offset-transparent
+			focus:yst-ring-primary-500;
+		}
+
+		a.yst-sidebar-navigation__link {
+			/* Override anchor defaults that conflict. */
+			@apply
+			focus:yst-text-[var(--yst-menu-text-color)]
+			focus:yst-rounded-md
+			visited:yst-text-[var(--yst-menu-text-color)]
+			visited:hover:yst-text-slate-900;
+		}
+
+		.yst-sidebar-navigation__icon {
+			@apply yst-flex-shrink-0 yst-text-slate-400 group-hover:yst-text-slate-500;
+		}
 	}
 }

--- a/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
+++ b/packages/ui-library/src/components/sidebar-navigation/submenu-item.js
@@ -1,51 +1,28 @@
-import classNames from "classnames";
 import PropTypes from "prop-types";
-import React, { useCallback } from "react";
-import { useNavigationContext } from "./index";
+import React from "react";
+import { Item } from "./item";
+import { Link } from "./link";
 
 /**
  * @param {JSX.node} label The label.
  * @param {JSX.ElementClass} [as] The field component.
  * @param {string} [pathProp] The key of the path in the props. Defaults to `href`.
- * @param {JSX.ElementClass} [icon] The Icon component.
  * @param {Object} [props] Extra props.
  * @returns {JSX.Element} The submenu item element.
  */
-const SubmenuItem = ( { as: Component = "a", pathProp = "href", label, icon: Icon = null, ...props } ) => {
-	const { activePath, setMobileMenuOpen } = useNavigationContext();
-
-	const handleClick = useCallback( () => setMobileMenuOpen( false ), [ setMobileMenuOpen ] );
-
-	return (
-		<li className="yst-m-0 yst-pb-1">
-			<Component
-				className={ classNames(
-					"yst-group yst-flex yst-items-center yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-rounded-md yst-no-underline focus:yst-outline-none focus:yst-ring-1 focus:yst-ring-offset-1 focus:yst-ring-offset-transparent focus:yst-ring-primary-500",
-					activePath === props[ pathProp ]
-						? "yst-bg-slate-200 yst-text-slate-900"
-						: "yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-50",
-				) }
-				aria-current={ activePath === props[ pathProp ] ? "page" : null }
-				onClick={ handleClick }
-				{ ...props }
-			>
-				<span className="yst-flex yst-items-center yst-gap-3">
-					{ Icon &&
-						<Icon className="yst-flex-shrink-0 yst--ml-1 yst-h-6 yst-w-6 yst-text-slate-400 group-hover:yst-text-slate-500" />
-					}
-					{ label }
-				</span>
-			</Component>
-		</li>
-	);
-};
+const SubmenuItem = ( { as = "a", pathProp = "href", label, ...props } ) => (
+	<Item>
+		<Link as={ as } pathProp={ pathProp } { ...props }>
+			{ label }
+		</Link>
+	</Item>
+);
 
 SubmenuItem.propTypes = {
 	as: PropTypes.elementType,
 	pathProp: PropTypes.string,
 	label: PropTypes.node.isRequired,
 	isActive: PropTypes.bool,
-	icon: PropTypes.elementType,
 };
 
 export default SubmenuItem;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the UI library SidebarNavigation change from [#21614](https://github.com/Yoast/wordpress-seo/pull/21614).
* [@yoast/ui-library 0.1.0 enhancement] Adds lower level components to SidebarNavigation: List, Item, Collapsible, Link and Icon.
* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the SidebarNavigation colors would not be consistent on indentation.
* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the SidebarNavigation spacing would cause overlapping when focused or active.

## Relevant technical choices:

[Abstract out SidebarNavigation building blocks](https://github.com/Yoast/wordpress-seo/commit/6866b5d6c6b45af0619468fa03ee57c230dedcfc) 

The current MenuItem and SubmenuItem are doing too much and are a bit confusing.
This creates sub components, to have more flexibility.
* allow an Item or Link on the first level of the navigation
* a first level should be able to include an icon
* fix colors for main level vs indented level

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Devs: test with the storybook
* Run `yarn workspace @yoast/ui-library storybook` to start it (do the normal composer & yarn dep stuff first)
* Go to components => SidebarNavigation
* You can compare with the currently released version on: https://ui-library.yoast.com/?path=/docs/2-components-sidebar-navigation--docs
* The main story now:
  * has a nesting `ul` with the class from List
  * has a SubmenuItem with an icon on the first level (the non-collapsible) (this was already like this on `trunk`)
* Verify the SubmenuItem with icon on the first level has the correct color: slate-800 (#1e293b)
  * For the colors, see Tailwind: https://tailwindcss.com/docs/customizing-colors 
* Click on the MenuItems, the selection and collapsing should work the same
* Verify the selection does not overlap anymore, previously: <img width="348" alt="image" src="https://github.com/user-attachments/assets/acc974b3-dcb4-41cc-8a6f-bf56590498b6">
* Scroll down to the `Using the smaller building blocks` story, this is the new one
* Play around with it, clicking the links will make them `active`
* Verify the active style is correct:  foreground slate-900 (#0f172a), background slate-200 (#e2e8f0) and icon slate-500 (#64748b)

#### General page menu
* Add `define( 'YOAST_SEO_NEW_DASHBOARD_UI', true );` to your project (`wp-config.php`?)
* Go to Yoast > General in the admin
* Verify the menu works and has the correct colors
  * correct active style:  foreground slate-900 (#0f172a), background slate-200 (#e2e8f0) and icon slate-500 (#64748b)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/267
