### PR TITLE
refactor: restore the ignore_search_engines_discouraged_notice option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2480",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2479",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=252",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/integrations/watchers/search-engines-discouraged-watcher.php
+++ b/src/integrations/watchers/search-engines-discouraged-watcher.php
@@ -101,6 +101,8 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'manage_search_engines_discouraged_notification' ] );
 
+		\add_action( 'update_option_blog_public', [ $this, 'restore_ignore_option' ] );
+
 		/*
 		 * The `admin_notices` hook fires on single site admin pages vs.
 		 * `network_admin_notices` which fires on multisite admin pages and
@@ -229,5 +231,16 @@ class Search_Engines_Discouraged_Watcher implements Integration_Interface {
 				'priority'     => 1,
 			]
 		);
+	}
+
+	/**
+	 * Should restore the ignore option for the search engines discouraged notice.
+	 *
+	 * @return void
+	 */
+	public function restore_ignore_option() {
+		if ( ! $this->search_engines_are_discouraged() ) {
+			$this->options_helper->set( 'ignore_search_engines_discouraged_notice', false );
+		}
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to reset `ignore_search_engines_discouraged_notice` once user set his site to public again.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Resets the notice for search engines discouraged when changing Search engine visibility to visible.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Settings->Reading and check the checkbox for  Search engine visibility and save.
* Check you see in admin pages and in the notification center the following message:
> Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must [go to your Reading Settings](http://wordpress.test/wp-admin/options-reading.php) and uncheck the box for Search Engine Visibility. `I don't want this site to show in the search results.`

* Click on  `I don't want this site to show in the search results.` and check you don't see the notice again.
* Go to Settings->Reading and uncheck the checkbox for  Search engine visibility again and save.
* Check the general page still don't have the notice for huge SEO issue
* Go to Settings->Reading and check the checkbox for  Search engine visibility and save.
* Check you see the notice again.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21655
