### PR TITLE
Revert "Merge pull request #21674 from Yoast/1866-236---bf---black-fr…

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -112,9 +112,10 @@ class WPSEO_Premium_Upsell_Admin_Block {
 		echo '<div class="' . esc_attr( $class ) . '">';
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
-			$bf_label = esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' );
+			$bf_label   = esc_html__( 'BLACK FRIDAY', 'wordpress-seo' );
+			$sale_label = esc_html__( '30% OFF', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
-			echo "<div class='black-friday-container'><span>$bf_label</span></div>";
+			echo "<div class='black-friday-container'><span>$sale_label</span> <span style='margin-left: auto;'>$bf_label</span> </div>";
 		}
 
 		echo '<div class="' . esc_attr( $class . '--container' ) . '">';

--- a/admin/views/licenses.php
+++ b/admin/views/licenses.php
@@ -135,7 +135,7 @@ $premium_sale_badge = '';
 
 if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 	/* translators: %1$s expands to opening span, %2$s expands to closing span */
-	$sale_badge_span = sprintf( esc_html__( '%1$s30%% OFF | Use code: BF2024%2$s', 'wordpress-seo' ), '<span>', '</span>' );
+	$sale_badge_span = sprintf( esc_html__( '%1$s30%% OFF%2$s', 'wordpress-seo' ), '<span>', '</span>' );
 
 	$sale_badge = '<div class="yoast-seo-premium-extension-sale-badge">' . $sale_badge_span . '</div>';
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -590,7 +590,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 			$sale_percentage = sprintf(
 				'<span class="admin-bar-premium-promotion">%1$s</span>',
-				esc_html__( '30% OFF | Code: BF2024', 'wordpress-seo' )
+				esc_html__( '30% OFF', 'wordpress-seo' )
 			);
 		}
 		$wp_admin_bar->add_menu(

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -23,14 +23,14 @@ export const BlackFridayPromotion = ( {
 	const linkParams = useSelect( select => select( store ).selectLinkParams(), [ store ] );
 	const title = location === "sidebar"
 		? sprintf(
-			/* translators: %1$s expands to YOAST SEO PREMIUM */
-			__( "30%% OFF %1$s | Use code: BF2024", "wordpress-seo" ),
+			/* translators: %1$s expands to Yoast SEO Premium */
+			__( "Now with 30%% OFF: %1$s", "wordpress-seo" ),
 			"Yoast SEO Premium"
 		)
 		: createInterpolateElement(
 			sprintf(
-				/* translators: %1$s expands to YOAST SEO PREMIUM, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
-				__( "30%% OFF %1$s | Use code: BF2024 %2$sBuy now!%3$s", "wordpress-seo" ),
+				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
+				__( "Now with 30%% OFF: %1$s %2$sBuy now!%3$s", "wordpress-seo" ),
 				"Yoast SEO Premium",
 				"<a>",
 				"</a>"
@@ -49,7 +49,7 @@ export const BlackFridayPromotion = ( {
 			title={ title }
 			{ ...props }
 		>
-			<span className="yoast-bf-sale-badge">{ __( "Black Friday", "wordpress-seo" ) } </span>
+			<span className="yoast-bf-sale-badge">{ __( "BLACK FRIDAY SALE", "wordpress-seo" ) } </span>
 			{ location === "sidebar" && <a
 				// Styling is to counteract the WP paragraph margin-bottom.
 				className="yst-block yst--mb-[1em]"

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -115,10 +115,9 @@ class UpsellBox extends Component {
 		return (
 			<Fragment>
 				{ isBlackFriday &&
-					<div className="yst-flex yst-flex-col yst-items-center yst-bg-black yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-gap-2 yst-py-2 yst-leading-5">
-						<div className="yst-mx-auto yst-text-amber-300 yst-text-lg">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
-						<div className="yst-text-white yst-text-base yst-font-semibold">{ __( "Promo code", "wordpress-seo" ) }: BF2024</div>
-					</div> }
+				<div className="yst-flex  yst-items-center yst-text-lg yst-content-between yst-bg-black yst-text-amber-300 yst-h-9 yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-px-6">
+					<div className="yst-mx-auto">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
+				</div> }
 				<Container>
 					<Heading>{ this.props.title }</Heading>
 					<Description>{ this.props.description }</Description>

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -116,7 +116,7 @@ class UpsellBox extends Component {
 			<Fragment>
 				{ isBlackFriday &&
 				<div className="yst-flex  yst-items-center yst-text-lg yst-content-between yst-bg-black yst-text-amber-300 yst-h-9 yst-border-amber-300 yst-border-y yst-border-x-0 yst-border-solid yst-px-6">
-					<div className="yst-mx-auto">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</div>
+					<div className="yst-mx-auto">{ __( "30% OFF - BLACK FRIDAY", "wordpress-seo" ) }</div>
 				</div> }
 				<Container>
 					<Heading>{ this.props.title }</Heading>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -170,8 +170,11 @@ const PremiumUpsellList = () => {
 
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
-			{ isBlackFriday && <div className="yst-rounded-t-lg yst-h-9 yst-flex yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold">
-				<div>{ __( "30% OFF | Code: BF2024", "wordpress-seo" ) }</div>
+			{ isBlackFriday && <div
+				className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold"
+			>
+				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
+				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 			</div> }
 			<div className="yst-p-6 yst-flex yst-flex-col">
 				<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -54,7 +54,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 			</figure>
 			{ isBlackFriday && <div className="sidebar__sale_banner_container">
 				<div className="sidebar__sale_banner">
-					<span className="banner_text">{ __( "30% OFF | Code: BF2024", "wordpress-seo" ) }</span>
+					<span className="banner_text">{ __( "30% OFF - BLACK FRIDAY", "wordpress-seo" ) }</span>
 				</div>
 			</div> }
 			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -17,7 +17,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
-		$title = \__( '30% OFF | Code: BF2024', 'wordpress-seo' );
+		$title = \__( '30% OFF - BLACK FRIDAY', 'wordpress-seo' );
 
 		$assets_uri              = \trailingslashit( \plugin_dir_url( \WPSEO_FILE ) );
 		$buy_yoast_seo_shortlink = WPSEO_Shortlinker::get( 'https://yoa.st/jj' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We no longer want the promo code.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the promo code from the Black Friday sale.

## Relevant technical choices:

* Reverted https://github.com/Yoast/wordpress-seo/pull/21674

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast Premium is not active.
* Enable Black Friday promotion by editing `src/promotions/domain/black-friday-promotion.php` replace line 16:
```php
new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2023 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
```
* Edit a post
* Look at the top of the SEO tab in the metabox
* [x] Verify the promo code is no longer there, and we mention Black Friday again
<img width="617" alt="image" src="https://github.com/user-attachments/assets/a8248b50-b6cd-47eb-a853-940cd02da8f2">

* Look at the top of the Yoast sidebar
* [x] Verify the promo code is no longer there, and we mention Black Friday again
<img width="286" alt="image" src="https://github.com/user-attachments/assets/09d0f7e4-3aa9-466c-ab76-d292bfc8bea3">

* Click on the "Premium SEO analysis"
* [x] Verify the promo code is no longer there
<img width="428" alt="image" src="https://github.com/user-attachments/assets/0d84c905-eeb9-4ee6-aeb2-eab0cce1719b">

* You can verify the same for "Add related keyphrase", "Internal linking suggestions" and under SEO analysis: "+ Add synonyms" and "+ Add related keyphrase". However, they use the same code.
* Go to the General admin page
* Look at the footer
* [x] Verify the promo code is no longer there, and we mention Black Friday again
<img width="728" alt="image" src="https://github.com/user-attachments/assets/2ac41d70-4570-4937-85ec-9a65d1b36c47">

* Look at the sidebar
* [x] Verify the promo code is no longer there, and we mention Black Friday again
<img width="307" alt="image" src="https://github.com/user-attachments/assets/8482f27b-88cb-4c51-9217-22cab5c735f1">

* You can verify the same for the other PHP admin page: Tools. However, it uses the same code.
* Go to the Settings admin page
* Look at the footer
* [x] Verify the promo code is no longer there, and we mention Black Friday again
<img width="756" alt="image" src="https://github.com/user-attachments/assets/1c328f73-9143-4a78-80d9-ea12e3bf3cd3">

* Look at the sidebar
* [ ] Verify the promo code is no longer there, and we mention Black Friday again
<img width="263" alt="image" src="https://github.com/user-attachments/assets/1df5eb2b-0a3f-486e-86bd-ed8c4002bede">

* Look at the admin bar
* [ ] Verify the promo code is no longer there
<img width="265" alt="image" src="https://github.com/user-attachments/assets/b5a69a18-ee9b-4be0-a114-919762d637d4">

* Go to the Upgrades aadmin page
* [ ] Verify the promo code is no longer there, and we mention Black Friday again
<img width="931" alt="image" src="https://github.com/user-attachments/assets/3ae8df54-5067-4548-b4f2-d1cddfac8621">


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/284
