### PR TITLE
Fix slug always based on title for drafts

### DIFF
--- a/packages/js/src/elementor/initializers/editor-integration.js
+++ b/packages/js/src/elementor/initializers/editor-integration.js
@@ -188,6 +188,8 @@ export const initializeElementEditorIntegration = () => {
 		if ( data.slug && data.slug !== formData.slug ) {
 			dispatch( "yoast-seo/editor" ).updateData( { slug: data.slug } );
 		}
+		// Update the saved slug.
+		dispatch( "yoast-seo/editor" ).setEditorDataSlug( data.slug );
 
 		// Update the save as draft warning. Note: skipping the debounce to include it in the snapshot.
 		updateSaveAsDraftWarning( hasUnsavedSeoChanges );

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -63,6 +63,14 @@ const populateStore = store => {
 	store.dispatch( actions.setLinkParams( get( window, "wpseoScriptData.linkParams", {} ) ) );
 	store.dispatch( actions.setPluginUrl( get( window, "wpseoScriptData.pluginUrl", "" ) ) );
 	store.dispatch( actions.setWistiaEmbedPermissionValue( get( window, "wpseoScriptData.wistiaEmbedPermission", false ) === "1" ) );
+
+	// Due to Elementor not including a way to get the slug, we include it in our form data.
+	// Hydrate the store with that slug value on load.
+	const slugInput = document.getElementById( "yoast_wpseo_slug" );
+	if ( slugInput ) {
+		store.dispatch( actions.setEditorDataSlug( slugInput.value ) );
+		store.dispatch( actions.updateData( { slug: slugInput.value } ) );
+	}
 };
 
 /**

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -7,6 +7,7 @@ import { createSnapshotReducer } from "../../redux/utils/create-snapshot-reducer
 import * as snippetEditorActions from "../redux/actions/snippetEditor";
 import * as analysisSelectors from "../redux/selectors/analysis";
 import * as snippetEditorSelectors from "../redux/selectors/snippet-editor";
+import * as wincherSelectors from "../redux/selectors/wincher-seo-performance";
 
 /**
  * Populates the store.
@@ -89,6 +90,7 @@ export default function initEditorStore() {
 			// Add or override selectors that are specific for Elementor.
 			...analysisSelectors,
 			...snippetEditorSelectors,
+			...wincherSelectors,
 		},
 		actions: pickBy( {
 			...actions,

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -70,7 +70,6 @@ const populateStore = store => {
 	const slugInput = document.getElementById( "yoast_wpseo_slug" );
 	if ( slugInput ) {
 		store.dispatch( actions.setEditorDataSlug( slugInput.value ) );
-		store.dispatch( actions.updateData( { slug: slugInput.value } ) );
 	}
 };
 

--- a/packages/js/src/elementor/initializers/editor-store.js
+++ b/packages/js/src/elementor/initializers/editor-store.js
@@ -6,6 +6,7 @@ import { createFreezeReducer } from "../../redux/utils/create-freeze-reducer";
 import { createSnapshotReducer } from "../../redux/utils/create-snapshot-reducer";
 import * as snippetEditorActions from "../redux/actions/snippetEditor";
 import * as analysisSelectors from "../redux/selectors/analysis";
+import * as snippetEditorSelectors from "../redux/selectors/snippet-editor";
 
 /**
  * Populates the store.
@@ -88,6 +89,7 @@ export default function initEditorStore() {
 			...selectors,
 			// Add or override selectors that are specific for Elementor.
 			...analysisSelectors,
+			...snippetEditorSelectors,
 		},
 		actions: pickBy( {
 			...actions,

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -58,7 +58,7 @@ function removeMarks() {
 function getContent( editorDocument ) {
 	const content = [];
 
-	editorDocument.$element.find( ".elementor-widget-container" ).each( ( index, element ) => {
+	editorDocument.$element?.find( ".elementor-widget-container" ).each( ( index, element ) => {
 		// We remove \n and \t from the HTML as Elementor formats the HTML after saving.
 		// As this spacing is purely cosmetic, we can remove it for analysis purposes.
 		// When we apply the marks, we do need to make the same amendments.
@@ -114,9 +114,6 @@ function getEditorData( editorDocument ) {
  */
 function handleEditorChange() {
 	const currentDocument = elementor.documents.getCurrent();
-	if ( ! currentDocument.$element ) {
-		return;
-	}
 
 	// Don't update the editor data when the form ID is not equal to the document ID.
 	if ( ! isFormIdEqualToDocumentId() ) {
@@ -243,4 +240,7 @@ export default function initialize() {
 
 	// This hook will fire when the contents of the editor are modified.
 	registerElementorUIHookAfter( "document/save/set-is-modified", "yoast-seo/content-scraper/on-modified", debouncedHandleEditorChange, ( { document } ) => isFormId( document?.id || elementor.documents.getCurrent().id ) );
+
+	// Set the initial editor data (note: content is not there yet due to $element loading in later).
+	handleEditorChange();
 }

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -146,7 +146,9 @@ function handleEditorChange() {
 		editorData.title = data.title;
 		dispatch( "yoast-seo/editor" ).setEditorDataTitle( editorData.title );
 
-		if ( data.status === "draft" || data.status === "auto-draft" ) {
+		// Drafts might not have a slug (post_name), unless the slug has been manually changed.
+		if ( ( data.status === "draft" || data.status === "auto-draft" ) && select( "yoast-seo/editor" ).getEditorDataSlug() === "" ) {
+			// In this case we get it using the title.
 			dispatch( "yoast-seo/editor" ).updateData( { slug: cleanForSlug( editorData.title ) } );
 		}
 	}

--- a/packages/js/src/elementor/initializers/editor-watcher.js
+++ b/packages/js/src/elementor/initializers/editor-watcher.js
@@ -1,6 +1,5 @@
 /* global elementor, YoastSEO */
 import { dispatch, select } from "@wordpress/data";
-import { cleanForSlug } from "@wordpress/url";
 import { debounce, get, noop } from "lodash";
 import { markers, Paper } from "yoastseo";
 import { refreshDelay } from "../../analysis/constants";
@@ -145,12 +144,6 @@ function handleEditorChange() {
 	if ( data.title !== editorData.title ) {
 		editorData.title = data.title;
 		dispatch( "yoast-seo/editor" ).setEditorDataTitle( editorData.title );
-
-		// Drafts might not have a slug (post_name), unless the slug has been manually changed.
-		if ( ( data.status === "draft" || data.status === "auto-draft" ) && select( "yoast-seo/editor" ).getEditorDataSlug() === "" ) {
-			// In this case we get it using the title.
-			dispatch( "yoast-seo/editor" ).updateData( { slug: cleanForSlug( editorData.title ) } );
-		}
 	}
 
 	if ( data.excerpt !== editorData.excerpt ) {

--- a/packages/js/src/elementor/redux/selectors/analysis.js
+++ b/packages/js/src/elementor/redux/selectors/analysis.js
@@ -1,8 +1,8 @@
+import { selectors } from "@yoast/externals/redux";
 import { strings } from "@yoast/helpers";
 import measureTextWidth from "../../../helpers/measureTextWidth";
-import { selectors } from "@yoast/externals/redux";
-
 import { applyModifications } from "../../../initializers/pluggable";
+import { getSnippetEditorSlug } from "./snippet-editor";
 
 const {
 	getBaseUrlFromSettings,
@@ -10,7 +10,6 @@ const {
 	getEditorDataContent,
 	getFocusKeyphrase,
 	getSnippetEditorDescriptionWithTemplate,
-	getSnippetEditorSlug,
 	getSnippetEditorTitleWithTemplate,
 	getDateFromSettings,
 } = selectors;
@@ -25,6 +24,7 @@ const {
 export const getAnalysisData = ( state ) => {
 	let title = getSnippetEditorTitleWithTemplate( state );
 	let description = getSnippetEditorDescriptionWithTemplate( state );
+	// Use the Elementor override with fallbacks.
 	let slug = getSnippetEditorSlug( state );
 	const baseUrl = getBaseUrlFromSettings( state );
 

--- a/packages/js/src/elementor/redux/selectors/snippet-editor.js
+++ b/packages/js/src/elementor/redux/selectors/snippet-editor.js
@@ -1,0 +1,38 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { cleanForSlug } from "@wordpress/url";
+import { selectors } from "@yoast/externals/redux";
+import { get } from "lodash";
+
+const {
+	getEditorDataSlug,
+	getEditorDataTitle,
+	getSnippetEditorDescription,
+	getSnippetEditorSlug: getPureSnippetEditorSlug,
+	getSnippetEditorTitle,
+} = selectors;
+
+// Override the default `getSnippetEditorSlug` to use fallbacks.
+export const getSnippetEditorSlug = createSelector(
+	[
+		getEditorDataSlug,
+		getPureSnippetEditorSlug,
+		getEditorDataTitle,
+		() => get( window, "elementor.documents.currentDocument.id", 0 ),
+	],
+	/**
+	 * Gets the slug for the snippet editor.
+	 *
+	 * Using fallbacks like WordPress does in the editor.
+	 * @see https://github.com/WordPress/gutenberg/blob/3aa19d28dd46433c6c5677fe76a9e0f500678905/packages/editor/src/store/selectors.js#L989-L1004
+	 *
+	 * @param {string} savedSlug The slug saved in the database.
+	 * @param {string} editedSlug The slug edited by the user.
+	 * @param {string} documentTitle The title of the document.
+	 * @param {number} documentId The ID of the document.
+	 *
+	 * @returns {string} The slug.
+	 */
+	( savedSlug, editedSlug, documentTitle, documentId ) => {
+		return editedSlug || savedSlug || cleanForSlug( documentTitle ) || String( documentId );
+	}
+);

--- a/packages/js/src/elementor/redux/selectors/snippet-editor.js
+++ b/packages/js/src/elementor/redux/selectors/snippet-editor.js
@@ -36,3 +36,13 @@ export const getSnippetEditorSlug = createSelector(
 		return editedSlug || savedSlug || cleanForSlug( documentTitle ) || String( documentId );
 	}
 );
+
+// Override the default `getSnippetEditorData` to include the "slug with fallback" override.
+export const getSnippetEditorData = createSelector(
+	[
+		getSnippetEditorTitle,
+		getSnippetEditorDescription,
+		getSnippetEditorSlug,
+	],
+	( title, description, slug ) => ( { title, description, slug } )
+);

--- a/packages/js/src/elementor/redux/selectors/wincher-seo-performance.js
+++ b/packages/js/src/elementor/redux/selectors/wincher-seo-performance.js
@@ -1,0 +1,13 @@
+import { createSelector } from "@reduxjs/toolkit";
+import { getBaseUrlFromSettings } from "../../../redux/selectors";
+import { getSnippetEditorSlug } from "./snippet-editor";
+
+// Override to use the Elementor `getSnippetEditorSlug` override (and not the full analysis data).
+export const getWincherPermalink = createSelector(
+	[
+		getBaseUrlFromSettings,
+		// Use the Elementor override with fallbacks.
+		getSnippetEditorSlug,
+	],
+	( baseUrl, slug ) => baseUrl + slug
+);

--- a/packages/js/tests/__mocks__/@wordpress/url.js
+++ b/packages/js/tests/__mocks__/@wordpress/url.js
@@ -1,6 +1,0 @@
-module.exports = {
-	addQueryArgs: ( url, args ) => {
-		const link = new URLSearchParams( args );
-		return `${ url }?${ link.toString() }`;
-	},
-};

--- a/packages/js/tests/elementor/redux/selectors/snippet-editor.test.js
+++ b/packages/js/tests/elementor/redux/selectors/snippet-editor.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@jest/globals";
+import { getSnippetEditorSlug } from "../../../../src/elementor/redux/selectors/snippet-editor";
+import {
+	getSnippetEditorSlug as getPureSnippetEditorSlug,
+} from "../../../../src/redux/selectors/snippetEditor";
+import { withWindowMock } from "../../../test-utils";
+
+describe( "getSnippetEditorSlug", () => {
+	it( "exists", () => {
+		expect( getSnippetEditorSlug ).toBeTruthy();
+	} );
+
+	it( "should return the saved slug if one exists and has not been edited", () => {
+		const state = {
+			editorData: {
+				slug: "saved-slug",
+			},
+		};
+
+		expect( getSnippetEditorSlug( state ) ).toBe( "saved-slug" );
+	} );
+
+	it( "should return the edited slug if it has been edited", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					slug: "edited-slug",
+				},
+			},
+		};
+
+		expect( getSnippetEditorSlug( state ) ).toBe( "edited-slug" );
+	} );
+
+	it( "should return the cleaned title as slug if no saved or edited slug exists", () => {
+		const state = {
+			editorData: {
+				title: "Sample Post",
+			},
+		};
+
+		expect( getSnippetEditorSlug( state ) ).toBe( "sample-post" );
+	} );
+
+	it( "should return the post ID if no slug or post title exists", () => {
+		const state = {};
+
+		withWindowMock( { elementor: { documents: { currentDocument: { id: 123 } } } }, () => {
+			expect( getSnippetEditorSlug( state ) ).toBe( String( 123 ) );
+		} );
+	} );
+
+	it( "should return the same as the non-Elementor override", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					slug: "edited-slug",
+				},
+			},
+		};
+
+		expect( getSnippetEditorSlug( state ) ).toBe( getPureSnippetEditorSlug( state ) );
+	} );
+} );

