### PR TITLE
Replace request helper usage with core function

### DIFF
--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -23,6 +23,7 @@ use Yoast\WP\SEO\Conditionals\Third_Party\Wordproof_Integration_Active_Condition
 use Yoast\WP\SEO\Conditionals\Third_Party\Wordproof_Plugin_Inactive_Conditional;
 use Yoast\WP\SEO\Config\Wordproof_App_Config;
 use Yoast\WP\SEO\Config\Wordproof_Translations;
+use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Helpers\Wordproof_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Disable_Concatenate_Scripts_Integration;
 use Yoast\WP\SEO\Integrations\Admin\Old_Premium_Integration;
@@ -45,6 +46,7 @@ $deprecated_classes = [
 	Ai_Generate_Titles_And_Descriptions_Introduction_Upsell::class => '23.2',
 	Disable_Concatenate_Scripts_Integration::class                 => '23.2',
 	Duplicate_Post_Integration::class                              => '23.4',
+	Request_Helper::class                                          => '23.6',
 ];
 
 foreach ( $deprecated_classes as $original_class => $version ) {

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -11,7 +11,6 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
@@ -123,13 +122,6 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	private $id_helper;
 
 	/**
-	 * The request helper.
-	 *
-	 * @var Request_Helper
-	 */
-	private $request_helper;
-
-	/**
 	 * The WPSEO Replace Vars object.
 	 *
 	 * @var WPSEO_Replace_Vars
@@ -184,7 +176,6 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @param Permalink_Helper     $permalink_helper     The permalink helper.
 	 * @param Indexable_Helper     $indexable_helper     The indexable helper.
 	 * @param Indexable_Repository $indexable_repository The indexable repository.
-	 * @param Request_Helper       $request_helper       The request helper.
 	 */
 	public function __construct(
 		Options_Helper $options,
@@ -196,8 +187,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		User_Helper $user,
 		Permalink_Helper $permalink_helper,
 		Indexable_Helper $indexable_helper,
-		Indexable_Repository $indexable_repository,
-		Request_Helper $request_helper
+		Indexable_Repository $indexable_repository
 	) {
 		$this->options              = $options;
 		$this->url                  = $url;
@@ -209,7 +199,6 @@ class Meta_Tags_Context extends Abstract_Presentation {
 		$this->permalink_helper     = $permalink_helper;
 		$this->indexable_helper     = $indexable_helper;
 		$this->indexable_repository = $indexable_repository;
-		$this->request_helper       = $request_helper;
 	}
 
 	/**
@@ -625,7 +614,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			return $this->image->get_attachment_image_url( $this->main_image_id, 'full' );
 		}
 
-		if ( $this->request_helper->is_rest_request() ) {
+		if ( \wp_is_serving_rest_request() ) {
 			return $this->get_main_image_url_for_rest_request();
 		}
 
@@ -647,7 +636,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return int|null The main image ID.
 	 */
 	public function generate_main_image_id() {
-		if ( $this->request_helper->is_rest_request() ) {
+		if ( \wp_is_serving_rest_request() ) {
 			return $this->get_main_image_id_for_rest_request();
 		}
 

--- a/src/deprecated/src/helpers/request-helper.php
+++ b/src/deprecated/src/helpers/request-helper.php
@@ -4,6 +4,8 @@ namespace Yoast\WP\SEO\Helpers;
 
 /**
  * A helper object for the request state.
+ *
+ * @codeCoverageIgnore Because of deprecation.
  */
 class Request_Helper {
 
@@ -11,8 +13,13 @@ class Request_Helper {
 	 * Checks if the current request is a REST request.
 	 *
 	 * @return bool True when the current request is a REST request.
+	 *
+	 * @deprecated 23.6
+	 * @codeCoverageIgnore
 	 */
 	public function is_rest_request() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 23.6', 'wp_is_serving_rest_request' );
+
 		return \defined( 'REST_REQUEST' ) && \REST_REQUEST === true;
 	}
 }

--- a/src/integrations/blocks/breadcrumbs-block.php
+++ b/src/integrations/blocks/breadcrumbs-block.php
@@ -3,7 +3,6 @@
 namespace Yoast\WP\SEO\Integrations\Blocks;
 
 use WPSEO_Replace_Vars;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Breadcrumbs_Presenter;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
@@ -57,33 +56,23 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 	private $indexable_repository;
 
 	/**
-	 * The request helper.
-	 *
-	 * @var Request_Helper
-	 */
-	private $request_helper;
-
-	/**
 	 * Siblings_Block constructor.
 	 *
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer     The context.
 	 * @param WPSEO_Replace_Vars         $replace_vars         The replace variable helper.
 	 * @param Helpers_Surface            $helpers              The Helpers surface.
 	 * @param Indexable_Repository       $indexable_repository The indexable repository.
-	 * @param Request_Helper             $request_helper       The request helper.
 	 */
 	public function __construct(
 		Meta_Tags_Context_Memoizer $context_memoizer,
 		WPSEO_Replace_Vars $replace_vars,
 		Helpers_Surface $helpers,
-		Indexable_Repository $indexable_repository,
-		Request_Helper $request_helper
+		Indexable_Repository $indexable_repository
 	) {
 		$this->context_memoizer     = $context_memoizer;
 		$this->replace_vars         = $replace_vars;
 		$this->helpers              = $helpers;
 		$this->indexable_repository = $indexable_repository;
-		$this->request_helper       = $request_helper;
 
 		$this->base_path = \WPSEO_PATH . 'blocks/dynamic-blocks/';
 	}
@@ -99,7 +88,7 @@ class Breadcrumbs_Block extends Dynamic_Block_V3 {
 		$presenter = new Breadcrumbs_Presenter();
 		// $this->context_memoizer->for_current_page only works on the frontend. To render the right breadcrumb in the
 		// editor, we need the repository.
-		if ( $this->request_helper->is_rest_request() || \is_admin() ) {
+		if ( \wp_is_serving_rest_request() || \is_admin() ) {
 			$post_id = \get_the_ID();
 			if ( $post_id ) {
 				$indexable = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -7,7 +7,6 @@ use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presenters\Abstract_Indexable_Presenter;
 use Yoast\WP\SEO\Presenters\Debug\Marker_Close_Presenter;
@@ -41,13 +40,6 @@ class Front_End_Integration implements Integration_Interface {
 	 * @var Options_Helper
 	 */
 	protected $options;
-
-	/**
-	 * Represents the request helper.
-	 *
-	 * @var Request_Helper
-	 */
-	protected $request;
 
 	/**
 	 * The helpers surface.
@@ -207,7 +199,6 @@ class Front_End_Integration implements Integration_Interface {
 	 * @param Meta_Tags_Context_Memoizer $context_memoizer  The meta tags context memoizer.
 	 * @param ContainerInterface         $service_container The DI container.
 	 * @param Options_Helper             $options           The options helper.
-	 * @param Request_Helper             $request           The request helper.
 	 * @param Helpers_Surface            $helpers           The helpers surface.
 	 * @param WPSEO_Replace_Vars         $replace_vars      The replace vars helper.
 	 */
@@ -215,14 +206,12 @@ class Front_End_Integration implements Integration_Interface {
 		Meta_Tags_Context_Memoizer $context_memoizer,
 		ContainerInterface $service_container,
 		Options_Helper $options,
-		Request_Helper $request,
 		Helpers_Surface $helpers,
 		WPSEO_Replace_Vars $replace_vars
 	) {
 		$this->container        = $service_container;
 		$this->context_memoizer = $context_memoizer;
 		$this->options          = $options;
-		$this->request          = $request;
 		$this->helpers          = $helpers;
 		$this->replace_vars     = $replace_vars;
 	}
@@ -353,7 +342,7 @@ class Front_End_Integration implements Integration_Interface {
 			return $presenters;
 		}
 
-		if ( $this->request->is_rest_request() ) {
+		if ( \wp_is_serving_rest_request() ) {
 			return $presenters;
 		}
 
@@ -559,7 +548,7 @@ class Front_End_Integration implements Integration_Interface {
 	 */
 	private function maybe_remove_title_presenter( $presenters ) {
 		// Do not remove the title if we're on a REST request.
-		if ( $this->request->is_rest_request() ) {
+		if ( \wp_is_serving_rest_request() ) {
 			return $presenters;
 		}
 

--- a/src/integrations/third-party/wincher-publish.php
+++ b/src/integrations/third-party/wincher-publish.php
@@ -105,8 +105,12 @@ class Wincher_Publish implements Integration_Interface {
 	 * Determines whether the current request is a REST request.
 	 *
 	 * @return bool Whether the request is a REST request.
+	 *
+	 * @deprecated 23.6
+	 * @codeCoverageIgnore
 	 */
 	public function is_rest_request() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 23.6', 'wp_is_serving_rest_request' );
 		return \defined( 'REST_REQUEST' ) && \REST_REQUEST;
 	}
 
@@ -153,7 +157,7 @@ class Wincher_Publish implements Integration_Interface {
 	 * @return void
 	 */
 	public function track_after_post_request( $post_id, $post ) {
-		if ( $this->is_rest_request() ) {
+		if ( \wp_is_serving_rest_request() ) {
 			return;
 		}
 

--- a/src/surfaces/helpers-surface.php
+++ b/src/surfaces/helpers-surface.php
@@ -35,7 +35,6 @@ use YoastSEO_Vendor\Symfony\Component\DependencyInjection\ContainerInterface;
  * @property Helpers\Primary_Term_Helper                    $primary_term
  * @property Helpers\Product_Helper                         $product
  * @property Helpers\Redirect_Helper                        $redirect
- * @property Helpers\Request_Helper                         $request
  * @property Helpers\Require_File_Helper                    $require_file
  * @property Helpers\Robots_Helper                          $robots
  * @property Helpers\Short_Link_Helper                      $short_link

--- a/tests/Unit/Context/Meta_Tags_Context_Test.php
+++ b/tests/Unit/Context/Meta_Tags_Context_Test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Permalink_Helper;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Helpers\Schema\ID_Helper;
 use Yoast\WP\SEO\Helpers\Site_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
@@ -93,13 +92,6 @@ final class Meta_Tags_Context_Test extends TestCase {
 	private $indexable_helper;
 
 	/**
-	 * The request helper.
-	 *
-	 * @var Request_Helper
-	 */
-	private $request_helper;
-
-	/**
 	 * The indexable repository.
 	 *
 	 * @var Indexable_Repository
@@ -131,7 +123,6 @@ final class Meta_Tags_Context_Test extends TestCase {
 		$this->permalink_helper     = Mockery::mock( Permalink_Helper::class );
 		$this->indexable_helper     = Mockery::mock( Indexable_Helper::class );
 		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
-		$this->request_helper       = Mockery::mock( Request_Helper::class );
 
 		$this->instance = new Meta_Tags_Context(
 			$this->options,
@@ -143,8 +134,7 @@ final class Meta_Tags_Context_Test extends TestCase {
 			$this->user,
 			$this->permalink_helper,
 			$this->indexable_helper,
-			$this->indexable_repository,
-			$this->request_helper
+			$this->indexable_repository
 		);
 	}
 

--- a/tests/Unit/Integrations/Front_End_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End_Integration_Test.php
@@ -8,7 +8,6 @@ use WP_Query;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Integrations\Front_End_Integration;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
@@ -49,13 +48,6 @@ final class Front_End_Integration_Test extends TestCase {
 	private $options;
 
 	/**
-	 * Represents the request helper.
-	 *
-	 * @var Mockery\MockInterface|Request_Helper
-	 */
-	private $request;
-
-	/**
 	 * Represents the meta tags context memoizer.
 	 *
 	 * @var Mockery\MockInterface|Meta_Tags_Context_Memoizer
@@ -94,7 +86,6 @@ final class Front_End_Integration_Test extends TestCase {
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->container        = Mockery::mock( ContainerInterface::class );
 		$this->options          = Mockery::mock( Options_Helper::class );
-		$this->request          = Mockery::mock( Request_Helper::class );
 
 		$this->instance = Mockery::mock(
 			Front_End_Integration::class,
@@ -102,7 +93,6 @@ final class Front_End_Integration_Test extends TestCase {
 				$this->context_memoizer,
 				$this->container,
 				$this->options,
-				$this->request,
 				Mockery::mock( Helpers_Surface::class ),
 				Mockery::mock( WPSEO_Replace_Vars::class ),
 			]
@@ -219,8 +209,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -287,8 +276,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -360,8 +348,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -419,8 +406,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -486,8 +472,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -533,8 +518,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnTrue();
 
@@ -588,8 +572,7 @@ final class Front_End_Integration_Test extends TestCase {
 			->once()
 			->andReturn( $this->context );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -662,8 +645,7 @@ final class Front_End_Integration_Test extends TestCase {
 
 		\add_action( 'wp_head', 'wp_robots' );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -694,8 +676,7 @@ final class Front_End_Integration_Test extends TestCase {
 
 		\add_action( 'wp_head', 'wp_robots' );
 
-		$this->request
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnTrue();
 

--- a/tests/Unit/Integrations/Third_Party/Wincher_Publish_Test.php
+++ b/tests/Unit/Integrations/Third_Party/Wincher_Publish_Test.php
@@ -272,8 +272,7 @@ final class Wincher_Publish_Test extends TestCase {
 	public function test_track_after_post_request() {
 		$post = Mockery::mock( WP_Post::class );
 
-		$this->instance
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnFalse();
 
@@ -295,8 +294,7 @@ final class Wincher_Publish_Test extends TestCase {
 	public function test_track_after_post_request_during_rest_request() {
 		$post = Mockery::mock( WP_Post::class );
 
-		$this->instance
-			->expects( 'is_rest_request' )
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
 			->once()
 			->andReturnTrue();
 

--- a/tests/WP/Frontend/Front_End_Integration_Test.php
+++ b/tests/WP/Frontend/Front_End_Integration_Test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\WP\Frontend;
 use Mockery;
 use WPSEO_Replace_Vars;
 use Yoast\WP\SEO\Helpers\Options_Helper;
-use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Presentations\Indexable_Presentation;
 use Yoast\WP\SEO\Surfaces\Helpers_Surface;
@@ -42,13 +41,6 @@ final class Front_End_Integration_Test extends TestCase {
 	protected $options;
 
 	/**
-	 * Represents the request helper.
-	 *
-	 * @var Request_Helper
-	 */
-	protected $request;
-
-	/**
 	 * The helpers surface.
 	 *
 	 * @var Helpers_Surface
@@ -79,7 +71,6 @@ final class Front_End_Integration_Test extends TestCase {
 		$this->context_memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
 		$this->container        = Mockery::mock( ContainerInterface::class );
 		$this->options          = Mockery::mock( Options_Helper::class );
-		$this->request          = Mockery::mock( Request_Helper::class );
 		$this->helpers          = Mockery::mock( Helpers_Surface::class );
 		$this->replace_vars     = Mockery::mock( WPSEO_Replace_Vars::class );
 
@@ -87,7 +78,6 @@ final class Front_End_Integration_Test extends TestCase {
 			$this->context_memoizer,
 			$this->container,
 			$this->options,
-			$this->request,
 			$this->helpers,
 			$this->replace_vars
 		);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replace custom code with core's `wp_is_serving_rest_request()`

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

All instructions are basically regression tests.

For meta tags context:
* Have a post with no feature image and with an image in the content
* Visit the post with this PR and without and confirm that the meta tags and the schema stays the same
* Visit the post in REST API (aka, `http://ai.local/wp-json/wp/v2/posts/<POST_ID>` with this PR and without and confirm that the `yoast_head` attribute stays the same
* Now add a feature image in the post and repeat the test

For breadcrumb block:
* Have a post with a breadcrumb block
* Visit the post with this PR and without and confirm that the content stays the same
* Visit the post in REST API (aka, `http://ai.local/wp-json/wp/v2/posts/<POST_ID>` with this PR and without and confirm that the `content: rendered` attribute stays the same

For frontend integration:
* Have a post with a title
* Visit the post with this PR and without and confirm that there is no `title` meta tag in both cases. Also confirm that the robots meta tag stays the same.
* Visit the post in REST API (aka, `http://ai.local/wp-json/wp/v2/posts/<POST_ID>` with this PR and without and confirm that the `yoast_head` attribute contains a `title` meta tag. Also confirm that the `robots` attribute in `yoast_head_json` stays the same

For Wincher Integration
* Smoke test tracking a post's keywords with Wincher, both with the block editor and the classic one

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The test instructions serve as impact check

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21333
