### PR TITLE
Make sure assets are also enqueued for non block editor editors.

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -75,7 +75,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
 		// Enqueue metabox assets for the block editor.
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue' ] );
 		// Enqueue metabox assets for other editors.
 		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue_assets_non_block_editor' ] );
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -825,7 +825,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 *
 	 * @return void
 	 */
-	public function maybe_enqueue_assets_non_block_editor(): void {
+	public function maybe_enqueue_assets_non_block_editor() {
 		global $pagenow;
 
 		if ( ( self::is_post_edit( $pagenow ) === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || WP_Screen::get()->is_block_editor() ) {

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -826,7 +826,9 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return void
 	 */
 	public function maybe_enqueue_assets_non_block_editor(): void {
-		if ( WP_Screen::get()->is_block_editor() ) {
+		global $pagenow;
+
+		if ( (self::is_post_edit( $pagenow ) === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || WP_Screen::get()->is_block_editor() ) {
 			return;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -828,7 +828,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	public function maybe_enqueue_assets_non_block_editor(): void {
 		global $pagenow;
 
-		if ( (self::is_post_edit( $pagenow ) === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || WP_Screen::get()->is_block_editor() ) {
+		if ( ( self::is_post_edit( $pagenow ) === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || WP_Screen::get()->is_block_editor() ) {
 			return;
 		}
 

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -843,16 +843,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 	 * @return void
 	 */
 	public function enqueue() {
-		global $pagenow;
-
-		$asset_manager = new WPSEO_Admin_Asset_Manager();
-
-		$is_editor = self::is_post_overview( $pagenow ) || self::is_post_edit( $pagenow );
-
-		/* Filter 'wpseo_always_register_metaboxes_on_admin' documented in wpseo-main.php */
-		if ( ( $is_editor === false && apply_filters( 'wpseo_always_register_metaboxes_on_admin', false ) === false ) || $this->display_metabox() === false ) {
+		if ( $this->display_metabox() === false ) {
 			return;
 		}
+
+		$asset_manager = new WPSEO_Admin_Asset_Manager();
 
 		$post_id = get_queried_object_id();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.

--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -74,7 +74,11 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		}
 
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_box' ] );
+		// Enqueue metabox assets for the block editor.
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue' ] );
+		// Enqueue metabox assets for other editors.
+		add_action( 'admin_enqueue_scripts', [ $this, 'maybe_enqueue_assets_non_block_editor' ] );
+
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_post_overview_assets' ] );
 		add_action( 'wp_insert_post', [ $this, 'save_postdata' ] );
 		add_action( 'edit_attachment', [ $this, 'save_postdata' ] );
@@ -813,6 +817,20 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			$asset_manager->enqueue_style( 'edit-page' );
 			$asset_manager->enqueue_script( 'edit-page' );
 		}
+	}
+
+	/**
+	 * Checks to make sure the current editor used is not the block editor to enqueue all needed assets.
+	 * If it is the block editor the assets are already enqueued in the `enqueue_block_assets` action.
+	 *
+	 * @return void
+	 */
+	public function maybe_enqueue_assets_non_block_editor(): void {
+		if ( WP_Screen::get()->is_block_editor() ) {
+			return;
+		}
+
+		$this->enqueue();
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We need to enqueue our metabox assets differently for non block editor editors.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the assets for non block editor editors were no longer enqueued.

## Relevant technical choices:

* I added a `maybe` callback method since at construct time the system does not know if we are in the block editor yet. The `current_screen` methods are not yet defined.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Test the assets get correctly enqueued in all the editors
* Make sure all editor metaboxes still work. So classic, block editor, product editor and Elementor.
* Also test that https://github.com/Yoast/wordpress-seo/pull/21696 is still fixed.

### Test the assets get correctly enqueued by third-party plugins
* Install [Tabify Edit Screen](https://wordpress.org/plugins/tabify-edit-screen/)
* Go to `Settings` -> `Tabify edit screen`
  * click on `Create new tab`
  * name the tab `Yoast` and make sure `Yoast SEO` is in it
  * toggle `Show tabs in this post type` to `on`
  * click `Save changes`
* Activate the Classic editor
* Edit a post
  * you should see the following:
   <img width="416" alt="Screenshot 2024-10-15 at 11 22 36" src="https://github.com/user-attachments/assets/7d1047fb-7adf-488f-bea8-f0acd19e0c2a">
  * click on `Yoast` and make sure the metabox is correctly loaded


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
