### PR TITLE
Enhance the admin asset API to cover loading strategy as well

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -88,14 +88,21 @@ class WPSEO_Admin_Asset_Manager {
 	 * @return void
 	 */
 	public function register_script( WPSEO_Admin_Asset $script ) {
-		$url = $script->get_src() ? $this->get_url( $script, WPSEO_Admin_Asset::TYPE_JS ) : false;
+		$url  = $script->get_src() ? $this->get_url( $script, WPSEO_Admin_Asset::TYPE_JS ) : false;
+		$args = [
+			'in_footer' => $script->is_in_footer(),
+		];
+
+		if ( $script->get_strategy() !== '' ) {
+			$args['strategy'] = $script->get_strategy();
+		}
 
 		wp_register_script(
 			$this->prefix . $script->get_name(),
 			$url,
 			$script->get_deps(),
 			$script->get_version(),
-			$script->is_in_footer()
+			$args
 		);
 
 		if ( in_array( 'wp-i18n', $script->get_deps(), true ) ) {

--- a/admin/class-asset.php
+++ b/admin/class-asset.php
@@ -122,6 +122,13 @@ class WPSEO_Admin_Asset {
 	protected $in_footer;
 
 	/**
+	 * For JS Assets. The script's async/defer strategy.
+	 *
+	 * @var string
+	 */
+	protected $strategy;
+
+	/**
 	 * For CSS Assets. Whether this stylesheet is a right-to-left stylesheet.
 	 *
 	 * @var bool
@@ -147,6 +154,7 @@ class WPSEO_Admin_Asset {
 		'media'     => 'all',
 		'version'   => '',
 		'suffix'    => '',
+		'strategy'  => '',
 	];
 
 	/**
@@ -173,6 +181,7 @@ class WPSEO_Admin_Asset {
 		$this->version   = $args['version'];
 		$this->media     = $args['media'];
 		$this->in_footer = $args['in_footer'];
+		$this->strategy  = $args['strategy'];
 		$this->rtl       = $args['rtl'];
 		$this->suffix    = $args['suffix'];
 	}
@@ -233,6 +242,15 @@ class WPSEO_Admin_Asset {
 	 */
 	public function is_in_footer() {
 		return $this->in_footer;
+	}
+
+	/**
+	 * Returns the script asset's async/defer loading strategy.
+	 *
+	 * @return string
+	 */
+	public function get_strategy() {
+		return $this->strategy;
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This change is to accommodate our changes in https://github.com/Yoast/wordpress-seo-local/pull/2548. Specifically, we needed a way to register scripts with an `async` strategy, so we had to enhance our asset manager API.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows scripts to register their loading strategy.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Regression tests:
* Go to Yoast SEO->Settings both with this PR/RC and trunk/released version, check the source code and confirm that all `<scripts>` have stayed the same and in the same spot (header/footer)
* Confirm that you dont get any new console errors
* Repeat the test for:
  * The post edit page, in all editors
  * The frontend of the site

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1869