--- a/packages/js/tests/elementor/redux/selectors/snippet-editor.test.js
+++ b/packages/js/tests/elementor/redux/selectors/snippet-editor.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@jest/globals";
-import { getSnippetEditorSlug } from "../../../../src/elementor/redux/selectors/snippet-editor";
+import { getSnippetEditorData, getSnippetEditorSlug } from "../../../../src/elementor/redux/selectors/snippet-editor";
 import {
+	getSnippetEditorData as getPureSnippetEditorData,
 	getSnippetEditorSlug as getPureSnippetEditorSlug,
 } from "../../../../src/redux/selectors/snippetEditor";
 import { withWindowMock } from "../../../test-utils";
@@ -60,5 +61,100 @@ describe( "getSnippetEditorSlug", () => {
 		};
 
 		expect( getSnippetEditorSlug( state ) ).toBe( getPureSnippetEditorSlug( state ) );
+	} );
+} );
+
+describe( "getSnippetEditorData", () => {
+	it( "exists", () => {
+		expect( getSnippetEditorData ).toBeTruthy();
+	} );
+
+	it( "should return the title, description, and slug", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+					slug: "slug",
+				},
+			},
+		};
+
+		expect( getSnippetEditorData( state ) ).toEqual( { title: "Title", description: "Description", slug: "slug" } );
+	} );
+
+	it( "should return the saved slug if one exists and has not been edited", () => {
+		const state = {
+			editorData: {
+				slug: "saved-slug",
+			},
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+				},
+			},
+		};
+
+		expect( getSnippetEditorData( state ) ).toEqual( { title: "Title", description: "Description", slug: "saved-slug" } );
+	} );
+
+	it( "should return the edited slug if it has been edited", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+					slug: "edited-slug",
+				},
+			},
+		};
+
+		expect( getSnippetEditorData( state ) ).toEqual( { title: "Title", description: "Description", slug: "edited-slug" } );
+	} );
+
+	it( "should return the cleaned title as slug if no saved or edited slug exists", () => {
+		const state = {
+			editorData: {
+				title: "Sample Post",
+			},
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+				},
+			},
+		};
+
+		expect( getSnippetEditorData( state ) ).toEqual( { title: "Title", description: "Description", slug: "sample-post" } );
+	} );
+
+	it( "should return the post ID if no slug or post title exists", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+				},
+			},
+		};
+
+		withWindowMock( { elementor: { documents: { currentDocument: { id: 123 } } } }, () => {
+			expect( getSnippetEditorData( state ) ).toEqual( { title: "Title", description: "Description", slug: String( 123 ) } );
+		} );
+	} );
+
+	it( "should return the same as the non-Elementor override", () => {
+		const state = {
+			snippetEditor: {
+				data: {
+					title: "Title",
+					description: "Description",
+					slug: "slug",
+				},
+			},
+		};
+
+		expect( getSnippetEditorData( state ) ).toEqual( getPureSnippetEditorData( state ) );
 	} );
 } );

