### PR TITLE
Dont query for unindexed stuff if no public taxonomies

### DIFF
--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -57,7 +57,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		$query = $this->get_select_query( $limit );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$unindexed_object_ids = ( $query !== '' ) ? $this->wpdb->get_col( $query ) : [];
+		$unindexed_object_ids = ( $query === '' ) ? [] : $this->wpdb->get_col( $query );
 		$count                = (int) \count( $unindexed_object_ids );
 
 		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, ( \MINUTE_IN_SECONDS * 15 ) );
@@ -83,7 +83,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		$query = $this->get_count_query();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$count = ( $query !== '' ) ? $this->wpdb->get_var( $query ) : 0;
+		$count = ( $query === '' ) ? 0 : $this->wpdb->get_var( $query );
 
 		if ( \is_null( $count ) ) {
 			return false;

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -57,7 +57,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		$query = $this->get_select_query( $limit );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$unindexed_object_ids = $this->wpdb->get_col( $query );
+		$unindexed_object_ids = ( $query !== '' ) ? $this->wpdb->get_col( $query ) : [];
 		$count                = (int) \count( $unindexed_object_ids );
 
 		\set_transient( static::UNINDEXED_LIMITED_COUNT_TRANSIENT, $count, ( \MINUTE_IN_SECONDS * 15 ) );
@@ -83,7 +83,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		$query = $this->get_count_query();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
-		$count = $this->wpdb->get_var( $query );
+		$count = ( $query !== '' ) ? $this->wpdb->get_var( $query ) : 0;
 
 		if ( \is_null( $count ) ) {
 			return false;

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -128,6 +128,10 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 		$taxonomy_table    = $this->wpdb->term_taxonomy;
 		$public_taxonomies = $this->taxonomy->get_indexable_taxonomies();
 
+		if ( empty( $public_taxonomies ) ) {
+			return '';
+		}
+
 		$taxonomies_placeholders = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
 		$replacements = [ $this->version ];
@@ -159,7 +163,12 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 		$indexable_table   = Model::get_table_name( 'Indexable' );
 		$taxonomy_table    = $this->wpdb->term_taxonomy;
 		$public_taxonomies = $this->taxonomy->get_indexable_taxonomies();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
+
+		if ( empty( $public_taxonomies ) ) {
+			return '';
+		}
+
+		$placeholders = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
 
 		$replacements = [ $this->version ];
 		\array_push( $replacements, ...$public_taxonomies );

--- a/src/actions/indexing/indexable-term-indexation-action.php
+++ b/src/actions/indexing/indexable-term-indexation-action.php
@@ -83,7 +83,7 @@ class Indexable_Term_Indexation_Action extends Abstract_Indexing_Action {
 		$query = $this->get_select_query( $this->get_limit() );
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
-		$term_ids = $this->wpdb->get_col( $query );
+		$term_ids = ( $query === '' ) ? [] : $this->wpdb->get_col( $query );
 
 		$indexables = [];
 		foreach ( $term_ids as $term_id ) {

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -52,6 +52,10 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	protected function get_objects() {
 		$query = $this->get_select_query( $this->get_limit() );
 
+		if ( $query === '' ) {
+			return [];
+		}
+
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
 		$terms = $this->wpdb->get_results( $query );
 
@@ -74,8 +78,13 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 */
 	protected function get_count_query() {
 		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
-		$placeholders      = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
-		$indexable_table   = Model::get_table_name( 'Indexable' );
+
+		if ( empty( $public_taxonomies ) ) {
+			return '';
+		}
+
+		$placeholders    = \implode( ', ', \array_fill( 0, \count( $public_taxonomies ), '%s' ) );
+		$indexable_table = Model::get_table_name( 'Indexable' );
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
 		return $this->wpdb->prepare(
@@ -101,6 +110,10 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 */
 	protected function get_select_query( $limit = false ) {
 		$public_taxonomies = $this->taxonomy_helper->get_indexable_taxonomies();
+
+		if ( empty( $public_taxonomies ) ) {
+			return '';
+		}
 
 		$indexable_table = Model::get_table_name( 'Indexable' );
 		$replacements    = $public_taxonomies;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a database error would occur when there were no public taxonomies available for indexing.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a website with no other custom taxomies (so a website with only Yoast SEO enabled), add the following filter, so as to have no public taxonomies:
```
add_filter( 'wpseo_indexable_excluded_taxonomies', 'exclude_category' );
function exclude_category ( ) {
	return ['category', 'post_tag', 'post_format'];
}
```
* Use the Yoast Test Helper to reset indexables and also run the `wp transient delete --all` WP CLI command
* Visit the Yoast SEO->Tools page

**Without this PR**:
* You would get a 
```
WordPress database error: [You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') LIMIT 2' at line 8]
SELECT term_id FROM wp_term_taxonomy AS T LEFT JOIN wp_yoast_indexable AS I ON T.term_id = I.object_id AND I.object_type = 'term' AND I.version = 2 WHERE I.object_id IS NULL AND taxonomy IN () LIMIT 2
```
error in your debug.log

**With this PR**:
* There would be no such error

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Regression test how we calculate unindexed links and how we index them, likeso:
* Have a site with some posts and some internal links
* Go to to Yoast SEO->Tools page, run `yoastIndexingData.amount` in the browser console and take a note of the number you get
* Run the SEOO and visit the `wp_yoast_indexable` & `wp_yoast_seo_links` tables to take a note of how many rows were created
* Reset indexables and transients and do the same with the production plugin and confirm:
  * that you get the same number in the console
  * that you get the same number of rows created after the SEOO was ran
* Also enable the `wpseo_indexable_excluded_taxonomies` filter mentioned above and do the same

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21124
