### PR TITLE
Call _load_textdomain_just_in_time correctly

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -75,8 +75,6 @@ class WPSEO_Admin {
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		}
 
-		$this->set_upsell_notice();
-
 		$this->initialize_cornerstone_content();
 
 		if ( WPSEO_Utils::is_plugin_network_active() ) {
@@ -365,17 +363,6 @@ class WPSEO_Admin {
 			],
 			YoastSEO()->helpers->wincher->get_admin_global_links()
 		);
-	}
-
-	/**
-	 * Sets the upsell notice.
-	 *
-	 * @return void
-	 */
-	protected function set_upsell_notice() {
-		$upsell = new WPSEO_Product_Upsell_Notice();
-		$upsell->dismiss_notice_listener();
-		$upsell->initialize();
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -104,10 +104,6 @@ class WPSEO_Upgrade {
 			add_action( 'init', [ $this, 'upgrade_125' ] );
 		}
 
-		// Since 3.7.
-		$upsell_notice = new WPSEO_Product_Upsell_Notice();
-		$upsell_notice->set_upgrade_notice();
-
 		/**
 		 * Filter: 'wpseo_run_upgrade' - Runs the upgrade hook which are dependent on Yoast SEO.
 		 *

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -91,7 +91,7 @@ class WPSEO_Upgrade {
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
 			'22.6-RC0'   => 'upgrade_226',
-			'23.7-RC0'   => 'upgrade_237',
+			'23.8-RC0'   => 'upgrade_238',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -1148,12 +1148,12 @@ class WPSEO_Upgrade {
 	}
 
 	/**
-	 * Performs the 22.6 upgrade routine.
+	 * Performs the 23.8 upgrade routine.
 	 * Schedules another cleanup scheduled action, but starting from the last cleanup action we just added (if there aren't any running cleanups already).
 	 *
 	 * @return void
 	 */
-	private function upgrade_237() {
+	private function upgrade_238() {
 		WPSEO_Options::set( 'set_up_options', true );
 	}
 

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -91,6 +91,7 @@ class WPSEO_Upgrade {
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
 			'22.6-RC0'   => 'upgrade_226',
+			'23.7-RC0'   => 'upgrade_237',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -1148,6 +1149,17 @@ class WPSEO_Upgrade {
 			$cleanup_integration = YoastSEO()->classes->get( Cleanup_Integration::class );
 			$cleanup_integration->start_cron_job( 'clean_selected_empty_usermeta', DAY_IN_SECONDS );
 		}
+	}
+
+	/**
+	 * Performs the 22.6 upgrade routine.
+	 * Schedules another cleanup scheduled action, but starting from the last cleanup action we just added (if there aren't any running cleanups already).
+	 *
+	 * @return void
+	 */
+	private function upgrade_237() {
+		error_log('set_home_url_for_151');
+		WPSEO_Options::set( 'set_up_options', true );
 	}
 
 	/**

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1158,7 +1158,6 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	private function upgrade_237() {
-		error_log('set_home_url_for_151');
 		WPSEO_Options::set( 'set_up_options', true );
 	}
 

--- a/inc/options/class-wpseo-option-social.php
+++ b/inc/options/class-wpseo-option-social.php
@@ -107,7 +107,7 @@ class WPSEO_Option_Social extends WPSEO_Option {
 	 * @return void
 	 */
 	public function translate_defaults() {
-		self::$twitter_card_types['summary_large_image'] = __( 'Summary with large image', 'wordpress-seo' );
+		self::$twitter_card_types['summary_large_image'] = 'Summary with large image';
 	}
 
 	/**

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -302,11 +302,13 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	/**
 	 * Get enriched defaults, possibly translated.
 	 *
-	 * @param bool $translated Whether the enriched defaults should be returned as translated.
+	 * @param bool         $translated         Whether the enriched defaults should be returned as translated.
+	 * @param string|false $specific_post_type The post types whose defaults should be enriched, false for all post types.
+	 * @param string|false $specific_taxonomy  The taxonomies whose defaults should be enriched, false for all taxonomies.
 	 *
 	 * @return array<string, string> The enriched defaults, possibly translated
 	 */
-	public static function get_maybe_translated_enriched_defaults( $translated = true ) {
+	public static function get_maybe_translated_enriched_defaults( $translated = true, $specific_post_type = false, $specific_taxonomy = false ) {
 		$enriched_defaults = [];
 
 		/*
@@ -315,7 +317,11 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
 		 * These are the defaults and can be prepared for any public post type.
 		 */
-		$post_type_objects = get_post_types( [ 'public' => true ], 'objects' );
+		$args = array( 'public' => true );
+		if ( $specific_post_type !== false ) {
+			$args['name'] = $specific_post_type;
+		}
+		$post_type_objects = get_post_types( $args, 'objects' );
 
 		if ( $post_type_objects ) {
 			/* translators: %s expands to the name of a post type (plural). */
@@ -351,6 +357,10 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			}
 		}
 
+		$args = array( 'public' => true );
+		if ( $specific_taxonomy !== false ) {
+			$args['name'] = $specific_taxonomy;
+		}
 		$taxonomy_objects = get_taxonomies( [ 'public' => true ], 'object' );
 
 		if ( $taxonomy_objects ) {

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -276,7 +276,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		$maybe_translated_defaults['title-author-wpseo'] = ( $translated ) ? sprintf( __( '%1$s, Author at %2$s', 'wordpress-seo' ), '%%name%%', '%%sitename%%' ) . ' %%page%% ' : sprintf( '%1$s, Author at %2$s', '%%name%%', '%%sitename%%' ) . ' %%page%% ';
 		/* translators: %s expands to the search phrase. */
 		$maybe_translated_defaults['title-search-wpseo'] = ( $translated ) ? sprintf( __( 'You searched for %s', 'wordpress-seo' ), '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%' : sprintf( 'You searched for %s', '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%';
-		$maybe_translated_defaults['title-404-wpseo']    = ( $translated ) ? __( 'Page not found', 'wordpress-seo' ) . ' %%sep%% %%sitename%%' : 'Page not found' . ' %%sep%% %%sitename%%';
+		$maybe_translated_defaults['title-404-wpseo']    = ( $translated ) ? __( 'Page not found', 'wordpress-seo' ) . ' %%sep%% %%sitename%%' : 'Page not found %%sep%% %%sitename%%';
 		/* translators: 1: link to post; 2: link to blog. */
 		$maybe_translated_defaults['rssafter'] = ( $translated ) ? sprintf( __( 'The post %1$s appeared first on %2$s.', 'wordpress-seo' ), '%%POSTLINK%%', '%%BLOGLINK%%' ) : sprintf( 'The post %1$s appeared first on %2$s.', '%%POSTLINK%%', '%%BLOGLINK%%' );
 

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -317,7 +317,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 		 * WPSEO_Post_Type::get_accessible_post_types() should *not* be used here.
 		 * These are the defaults and can be prepared for any public post type.
 		 */
-		$args = array( 'public' => true );
+		$args = [ 'public' => true ];
 		if ( $specific_post_type !== false ) {
 			$args['name'] = $specific_post_type;
 		}
@@ -357,7 +357,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 			}
 		}
 
-		$args = array( 'public' => true );
+		$args = [ 'public' => true ];
 		if ( $specific_taxonomy !== false ) {
 			$args['name'] = $specific_taxonomy;
 		}

--- a/inc/options/class-wpseo-option-titles.php
+++ b/inc/options/class-wpseo-option-titles.php
@@ -263,37 +263,50 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 	}
 
 	/**
+	 * Get defaults, possibly translated.
+	 *
+	 * @param bool $translated Whether the defaults should be returned as translated.
+	 *
+	 * @return array<string, string> The defaults, possibly translated
+	 */
+	public static function get_maybe_translated_defaults( $translated = true ) {
+		$maybe_translated_defaults = [];
+
+		/* translators: 1: Author name; 2: Site name. */
+		$maybe_translated_defaults['title-author-wpseo'] = ( $translated ) ? sprintf( __( '%1$s, Author at %2$s', 'wordpress-seo' ), '%%name%%', '%%sitename%%' ) . ' %%page%% ' : sprintf( '%1$s, Author at %2$s', '%%name%%', '%%sitename%%' ) . ' %%page%% ';
+		/* translators: %s expands to the search phrase. */
+		$maybe_translated_defaults['title-search-wpseo'] = ( $translated ) ? sprintf( __( 'You searched for %s', 'wordpress-seo' ), '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%' : sprintf( 'You searched for %s', '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%';
+		$maybe_translated_defaults['title-404-wpseo']    = ( $translated ) ? __( 'Page not found', 'wordpress-seo' ) . ' %%sep%% %%sitename%%' : 'Page not found' . ' %%sep%% %%sitename%%';
+		/* translators: 1: link to post; 2: link to blog. */
+		$maybe_translated_defaults['rssafter'] = ( $translated ) ? sprintf( __( 'The post %1$s appeared first on %2$s.', 'wordpress-seo' ), '%%POSTLINK%%', '%%BLOGLINK%%' ) : sprintf( 'The post %1$s appeared first on %2$s.', '%%POSTLINK%%', '%%BLOGLINK%%' );
+
+		$maybe_translated_defaults['breadcrumbs-404crumb']      = ( $translated ) ? __( 'Error 404: Page not found', 'wordpress-seo' ) : 'Error 404: Page not found';
+		$maybe_translated_defaults['breadcrumbs-archiveprefix'] = ( $translated ) ? __( 'Archives for', 'wordpress-seo' ) : 'Archives for';
+		$maybe_translated_defaults['breadcrumbs-home']          = ( $translated ) ? __( 'Home', 'wordpress-seo' ) : 'Home';
+		$maybe_translated_defaults['breadcrumbs-searchprefix']  = ( $translated ) ? __( 'You searched for', 'wordpress-seo' ) : 'You searched for';
+
+		return $maybe_translated_defaults;
+	}
+
+	/**
 	 * Translate strings used in the option defaults.
 	 *
 	 * @return void
 	 */
 	public function translate_defaults() {
-		/* translators: 1: Author name; 2: Site name. */
-		$this->defaults['title-author-wpseo'] = sprintf( __( '%1$s, Author at %2$s', 'wordpress-seo' ), '%%name%%', '%%sitename%%' ) . ' %%page%% ';
-		/* translators: %s expands to the search phrase. */
-		$this->defaults['title-search-wpseo'] = sprintf( __( 'You searched for %s', 'wordpress-seo' ), '%%searchphrase%%' ) . ' %%page%% %%sep%% %%sitename%%';
-		$this->defaults['title-404-wpseo']    = __( 'Page not found', 'wordpress-seo' ) . ' %%sep%% %%sitename%%';
-		/* translators: 1: link to post; 2: link to blog. */
-		$this->defaults['rssafter'] = sprintf( __( 'The post %1$s appeared first on %2$s.', 'wordpress-seo' ), '%%POSTLINK%%', '%%BLOGLINK%%' );
-
-		$this->defaults['breadcrumbs-404crumb']      = __( 'Error 404: Page not found', 'wordpress-seo' );
-		$this->defaults['breadcrumbs-archiveprefix'] = __( 'Archives for', 'wordpress-seo' );
-		$this->defaults['breadcrumbs-home']          = __( 'Home', 'wordpress-seo' );
-		$this->defaults['breadcrumbs-searchprefix']  = __( 'You searched for', 'wordpress-seo' );
+		foreach ( self::get_maybe_translated_defaults( false ) as $key => $value ) {
+			$this->defaults[ $key ] = $value;
+		}
 	}
 
 	/**
-	 * Add dynamically created default options based on available post types and taxonomies.
+	 * Get enriched defaults, possibly translated.
 	 *
-	 * @return  void
+	 * @param bool $translated Whether the enriched defaults should be returned as translated.
+	 *
+	 * @return array<string, string> The enriched defaults, possibly translated
 	 */
-	public function enrich_defaults() {
-		$enriched_defaults = $this->enriched_defaults;
-		if ( $enriched_defaults !== null ) {
-			$this->defaults += $enriched_defaults;
-			return;
-		}
-
+	public static function get_maybe_translated_enriched_defaults( $translated = true ) {
 		$enriched_defaults = [];
 
 		/*
@@ -306,7 +319,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 		if ( $post_type_objects ) {
 			/* translators: %s expands to the name of a post type (plural). */
-			$archive = sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' );
+			$archive = ( $translated ) ? sprintf( __( '%s Archive', 'wordpress-seo' ), '%%pt_plural%%' ) : sprintf( '%s Archive', '%%pt_plural%%' );
 
 			foreach ( $post_type_objects as $pt ) {
 				$enriched_defaults[ 'title-' . $pt->name ]                   = '%%title%% %%page%% %%sep%% %%sitename%%'; // Text field.
@@ -342,7 +355,7 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 
 		if ( $taxonomy_objects ) {
 			/* translators: %s expands to the variable used for term title. */
-			$archives = sprintf( __( '%s Archives', 'wordpress-seo' ), '%%term_title%%' );
+			$archives = ( $translated ) ? sprintf( __( '%s Archives', 'wordpress-seo' ), '%%term_title%%' ) : sprintf( '%s Archives', '%%term_title%%' );
 
 			foreach ( $taxonomy_objects as $tax ) {
 				$enriched_defaults[ 'title-tax-' . $tax->name ]           = $archives . ' %%page%% %%sep%% %%sitename%%'; // Text field.
@@ -359,6 +372,23 @@ class WPSEO_Option_Titles extends WPSEO_Option {
 				$enriched_defaults[ 'taxonomy-' . $tax->name . '-ptparent' ] = 0; // Select box;.
 			}
 		}
+
+		return $enriched_defaults;
+	}
+
+	/**
+	 * Add dynamically created default options based on available post types and taxonomies.
+	 *
+	 * @return  void
+	 */
+	public function enrich_defaults() {
+		$enriched_defaults = $this->enriched_defaults;
+		if ( $enriched_defaults !== null ) {
+			$this->defaults += $enriched_defaults;
+			return;
+		}
+
+		$enriched_defaults = self::get_maybe_translated_enriched_defaults( false );
 
 		$this->enriched_defaults = $enriched_defaults;
 		$this->defaults         += $enriched_defaults;

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -139,6 +139,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'new_post_types'                           => [],
 		'new_taxonomies'                           => [],
 		'show_new_content_type_notification'       => false,
+		'set_up_options'                           => false,
 	];
 
 	/**
@@ -507,6 +508,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'redirect_search_pretty_urls'
 				 *  'should_redirect_after_install_free'
 				 *  'show_new_content_type_notification'
+				 *  'set_up_options'
 				 *  and most of the feature variables.
 				 */
 				default:

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -138,4 +138,26 @@ class Options_Helper {
 	public function is_twitter_id_valid( $twitter_id ) {
 		return empty( $twitter_id ) || WPSEO_Option_Social::get_instance()->validate_twitter_id( $twitter_id, false );
 	}
+
+	/**
+	 * Get title defaults, possibly translated.
+	 *
+	 * @param bool $translated Whether the defaults should be returned as translated.
+	 *
+	 * @return array<string, string> The title defaults, possibly translated
+	 */
+	public function get_maybe_translated_default_titles( $translated ) {
+		return WPSEO_Option_Titles::get_maybe_translated_defaults( $translated );
+	}
+
+	/**
+	 * Get enriched title defaults, possibly translated.
+	 *
+	 * @param bool $translated Whether the enriched title defaults should be returned as translated.
+	 *
+	 * @return array<string, string> The enriched title defaults, possibly translated
+	 */
+	public function get_maybe_translated_enriched_defaults( $translated ) {
+		return WPSEO_Option_Titles::get_maybe_translated_enriched_defaults( $translated );
+	}
 }

--- a/src/helpers/options-helper.php
+++ b/src/helpers/options-helper.php
@@ -153,11 +153,13 @@ class Options_Helper {
 	/**
 	 * Get enriched title defaults, possibly translated.
 	 *
-	 * @param bool $translated Whether the enriched title defaults should be returned as translated.
+	 * @param bool         $translated         Whether the enriched defaults should be returned as translated.
+	 * @param string|false $specific_post_type The post types whose defaults should be enriched, false for all post types.
+	 * @param string|false $specific_taxonomy  The taxonomies whose defaults should be enriched, false for all taxonomies.
 	 *
 	 * @return array<string, string> The enriched title defaults, possibly translated
 	 */
-	public function get_maybe_translated_enriched_defaults( $translated ) {
-		return WPSEO_Option_Titles::get_maybe_translated_enriched_defaults( $translated );
+	public function get_maybe_translated_enriched_defaults( $translated, $specific_post_type, $specific_taxonomy ) {
+		return WPSEO_Option_Titles::get_maybe_translated_enriched_defaults( $translated, $specific_post_type, $specific_taxonomy );
 	}
 }

--- a/src/integrations/admin/initial-option-setup-integration.php
+++ b/src/integrations/admin/initial-option-setup-integration.php
@@ -45,6 +45,34 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'admin_init', [ $this, 'maybe_translate_defaults' ] );
+		\add_action( 'new_public_post_type_notifications', [ $this, 'new_post_types' ], 20, 1 );
+		\add_action( 'new_public_taxonomy_notifications', [ $this, 'new_taxonomies' ], 20, 1 );
+	}
+
+	/**
+	 * Translate defaults of newly made public post types.
+	 *
+	 * @param array<string> $newly_made_public_post_types The newly made public post types.
+	 *
+	 * @return void
+	 */
+	public function new_post_types( $newly_made_public_post_types ) {
+		foreach ( $newly_made_public_post_types as $newly_made_public_post_type ) {
+			$this->replace_enriched_defaults_with_translations( $newly_made_public_post_type, false );
+		}
+	}
+
+	/**
+	 * Translate defaults of newly made public taxonomies.
+	 *
+	 * @param array<string> $newly_made_public_taxonomies The newly made public taxonomies.
+	 *
+	 * @return void
+	 */
+	public function new_taxonomies( $newly_made_public_taxonomies ) {
+		foreach ( $newly_made_public_taxonomies as $newly_made_public_taxonomy ) {
+			$this->replace_enriched_defaults_with_translations( false, $newly_made_public_taxonomy );
+		}
 	}
 
 	/**
@@ -60,7 +88,7 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 		$this->options_helper->set( 'set_up_options', true );
 
 		$this->replace_defaults_with_translations();
-		$this->replace_enriched_defaults_with_translations();
+		$this->replace_enriched_defaults_with_translations( false, false );
 	}
 
 	/**
@@ -82,11 +110,14 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 	/**
 	 * Replaces enriched options with translations, if values are the default ones.
 	 *
+	 * @param string|false $specific_post_type The post types whose defaults should be enriched, false for all post types.
+	 * @param string|false $specific_taxonomy  The taxonomies whose defaults should be enriched, false for all taxonomies.
+	 *
 	 * @return void
 	 */
-	private function replace_enriched_defaults_with_translations() {
-		$translated_enriched_default_titles   = $this->options_helper->get_maybe_translated_enriched_defaults( true );
-		$untranslated_enriched_default_titles = $this->options_helper->get_maybe_translated_enriched_defaults( false );
+	private function replace_enriched_defaults_with_translations( $specific_post_type, $specific_taxonomy ) {
+		$translated_enriched_default_titles   = $this->options_helper->get_maybe_translated_enriched_defaults( true, $specific_post_type, $specific_taxonomy );
+		$untranslated_enriched_default_titles = $this->options_helper->get_maybe_translated_enriched_defaults( false, $specific_post_type, $specific_taxonomy );
 
 		foreach ( $translated_enriched_default_titles as $key => $value ) {
 			if ( \trim( $this->options_helper->get( $key ) ) === \trim( $untranslated_enriched_default_titles[ $key ] ) ) {

--- a/src/integrations/admin/initial-option-setup-integration.php
+++ b/src/integrations/admin/initial-option-setup-integration.php
@@ -92,7 +92,7 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Replaces options with translations, if values are the default ones.
+	 * Replaces options with translations, if stored values are the default ones.
 	 *
 	 * @return void
 	 */
@@ -100,7 +100,9 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 		$translated_default_titles   = $this->options_helper->get_maybe_translated_default_titles( true );
 		$untranslated_default_titles = $this->options_helper->get_maybe_translated_default_titles( false );
 
+		// Replace stored settings with their translated default, but only if the stored settings are still the (non-translated) defaults.
 		foreach ( $translated_default_titles as $key => $value ) {
+			// Let's check the trimmed values, because the options framework returns the stored values as trimmed.
 			if ( \trim( $this->options_helper->get( $key ) ) === \trim( $untranslated_default_titles[ $key ] ) ) {
 				$this->options_helper->set( $key, $value );
 			}
@@ -108,7 +110,7 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Replaces enriched options with translations, if values are the default ones.
+	 * Replaces enriched options with translations, if stored values are the default ones.
 	 *
 	 * @param string|false $specific_post_type The post types whose defaults should be enriched, false for all post types.
 	 * @param string|false $specific_taxonomy  The taxonomies whose defaults should be enriched, false for all taxonomies.
@@ -119,7 +121,9 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 		$translated_enriched_default_titles   = $this->options_helper->get_maybe_translated_enriched_defaults( true, $specific_post_type, $specific_taxonomy );
 		$untranslated_enriched_default_titles = $this->options_helper->get_maybe_translated_enriched_defaults( false, $specific_post_type, $specific_taxonomy );
 
+		// Replace stored settings with their translated enriched default, but only if the stored settings are still the (non-translated) enriched defaults.
 		foreach ( $translated_enriched_default_titles as $key => $value ) {
+			// Let's check the trimmed values, because the options framework returns the stored values as trimmed.
 			if ( \trim( $this->options_helper->get( $key ) ) === \trim( $untranslated_enriched_default_titles[ $key ] ) ) {
 				$this->options_helper->set( $key, $value );
 			}

--- a/src/integrations/admin/initial-option-setup-integration.php
+++ b/src/integrations/admin/initial-option-setup-integration.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use WPSEO_Post_Type;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * This integration registers a run of the translating option defaults, whenever applicable.
+ */
+class Initial_Option_Setup_Integration implements Integration_Interface {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * In this case: when on an admin page.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Initial_Option_Setup_Integration constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * Registers hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'maybe_translate_defaults' ] );
+	}
+
+	/**
+	 * Possibly translates option defaults.
+	 *
+	 * @return void
+	 */
+	public function maybe_translate_defaults() {
+		error_log('blabla1');
+		if ( $this->options_helper->get( 'set_up_options', false ) ) {
+			return;
+		}
+		error_log('blabla2');
+
+		$this->options_helper->set( 'set_up_options', true );
+
+		$this->replace_defaults_with_translations();
+		$this->replace_enriched_defaults_with_translations();
+	}
+
+	/**
+	 * Replaces options with translations, if values are the default ones.
+	 *
+	 * @return void
+	 */
+	private function replace_defaults_with_translations() {
+		$translated_default_titles   = $this->options_helper->get_maybe_translated_default_titles( true );
+		$untranslated_default_titles = $this->options_helper->get_maybe_translated_default_titles( false );
+
+		foreach ( $translated_default_titles as $key => $value ) {
+			if ( trim( $this->options_helper->get( $key ) ) === trim( $untranslated_default_titles[ $key ] ) ) {
+				$this->options_helper->set( $key, $value );
+			}
+		}
+	}
+
+	/**
+	 * Replaces enriched options with translations, if values are the default ones.
+	 *
+	 * @return void
+	 */
+	private function replace_enriched_defaults_with_translations() {
+		$translated_enriched_default_titles   = $this->options_helper->get_maybe_translated_enriched_defaults( true );
+		$untranslated_enriched_default_titles = $this->options_helper->get_maybe_translated_enriched_defaults( false );
+
+		foreach ( $translated_enriched_default_titles as $key => $value ) {
+			if ( trim( $this->options_helper->get( $key ) ) === trim( $untranslated_enriched_default_titles[ $key ] ) ) {
+				$this->options_helper->set( $key, $value );
+			}
+		}
+	}
+
+
+}

--- a/src/integrations/admin/initial-option-setup-integration.php
+++ b/src/integrations/admin/initial-option-setup-integration.php
@@ -94,6 +94,4 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 			}
 		}
 	}
-
-
 }

--- a/src/integrations/admin/initial-option-setup-integration.php
+++ b/src/integrations/admin/initial-option-setup-integration.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
-use WPSEO_Post_Type;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -54,11 +53,9 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function maybe_translate_defaults() {
-		error_log('blabla1');
 		if ( $this->options_helper->get( 'set_up_options', false ) ) {
 			return;
 		}
-		error_log('blabla2');
 
 		$this->options_helper->set( 'set_up_options', true );
 
@@ -76,7 +73,7 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 		$untranslated_default_titles = $this->options_helper->get_maybe_translated_default_titles( false );
 
 		foreach ( $translated_default_titles as $key => $value ) {
-			if ( trim( $this->options_helper->get( $key ) ) === trim( $untranslated_default_titles[ $key ] ) ) {
+			if ( \trim( $this->options_helper->get( $key ) ) === \trim( $untranslated_default_titles[ $key ] ) ) {
 				$this->options_helper->set( $key, $value );
 			}
 		}
@@ -92,7 +89,7 @@ class Initial_Option_Setup_Integration implements Integration_Interface {
 		$untranslated_enriched_default_titles = $this->options_helper->get_maybe_translated_enriched_defaults( false );
 
 		foreach ( $translated_enriched_default_titles as $key => $value ) {
-			if ( trim( $this->options_helper->get( $key ) ) === trim( $untranslated_enriched_default_titles[ $key ] ) ) {
+			if ( \trim( $this->options_helper->get( $key ) ) === \trim( $untranslated_enriched_default_titles[ $key ] ) ) {
 				$this->options_helper->set( $key, $value );
 			}
 		}

--- a/tests/Unit/Admin/Admin_Features_Test.php
+++ b/tests/Unit/Admin/Admin_Features_Test.php
@@ -5,12 +5,9 @@ namespace Yoast\WP\SEO\Tests\Unit\Admin;
 use Brain\Monkey;
 use Mockery;
 use Wincher_Dashboard_Widget;
-use WP_User;
 use WPSEO_Admin;
 use WPSEO_Primary_Term_Admin;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
-use Yoast\WP\SEO\Helpers\Product_Helper;
-use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\Url_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast_Dashboard_Widget;
@@ -23,32 +20,6 @@ use Yoast_Dashboard_Widget;
 final class Admin_Features_Test extends TestCase {
 
 	/**
-	 * Returns an instance with set expectations for the dependencies.
-	 *
-	 * @return WPSEO_Admin Instance to test against.
-	 */
-	private function get_admin_with_expectations() {
-		Monkey\Functions\expect( 'admin_url' )
-			->once()
-			->with( '?page=' . WPSEO_Admin::PAGE_IDENTIFIER . '&yoast_dismiss=upsell' )
-			->andReturn( 'https://example.org' );
-
-		Monkey\Functions\expect( 'wp_nonce_url' )
-			->once()
-			->with( 'https://example.org', 'dismiss-5star-upsell' )
-			->andReturn( 'https://example.org?_wpnonce=test-nonce' );
-
-		$admin_user     = Mockery::mock( WP_User::class );
-		$admin_user->ID = 1;
-
-		Monkey\Functions\expect( 'get_current_user_id' )
-			->once()
-			->andReturn( $admin_user->ID );
-
-		return new WPSEO_Admin();
-	}
-
-	/**
 	 * Sets up the YoastSEO function with the right expectations.
 	 *
 	 * @return void
@@ -59,26 +30,18 @@ final class Admin_Features_Test extends TestCase {
 		$current_page_helper = Mockery::mock( Current_Page_Helper::class );
 		$current_page_helper->expects( 'is_yoast_seo_page' )->once()->andReturn( true );
 
-		$product_helper = Mockery::mock( Product_Helper::class );
-		$product_helper->expects( 'is_premium' )->once()->andReturn( false );
-
-		$short_link = Mockery::mock( Short_Link_Helper::class );
-		$short_link->expects( 'get' )->times( 3 )->andReturn( 'https://www.example.com?some=var' );
-
 		$url_helper = Mockery::mock( Url_Helper::class );
 		$url_helper->expects( 'is_plugin_network_active' )->twice()->andReturn( false );
 
 		$container = $this->create_container_with(
 			[
 				Current_Page_Helper::class => $current_page_helper,
-				Product_Helper::class      => $product_helper,
-				Short_Link_Helper::class   => $short_link,
 				Url_Helper::class          => $url_helper,
 			]
 		);
 
 		Monkey\Functions\expect( 'YoastSEO' )
-			->times( 7 )
+			->times( 3 )
 			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
 
 		Monkey\Functions\expect( 'get_user_locale' )
@@ -98,7 +61,7 @@ final class Admin_Features_Test extends TestCase {
 
 		$this->setup_yoastseo_with_expectations();
 
-		$class_instance = $this->get_admin_with_expectations();
+		$class_instance = new WPSEO_Admin();
 
 		$admin_features = [
 			'primary_category'         => new WPSEO_Primary_Term_Admin(),
@@ -122,7 +85,7 @@ final class Admin_Features_Test extends TestCase {
 
 		$this->setup_yoastseo_with_expectations();
 
-		$class_instance = $this->get_admin_with_expectations();
+		$class_instance = new WPSEO_Admin();
 
 		$admin_features = [
 			'dashboard_widget'         => new Yoast_Dashboard_Widget(),

--- a/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Initial_Option_Setup_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Initial_Option_Setup_Integration_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Initial_Option_Setup_Integration
+ */
+final class Initial_Option_Setup_Integration_Test extends TestCase {
+
+	/**
+	 * The initial option setup under test.
+	 *
+	 * @var Initial_Option_Setup_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * Sets up the tests.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->options_helper = Mockery::mock( Options_Helper::class );
+
+		$this->instance = new Initial_Option_Setup_Integration( $this->options_helper );
+	}
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			self::getPropertyValue( $this->instance, 'options_helper' )
+		);
+	}
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @covers ::get_conditionals
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$actual   = Initial_Option_Setup_Integration::get_conditionals();
+		$expected = [
+			Admin_Conditional::class,
+		];
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests the register hooks method.
+	 *
+	 * @covers ::register_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'admin_init' );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests maybe translating defaults.
+	 *
+	 * @dataProvider provider_maybe_translate_defaults
+	 * @covers ::maybe_translate_defaults
+	 * @covers ::replace_defaults_with_translations
+	 * @covers ::replace_enriched_defaults_with_translations
+	 *
+	 * @param bool $set_up_options                                  Whether options are set up.
+	 * @param int  $times_setting_set_up_options                    The number of times the set_up_options option is set.
+	 * @param array<string, string> $translated_default_titles      The translated default titles.
+	 * @param array<string, string> $untranslated_default_titles    The untranslated default titles.
+	 * @param array<string, string> $translated_enriched_defaults   The translated enriched defaults.
+	 * @param array<string, string> $untranslated_enriched_defaults The untranslated enriched defaults.
+	 * @param array<string> $current_setting_values                 The current setting values.
+	 * @param int $translate_times                                  The number of times the set method is called.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_translate_defaults( $set_up_options, $times_setting_set_up_options, $translated_default_titles, $untranslated_default_titles, $translated_enriched_defaults, $untranslated_enriched_defaults, $current_setting_values, $translate_times ) {
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'set_up_options', false )
+			->once()
+			->andReturn( $set_up_options );
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'set_up_options', true )
+			->times( $times_setting_set_up_options );
+
+		$this->options_helper
+			->expects( 'get_maybe_translated_default_titles' )
+			->with( true )
+			->times( $times_setting_set_up_options )
+			->andReturn( $translated_default_titles );
+
+		$this->options_helper
+			->expects( 'get_maybe_translated_default_titles' )
+			->with( false )
+			->times( $times_setting_set_up_options )
+			->andReturn( $untranslated_default_titles );
+
+		$this->options_helper
+			->expects( 'get_maybe_translated_enriched_defaults' )
+			->with( true )
+			->times( $times_setting_set_up_options )
+			->andReturn( $translated_enriched_defaults );
+
+		$this->options_helper
+			->expects( 'get_maybe_translated_enriched_defaults' )
+			->with( false )
+			->times( $times_setting_set_up_options )
+			->andReturn( $untranslated_enriched_defaults );
+
+		$this->options_helper
+			->expects( 'get' )
+			->times( \count( \array_merge( $translated_default_titles, $translated_enriched_defaults ) ) )
+			->andReturn( ...$current_setting_values );
+
+		$this->options_helper
+			->expects( 'set' )
+			->times( $translate_times );
+
+		$this->instance->maybe_translate_defaults();
+	}
+
+	/**
+	 * Data provider for test_maybe_translate_defaults.
+	 *
+	 * @return array<string, array<string, bool|int|array<string, string>>
+	 */
+	public static function provider_maybe_translate_defaults() {
+		yield 'Already set up options' => [
+			'set_up_options'                 => true,
+			'times_setting_set_up_options'   => 0,
+			'translated_default_titles'      => [],
+			'untranslated_default_titles'    => [],
+			'translated_enriched_defaults'   => [],
+			'untranslated_enriched_defaults' => [],
+			'current_setting_values'         => [],
+			'translate_times'                => 0,
+		];
+		yield 'No changed defaults and enriched defaults, to be replaced with translations' => [
+			'set_up_options'                 => false,
+			'times_setting_set_up_options'   => 1,
+			'translated_default_titles'      => [
+				'breadcrumbs-404crumb'      => 'Lorem 404: Ipsum',
+				'breadcrumbs-archiveprefix' => 'Ipsum for',
+			],
+			'untranslated_default_titles'    => [
+				'breadcrumbs-404crumb'      => 'Error 404: Page not found',
+				'breadcrumbs-archiveprefix' => 'Archives for',
+			],
+			'translated_enriched_defaults'   => [
+				'title-tax-category'      => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format' => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+			],
+			'untranslated_enriched_defaults' => [
+				'title-tax-category'      => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format' => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+			],
+			'current_setting_values'         => [
+				'Error 404: Page not found',
+				'Archives for',
+				'%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+			],
+			'translate_times'                => 4,
+		];
+		yield 'All defaults and enriched defaults are change, to not be replaced with translations' => [
+			'set_up_options'                 => false,
+			'times_setting_set_up_options'   => 1,
+			'translated_default_titles'      => [
+				'breadcrumbs-404crumb'      => 'Lorem 404: Ipsum',
+				'breadcrumbs-archiveprefix' => 'Ipsum for',
+			],
+			'untranslated_default_titles'    => [
+				'breadcrumbs-404crumb'      => 'Error 404: Page not found',
+				'breadcrumbs-archiveprefix' => 'Archives for',
+			],
+			'translated_enriched_defaults'   => [
+				'title-tax-category'      => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format' => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+			],
+			'untranslated_enriched_defaults' => [
+				'title-tax-category'      => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format' => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+			],
+			'current_setting_values'         => [
+				'Custom error page',
+				'Custom archive page',
+				'Custom archive for category',
+				'Custom archive for post gormat',
+			],
+			'translate_times'                => 0,
+		];
+	}
+}

--- a/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
@@ -131,13 +131,13 @@ final class Initial_Option_Setup_Integration_Test extends TestCase {
 
 		$this->options_helper
 			->expects( 'get_maybe_translated_enriched_defaults' )
-			->with( true )
+			->with( true, false, false )
 			->times( $times_setting_set_up_options )
 			->andReturn( $translated_enriched_defaults );
 
 		$this->options_helper
 			->expects( 'get_maybe_translated_enriched_defaults' )
-			->with( false )
+			->with( false, false, false )
 			->times( $times_setting_set_up_options )
 			->andReturn( $untranslated_enriched_defaults );
 

--- a/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Initial_Option_Setup_Integration_Test.php
@@ -94,14 +94,14 @@ final class Initial_Option_Setup_Integration_Test extends TestCase {
 	 * @covers ::replace_defaults_with_translations
 	 * @covers ::replace_enriched_defaults_with_translations
 	 *
-	 * @param bool $set_up_options                                  Whether options are set up.
-	 * @param int  $times_setting_set_up_options                    The number of times the set_up_options option is set.
+	 * @param bool                  $set_up_options                 Whether options are set up.
+	 * @param int                   $times_setting_set_up_options   The number of times the set_up_options option is set.
 	 * @param array<string, string> $translated_default_titles      The translated default titles.
 	 * @param array<string, string> $untranslated_default_titles    The untranslated default titles.
 	 * @param array<string, string> $translated_enriched_defaults   The translated enriched defaults.
 	 * @param array<string, string> $untranslated_enriched_defaults The untranslated enriched defaults.
-	 * @param array<string> $current_setting_values                 The current setting values.
-	 * @param int $translate_times                                  The number of times the set method is called.
+	 * @param array<string>         $current_setting_values         The current setting values.
+	 * @param int                   $translate_times                The number of times the set method is called.
 	 *
 	 * @return void
 	 */
@@ -156,7 +156,7 @@ final class Initial_Option_Setup_Integration_Test extends TestCase {
 	/**
 	 * Data provider for test_maybe_translate_defaults.
 	 *
-	 * @return array<string, array<string, bool|int|array<string, string>>
+	 * @return array<string, array<string, bool|int|array<string, string>>>
 	 */
 	public static function provider_maybe_translate_defaults() {
 		yield 'Already set up options' => [
@@ -182,11 +182,11 @@ final class Initial_Option_Setup_Integration_Test extends TestCase {
 			],
 			'translated_enriched_defaults'   => [
 				'title-tax-category'      => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
-				'title-tax-post_format' => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format'   => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
 			],
 			'untranslated_enriched_defaults' => [
 				'title-tax-category'      => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
-				'title-tax-post_format' => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format'   => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
 			],
 			'current_setting_values'         => [
 				'Error 404: Page not found',
@@ -209,11 +209,11 @@ final class Initial_Option_Setup_Integration_Test extends TestCase {
 			],
 			'translated_enriched_defaults'   => [
 				'title-tax-category'      => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
-				'title-tax-post_format' => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format'   => '%%term_title%% Lorem %%page%% %%sep%% %%sitename%%',
 			],
 			'untranslated_enriched_defaults' => [
 				'title-tax-category'      => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
-				'title-tax-post_format' => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
+				'title-tax-post_format'   => '%%term_title%% Archives %%page%% %%sep%% %%sitename%%',
 			],
 			'current_setting_values'         => [
 				'Custom error page',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Stops PHP notices about `_load_textdomain_just_in_time` loading incorrectly, on WP 6.7.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install WP 6.7 (at the time of the writing it's on beta3)
* Change your site language to something other than english
* Visit both the admin and the frontend of your site and confirm you dont get any PHP notices regarding `Function load_plugin_textdomain was called incorrectly` or `Function _load_textdomain_just_in_time was called incorrectly`

Also:
* Install Yoast SEO in a fresh site, with the site language set to not English (eg. greek)
* Go to Settings and compare the following settings to what you would get if you installed a previous Yoast SEO version:
  * `Author archives - SEO title`
  * `Special pages - Internal search pages`
  * `Special pages - 404 error pages`
  * `RSS - `Content to put after each post in the feed`
  * `Breadcrumbs - Anchor text for the Homepage`
  * `Breadcrumbs - Prefix for archive breadcrumbs`
  * `Breadcrumbs - Prefix for search page breadcrumbs`
  * `Breadcrumbs - Breadcrumb for 404 page`
  * `Content types - Search appearance - SEO title` (for every public post type you have in your site that have archives - you have to enable Books)
  * `Content types - Social media appearance - Social title` (for every public post type you have in your site that have archives - you have to enable Books)
  * `Categories - Search appearance - SEO title` (for every public taxonomy you have in your site)
  * `Categories - Social media appearance - Social title` (for every public taxonomy you have in your site)
* Do the same for an english site
* Do the same for an english site but a non-english user (so, in `Users->Profile`, you should save a non-english language for `Language`)
  * In this case, you will get the user language in the above settings instead of the site language - compared to our production versions where you would get the site language

Also: 
* Install the previous Yoast SEO version in a fresh site that's in english
* Switch the site language to a non-english language
* Upgrade to the current PR/RC (for devs, make sure to run the upgrade routine if you do it via `git checkout`) 
* Confirm that the above settings have not been translated to the non-english language
* Do the above again, but this time install the previous Yoast SEO version in a fresh site that's NOT in english and then switch it to english - again confirm that the settings have not been translated to english after the upgrade

Also:
* Every time you switch to a different site language, confirm that the above settings do not change
* Every time you `Reset options` via the test helper, confirm that the above settings do change, to the current site language

Also (final, I promise):
* In a fresh site, switch to a non-english language and then install the previous Yoast SEO version
* Change a couple of the above settings, but not all
* Uninstall Yoast SEO switch to a different non-english language and then install the current RC/PR
* Confirm that the settings that you changed before, have stayed the same
* Confirm that the settings that you didn't change before, have been translated to the new language


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The test instructions themselves are mostly impact check

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1871
