### PR TITLE
Adds promo code to upsell ad in upsell modals

### DIFF
--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -115,9 +115,10 @@ class UpsellBox extends Component {
 		return (
 			<Fragment>
 				{ isBlackFriday &&
-				<div className="yst-flex  yst-items-center yst-text-lg yst-content-between yst-bg-black yst-text-amber-300 yst-h-9 yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-px-6">
-					<div className="yst-mx-auto">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
-				</div> }
+					<div className="yst-flex yst-flex-col yst-items-center yst-bg-black yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-gap-2 yst-py-2 yst-leading-5">
+						<div className="yst-mx-auto yst-text-amber-300 yst-text-lg">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
+						<div className="yst-text-white yst-text-base yst-font-semibold">Promo code: BF2024</div> 
+					</div> }
 				<Container>
 					<Heading>{ this.props.title }</Heading>
 					<Description>{ this.props.description }</Description>

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -117,7 +117,7 @@ class UpsellBox extends Component {
 				{ isBlackFriday &&
 					<div className="yst-flex yst-flex-col yst-items-center yst-bg-black yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-gap-2 yst-py-2 yst-leading-5">
 						<div className="yst-mx-auto yst-text-amber-300 yst-text-lg">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
-						<div className="yst-text-white yst-text-base yst-font-semibold">Promo code: BF2024</div> 
+						<div className="yst-text-white yst-text-base yst-font-semibold">{ __( "Promo code", "wordpress-seo" ) }: BF2024</div>
 					</div> }
 				<Container>
 					<Heading>{ this.props.title }</Heading>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds promo code to Black Friday ad in the upsell modals.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast premium is not active.
* Enable Black Friday promotion by editing `src/promotions/domain/black-friday-promotion.php` replace line 16:
```php
new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2023 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
```
* Edit a post and click on the "Add related keyphrase" and "Add synonyms" links.
* [ ] Check you see the promo code in the black Friday strip as [in the design.](https://www.figma.com/design/1DRC9Y2EmMXJ2Fe49v5PgB/Upsell-modals?node-id=1-2167&node-type=frame&t=ee4z1pV6yB8v6Pao-0)
![Screenshot 2024-10-01 at 12 44 17](https://github.com/user-attachments/assets/fcda7df2-5891-4c03-91e6-50f80ac46be7)


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [23.6 - BF - Black Friday promo code is missing in upsell popup](https://github.com/Yoast/plugins-automated-testing/issues/1866)