### PR TITLE
Fix FTC navigation

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -5,6 +5,7 @@
  * @package WPSEO\Admin
  */
 
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Integrations\Settings_Integration;
 
 /**
@@ -241,7 +242,8 @@ class WPSEO_Admin {
 			$configuration_title = ( ! $first_time_configuration_notice_helper->should_show_alternate_message() ) ? 'first-time configuration' : 'SEO configuration';
 			/* translators: CTA to finish the first time configuration. %s: Either first-time SEO configuration or SEO configuration. */
 			$message  = sprintf( __( 'Finish your %s', 'wordpress-seo' ), $configuration_title );
-			$ftc_link = '<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '" target="_blank">' . $message . '</a>';
+			$ftc_page = ( ( new New_Dashboard_Ui_Conditional() )->is_met() ) ? 'admin.php?page=wpseo_dashboard#/first-time-configuration' : 'admin.php?page=wpseo_dashboard#top#first-time-configuration';
+			$ftc_link = '<a href="' . esc_url( admin_url( $ftc_page ) ) . '" target="_blank">' . $message . '</a>';
 			array_unshift( $links, $ftc_link );
 		}
 

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -5,6 +5,8 @@
  * @package WPSEO\Admin\Views
  */
 
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
+
 if ( ! defined( 'WPSEO_VERSION' ) ) {
 	header( 'Status: 403 Forbidden' );
 	header( 'HTTP/1.1 403 Forbidden' );
@@ -100,10 +102,11 @@ function wpseo_import_external_select( $name, $plugins ) {
 	<h3><?php esc_html_e( 'Step 4: Go through the first time configuration', 'wordpress-seo' ); ?></h3>
 	<p>
 		<?php
+		$ftc_page = ( ( new New_Dashboard_Ui_Conditional() )->is_met() ) ? 'admin.php?page=wpseo_dashboard#/first-time-configuration' : 'admin.php?page=wpseo_dashboard#top#first-time-configuration';
 		printf(
 			/* translators: 1: Link start tag to the First time configuration tab in the General page, 2: Link closing tag. */
 			esc_html__( 'You should finish the %1$sfirst time configuration%2$s to make sure your SEO data has been optimized and you’ve set the essential Yoast SEO settings for your site.', 'wordpress-seo' ),
-			'<a href="' . esc_url( admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ) . '">',
+			'<a href="' . esc_url( admin_url( $ftc_page ) ) . '">',
 			'</a>'
 		);
 		?>

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -113,7 +113,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 		$title    = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();
-		$link_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+		$link_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
 
 		if ( ! $this->first_time_configuration_notice_helper->should_show_alternate_message() ) {
 			$content = \sprintf(

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -36,6 +37,13 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	private $first_time_configuration_notice_helper;
 
 	/**
+	 * The New Dashboard UI conditional.
+	 *
+	 * @var New_Dashboard_Ui_Conditional
+	 */
+	private $new_dashboard_ui_conditional;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -48,15 +56,18 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 	 * @param Options_Helper                         $options_helper                         The options helper.
 	 * @param First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper The first time configuration notice helper.
 	 * @param WPSEO_Admin_Asset_Manager              $admin_asset_manager                    The admin asset manager.
+	 * @param New_Dashboard_Ui_Conditional           $new_dashboard_ui_conditional           The new dashboard UI conditional.
 	 */
 	public function __construct(
 		Options_Helper $options_helper,
 		First_Time_Configuration_Notice_Helper $first_time_configuration_notice_helper,
-		WPSEO_Admin_Asset_Manager $admin_asset_manager
+		WPSEO_Admin_Asset_Manager $admin_asset_manager,
+		New_Dashboard_Ui_Conditional $new_dashboard_ui_conditional
 	) {
 		$this->options_helper                         = $options_helper;
 		$this->admin_asset_manager                    = $admin_asset_manager;
 		$this->first_time_configuration_notice_helper = $first_time_configuration_notice_helper;
+		$this->new_dashboard_ui_conditional           = $new_dashboard_ui_conditional;
 	}
 
 	/**
@@ -102,7 +113,7 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 		$title    = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();
-		$link_url = \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+		$link_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \self_admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
 
 		if ( ! $this->first_time_configuration_notice_helper->should_show_alternate_message() ) {
 			$content = \sprintf(

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -28,6 +29,13 @@ class Installation_Success_Integration implements Integration_Interface {
 	protected $product_helper;
 
 	/**
+	 * The New Dashboard UI conditional.
+	 *
+	 * @var New_Dashboard_Ui_Conditional
+	 */
+	private $new_dashboard_ui_conditional;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -37,12 +45,18 @@ class Installation_Success_Integration implements Integration_Interface {
 	/**
 	 * Installation_Success_Integration constructor.
 	 *
-	 * @param Options_Helper $options_helper The options helper.
-	 * @param Product_Helper $product_helper The product helper.
+	 * @param Options_Helper               $options_helper               The options helper.
+	 * @param Product_Helper               $product_helper               The product helper.
+	 * @param New_Dashboard_Ui_Conditional $new_dashboard_ui_conditional The new dashboard UI conditional.
 	 */
-	public function __construct( Options_Helper $options_helper, Product_Helper $product_helper ) {
-		$this->options_helper = $options_helper;
-		$this->product_helper = $product_helper;
+	public function __construct(
+		Options_Helper $options_helper,
+		Product_Helper $product_helper,
+		New_Dashboard_Ui_Conditional $new_dashboard_ui_conditional
+	) {
+		$this->options_helper               = $options_helper;
+		$this->product_helper               = $product_helper;
+		$this->new_dashboard_ui_conditional = $new_dashboard_ui_conditional;
 	}
 
 	/**
@@ -127,12 +141,14 @@ class Installation_Success_Integration implements Integration_Interface {
 		$asset_manager->enqueue_style( 'tailwind' );
 		$asset_manager->enqueue_style( 'monorepo' );
 
+		$ftc_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+
 		$asset_manager->localize_script(
 			'installation-success',
 			'wpseoInstallationSuccess',
 			[
 				'pluginUrl'                 => \esc_url( \plugins_url( '', \WPSEO_FILE ) ),
-				'firstTimeConfigurationUrl' => \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ),
+				'firstTimeConfigurationUrl' => $ftc_url,
 				'dashboardUrl'              => \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard' ) ),
 			]
 		);

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -141,7 +141,7 @@ class Installation_Success_Integration implements Integration_Interface {
 		$asset_manager->enqueue_style( 'tailwind' );
 		$asset_manager->enqueue_style( 'monorepo' );
 
-		$ftc_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+		$ftc_url = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
 
 		$asset_manager->localize_script(
 			'installation-success',

--- a/src/integrations/admin/old-configuration-integration.php
+++ b/src/integrations/admin/old-configuration-integration.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Integrations\Admin;
 
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -64,7 +65,8 @@ class Old_Configuration_Integration implements Integration_Interface {
 		if ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'wpseo_configurator' ) {
 			return;
 		}
-		\wp_safe_redirect( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ), 302, 'Yoast SEO' );
+		$redirect_url = ( ( new New_Dashboard_Ui_Conditional() )->is_met() ) ? 'admin.php?page=wpseo_dashboard#/first-time-configuration' : 'admin.php?page=wpseo_dashboard#top#first-time-configuration';
+		\wp_safe_redirect( \admin_url( $redirect_url ), 302, 'Yoast SEO' );
 		exit;
 	}
 }

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -155,7 +155,7 @@ class Workouts_Integration implements Integration_Interface {
 		$this->admin_asset_manager->enqueue_style( 'workouts' );
 
 		$workouts_option = $this->get_workouts_option();
-		$ftc_url         = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
+		$ftc_url         = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
 
 		$this->admin_asset_manager->enqueue_script( 'workouts' );
 		$this->admin_asset_manager->localize_script(

--- a/src/integrations/admin/workouts-integration.php
+++ b/src/integrations/admin/workouts-integration.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Integrations\Admin;
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -44,6 +45,13 @@ class Workouts_Integration implements Integration_Interface {
 	private $product_helper;
 
 	/**
+	 * The New Dashboard UI conditional.
+	 *
+	 * @var New_Dashboard_Ui_Conditional
+	 */
+	private $new_dashboard_ui_conditional;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_conditionals() {
@@ -53,21 +61,24 @@ class Workouts_Integration implements Integration_Interface {
 	/**
 	 * Workouts_Integration constructor.
 	 *
-	 * @param WPSEO_Addon_Manager       $addon_manager       The addon manager.
-	 * @param WPSEO_Admin_Asset_Manager $admin_asset_manager The admin asset manager.
-	 * @param Options_Helper            $options_helper      The options helper.
-	 * @param Product_Helper            $product_helper      The product helper.
+	 * @param WPSEO_Addon_Manager          $addon_manager                The addon manager.
+	 * @param WPSEO_Admin_Asset_Manager    $admin_asset_manager          The admin asset manager.
+	 * @param Options_Helper               $options_helper               The options helper.
+	 * @param Product_Helper               $product_helper               The product helper.
+	 * @param New_Dashboard_Ui_Conditional $new_dashboard_ui_conditional The new dashboard UI conditional.
 	 */
 	public function __construct(
 		WPSEO_Addon_Manager $addon_manager,
 		WPSEO_Admin_Asset_Manager $admin_asset_manager,
 		Options_Helper $options_helper,
-		Product_Helper $product_helper
+		Product_Helper $product_helper,
+		New_Dashboard_Ui_Conditional $new_dashboard_ui_conditional
 	) {
-		$this->addon_manager       = $addon_manager;
-		$this->admin_asset_manager = $admin_asset_manager;
-		$this->options_helper      = $options_helper;
-		$this->product_helper      = $product_helper;
+		$this->addon_manager                = $addon_manager;
+		$this->admin_asset_manager          = $admin_asset_manager;
+		$this->options_helper               = $options_helper;
+		$this->product_helper               = $product_helper;
+		$this->new_dashboard_ui_conditional = $new_dashboard_ui_conditional;
 	}
 
 	/**
@@ -144,6 +155,7 @@ class Workouts_Integration implements Integration_Interface {
 		$this->admin_asset_manager->enqueue_style( 'workouts' );
 
 		$workouts_option = $this->get_workouts_option();
+		$ftc_url         = ( $this->new_dashboard_ui_conditional->is_met() ) ? \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#/first-time-configuration' ) ) : $link_url = \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) );
 
 		$this->admin_asset_manager->enqueue_script( 'workouts' );
 		$this->admin_asset_manager->localize_script(
@@ -155,7 +167,7 @@ class Workouts_Integration implements Integration_Interface {
 				'pluginUrl'                 => \esc_url( \plugins_url( '', \WPSEO_FILE ) ),
 				'toolsPageUrl'              => \esc_url( \admin_url( 'admin.php?page=wpseo_tools' ) ),
 				'usersPageUrl'              => \esc_url( \admin_url( 'users.php' ) ),
-				'firstTimeConfigurationUrl' => \esc_url( \admin_url( 'admin.php?page=wpseo_dashboard#top#first-time-configuration' ) ),
+				'firstTimeConfigurationUrl' => $ftc_url,
 				'isPremium'                 => $this->product_helper->is_premium(),
 				'upsellText'                => $this->get_upsell_text(),
 				'upsellLink'                => $this->get_upsell_link(),

--- a/tests/Unit/Integrations/Admin/First_Time_Configuration_Notice_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/First_Time_Configuration_Notice_Integration_Test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\First_Time_Configuration_Notice_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Admin\First_Time_Configuration_Notice_Integration;
@@ -44,11 +45,18 @@ final class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 	private $first_time_configuration_notice_helper;
 
 	/**
-	 * The the mock for a notice.
+	 * The mock for a notice.
 	 *
 	 * @var Yoast\WP\SEO\Presenters\Admin\Notice_Presenter
 	 */
 	private $notice_presenter;
+
+	/**
+	 * The mock for the New Dashboard UI conditional.
+	 *
+	 * @var New_Dashboard_Ui_Conditional
+	 */
+	private $new_dashboard_ui_conditional;
 
 	/**
 	 * The instance under test.
@@ -71,11 +79,13 @@ final class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 		$this->options_helper                         = Mockery::mock( Options_Helper::class );
 		$this->admin_asset_manager                    = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
 		$this->first_time_configuration_notice_helper = Mockery::mock( First_Time_Configuration_Notice_Helper::class );
+		$this->new_dashboard_ui_conditional           = Mockery::mock( New_Dashboard_Ui_Conditional::class );
 
 		$this->instance = new First_Time_Configuration_Notice_Integration(
 			$this->options_helper,
 			$this->first_time_configuration_notice_helper,
-			$this->admin_asset_manager
+			$this->admin_asset_manager,
+			$this->new_dashboard_ui_conditional
 		);
 
 		$this->notice_presenter = Mockery::mock( Notice_Presenter::class );
@@ -250,6 +260,11 @@ final class First_Time_Configuration_Notice_Integration_Test extends TestCase {
 			->expects( 'should_show_alternate_message' )
 			->once()
 			->andReturn( $should_show_alternate_message );
+
+		$this->new_dashboard_ui_conditional
+				->expects( 'is_met' )
+				->once()
+				->andReturnFalse();
 
 		Monkey\Functions\expect( 'self_admin_url' )
 			->once()

--- a/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\New_Dashboard_Ui_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Installation_Success_Integration;
@@ -41,6 +42,13 @@ final class Installation_Success_Integration_Test extends TestCase {
 	protected $product_helper;
 
 	/**
+	 * The New Dashboard UI conditional.
+	 *
+	 * @var New_Dashboard_Ui_Conditional
+	 */
+	private $new_dashboard_ui_conditional;
+
+	/**
 	 * Set up the fixtures for the tests.
 	 *
 	 * @return void
@@ -48,11 +56,17 @@ final class Installation_Success_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->options_helper = Mockery::mock( Options_Helper::class );
-		$this->product_helper = Mockery::mock( Product_Helper::class );
-		$this->instance       = Mockery::mock(
+		$this->options_helper               = Mockery::mock( Options_Helper::class );
+		$this->product_helper               = Mockery::mock( Product_Helper::class );
+		$this->new_dashboard_ui_conditional = Mockery::mock( New_Dashboard_Ui_Conditional::class );
+
+		$this->instance = Mockery::mock(
 			Installation_Success_Integration::class,
-			[ $this->options_helper, $this->product_helper ]
+			[
+				$this->options_helper,
+				$this->product_helper,
+				$this->new_dashboard_ui_conditional,
+			]
 		)->makePartial();
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the FTC link wherever it's used in the plugin

## Relevant technical choices:

* Went with replacing each link instead of filtering all the `admin_url` calls, as per [this conversation](https://yoast.slack.com/archives/C03KU0EHCNQ/p1727335955308109?thread_ts=1727332585.854019&cid=C03KU0EHCNQ).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For each of the below tests, test with the `YOAST_SEO_NEW_DASHBOARD_UI` feature flag both enabled and disabled.

**For the FTC admin notice**:
* In a fresh install (or with options reset from the Yoast Test Helper), check that you see the following admin notice:
![image](https://github.com/user-attachments/assets/0481c7b0-703b-4a20-b015-3e86bc7f3d05)
* Click on the **First Time Configuration** link
* Confirm that you are redirected to the FTC tab in the dashboard

**For the redirection from the old FTC**:
* Go to the `/wp-admin/?page=wpseo_configurator` page (or `http://example.com/site2/wp-admin/admin.php?page=wpseo_configurator` for a subsite)
* Confirm that you are redirected to the FTC tab in the dashboard

**For the action links of Yoast SEO in the plugins page**:
* Go to the plugins page
* Click the **Finish your SEO configuration** link under the Yoast SEO entry
* Confirm that you are redirected to the FTC tab in the dashboard

**For the link in the import page**:
* Install and activate another SEO plug-in (for which we have foreseen an importing procedure, e.g. AIOSEO).
* Visit `Tools` -> `Import and Export` and click on `Import from other SEO plugins` tab.
* Click on the **first time configuration** link in the 4th step
* Confirm that you are redirected to the FTC tab in the dashboard 

**For the link in the Successful Activation screen**:
* Go to `/wp-admin/admin.php?page=wpseo_installation_successful_free`
* Click on the **Start first-time configuration!** link
* Confirm that you are redirected to the FTC tab in the dashboard 

**For the link in the Workouts page**:
* Go to the Workouts page
* In the console, add `wpseoWorkoutsData.firstTimeConfigurationUrl`
* Click on the link that is returned
* Confirm that you are redirected to the FTC tab in the dashboard 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/279
