### PR TITLE
Change BF ad title

### DIFF
--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -35,11 +35,12 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 
 		getPremium = createInterpolateElement(
 			sprintf(
-				/* translators: %1$s and %3$s expand to a span wrap to avoid linebreaks. %2$s expands to "Yoast SEO Premium". */
-				__( "%1$sBuy %2$s%3$s", "wordpress-seo" ),
+				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+				__( "%1$sBuy%2$s %3$s", "wordpress-seo" ),
 				"<nowrap>",
-				"Yoast SEO Premium",
-				"</nowrap>"
+				"</nowrap>",
+				"Yoast SEO Premium"
+
 			),
 			{
 				nowrap: <span className="yst-whitespace-nowrap" />,

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -36,8 +36,9 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 		getPremium = createInterpolateElement(
 			sprintf(
 				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$sAll annual plans incl. %2$s", "wordpress-seo" ),
+				__( "%1$sBuy %2$s%3$s", "wordpress-seo" ),
 				"<nowrap>",
+				"Yoast SEO Premium",
 				"</nowrap>"
 			),
 			{

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -35,7 +35,7 @@ export const PremiumUpsellCard = ( { link, linkProps, promotions } ) => {
 
 		getPremium = createInterpolateElement(
 			sprintf(
-				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+				/* translators: %1$s and %3$s expand to a span wrap to avoid linebreaks. %2$s expands to "Yoast SEO Premium". */
 				__( "%1$sBuy %2$s%3$s", "wordpress-seo" ),
 				"<nowrap>",
 				"Yoast SEO Premium",

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -55,7 +55,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
-								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. */
+								/* translators: %1$s and %3$s expand to a span wrap to avoid linebreaks. %2$s expands to "Yoast SEO Premium". */
 								\printf( \esc_html__( '%1$sBuy %2$s%3$s', 'wordpress-seo' ), '<span>', 'Yoast SEO Premium', '</span>' );
 							}
 							else {

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -56,7 +56,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							<?php
 							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. */
-								\printf( \esc_html__( '%1$sAll annual plans incl.%2$s', 'wordpress-seo' ), '<span>', '</span>' );
+								\printf( \esc_html__( '%1$sBuy %2$s%3$s', 'wordpress-seo' ), '<span>', 'Yoast SEO Premium', '</span>' );
 							}
 							else {
 								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -55,8 +55,8 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<h2 class="yoast-get-premium-title">
 							<?php
 							if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
-								/* translators: %1$s and %3$s expand to a span wrap to avoid linebreaks. %2$s expands to "Yoast SEO Premium". */
-								\printf( \esc_html__( '%1$sBuy %2$s%3$s', 'wordpress-seo' ), '<span>', 'Yoast SEO Premium', '</span>' );
+								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+								\printf( \esc_html__( '%1$sBuy%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
 							}
 							else {
 								/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Change the Black Friday ad title

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the Black Friday ad title.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast Premium is not active.
* Enable Black Friday promotion by editing `src/promotions/domain/black-friday-promotion.php` replace line 16:
```php
new Time_Interval( \gmmktime( 12, 00, 00, 11, 28, 2023 ), \gmmktime( 12, 00, 00, 12, 3, 2024 ) )
```
* Go to `Yoast SEO` -> `General`
  * Verify the Black Friday ad title  in the sidebar is `Buy Yoast SEO Premium` and not `All annual plans incl.`
* Go to `Yoast SEO` -> `Settings and verify the same  

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#291](https://github.com/Yoast/reserved-tasks/issues/291)