--- a/packages/js/tests/elementor/redux/selectors/wincher-seo-performance.js
+++ b/packages/js/tests/elementor/redux/selectors/wincher-seo-performance.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "@jest/globals";
+import { getWincherPermalink } from "../../../../src/elementor/redux/selectors/wincher-seo-performance";
+import { getWincherPermalink as getPureWincherPermalink } from "../../../../src/redux/selectors/WincherSEOPerformance";
+
+describe( "getWincherPermalink", () => {
+	it( "exists", () => {
+		expect( getWincherPermalink ).toBeTruthy();
+	} );
+
+	it( "should return the base URL plus the slug", () => {
+		const state = {
+			settings: {
+				snippetEditor: {
+					baseUrl: "https://example.com/",
+				},
+			},
+			snippetEditor: {
+				data: {
+					slug: "slug",
+				},
+			},
+		};
+
+		expect( getWincherPermalink( state ) ).toBe( "https://example.com/slug" );
+	} );
+
+	it( "should return the same as the non-Elementor override", () => {
+		const state = {
+			settings: {
+				snippetEditor: {
+					baseUrl: "https://example.com/",
+				},
+			},
+			snippetEditor: {
+				data: {
+					slug: "slug",
+				},
+			},
+		};
+
+		expect( getWincherPermalink( state ) ).toBe( getPureWincherPermalink( state ) );
+	} );
+} );

