### PR TITLE
Separate ad from the alerts card grid, fix grid and sticky upsell ad

### DIFF
--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -14,7 +14,7 @@ const SidebarRecommendations = () => {
 	}
 
 	return (
-		<div>
+		<div className="2xl:yst-basis-1/5">
 			<div className="yst-sticky yst-top-16">
 				<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
 					<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />

--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -1,9 +1,11 @@
-import { AcademyUpsellCard, PremiumUpsellCard, RecommendationsSidebar } from "../../shared-admin/components";
+import { useEffect, useState, useCallback } from "@wordpress/element";
+import PropTypes from "prop-types";
+import { AcademyUpsellCard, PremiumUpsellCard } from "../../shared-admin/components";
 import { useSelectDashboard } from "../hooks";
 /**
  * @returns {JSX.Element} The sidebar recommendations.
  */
-const SidebarRecommendations = () => {
+const SidebarRecommendations = ( { position } ) => {
 	const isPremium = useSelectDashboard( "selectPreference", [], "isPremium" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/jj" );
@@ -13,12 +15,49 @@ const SidebarRecommendations = () => {
 		return null;
 	}
 
+	const [ sidebarPosition, setSidebarPosition ] = useState( {} );
+	const [ scrollY, setScrollY ] = useState( 0 );
+
+	const updatePosition = useCallback( () => {
+		setScrollY( window.scrollY );
+	}, [ setScrollY ] );
+
+	useEffect( () => {
+		if ( ! position?.top ) {
+			return;
+		}
+
+		if ( position.top > scrollY ) {
+			setSidebarPosition( { top: position.top - scrollY } );
+		} else {
+			setSidebarPosition( { top: "64px" } );
+		}
+	}, [ scrollY ] );
+
+	useEffect( () => {
+		setScrollY( window.scrollY );
+		window.addEventListener( "scroll", updatePosition );
+		window.addEventListener( "resize", updatePosition );
+		return () => {
+			window.removeEventListener( "scroll", updatePosition );
+			window.removeEventListener( "resize", updatePosition );
+		};
+	}, [] );
+
 	return (
-		<RecommendationsSidebar>
-			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
-			<AcademyUpsellCard link={ academyLink } />
-		</RecommendationsSidebar>
+		<div className="xl:yst-max-w-3xl xl:yst-fixed xl:yst-right-8 xl:yst-w-[16rem]" style={ sidebarPosition }>
+			<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
+				<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
+				<AcademyUpsellCard link={ academyLink } />
+			</div>
+		</div>
 	);
+};
+
+SidebarRecommendations.propTypes = {
+	position: PropTypes.shape( {
+		top: PropTypes.number,
+	} ),
 };
 
 export default SidebarRecommendations;

--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -14,7 +14,7 @@ const SidebarRecommendations = () => {
 	}
 
 	return (
-		<div className="2xl:yst-basis-1/5">
+		<div className="yst-min-w-[16rem] xl:yst-max-w-[16rem]">
 			<div className="yst-sticky yst-top-16">
 				<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
 					<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />

--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -1,11 +1,9 @@
-import { useEffect, useState, useCallback } from "@wordpress/element";
-import PropTypes from "prop-types";
-import { AcademyUpsellCard, PremiumUpsellCard } from "../../shared-admin/components";
+import { AcademyUpsellCard, PremiumUpsellCard, RecommendationsSidebar } from "../../shared-admin/components";
 import { useSelectDashboard } from "../hooks";
 /**
  * @returns {JSX.Element} The sidebar recommendations.
  */
-const SidebarRecommendations = ( { position } ) => {
+const SidebarRecommendations = () => {
 	const isPremium = useSelectDashboard( "selectPreference", [], "isPremium" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/jj" );
@@ -15,49 +13,12 @@ const SidebarRecommendations = ( { position } ) => {
 		return null;
 	}
 
-	const [ sidebarPosition, setSidebarPosition ] = useState( {} );
-	const [ scrollY, setScrollY ] = useState( 0 );
-
-	const updatePosition = useCallback( () => {
-		setScrollY( window.scrollY );
-	}, [ setScrollY ] );
-
-	useEffect( () => {
-		if ( ! position?.top ) {
-			return;
-		}
-
-		if ( position.top > scrollY ) {
-			setSidebarPosition( { top: position.top - scrollY } );
-		} else {
-			setSidebarPosition( { top: "64px" } );
-		}
-	}, [ scrollY ] );
-
-	useEffect( () => {
-		setScrollY( window.scrollY );
-		window.addEventListener( "scroll", updatePosition );
-		window.addEventListener( "resize", updatePosition );
-		return () => {
-			window.removeEventListener( "scroll", updatePosition );
-			window.removeEventListener( "resize", updatePosition );
-		};
-	}, [] );
-
 	return (
-		<div className="xl:yst-max-w-3xl xl:yst-fixed xl:yst-right-8 xl:yst-w-[16rem]" style={ sidebarPosition }>
-			<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
-				<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
-				<AcademyUpsellCard link={ academyLink } />
-			</div>
-		</div>
+		<RecommendationsSidebar>
+			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
+			<AcademyUpsellCard link={ academyLink } />
+		</RecommendationsSidebar>
 	);
-};
-
-SidebarRecommendations.propTypes = {
-	position: PropTypes.shape( {
-		top: PropTypes.number,
-	} ),
 };
 
 export default SidebarRecommendations;

--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -14,7 +14,7 @@ const SidebarRecommendations = () => {
 	}
 
 	return (
-		<div className="yst-w-full">
+		<div>
 			<div className="yst-sticky yst-top-16">
 				<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
 					<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />

--- a/packages/js/src/dashboard/components/sidebar-recommendations.js
+++ b/packages/js/src/dashboard/components/sidebar-recommendations.js
@@ -1,4 +1,4 @@
-import { AcademyUpsellCard, PremiumUpsellCard, RecommendationsSidebar } from "../../shared-admin/components";
+import { AcademyUpsellCard, PremiumUpsellCard } from "../../shared-admin/components";
 import { useSelectDashboard } from "../hooks";
 /**
  * @returns {JSX.Element} The sidebar recommendations.
@@ -14,10 +14,14 @@ const SidebarRecommendations = () => {
 	}
 
 	return (
-		<RecommendationsSidebar>
-			<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
-			<AcademyUpsellCard link={ academyLink } />
-		</RecommendationsSidebar>
+		<div className="yst-w-full">
+			<div className="yst-sticky yst-top-16">
+				<div className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 min-[783px]:yst-grid-cols-1 lg:yst-grid-cols-2 xl:yst-grid-cols-1 yst-gap-4">
+					<PremiumUpsellCard link={ premiumLink } linkProps={ premiumUpsellConfig } promotions={ promotions } />
+					<AcademyUpsellCard link={ academyLink } />
+				</div>
+			</div>
+		</div>
 	);
 };
 

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -26,7 +26,7 @@ export const AlertCenter = () => {
 					</div>
 				</header>
 			</Paper>
-			<div>
+			<div className="yst-basis-full">
 				<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
 					<Problems />
 					<Notifications />

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -15,9 +15,9 @@ export const AlertCenter = () => {
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
 	return <div className="yst-flex yst-gap-8 2xl:yst-flex-row yst-flex-col">
 		 { /* Alert center */ }
-		<div className="yst-flex yst-flex-wrap yst-grow xl:yst-flex-row yst-flex-col">
+		<div className="yst-flex yst-flex-wrap 2xl:yst-basis-4/5 2xl::yst-flex-row yst-flex-col">
 			<Paper className="yst-grow">
-				<header className="yst-p-8 yst-border-b yst-border-slate-200">
+				<header className="yst-p-8">
 					<div className="yst-max-w-screen-sm">
 						<Title>{ __( "Alert center", "wordpress-seo" ) }</Title>
 						<p className="yst-text-tiny yst-mt-3">

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -13,7 +13,7 @@ export const AlertCenter = () => {
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectDashboard( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
-	return <div className="yst-flex yst-gap-8">
+	return <div className="yst-flex yst-gap-8 2xl:yst-flex-row yst-flex-col">
 		 { /* Alert center */ }
 		<div className="yst-flex yst-flex-wrap yst-grow xl:yst-flex-row yst-flex-col">
 			<Paper className="yst-grow">

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -13,9 +13,9 @@ export const AlertCenter = () => {
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectDashboard( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
-	return <div className="yst-flex yst-gap-8 2xl:yst-flex-row yst-flex-col">
+	return <div className="yst-flex yst-gap-8 xl:yst-flex-row yst-flex-col">
 		 { /* Alert center */ }
-		<div className="yst-flex yst-flex-wrap 2xl:yst-basis-4/5 2xl::yst-flex-row yst-flex-col">
+		<div className="yst-flex yst-flex-wrap yst-flex-grow xl:yst-flex-row yst-flex-col">
 			<Paper className="yst-grow">
 				<header className="yst-p-8">
 					<div className="yst-max-w-screen-sm">

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -1,5 +1,4 @@
 import { __ } from "@wordpress/i18n";
-import { useRef, useEffect, useState } from "@wordpress/element";
 import { Paper, Title } from "@yoast/ui-library";
 import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-list";
 import { Notifications, Problems } from "../components";
@@ -14,18 +13,8 @@ export const AlertCenter = () => {
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectDashboard( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
-	const paperRef = useRef( null );
-	const [ position, setPosition ] = useState( { top: 0 } );
-
-	useEffect( () => {
-		if ( paperRef.current ) {
-			const rect = paperRef.current.getBoundingClientRect();
-			setPosition( { top: rect.top + window.scrollY } );
-		}
-	}, [] );
-
 	return <>
-		<div ref={ paperRef } className={ classNames( {  "yst-flex yst-flex-wrap xl:yst-pr-[17.5rem]": ! isPremium } ) }>
+		<div className={ classNames( {  "yst-flex yst-flex-wrap xl:yst-pr-[17.5rem]": ! isPremium } ) }>
 			<Paper className="yst-grow">
 				<header className="yst-p-8 yst-border-b yst-border-slate-200">
 					<div className="yst-max-w-screen-sm">
@@ -47,7 +36,7 @@ export const AlertCenter = () => {
 					promotions={ promotions }
 				/> }
 			</div>
-			<SidebarRecommendations position={ position } />
+			<SidebarRecommendations />
 		</div>
 	</>;
 };

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -1,4 +1,5 @@
 import { __ } from "@wordpress/i18n";
+import { useRef, useEffect, useState } from "@wordpress/element";
 import { Paper, Title } from "@yoast/ui-library";
 import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-list";
 import { Notifications, Problems } from "../components";
@@ -13,8 +14,18 @@ export const AlertCenter = () => {
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectDashboard( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
+	const paperRef = useRef( null );
+	const [ position, setPosition ] = useState( { top: 0 } );
+
+	useEffect( () => {
+		if ( paperRef.current ) {
+			const rect = paperRef.current.getBoundingClientRect();
+			setPosition( { top: rect.top + window.scrollY } );
+		}
+	}, [] );
+
 	return <>
-		<div className={ classNames( {  "yst-flex yst-flex-wrap xl:yst-pr-[17.5rem]": ! isPremium } ) }>
+		<div ref={ paperRef } className={ classNames( {  "yst-flex yst-flex-wrap xl:yst-pr-[17.5rem]": ! isPremium } ) }>
 			<Paper className="yst-grow">
 				<header className="yst-p-8 yst-border-b yst-border-slate-200">
 					<div className="yst-max-w-screen-sm">
@@ -36,7 +47,7 @@ export const AlertCenter = () => {
 					promotions={ promotions }
 				/> }
 			</div>
-			<SidebarRecommendations />
+			<SidebarRecommendations position={ position } />
 		</div>
 	</>;
 };

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -26,7 +26,7 @@ export const AlertCenter = () => {
 				</header>
 			</Paper>
 			<div>
-				<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow">
+				<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
 					<Problems />
 					<Notifications />
 				</div>

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -25,9 +25,11 @@ export const AlertCenter = () => {
 					</div>
 				</header>
 			</Paper>
-			<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow">
-				<Problems />
-				<Notifications />
+			<div>
+				<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow">
+					<Problems />
+					<Notifications />
+				</div>
 				{ ! isPremium && <PremiumUpsellList
 					premiumLink={ premiumLink }
 					premiumUpsellConfig={ premiumUpsellConfig }

--- a/packages/js/src/dashboard/routes/alert-center.js
+++ b/packages/js/src/dashboard/routes/alert-center.js
@@ -4,7 +4,7 @@ import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-
 import { Notifications, Problems } from "../components";
 import SidebarRecommendations from "../components/sidebar-recommendations";
 import { useSelectDashboard } from "../hooks";
-import classNames from "classnames";
+
 /**
  * @returns {JSX.Element} The dashboard content placeholder.
  */
@@ -13,8 +13,9 @@ export const AlertCenter = () => {
 	const premiumLink = useSelectDashboard( "selectLink", [], "https://yoa.st/17h" );
 	const premiumUpsellConfig = useSelectDashboard( "selectUpsellSettingsAsProps" );
 	const promotions = useSelectDashboard( "selectPreference", [], "promotions", [] );
-	return <>
-		<div className={ classNames( {  "yst-flex yst-flex-wrap xl:yst-pr-[17.5rem]": ! isPremium } ) }>
+	return <div className="yst-flex yst-gap-8">
+		 { /* Alert center */ }
+		<div className="yst-flex yst-flex-wrap yst-grow xl:yst-flex-row yst-flex-col">
 			<Paper className="yst-grow">
 				<header className="yst-p-8 yst-border-b yst-border-slate-200">
 					<div className="yst-max-w-screen-sm">
@@ -36,7 +37,8 @@ export const AlertCenter = () => {
 					promotions={ promotions }
 				/> }
 			</div>
-			<SidebarRecommendations />
 		</div>
-	</>;
+		{ /* Sidebar Recommendations */ }
+		<SidebarRecommendations />
+	</div>;
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Separate ad from alerts cards grid in the general page, fix grid height and sticky effect to the upsell sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate premium if it's active.
* Enable the new general page by adding:
```php
define( 'YOAST_SEO_NEW_DASHBOARD_UI', true );
```
* Check that the ad under the cards in the new general page is not the same width as the cards:
![Screenshot 2024-09-26 at 11 24 45](https://github.com/user-attachments/assets/1888519f-4179-4b51-b848-2a6d27290970)

This is an example of how it looks like without this PR:
![Screenshot 2024-09-26 at 11 24 26](https://github.com/user-attachments/assets/2d37dff3-af4d-4b06-b47c-fd0b2d8a05b3)

* Check the alerts card problems and notification can be in different heights, not like in the above screenshot
* Check the sidebar is sticky to the top of the alert center.
* Check sidebar recommendation is responsive.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
