### PR TITLE
Fix copy in the Alert center when no problems are detected

### DIFF
--- a/admin/views/partial-notifications-errors.php
+++ b/admin/views/partial-notifications-errors.php
@@ -17,8 +17,8 @@ $yoast_seo_active_total    = count( $yoast_seo_active );
 $yoast_seo_dismissed_total = count( $yoast_seo_dismissed );
 $yoast_seo_total           = $notifications_data['metrics']['errors'];
 
-$yoast_seo_i18n_title              = __( 'Problems', 'wordpress-seo' );
-$yoast_seo_i18n_issues             = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
-$yoast_seo_i18n_no_issues          = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
+$yoast_seo_i18n_title     = __( 'Problems', 'wordpress-seo' );
+$yoast_seo_i18n_issues    = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
+$yoast_seo_i18n_no_issues = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
 
 require WPSEO_PATH . 'admin/views/partial-notifications-template.php';

--- a/admin/views/partial-notifications-errors.php
+++ b/admin/views/partial-notifications-errors.php
@@ -20,10 +20,5 @@ $yoast_seo_total           = $notifications_data['metrics']['errors'];
 $yoast_seo_i18n_title              = __( 'Problems', 'wordpress-seo' );
 $yoast_seo_i18n_issues             = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
 $yoast_seo_i18n_no_issues          = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
-$yoast_seo_i18n_muted_issues_title = sprintf(
-	/* translators: %d expands the amount of hidden problems. */
-	_n( 'You have %d hidden problem:', 'You have %d hidden problems:', $yoast_seo_dismissed_total, 'wordpress-seo' ),
-	$yoast_seo_dismissed_total
-);
 
 require WPSEO_PATH . 'admin/views/partial-notifications-template.php';

--- a/packages/js/src/general/components/alerts-list.js
+++ b/packages/js/src/general/components/alerts-list.js
@@ -5,7 +5,7 @@ import { Button } from "@yoast/ui-library";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { AlertsContext } from "../contexts/alerts-context";
-import { STORE_NAME } from "../constants/index";
+import { STORE_NAME } from "../constants";
 
 /**
  * The alert item object.

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -16,7 +16,7 @@ export const Problems = () => {
 	const dismissedProblemsList = useSelect( ( select ) => select( STORE_NAME ).selectDismissedProblems(), [] );
 
 	const dismissedProblems = dismissedProblemsList.length;
-	const problems = problemsList.length;
+	const problemCount = problemsList.length;
 
 	const dismissedProblemsLabel = _n(
 		"hidden problem",

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -16,6 +16,7 @@ export const Problems = () => {
 	const dismissedProblemsList = useSelect( ( select ) => select( STORE_NAME ).selectDismissedProblems(), [] );
 
 	const dismissedProblems = dismissedProblemsList.length;
+	const problems = problemsList.length;
 
 	const dismissedProblemsLabel = _n(
 		"hidden problem",
@@ -35,7 +36,11 @@ export const Problems = () => {
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ { ...problemsTheme } }>
 					<AlertsTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
-						<p className="yst-mt-2 yst-text-sm">{ __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" ) }</p>
+						{ problems > 0 ? (
+							<p className="yst-mt-2 yst-text-sm">{ __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" ) }</p>
+						) :  (
+							<p className="yst-mt-2 yst-text-sm">{ __( "Good job! We could detect no serious SEO problems.", "wordpress-seo" ) }</p>
+						) }
 					</AlertsTitle>
 					<AlertsList items={ problemsList } />
 

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -36,11 +36,12 @@ export const Problems = () => {
 			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-6">
 				<AlertsContext.Provider value={ { ...problemsTheme } }>
 					<AlertsTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
-						{ problems > 0 ? (
-							<p className="yst-mt-2 yst-text-sm">{ __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" ) }</p>
-						) :  (
-							<p className="yst-mt-2 yst-text-sm">{ __( "Good job! We could detect no serious SEO problems.", "wordpress-seo" ) }</p>
-						) }
+						<p className="yst-mt-2 yst-text-sm">
+							{ problemCount > 0
+								 ? __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" )
+								 : __( "Good job! We could detect no serious SEO problems.", "wordpress-seo" )
+						 }
+						</p>
 					</AlertsTitle>
 					<AlertsList items={ problemsList } />
 

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -16,7 +16,6 @@ export const Problems = () => {
 	const dismissedProblemsList = useSelect( ( select ) => select( STORE_NAME ).selectDismissedProblems(), [] );
 
 	const dismissedProblems = dismissedProblemsList.length;
-	const problemCount = problemsList.length;
 
 	const dismissedProblemsLabel = _n(
 		"hidden problem",

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -5,7 +5,6 @@ import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
 import { AlertsTitle } from "./alerts-title";
 import { Collapsible } from "./collapsible";
-import { STORE_NAME } from "../constants";
 
 import { AlertsContext } from "../contexts/alerts-context";
 import { STORE_NAME } from "../constants/index";

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -5,6 +5,8 @@ import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
 import { AlertsTitle } from "./alerts-title";
 import { Collapsible } from "./collapsible";
+import { STORE_NAME } from "../constants";
+
 import { AlertsContext } from "../contexts/alerts-context";
 import { STORE_NAME } from "../constants/index";
 

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -36,7 +36,7 @@ export const Problems = () => {
 				<AlertsContext.Provider value={ { ...problemsTheme } }>
 					<AlertsTitle title={ __( "Problems", "wordpress-seo" ) } counts={ problemsList.length }>
 						<p className="yst-mt-2 yst-text-sm">
-							{ problemCount > 0
+							{ problemsList.length > 0
 								 ? __( "We have detected the following issues that affect the SEO of your site.", "wordpress-seo" )
 								 : __( "Good job! We could detect no serious SEO problems.", "wordpress-seo" )
 						 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show `Good job! We could detect no serious SEO problems.` instead of `We have detected the following issues that affect the SEO of your site.` if no issues are detected.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes copy in the Alert center when no problems are detected.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Settings` -> `Reading`
  * tick the `Discourage search engines from indexing this site` checkbox
* Go to `Yoast SEO` -> `General`, you should see a problem titled `Huge SEO Issue: You're blocking access to robots.`
* Hide the problem and verify the `Problems` widget now shows `Good job! We could detect no serious SEO problems.`
* Go to `Settings` -> `Reading`
  * untick the `Discourage search engines from indexing this site` checkbox
* Go to `Yoast SEO` -> `General`, and verify the `Problems` widget still shows `Good job! We could detect no serious SEO problems.`
   

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#21713](https://github.com/Yoast/wordpress-seo/issues/21713)
