### PR TITLE
fix: move promotion properties to site base info

### DIFF
--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -7,6 +7,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 
 /**
@@ -50,6 +51,13 @@ abstract class Base_Site_Information {
 	protected $options_helper;
 
 	/**
+	 * The promotion manager.
+	 *
+	 * @var Promotion_Manager $promotion_manager
+	 */
+	protected $promotion_manager;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param Short_Link_Helper                  $short_link_helper                  The short link helper.
@@ -58,19 +66,22 @@ abstract class Base_Site_Information {
 	 * @param Meta_Surface                       $meta                               The meta surface.
 	 * @param Product_Helper                     $product_helper                     The product helper.
 	 * @param Options_Helper                     $options_helper                     The options helper.
+	 * @param Promotion_Manager                  $promotion_manager                  The promotion manager.
 	 */
 	public function __construct(
 		Short_Link_Helper $short_link_helper,
 		Wistia_Embed_Permission_Repository $wistia_embed_permission_repository,
 		Meta_Surface $meta,
 		Product_Helper $product_helper,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Promotion_Manager $promotion_manager
 	) {
 		$this->short_link_helper                  = $short_link_helper;
 		$this->wistia_embed_permission_repository = $wistia_embed_permission_repository;
 		$this->meta                               = $meta;
 		$this->product_helper                     = $product_helper;
 		$this->options_helper                     = $options_helper;
+		$this->promotion_manager                  = $promotion_manager;
 	}
 
 	/**
@@ -81,23 +92,25 @@ abstract class Base_Site_Information {
 	 */
 	public function get_site_information(): array {
 		return [
-			'adminUrl'              => \admin_url( 'admin.php' ),
-			'linkParams'            => $this->short_link_helper->get_query_params(),
-			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
-			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
-			'site_name'             => $this->meta->for_current_page()->site_name,
-			'contentLocale'         => \get_locale(),
-			'userLocale'            => \get_user_locale(),
-			'isRtl'                 => \is_rtl(),
-			'isPremium'             => $this->product_helper->is_premium(),
-			'siteIconUrl'           => \get_site_icon_url(),
-			'showSocial'            => [
+			'adminUrl'                  => \admin_url( 'admin.php' ),
+			'linkParams'                => $this->short_link_helper->get_query_params(),
+			'pluginUrl'                 => \plugins_url( '', \WPSEO_FILE ),
+			'wistiaEmbedPermission'     => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
+			'site_name'                 => $this->meta->for_current_page()->site_name,
+			'contentLocale'             => \get_locale(),
+			'userLocale'                => \get_user_locale(),
+			'isRtl'                     => \is_rtl(),
+			'isPremium'                 => $this->product_helper->is_premium(),
+			'siteIconUrl'               => \get_site_icon_url(),
+			'showSocial'                => [
 				'facebook' => $this->options_helper->get( 'opengraph', false ),
 				'twitter'  => $this->options_helper->get( 'twitter', false ),
 			],
-			'sitewideSocialImage'   => $this->options_helper->get( 'og_default_image' ),
+			'sitewideSocialImage'       => $this->options_helper->get( 'og_default_image' ),
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
-			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
+			'isPrivateBlog'             => ( (string) \get_option( 'blog_public' ) ) === '0',
+			'currentPromotions'         => $this->promotion_manager->get_current_promotions(),
+			'blackFridayBlockEditorUrl' => ( $this->promotion_manager->is( 'black-friday-2023-checklist' ) ) ? $this->short_link_helper->get( 'https://yoa.st/black-friday-checklist' ) : '',
 		];
 	}
 
@@ -109,14 +122,16 @@ abstract class Base_Site_Information {
 	 */
 	public function get_legacy_site_information(): array {
 		return [
-			'adminUrl'              => \admin_url( 'admin.php' ),
-			'linkParams'            => $this->short_link_helper->get_query_params(),
-			'pluginUrl'             => \plugins_url( '', \WPSEO_FILE ),
-			'wistiaEmbedPermission' => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
-			'sitewideSocialImage'   => $this->options_helper->get( 'og_default_image' ),
+			'adminUrl'                  => \admin_url( 'admin.php' ),
+			'linkParams'                => $this->short_link_helper->get_query_params(),
+			'pluginUrl'                 => \plugins_url( '', \WPSEO_FILE ),
+			'wistiaEmbedPermission'     => $this->wistia_embed_permission_repository->get_value_for_user( \get_current_user_id() ),
+			'sitewideSocialImage'       => $this->options_helper->get( 'og_default_image' ),
 			// phpcs:ignore Generic.ControlStructures.DisallowYodaConditions -- Bug: squizlabs/PHP_CodeSniffer#2962.
-			'isPrivateBlog'         => ( (string) \get_option( 'blog_public' ) ) === '0',
-			'metabox'               => [
+			'isPrivateBlog'             => ( (string) \get_option( 'blog_public' ) ) === '0',
+			'currentPromotions'         => $this->promotion_manager->get_current_promotions(),
+			'blackFridayBlockEditorUrl' => ( $this->promotion_manager->is( 'black-friday-2023-checklist' ) ) ? $this->short_link_helper->get( 'https://yoa.st/black-friday-checklist' ) : '',
+			'metabox'                   => [
 				'site_name'     => $this->meta->for_current_page()->site_name,
 				'contentLocale' => \get_locale(),
 				'userLocale'    => \get_user_locale(),

--- a/src/editors/framework/site/post-site-information.php
+++ b/src/editors/framework/site/post-site-information.php
@@ -30,16 +30,8 @@ class Post_Site_Information extends Base_Site_Information {
 	private $alert_dismissal_action;
 
 	/**
-	 * The promotion manager.
-	 *
-	 * @var Promotion_Manager $promotion_manager
-	 */
-	private $promotion_manager;
-
-	/**
 	 * Constructs the class.
 	 *
-	 * @param Promotion_Manager                  $promotion_manager                  The promotion manager.
 	 * @param Short_Link_Helper                  $short_link_helper                  The short link helper.
 	 * @param Wistia_Embed_Permission_Repository $wistia_embed_permission_repository The wistia embed permission
 	 *                                                                               repository.
@@ -47,20 +39,20 @@ class Post_Site_Information extends Base_Site_Information {
 	 * @param Product_Helper                     $product_helper                     The product helper.
 	 * @param Alert_Dismissal_Action             $alert_dismissal_action             The alert dismissal action.
 	 * @param Options_Helper                     $options_helper                     The options helper.
+	 * @param Promotion_Manager                  $promotion_manager                  The promotion manager.
 	 *
 	 * @return void
 	 */
 	public function __construct(
-		Promotion_Manager $promotion_manager,
 		Short_Link_Helper $short_link_helper,
 		Wistia_Embed_Permission_Repository $wistia_embed_permission_repository,
 		Meta_Surface $meta,
 		Product_Helper $product_helper,
 		Alert_Dismissal_Action $alert_dismissal_action,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Promotion_Manager $promotion_manager
 	) {
-		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper, $options_helper );
-		$this->promotion_manager      = $promotion_manager;
+		parent::__construct( $short_link_helper, $wistia_embed_permission_repository, $meta, $product_helper, $options_helper, $promotion_manager );
 		$this->alert_dismissal_action = $alert_dismissal_action;
 	}
 
@@ -85,9 +77,7 @@ class Post_Site_Information extends Base_Site_Information {
 
 		$data = [
 			'dismissedAlerts'            => $dismissed_alerts,
-			'currentPromotions'          => $this->promotion_manager->get_current_promotions(),
 			'webinarIntroBlockEditorUrl' => $this->short_link_helper->get( 'https://yoa.st/webinar-intro-block-editor' ),
-			'blackFridayBlockEditorUrl'  => ( $this->promotion_manager->is( 'black-friday-2023-checklist' ) ) ? $this->short_link_helper->get( 'https://yoa.st/black-friday-checklist' ) : '',
 			'metabox'                    => [
 				'search_url'    => $this->search_url(),
 				'post_edit_url' => $this->edit_url(),
@@ -108,9 +98,7 @@ class Post_Site_Information extends Base_Site_Information {
 
 		$data = [
 			'dismissedAlerts'            => $dismissed_alerts,
-			'currentPromotions'          => $this->promotion_manager->get_current_promotions(),
 			'webinarIntroBlockEditorUrl' => $this->short_link_helper->get( 'https://yoa.st/webinar-intro-block-editor' ),
-			'blackFridayBlockEditorUrl'  => ( $this->promotion_manager->is( 'black-friday-2023-checklist' ) ) ? $this->short_link_helper->get( 'https://yoa.st/black-friday-checklist' ) : '',
 			'search_url'                 => $this->search_url(),
 			'post_edit_url'              => $this->edit_url(),
 			'base_url'                   => $this->base_url_for_js(),

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -98,7 +98,7 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->alert_dismissal_action = Mockery::mock( Alert_Dismissal_Action::class );
 		$this->options_helper         = Mockery::mock( Options_Helper::class );
 
-		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper );
+		$this->instance = new Post_Site_Information( $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper, $this->promotion_manager );
 		$this->instance->set_permalink( 'perma' );
 		$this->set_mocks();
 	}
@@ -120,12 +120,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'dismissedAlerts'            => [
 				'the alert',
 			],
-			'currentPromotions'          => [
-				'the promotion',
-				'another one',
-			],
 			'webinarIntroBlockEditorUrl' => 'https://expl.c',
-			'blackFridayBlockEditorUrl'  => '',
 			'metabox'                    => [
 				'search_url'    => 'https://example.org',
 				'post_edit_url' => 'https://example.org',
@@ -151,6 +146,11 @@ final class Post_Site_Information_Test extends TestCase {
 			'wistiaEmbedPermission'      => true,
 			'sitewideSocialImage'        => null,
 			'isPrivateBlog'              => false,
+			'currentPromotions'          => [
+				'the promotion',
+				'another one',
+			],
+			'blackFridayBlockEditorUrl'  => '',
 
 		];
 
@@ -186,12 +186,7 @@ final class Post_Site_Information_Test extends TestCase {
 			'dismissedAlerts'                => [
 				'the alert',
 			],
-			'currentPromotions'              => [
-				'the promotion',
-				'another one',
-			],
 			'webinarIntroBlockEditorUrl'     => 'https://expl.c',
-			'blackFridayBlockEditorUrl'      => '',
 			'search_url'                     => 'https://example.org',
 			'post_edit_url'                  => 'https://example.org',
 			'base_url'                       => 'https://example.org',
@@ -215,6 +210,11 @@ final class Post_Site_Information_Test extends TestCase {
 			],
 			'sitewideSocialImage'            => null,
 			'isPrivateBlog'                  => false,
+			'currentPromotions'              => [
+				'the promotion',
+				'another one',
+			],
+			'blackFridayBlockEditorUrl'      => '',
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );

--- a/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Term_Site_Information_Test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Wistia_Embed_Permission_Repository;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Editors\Site_Information_Mocks_Trait;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -63,6 +64,13 @@ final class Term_Site_Information_Test extends TestCase {
 	private $product_helper;
 
 	/**
+	 * Holds the Promotion_Manager instance.
+	 *
+	 * @var Mockery\MockInterface|Promotion_Manager
+	 */
+	private $promotion_manager;
+
+	/**
 	 * The Term_Site_Information container.
 	 *
 	 * @var Term_Site_Information
@@ -81,8 +89,9 @@ final class Term_Site_Information_Test extends TestCase {
 		$this->wistia_embed_repo = Mockery::mock( Wistia_Embed_Permission_Repository::class );
 		$this->meta_surface      = Mockery::mock( Meta_Surface::class );
 		$this->product_helper    = Mockery::mock( Product_Helper::class );
+		$this->promotion_manager = Mockery::mock( Promotion_Manager::class );
 
-		$this->instance      = new Term_Site_Information( $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->options_helper );
+		$this->instance      = new Term_Site_Information( $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->options_helper, $this->promotion_manager );
 		$taxonomy            = Mockery::mock( WP_Taxonomy::class )->makePartial();
 		$taxonomy->rewrite   = false;
 		$mock_term           = Mockery::mock( WP_Term::class )->makePartial();
@@ -114,28 +123,33 @@ final class Term_Site_Information_Test extends TestCase {
 	 */
 	public function test_site_information() {
 		$expected = [
-			'search_url'            => 'https://example.org',
-			'post_edit_url'         => 'https://example.org',
-			'base_url'              => 'https://example.org',
-			'adminUrl'              => 'https://example.org',
-			'linkParams'            => [
+			'search_url'                => 'https://example.org',
+			'post_edit_url'             => 'https://example.org',
+			'base_url'                  => 'https://example.org',
+			'adminUrl'                  => 'https://example.org',
+			'linkParams'                => [
 				'param',
 				'param2',
 			],
-			'pluginUrl'             => '/location',
-			'wistiaEmbedPermission' => true,
-			'site_name'             => 'examepl.com',
-			'contentLocale'         => 'nl_NL',
-			'userLocale'            => 'nl_NL',
-			'isRtl'                 => false,
-			'isPremium'             => true,
-			'siteIconUrl'           => 'https://example.org',
-			'showSocial'            => [
+			'pluginUrl'                 => '/location',
+			'wistiaEmbedPermission'     => true,
+			'site_name'                 => 'examepl.com',
+			'contentLocale'             => 'nl_NL',
+			'userLocale'                => 'nl_NL',
+			'isRtl'                     => false,
+			'isPremium'                 => true,
+			'siteIconUrl'               => 'https://example.org',
+			'showSocial'                => [
 				'facebook' => false,
 				'twitter'  => false,
 			],
-			'sitewideSocialImage'   => null,
-			'isPrivateBlog'         => true,
+			'sitewideSocialImage'       => null,
+			'isPrivateBlog'             => true,
+			'currentPromotions'         => [
+				'the promotion',
+				'another one',
+			],
+			'blackFridayBlockEditorUrl' => '',
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
@@ -144,6 +158,9 @@ final class Term_Site_Information_Test extends TestCase {
 			->once()
 			->with( 'blog_public' )
 			->andReturn( '0' );
+
+		$this->promotion_manager->expects( 'get_current_promotions' )->andReturn( [ 'the promotion', 'another one' ] );
+		$this->promotion_manager->expects( 'is' )->andReturnFalse();
 
 		$this->assertSame( $expected, $this->instance->get_site_information() );
 	}
@@ -163,7 +180,7 @@ final class Term_Site_Information_Test extends TestCase {
 	public function test_legacy_site_information() {
 
 		$expected = [
-			'metabox'               => [
+			'metabox'                   => [
 				'search_url'    => 'https://example.org',
 				'post_edit_url' => 'https://example.org',
 				'base_url'      => 'https://example.org',
@@ -178,19 +195,27 @@ final class Term_Site_Information_Test extends TestCase {
 					'twitter'  => false,
 				],
 			],
-			'adminUrl'              => 'https://example.org',
-			'linkParams'            => [
+			'adminUrl'                  => 'https://example.org',
+			'linkParams'                => [
 				'param',
 				'param2',
 			],
-			'pluginUrl'             => '/location',
-			'wistiaEmbedPermission' => true,
-			'sitewideSocialImage'   => null,
-			'isPrivateBlog'         => false,
+			'pluginUrl'                 => '/location',
+			'wistiaEmbedPermission'     => true,
+			'sitewideSocialImage'       => null,
+			'isPrivateBlog'             => false,
+			'currentPromotions'         => [
+				'the promotion',
+				'another one',
+			],
+			'blackFridayBlockEditorUrl' => '',
 		];
 
 		Monkey\Functions\expect( 'admin_url' )->andReturn( 'https://example.org' );
 		Monkey\Functions\expect( 'home_url' )->andReturn( 'https://example.org' );
+
+		$this->promotion_manager->expects( 'get_current_promotions' )->andReturn( [ 'the promotion', 'another one' ] );
+		$this->promotion_manager->expects( 'is' )->andReturnFalse();
 
 		$this->assertSame( $expected, $this->instance->get_legacy_site_information() );
 	}

--- a/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -95,7 +95,7 @@ final class Post_Site_Information_Test extends TestCase {
 		$this->options_helper         = \YoastSEO()->helpers->options;
 		$this->alert_dismissal_action = \YoastSEO()->classes->get( Alert_Dismissal_Action::class );
 
-		$this->instance = new Post_Site_Information( $this->promotion_manager, $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper );
+		$this->instance = new Post_Site_Information( $this->short_link_helper, $this->wistia_embed_repo, $this->meta_surface, $this->product_helper, $this->alert_dismissal_action, $this->options_helper, $this->promotion_manager );
 		$this->instance->set_permalink( 'perma' );
 	}
 
@@ -114,9 +114,7 @@ final class Post_Site_Information_Test extends TestCase {
 	public function test_legacy_site_information() {
 		$expected = [
 			'dismissedAlerts'            => false,
-			'currentPromotions'          => [],
 			'webinarIntroBlockEditorUrl' => $this->short_link_helper->get( 'https://yoa.st/webinar-intro-block-editor' ),
-			'blackFridayBlockEditorUrl'  => '',
 			'metabox'                    =>
 				[
 					'search_url'    => 'http://example.org/wp-admin/edit.php?seo_kw_filter={keyword}',
@@ -139,6 +137,8 @@ final class Post_Site_Information_Test extends TestCase {
 			'wistiaEmbedPermission'      => true,
 			'sitewideSocialImage'        => '',
 			'isPrivateBlog'              => false,
+			'currentPromotions'          => [],
+			'blackFridayBlockEditorUrl'  => '',
 		];
 
 		$this->assertSame( $expected, $this->instance->get_legacy_site_information() );
@@ -161,9 +161,7 @@ final class Post_Site_Information_Test extends TestCase {
 
 		$expected = [
 			'dismissedAlerts'            => false,
-			'currentPromotions'          => [],
 			'webinarIntroBlockEditorUrl' => $this->short_link_helper->get( 'https://yoa.st/webinar-intro-block-editor' ),
-			'blackFridayBlockEditorUrl'  => '',
 			'search_url'                 => 'http://example.org/wp-admin/edit.php?seo_kw_filter={keyword}',
 			'post_edit_url'              => 'http://example.org/wp-admin/post.php?post={id}&action=edit',
 			'base_url'                   => 'http://example.org/',
@@ -183,6 +181,8 @@ final class Post_Site_Information_Test extends TestCase {
 			],
 			'sitewideSocialImage'        => '',
 			'isPrivateBlog'              => true,
+			'currentPromotions'          => [],
+			'blackFridayBlockEditorUrl'  => '',
 		];
 
 		$site_info = $this->instance->get_site_information();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add the Black Friday ads to our Yoast editor  when editing taxonomies.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add Black Friday promotion ad to taxonomies editor.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast premium is not active.
* Enable Black Friday promotion by editing `src/promotions/domain/black-friday-promotion.php` replace line 16:
```php
new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2023 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
```

* Edit a category or any taxonomy and check you see the black friday ad on the editor and when clicking on "Add related keyphrase".
* Click on SEO analysis and click "add synonyms" the upsell modal should contain the Black Friday promotion.  

![Screenshot 2024-09-27 at 15 25 07](https://github.com/user-attachments/assets/88cd803e-f983-45aa-afdb-68426bcda08c)
![Screenshot 2024-09-27 at 15 26 11](https://github.com/user-attachments/assets/9916250f-285d-4b70-ab22-7af5835db38b)

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [23.6 - BF - Black Friday promotion is missing in metabox for taxonomies](https://github.com/Yoast/plugins-automated-testing/issues/1867)
