### PR TITLE
Refactor assets enqueing hooks and callbacks

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -810,7 +810,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		if ( self::is_post_overview( $pagenow ) ) {
-			error_log( 'This is the post overview' );
 			$asset_manager->enqueue_style( 'edit-page' );
 			$asset_manager->enqueue_script( 'edit-page' );
 		}

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -74,7 +74,8 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
+		add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_post_overview_assets' ] );
 		add_action( 'wp_insert_post', [ $this, 'save_postdata' ] );
 		add_action( 'edit_attachment', [ $this, 'save_postdata' ] );
 		add_action( 'add_attachment', [ $this, 'save_postdata' ] );
@@ -799,6 +800,23 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	}
 
 	/**
+	 * Enqueues assets for the post overview page.
+	 *
+	 * @return void
+	 */
+	public function enqueue_post_overview_assets() {
+		global $pagenow;
+
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
+
+		if ( self::is_post_overview( $pagenow ) ) {
+			error_log( 'This is the post overview' );
+			$asset_manager->enqueue_style( 'edit-page' );
+			$asset_manager->enqueue_script( 'edit-page' );
+		}
+	}
+
+	/**
 	 * Enqueues all the needed JS and CSS.
 	 *
 	 * @todo [JRF => whomever] Create css/metabox-mp6.css file and add it to the below allowed colors array when done.
@@ -811,13 +829,6 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		$is_editor = self::is_post_overview( $pagenow ) || self::is_post_edit( $pagenow );
-
-		if ( self::is_post_overview( $pagenow ) ) {
-			$asset_manager->enqueue_style( 'edit-page' );
-			$asset_manager->enqueue_script( 'edit-page' );
-
-			return;
-		}
 
 		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
 		if ( ( $is_editor === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->display_metabox() === false ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to refactor how we enqueue assets in order to correctly enqueue them in the iframed block editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Addresses a notice in WordPress 6.7 about assets being added to the iframe incorrectly.

## Relevant technical choices:

* I moved the logic to enqueue assets for the post overview page out of the big `enqueue` callback and gave it a specific callback + action hook.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Test the correct enqueing of assets in the post editor
* Make sure you're on WordPress 6.7
  * in case you're not, use the `WordPress Beta Tester` plugin to switch to it 
* Edit a post
  * In your console browse verify
    * there are no notices like: `yoast-seo-metabox-css-css was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.`  
    * go to the `Network` tab and make sure `metabox-[VERSION].css` is loaded
  * verify the Yoast metabox is styled properly and smoke-test some of its functions

### Test the callback refactoring did not introduce regressions
* Go to `Posts` -> `All posts`
  * verify the SEO score, readability and outgoing links columns iconsare properly styled, i.e.:
    <img width="151" alt="Screenshot 2024-10-10 at 11 13 31" src="https://github.com/user-attachments/assets/5fd10bab-9491-42f9-a5fa-7502b7860226">
    and not:
    <img width="167" alt="Screenshot 2024-10-10 at 11 15 05" src="https://github.com/user-attachments/assets/90acb455-fcf7-476d-a40a-90bdf19609bd">
  * in your console browse go to the `Network` tab and make sure `edit-page-[VERSION].css` and `edit-page-[VERSION].js` are loaded


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [WP 6.7: 23.6: yoast-seo-metabox-css-css was added to the iframe incorrectly. Please use block.json or enqueue_block_assets to add styles to the iframe.](https://github.com/Yoast/plugins-automated-testing/issues/1868)

