### PR TITLE
Disables the marks button when switching from editor and there is an active AI button

### DIFF
--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -78,15 +78,16 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 
 
 	/**
-	 * Toggles the markers status, based on the editor mode.
+	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
 	 *
 	 * @param {string} editorMode The editor mode.
+	 * @param {boolean} activeAIButtonId The active AI button ID.
 	 *
 	 * @returns {void}
 	 */
 	useEffect( () => {
 		// Toggle markers based on editor mode.
-		if ( editorMode === "visual" ) {
+		if ( editorMode === "visual" && ! activeAIButtonId ) {
 			setMarkerStatus( "enabled" );
 		} else {
 			setMarkerStatus( "disabled" );
@@ -94,9 +95,9 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 
 		// Cleanup function to reset the marker status when the component unmounts or editor mode changes
 		return () => {
-			setMarkerStatus( "enabled" );
+			setMarkerStatus( "disabled" );
 		};
-	}, [ editorMode, setMarkerStatus ] );
+	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
 
 	/**
 	 * Handles the button press state.
@@ -126,7 +127,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			 */
 			setMarkerStatus( "disabled" );
 		}
-
 		// Dismiss the tooltip when the button is pressed.
 		setButtonClass( "" );
 	};

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { useCallback, useRef, useState } from "@wordpress/element";
+import { useEffect, useCallback, useRef, useState } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 import { useSelect, useDispatch } from "@wordpress/data";
 
@@ -37,6 +37,9 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	// The button is pressed when the active AI button id is the same as the current button id.
 	const isButtonPressed = activeAIButtonId === aiFixesId;
 
+	// Get the editor mode using useSelect.
+	const editorMode = useSelect( ( select ) => select( "core/edit-post" ).getEditorMode(), [] );
+
 	// Enable the button when:
 	// (1) other AI buttons are not pressed.
 	// (2) the AI button is not disabled.
@@ -58,7 +61,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			};
 		}
 
-		const editorMode = select( "core/edit-post" ).getEditorMode();
 		if ( editorMode !== "visual" ) {
 			return {
 				isEnabled: false,
@@ -72,7 +74,29 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			isEnabled: allVisual,
 			ariaLabel: allVisual ? defaultLabel : htmlLabel,
 		};
-	}, [ isButtonPressed, activeAIButtonId ] );
+	}, [ isButtonPressed, activeAIButtonId, editorMode ] );
+
+
+	/**
+	 * Toggles the markers status, based on the editor mode.
+	 *
+	 * @param {string} editorMode The editor mode.
+	 *
+	 * @returns {void}
+	 */
+	useEffect( () => {
+		// Toggle markers based on editor mode.
+		if ( editorMode === "visual" ) {
+			setMarkerStatus( "enabled" );
+		} else {
+			setMarkerStatus( "disabled" );
+		}
+
+		// Cleanup function to reset the marker status when the component unmounts or editor mode changes
+		return () => {
+			setMarkerStatus( "enabled" );
+		};
+	}, [ editorMode, setMarkerStatus ] );
 
 	/**
 	 * Handles the button press state.

--- a/packages/js/src/initializers/post-scraper.js
+++ b/packages/js/src/initializers/post-scraper.js
@@ -51,7 +51,6 @@ import isBlockEditor from "../helpers/isBlockEditor";
 
 const {
 	setFocusKeyword,
-	setMarkerStatus,
 	updateData,
 	setCornerstoneContent,
 	refreshSnippetEditor,
@@ -361,24 +360,6 @@ export default function initPostScraper( $, store, editorData ) {
 	}
 
 	/**
-	 * Toggles the markers status in the state, based on the editor mode.
-	 *
-	 * @param {string} editorMode The editor mode.
-	 * @param {Object} store      The store to update.
-	 *
-	 * @returns {void}
-	 */
-	function toggleMarkers( editorMode, store ) {
-		if ( editorMode === "visual" ) {
-			store.dispatch( setMarkerStatus( "enabled" ) );
-
-			return;
-		}
-
-		store.dispatch( setMarkerStatus( "disabled" ) );
-	}
-
-	/**
 	 * Gets the current editor mode from the state.
 	 *
 	 * @returns {string} The current editor mode.
@@ -567,9 +548,6 @@ export default function initPostScraper( $, store, editorData ) {
 
 		if ( isBlockEditor() ) {
 			let editorMode = getEditorMode();
-
-			toggleMarkers( editorMode, store );
-
 			subscribe( () => {
 				const currentEditorMode = getEditorMode();
 
@@ -578,7 +556,6 @@ export default function initPostScraper( $, store, editorData ) {
 				}
 
 				editorMode = currentEditorMode;
-				toggleMarkers( editorMode, store );
 			} );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*We want to ensure that the marker button remains disabled while an AI toast notification is active, regardless of the editor mode changes from visual to code and vice-versa. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the highlighting marker button was incorrectly enabled when switching the editor mode from code to visual while the AI Optimize toast notification was still visible.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [X] This PR falls under an innovation project. I have attached the `innovation` label.
* [X] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
