### PR TITLE
Add GitHub workflow to update the Browserslist database

### DIFF
--- a/.github/workflows/browserslist-db.yml
+++ b/.github/workflows/browserslist-db.yml
@@ -1,0 +1,57 @@
+name: Update Browserslist database
+
+on:
+  workflow_dispatch
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    name: Update Browserslist database
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Set up Git user
+        run: |
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update Browserslist database and create PR
+        uses: c2corg/browserslist-update-action@b3c521a9a0336de4d4e646ddd2db5e05b2e1a2e6 # @v2.4.0 locked to a specific commit to avoid security issues due to a compromised repo.
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: browserslist-update
+          base_branch: ${{ github.ref_name }}
+          directory: .
+          commit_message: 'Update Browserslist database'
+          title: 'Update Browserslist database'
+          labels: 'changelog: non-user-facing'
+          body: |
+            ## Context
+
+            * We always want to target the latest browsers when building our JavaScript. This PR makes sure that the list/db on what is considered the "latest browsers" is up to date and consistent across our JavaScript packages.
+            * Solves the following build warning:
+            ```
+            Browserslist: caniuse-lite is outdated. Please run:
+              npx update-browserslist-db@latest
+              Why you should do it regularly: https://github.com/browserslist/update-db#readme
+            ```
+
+            ## Summary
+            This PR can be summarized in the following changelog entry:
+
+            * Updates the Browserslist database.
+
+            ## Relevant technical choices:
+
+            * Used [browserslist-update-action](https://github.com/c2corg/browserslist-update-action) to create this PR.
+            * Used `npx update-browserslist-db@latest` to update the Browserslist database.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Inspired by the State of the Code from @diedexx 
But then a tryout with a smaller scope: updating the Browserslist database via a GitHub workflow/action

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a GitHub workflow, that can be manually triggered, to create a PR to update the Browserslist or `caniuse` database.

## Relevant technical choices:

Using [browserslist-update-action](https://github.com/c2corg/browserslist-update-action) to:
* create the branch
* run `npx update-browserslist-db@latest` to update (see [update-db](https://github.com/browserslist/update-db))
* add files and commit
* create a PR

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

AFAIK we cannot test this on this repository without merging it first.
I did test this myself by:
* creating a new (private) repository on my account
* check `Allow GitHub Actions to create and approve pull requests` in the repo settings > actions 
  * this is needed for the workflow to be able to create a PR
* yarn init
* add dev deps as per a test fixture, including `yarn.lock`: https://github.com/browserslist/update-db/tree/main/test/fixtures/update-yarn
  * this is needed for the `update-db` to be able to have an update
* copy-pasting the workflow in there
* this I forgot, but you could create a label called `changelog: non-user-facing`
  * to test if that gets added to the PR
* run the workflow
![image](https://github.com/user-attachments/assets/bf05ce28-4b73-4d8d-ad8b-bdee7f929a62)
* see that a PR is created
* the PR text should be similar to https://github.com/Yoast/wordpress-seo/pull/20658

After merging we should ensure:
* the workflow indeed also works here
* the created PR should not trigger a changelog needed event on Slack 😅 
* maybe switch to cron, as it will try to reuse the same branch; from their example (every 1st and 15th of the month @ 2 in the night):
```yml
on:
  schedule:
    - cron: '0 2 1,15 * *'
```


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* N/A

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