--- a/packages/js/tests/helpers/fields/AnalysisFields.test.js
+++ b/packages/js/tests/helpers/fields/AnalysisFields.test.js
@@ -1,4 +1,5 @@
 import AnalysisFields from "../../../src/helpers/fields/AnalysisFields";
+import { mockWindow } from "../../test-utils";
 
 /**
  * Creates an input element.
@@ -11,22 +12,6 @@ const createInputElement = ( id ) => {
 	document.body.appendChild( inputElement );
 
 	return inputElement;
-};
-
-/**
- * Mocks the window to override specific data.
- * @param {Object} data The data to set on the window.
- * @returns {jest.SpyInstance} The spy. Be sure to restore at the end of the test.
- */
-const mockWindow = ( data ) => {
-	const original = { ...window };
-	const spy = jest.spyOn( global, "window", "get" );
-	spy.mockImplementation( () => ( {
-		...original,
-		...data,
-	} ) );
-
-	return spy;
 };
 
 describe( "keyphrase", () => {

--- a/packages/js/tests/test-utils.js
+++ b/packages/js/tests/test-utils.js
@@ -1,1 +1,34 @@
+import { jest } from "@jest/globals";
+
 export * from "@testing-library/react";
+
+/**
+ * Mocks the window to override specific data.
+ * @param {Object} data The data to set on the window.
+ * @returns {jest.SpyInstance} The spy. Be sure to restore at the end of the test.
+ */
+export const mockWindow = ( data ) => {
+	const original = { ...window };
+	const spy = jest.spyOn( global, "window", "get" );
+	spy.mockImplementation( () => ( {
+		...original,
+		...data,
+	} ) );
+
+	return spy;
+};
+
+/**
+ * Mocks the window to override specific data, cleaning up after the tests.
+ * @param {Object} data The data to set on the window.
+ * @param {function} runTests The callback to run with the mocked window, passing the spy.
+ * @returns {void}
+ */
+export function withWindowMock( data, runTests ) {
+	const spy = mockWindow( data );
+	try {
+		runTests( spy );
+	} finally {
+		spy.mockRestore();
+	}
+}

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -473,40 +473,18 @@ class Elementor implements Integration_Interface {
 		\printf(
 			'<input type="hidden" id="%1$s" name="%1$s" value="%2$s" />',
 			\esc_attr( WPSEO_Meta::$form_prefix . 'slug' ),
-			\esc_attr( $this->get_post_slug() )
+			/**
+			 * It is important that this slug value is the same as in the database.
+			 * If the DB value is empty we can auto-generate a slug.
+			 * But if not empty, we should not touch it anymore.
+			 */
+			\esc_attr( $this->get_metabox_post()->post_name )
 		);
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output should be escaped in the filter.
 		echo \apply_filters( 'wpseo_elementor_hidden_fields', '' );
 
 		echo '</form>';
-	}
-
-	/**
-	 * Returns the slug for the post being edited.
-	 *
-	 * @return string
-	 */
-	protected function get_post_slug() {
-		$post = $this->get_metabox_post();
-
-		// In case get_metabox_post returns null for whatever reason.
-		if ( ! $post instanceof WP_Post ) {
-			return '';
-		}
-
-		// Drafts might not have a post_name unless the slug has been manually changed.
-		// In this case we get it using get_sample_permalink.
-		if ( ! $post->post_name ) {
-			$sample = \get_sample_permalink( $post );
-
-			// Since get_sample_permalink runs through filters, ensure that it has the expected return value.
-			if ( \is_array( $sample ) && \count( $sample ) === 2 && \is_string( $sample[1] ) ) {
-				return $sample[1];
-			}
-		}
-
-		return $post->post_name;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Changing the slug is not supported in Elementor itself, we added that in via our Search appearance UI. So we should make sure we don't override previous values.

Introducing fallbacks for the slug in Elementor (based on the selectors in Gutenberg/block editor). The slug should be:
* Edited slug
* Saved slug
* Cleaned title
* Entity/document ID

A draft PR without changes has an empty slug. Meaning that unless you edit one, you will use the title. Unless that consist of only clean characters, then you fall back to the ID.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in our Elementor integration where previously saved slug values would be ignored for drafts.

## Relevant technical choices:

See context.
The fallback is done in the slug selector for the Search appearance component.
This means that Elementor has a different selector there than the other editors.
I did it like this because it seemed easier than altering the SnippetEditor itself. But I might've been mistaken. As I also needed to override the selectors that use the original selector directly: getAnalysisData and getSnippetEditorData. And then getWincherPermalink because it used getAnalysisData 😅 


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Classic Editor plugin, set it to default to the classic editor and don't allow users to switch. That makes it possible to create a draft in the classic editor
  * You could do the same in the block editor, just that you _need_ to add a title before you can save as draft there
* Enable Premium so you get redirect notices. That makes it easier to spot slug changes

#### Draft fix
* Create a new post in the Classic Editor
* Save as draft
* Take note of the slug e.g /newpost/
* Edit the slug to something different (e.g /newpermalink/)
* Save as draft
* Edit the post with Elementor
* Publish it
* Verify the published post has the slug - /newpermalink/
* Verify you get no redirect popup / there are no new redirects in the redirect manager

#### Regression for https://github.com/Yoast/wordpress-seo/pull/21182
Also testing the regression Leonidas found below.
* Create a new post
* Immediately click edit in Elementor (making sure it is a draft without specific slug)
* Change the title to `Test post`
* Publish the post
* Verify the slug is `test-post`
* Verify you get no redirect popup / there are no new redirects in the redirect manager
* Edit the post and change the title to something else
* Update the post and make sure the slug is still the same
* Edit the slug
* Update the post and make sure the slug is the one you just edited
* Verify you get a redirect popup

#### Regression for https://github.com/Yoast/wordpress-seo/pull/17771
* Create a new post
* Immediately click edit in Elementor (making sure it is a draft without specific slug)
* Click on Search appearance, to open the modal
* Verify that the permalink in the preview is correct (site URL + slug)
* Fill in a focus keyphrase
* Click on Track SEO Performance, to open the modal
* Verify there is no error message like this: "Before you can track your SEO performance make sure to set either the post’s title and save it as a draft or manually set the post’s slug" 

#### Regression
* Test if the slug is still properly editable for published posts
* Try changing the slug on the draft in the scenario above, testing if you can still override the previously saved slug
* Verify the `Keyphrase in slug` SEO assessment still works
* Test if it is compatible with the entity switching? Save or discard or none
  * The idea is that switching should not matter. Something like:
    * saving should be the same as without switching
    * no saving and switching back should be the same as without switching
    * discarding and switching back should be the same as reloading without switching

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Slug changes in Elementor

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21322
