### PR TITLE
Add target blank to server rendering of blocks.

### DIFF
--- a/src/integrations/blocks/abstract-dynamic-block-v3.php
+++ b/src/integrations/blocks/abstract-dynamic-block-v3.php
@@ -75,4 +75,21 @@ abstract class Dynamic_Block_V3 implements Integration_Interface {
 	 * @return string The block output.
 	 */
 	abstract public function present( $attributes );
+
+	/**
+	 * This is needed because when the editor is loaded in an Iframe the link needs to open in a different browser window.
+	 * We don't want this behaviour in the front-end and the way to check this is to check if the block is rendered in a REST request with the `context` set as 'edit'. Thus being in the editor.
+	 *
+	 * @return bool returns if the block should be opened in another window.
+	 */
+	protected function should_link_target_blank(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['context'] ) && \is_string( $_GET['context'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			if ( \wp_unslash( $_GET['context'] ) === 'edit' ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/src/integrations/blocks/abstract-dynamic-block-v3.php
+++ b/src/integrations/blocks/abstract-dynamic-block-v3.php
@@ -77,6 +77,8 @@ abstract class Dynamic_Block_V3 implements Integration_Interface {
 	abstract public function present( $attributes );
 
 	/**
+	 * Checks whether the links in the block should have target="blank".
+	 *
 	 * This is needed because when the editor is loaded in an Iframe the link needs to open in a different browser window.
 	 * We don't want this behaviour in the front-end and the way to check this is to check if the block is rendered in a REST request with the `context` set as 'edit'. Thus being in the editor.
 	 *

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -139,11 +139,7 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . \esc_attr( $breadcrumb['title'] ) . '"' : '';
 			$link      .= '<a';
 
-			/**
-			 * This is needed because when the editor is loaded in an Iframe the link needs to open in a different browser window.
-			 * We don't want this behaviour in the front-end and the way to check this is to check if the block is rendered in a REST request. Thus being in the editor.
-			 */
-			if ( \wp_is_serving_rest_request() ) {
+			if ( $this->should_link_target_blank() ) {
 				$link .= ' target="_blank"';
 			}
 			$link .= ' href="' . \esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
@@ -264,5 +260,22 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 		}
 
 		return $this->element;
+	}
+
+	/**
+	 * This is needed because when the editor is loaded in an Iframe the link needs to open in a different browser window.
+	 * We don't want this behaviour in the front-end and the way to check this is to check if the block is rendered in a REST request with the `context` set as 'edit'. Thus being in the editor.
+	 *
+	 * @return bool returns if the breadcrumb should be opened in another window.
+	 */
+	private function should_link_target_blank(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
+		if ( isset( $_GET['context'] ) && \is_string( $_GET['context'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are not processing form information, We are only strictly comparing.
+			if ( \wp_unslash( $_GET['context'] ) === 'edit' ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -137,8 +137,13 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			// If it's not the last element and we have a url.
 			$link      .= '<' . $this->get_element() . '>';
 			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . \esc_attr( $breadcrumb['title'] ) . '"' : '';
-			$link      .= '<a href="' . \esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
-			$link      .= '</' . $this->get_element() . '>';
+			$link      .= '<a';
+			// If the block is rendered server side (via a rest request) make sure the links target blank.
+			if ( \wp_is_serving_rest_request() ) {
+				$link .= ' target="_blank"';
+			}
+			$link .= ' href="' . \esc_url( $breadcrumb['url'] ) . '"' . $title_attr . '>' . $text . '</a>';
+			$link .= '</' . $this->get_element() . '>';
 		}
 		elseif ( $index === ( $total - 1 ) ) {
 			// If it's the last element.

--- a/src/presenters/breadcrumbs-presenter.php
+++ b/src/presenters/breadcrumbs-presenter.php
@@ -138,7 +138,11 @@ class Breadcrumbs_Presenter extends Abstract_Indexable_Presenter {
 			$link      .= '<' . $this->get_element() . '>';
 			$title_attr = isset( $breadcrumb['title'] ) ? ' title="' . \esc_attr( $breadcrumb['title'] ) . '"' : '';
 			$link      .= '<a';
-			// If the block is rendered server side (via a rest request) make sure the links target blank.
+
+			/**
+			 * This is needed because when the editor is loaded in an Iframe the link needs to open in a different browser window.
+			 * We don't want this behaviour in the front-end and the way to check this is to check if the block is rendered in a REST request. Thus being in the editor.
+			 */
 			if ( \wp_is_serving_rest_request() ) {
 				$link .= ' target="_blank"';
 			}

--- a/src/presenters/url-list-presenter.php
+++ b/src/presenters/url-list-presenter.php
@@ -8,6 +8,13 @@ namespace Yoast\WP\SEO\Presenters;
 class Url_List_Presenter extends Abstract_Presenter {
 
 	/**
+	 * If the url should be target blank.
+	 *
+	 * @var bool
+	 */
+	protected $target_blank;
+
+	/**
 	 * A list of arrays containing titles and URLs.
 	 *
 	 * @var array
@@ -24,12 +31,14 @@ class Url_List_Presenter extends Abstract_Presenter {
 	/**
 	 * Url_List_Presenter constructor.
 	 *
-	 * @param array  $links      A list of arrays containing titles and urls.
-	 * @param string $class_name Classname for the url list.
+	 * @param array  $links        A list of arrays containing titles and urls.
+	 * @param string $class_name   Classname for the url list.
+	 * @param bool   $target_blank If the url should be target blank.
 	 */
-	public function __construct( $links, $class_name = 'yoast-url-list' ) {
-		$this->links      = $links;
-		$this->class_name = $class_name;
+	public function __construct( $links, $class_name = 'yoast-url-list', $target_blank = false ) {
+		$this->links        = $links;
+		$this->class_name   = $class_name;
+		$this->target_blank = $target_blank;
 	}
 
 	/**
@@ -40,7 +49,12 @@ class Url_List_Presenter extends Abstract_Presenter {
 	public function present() {
 		$output = '<ul class="' . $this->class_name . '">';
 		foreach ( $this->links as $link ) {
-			$output .= '<li><a href="' . $link['permalink'] . '">' . $link['title'] . '</a></li>';
+			$output .= '<li><a';
+			if ( $this->target_blank ) {
+				$output .= ' target = "_blank"';
+			}
+			$output .= ' href="' . $link['permalink'] . '">' . $link['title'] . '</a></li>';
+
 		}
 		$output .= '</ul>';
 		return $output;

--- a/src/presenters/url-list-presenter.php
+++ b/src/presenters/url-list-presenter.php
@@ -12,7 +12,7 @@ class Url_List_Presenter extends Abstract_Presenter {
 	 *
 	 * @var bool
 	 */
-	protected $target_blank;
+	private $target_blank;
 
 	/**
 	 * A list of arrays containing titles and URLs.

--- a/tests/Unit/Presenters/Breadcrumbs_Presenter_Test.php
+++ b/tests/Unit/Presenters/Breadcrumbs_Presenter_Test.php
@@ -281,7 +281,9 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'url'  => 'home_url',
 			'text' => 'home_text',
 		];
-
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
+			->once()
+			->andReturnFalse();
 		$this->instance->expects( 'get_element' )
 			->twice()
 			->withNoArgs()
@@ -307,6 +309,9 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'url'  => 'home_url',
 			'text' => 'home_text',
 		];
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
+			->once()
+			->andReturnFalse();
 
 		$this->instance->expects( 'get_element' )
 			->twice()
@@ -340,13 +345,44 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'text'  => 'home_text',
 			'title' => 'home_title',
 		];
-
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
+			->once()
+			->andReturnFalse();
 		$this->instance->expects( 'get_element' )
 			->twice()
 			->withNoArgs()
 			->andReturn( 'span' );
 
 		$link = '<span><a href="home_url" title="home_title">home_text</a></span>';
+
+		$this->assertEquals(
+			$link,
+			$this->instance->crumb_to_link( $breadcrumb, 0, 2 )
+		);
+	}
+
+	/**
+	 * Tests the creation of a breadcrumb element has target blank in the editor.
+	 *
+	 * @covers ::crumb_to_link
+	 *
+	 * @return void
+	 */
+	public function test_crumb_in_editor() {
+		$breadcrumb = [
+			'url'   => 'home_url',
+			'text'  => 'home_text',
+			'title' => 'home_title',
+		];
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
+			->once()
+			->andReturnTrue();
+		$this->instance->expects( 'get_element' )
+			->twice()
+			->withNoArgs()
+			->andReturn( 'span' );
+
+		$link = '<span><a target="_blank" href="home_url" title="home_title">home_text</a></span>';
 
 		$this->assertEquals(
 			$link,

--- a/tests/Unit/Presenters/Breadcrumbs_Presenter_Test.php
+++ b/tests/Unit/Presenters/Breadcrumbs_Presenter_Test.php
@@ -281,9 +281,7 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'url'  => 'home_url',
 			'text' => 'home_text',
 		];
-		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
-			->once()
-			->andReturnFalse();
+
 		$this->instance->expects( 'get_element' )
 			->twice()
 			->withNoArgs()
@@ -309,9 +307,6 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'url'  => 'home_url',
 			'text' => 'home_text',
 		];
-		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
-			->once()
-			->andReturnFalse();
 
 		$this->instance->expects( 'get_element' )
 			->twice()
@@ -345,9 +340,7 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'text'  => 'home_text',
 			'title' => 'home_title',
 		];
-		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
-			->once()
-			->andReturnFalse();
+
 		$this->instance->expects( 'get_element' )
 			->twice()
 			->withNoArgs()
@@ -374,9 +367,7 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 			'text'  => 'home_text',
 			'title' => 'home_title',
 		];
-		Monkey\Functions\expect( 'wp_is_serving_rest_request' )
-			->once()
-			->andReturnTrue();
+
 		$this->instance->expects( 'get_element' )
 			->twice()
 			->withNoArgs()
@@ -384,10 +375,12 @@ final class Breadcrumbs_Presenter_Test extends TestCase {
 
 		$link = '<span><a target="_blank" href="home_url" title="home_title">home_text</a></span>';
 
+		$_GET['context'] = 'edit';
 		$this->assertEquals(
 			$link,
 			$this->instance->crumb_to_link( $breadcrumb, 0, 2 )
 		);
+		unset( $_GET['context'] );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that our links work in the new Iframe editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* improves the compatibility with WordPress 6.7 Iframe editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO and WP beta
* Activate WP 6.7-betaX
* Create a post and Breadcrumbs block there
* Click on Home in breadcrumbs
* Make sure you open your link in a new tab.
* Save the page en make sure the target blank is not active on the front-end.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
