### PR TITLE
Fix Uncaught TypeError when saving new user

### DIFF
--- a/src/user-meta/user-interface/additional-contactmethods-integration.php
+++ b/src/user-meta/user-interface/additional-contactmethods-integration.php
@@ -51,7 +51,7 @@ class Additional_Contactmethods_Integration implements Integration_Interface {
 	public function update_contactmethods( $contactmethods ) {
 		$additional_contactmethods = $this->additional_contactmethods_collector->get_additional_contactmethods_objects();
 
-		return \array_merge( ($contactmethods ?? []), ($additional_contactmethods ?? []) );
+		return \array_merge( ($contactmethods ?? [] ), ($additional_contactmethods ?? [] ) );
 	}
 
 	/**

--- a/src/user-meta/user-interface/additional-contactmethods-integration.php
+++ b/src/user-meta/user-interface/additional-contactmethods-integration.php
@@ -51,7 +51,7 @@ class Additional_Contactmethods_Integration implements Integration_Interface {
 	public function update_contactmethods( $contactmethods ) {
 		$additional_contactmethods = $this->additional_contactmethods_collector->get_additional_contactmethods_objects();
 
-		return \array_merge( $contactmethods, $additional_contactmethods );
+		return \array_merge( $contactmethods ?? [], $additional_contactmethods ?? []);
 	}
 
 	/**

--- a/src/user-meta/user-interface/additional-contactmethods-integration.php
+++ b/src/user-meta/user-interface/additional-contactmethods-integration.php
@@ -51,7 +51,7 @@ class Additional_Contactmethods_Integration implements Integration_Interface {
 	public function update_contactmethods( $contactmethods ) {
 		$additional_contactmethods = $this->additional_contactmethods_collector->get_additional_contactmethods_objects();
 
-		return \array_merge( $contactmethods ?? [], $additional_contactmethods ?? []);
+		return \array_merge( ($contactmethods ?? []), ($additional_contactmethods ?? []) );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes fatal errors such as the one below when saving a new user when using PHP 8.2 

`
Fatal error: Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given in /var/www/html/wp-content/plugins/wordpress-seo/src/user-meta/user-interface/additional-contactmethods-integration.php:54 Stack trace: #0 /var/www/html/wp-content/plugins/wordpress-seo/src/user-meta/user-interface/additional-contactmethods-integration.php(54): array_merge() #1 /var/www/html/wp-includes/class-wp-hook.php(326): Yoast\WP\SEO\User_Meta\User_Interface\Additional_Contactmethods_Integration->update_contactmethods() #2 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters() #3 /var/www/html/wp-includes/user.php(2839): apply_filters() #4 /var/www/html/wp-admin/includes/user.php(109): wp_get_user_contact_methods() #5 /var/www/html/wp-admin/user-new.php(195): edit_user() #6 {main} thrown in /var/www/html/wp-content/plugins/wordpress-seo/src/user-meta/user-interface/additional-contactmethods-integration.php on line 54"
`