### PR TITLE
Adds Yoast AI Generate upsell for WooCommerce product categories and tags

### DIFF
--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -14,50 +14,57 @@ export const ModalContent = () => {
 	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
 	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
 	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
-	const isPremium = useSelect( select => select( STORE ).getIsPremium(), [] );
-	const isWooSeoUpsell = useSelect( select => select( STORE ).getIsWooSeoUpsell(), [] );
-	const isProduct = useSelect( select => select( STORE ).getIsProduct(), [] );
-	const wooSeoNoPremium = isProduct && ! isWooSeoUpsell && ! isPremium;
-	const isProductCopy = !! ( isWooSeoUpsell || wooSeoNoPremium );
-	const postModalprops = {
-		isProductCopy,
+
+	const isPremiumActive = useSelect( select => select( STORE ).getIsPremium(), [] );
+	const isWooSeoActive = useSelect( select => select( STORE ).getIsWooSeoActive(), [] );
+	const isWooCommerceActive = useSelect( select => select( STORE ).getIsWooCommerceActive(), [] );
+
+	const isProductPost = useSelect( select => select( STORE ).getIsProduct(), [] );
+	const isProductTerm = useSelect( select => select( STORE ).getIsProductTerm(), [] );
+
+	const upsellProps = {
 		upsellLink: upsellLinkPremium,
 	};
 
-	if ( isProductCopy ) {
+	// Use specific copy for product posts.
+	if ( isWooCommerceActive && isProductPost ) {
+		upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
+		upsellProps.isProductCopy = true;
+	}
+
+	// Use specific copy for product posts and terms, otherwise revert to the defaults.
+	if ( isWooCommerceActive && ( isProductPost || isProductTerm ) ) {
 		const upsellPremiumWooLabel = sprintf(
 			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
 			__( "%1$s + %2$s", "wordpress-seo" ),
 			"Yoast SEO Premium",
 			"Yoast WooCommerce SEO"
 		);
-		postModalprops.newToText = sprintf(
+		upsellProps.newToText = sprintf(
 			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
 			__( "New in %1$s", "wordpress-seo" ),
 			upsellPremiumWooLabel
 		);
-		postModalprops.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
-		if ( ! isPremium && isWooSeoUpsell ) {
-			postModalprops.upsellLabel = `${ sprintf(
-				/* translators: %1$s expands to Woo Premium bundle. */
-				__( "Unlock with the %1$s", "wordpress-seo" ),
-				"Woo Premium bundle"
-			)}*`;
-			postModalprops.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
-				{ `*${upsellPremiumWooLabel}` }
-			</div>;
-			postModalprops.upsellLink = upsellLinkWooPremiumBundle;
-		}
-		if ( isPremium ) {
-			postModalprops.upsellLabel = sprintf(
+
+		if ( isPremiumActive ) {
+			upsellProps.upsellLabel = sprintf(
 				/* translators: %1$s expands to Yoast WooCommerce SEO. */
 				__( "Unlock with %1$s", "wordpress-seo" ),
 				"Yoast WooCommerce SEO"
 			);
-			postModalprops.upsellLink = upsellLinkWoo;
+			upsellProps.upsellLink = upsellLinkWoo;
+		} else if ( ! isWooSeoActive ) {
+			upsellProps.upsellLabel = `${sprintf(
+				/* translators: %1$s expands to Woo Premium bundle. */
+				__( "Unlock with the %1$s", "wordpress-seo" ),
+				"Woo Premium bundle"
+			)}*`;
+			upsellProps.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
+				{ `*${upsellPremiumWooLabel}` }
+			</div>;
+			upsellProps.upsellLink = upsellLinkWooPremiumBundle;
 		}
 	}
-
 
 	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-generator-preview.png" ), [] );
 	const thumbnail = useMemo( () => ( {
@@ -71,13 +78,12 @@ export const ModalContent = () => {
 	const { setWistiaEmbedPermission: set } = useDispatch( STORE );
 	const wistiaEmbedPermission = useMemo( () => ( { value, status, set } ), [ value, status, set ] );
 
-
 	return (
 		<AiGenerateTitlesAndDescriptionsUpsell
 			learnMoreLink={ learnMoreLink }
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
-			{ ...postModalprops }
+			{ ...upsellProps }
 		/>
 	);
 };

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -53,10 +53,9 @@ const STORE = "yoast-seo/editor";
  */
 const initializeAiGenerator = () => {
 	const isPremium = select( STORE ).getIsPremium();
-	const isWooSeoUpsell = select( STORE ).getIsWooSeoUpsell();
-	const isProduct = select( STORE ).getIsProduct();
-
-	const shouldShowAiGeneratorUpsell =  ( isProduct ) ? ! isPremium || isWooSeoUpsell : ! isPremium;
+	const isWooSeoUpsellPost = select( STORE ).getIsWooSeoUpsell();
+	const isWooSeoUpsellTerm = select( STORE ).getIsWooSeoUpsellTerm();
+	const shouldShowAiGeneratorUpsell = ! isPremium || isWooSeoUpsellPost || isWooSeoUpsellTerm;
 
 	addFilter(
 		"yoast.replacementVariableEditor.additionalButtons",
@@ -69,7 +68,6 @@ const initializeAiGenerator = () => {
 					</Fill>
 				);
 			}
-
 			return buttons;
 		}
 	);

--- a/packages/js/src/redux/reducers/editorContext.js
+++ b/packages/js/src/redux/reducers/editorContext.js
@@ -15,6 +15,7 @@ function getDefaultState() {
 		noIndex: get( window, "wpseoAdminL10n.noIndex", "0" ) === "1",
 		postTypeNameSingular: get( window, "wpseoAdminL10n.postTypeNameSingular", "" ),
 		postTypeNamePlural: get( window, "wpseoAdminL10n.postTypeNamePlural", "" ),
+		termType: get( window, "wpseoScriptData.termType", "" ),
 		postStatus: get( window, "wpseoScriptData.postStatus", "" ),
 		isFrontPage: get( window, "wpseoScriptData.isFrontPage", "0" ) === "1",
 	};

--- a/packages/js/src/redux/selectors/editorContext.js
+++ b/packages/js/src/redux/selectors/editorContext.js
@@ -27,10 +27,22 @@ export function getPostOrPageString( state ) {
  *
  * @param {Object} state The state.
  *
- * @returns {string} Whether you're editing a product.
+ * @returns {boolean} Whether you're editing a product.
  */
 export function getIsProduct( state ) {
 	return get( state, "editorContext.postTypeNameSingular" ) === "Product";
+}
+
+/**
+ * Returns whether you're editing a product term.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} Whether you're editing a product term.
+ */
+export function getIsProductTerm( state ) {
+	const termType = get( state, "editorContext.termType" );
+	return termType === "product_cat" || termType === "product_tag";
 }
 
 /**

--- a/packages/js/src/redux/selectors/preferences.js
+++ b/packages/js/src/redux/selectors/preferences.js
@@ -1,5 +1,5 @@
 import { get } from "lodash";
-import { getIsProduct } from "./editorContext";
+import { getIsProduct, getIsProductTerm } from "./editorContext";
 
 /**
  * Gets a preference.
@@ -50,7 +50,7 @@ export const getIsWooSeoActive = state => getPreference( state, "isWooCommerceSe
  * Determines whether the WooCommerce SEO addon is not active in a product page.
  *
  * @param {Object} state The state.
- * @returns {Boolean} Whether the plugin is WooCommerce SEO or not.
+ * @returns {Boolean} Whether the WooCommerce SEO addon is not active in a product page.
  */
 export const getIsWooSeoUpsell = ( state ) => {
 	const isWooSeoActive = getIsWooSeoActive( state );
@@ -58,4 +58,18 @@ export const getIsWooSeoUpsell = ( state ) => {
 	const isProductPage = getIsProduct( state );
 
 	return ! isWooSeoActive && isWooCommerceActive && isProductPage;
+};
+
+/**
+ * Determines whether the WooCommerce SEO addon is not active in a product term.
+ *
+ * @param {Object} state The state.
+ * @returns {Boolean} Whether the WooCommerce SEO addon is not active in a product term.
+ */
+export const getIsWooSeoUpsellTerm = ( state ) => {
+	const isWooSeoActive = getIsWooSeoActive( state );
+	const isWooCommerceActive = getIsWooCommerceActive( state );
+	const isProductTerm = getIsProductTerm( state );
+
+	return ! isWooSeoActive && isWooCommerceActive && isProductTerm;
 };

--- a/packages/js/src/term-edit.js
+++ b/packages/js/src/term-edit.js
@@ -33,11 +33,6 @@ domReady( () => {
 	// Initialize the insights.
 	initializeInsights();
 
-	// Don't initialize the AI generator for WooCommerce categories and tags.
-	const AI_IGNORED_TAXONOMIES = [ "product_cat", "product_tag" ];
-
-	if ( window.wpseoScriptData.termType && ! AI_IGNORED_TAXONOMIES.includes( window.wpseoScriptData.termType ) ) {
-		// Initialize the AI Generator upsell.
-		initializeAiGenerator();
-	}
+	// Initialize the AI Generator upsell.
+	initializeAiGenerator();
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We are going to enable Yoast AI Generate for product taxonomies, see https://github.com/Yoast/wordpress-seo-premium/issues/4482. This PR adds an upsell for that functionality in Free.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an upsell for Yoast AI Generate on WooCommerce product categories and tags.

## Relevant technical choices:

* This PR slightly refactors the original implementation. I personally find the code more readable now 😅 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* See [the ATP](https://docs.google.com/document/d/1RGFhYdF2eaBn6BHaA_QGCO3Wjy7ARXP_GNKrnoS6sUA/edit#heading=h.qft97prdszns). 
* Confirm that the upsell is correct for other post types:
  * For regular posts and taxonomies, the upsell modal is the same as before (and does not mention "products")
  * For product posts with WooCommerce active, the upsell has a different header (see the ATP) and both the title and text specifically mention "products". The upsell button differs depending on which products the customer already has. 
  * For product taxonomies (as stated in the ATP), the header and upsell button the same as for product posts, but the title and the upsell do not mention "products". 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The upsell for Yoast AI Generate.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/458
