### PR TITLE
New general page: fix alert center notification breaking out of space

### DIFF
--- a/css/src/general-page.css
+++ b/css/src/general-page.css
@@ -215,8 +215,8 @@ body.toplevel_page_wpseo_dashboard {
 				yst-px-2.5
 				yst-py-1.5;
 
-				/* custom for general page */
-				@apply yst-mt-3 yst-whitespace-normal;
+				/* custom for general page and reset WP styles */
+				@apply yst-mt-3 yst-whitespace-normal yst-min-h-[unset] yst-mb-[unset] yst-align-[unset];
 			}
 
 			.button-link {

--- a/css/src/general-page.css
+++ b/css/src/general-page.css
@@ -1,13 +1,13 @@
 body.toplevel_page_wpseo_dashboard {
 	.notice, .yoast-migrated-notice {
-		display:none;
+		display: none;
 	}
 
-	.yoast-general-page-notices:last-child{
+	.yoast-general-page-notices:last-child {
 		margin-bottom: 2rem;
 	}
 
-	.yoast-general-page-notice, .yoast-webinar-dashboard{
+	.yoast-general-page-notice, .yoast-webinar-dashboard {
 		background: white;
 		padding: 0.75rem;
 		border-radius: 0.375rem;
@@ -36,15 +36,15 @@ body.toplevel_page_wpseo_dashboard {
 		hover:yst-text-slate-500
 	}
 
-	.yoast-general-page-notice .notice-dismiss:before{
+	.yoast-general-page-notice .notice-dismiss:before {
 		display: none;
 	}
 
-	.yoast-general-page-notice .notice-yoast img{
+	.yoast-general-page-notice .notice-yoast img {
 		display: none;
 	}
 
-	.yoast-general-page-notice a{
+	.yoast-general-page-notice a {
 		font-weight: 500;
 	}
 
@@ -53,40 +53,40 @@ body.toplevel_page_wpseo_dashboard {
 		margin-top: 0;
 	}
 
-	.yoast-webinar-dashboard .notice-dismiss:before{
+	.yoast-webinar-dashboard .notice-dismiss:before {
 		/* yst-text-slate-400 */
 		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2394A3B8' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>");
 		content: '';
 	}
 
-	.yoast-webinar-dashboard .notice-dismiss:hover:before{
+	.yoast-webinar-dashboard .notice-dismiss:hover:before {
 		/* yst-text-slate-500 */
 		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2364748b' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>");
 		content: '';
 	}
 
-	.yoast-webinar-dashboard p{
+	.yoast-webinar-dashboard p {
 		padding-left: 1.8rem;
 	}
 
-	.yoast-webinar-dashboard .yoast-icon{
+	.yoast-webinar-dashboard .yoast-icon {
 		width: 17px;
 		height: 17px;
 		margin-right: 12px;
 	}
 
-	.yoast-notice-migrated-header{
+	.yoast-notice-migrated-header {
 		font-weight: 500;
 		font-size: .8125rem;
-		color: #1E293B;
+		color: #1e293b;
 		line-height: 19px;
 	}
 
-	.yoast-webinar-dashboard a{
+	.yoast-webinar-dashboard a {
 		font-weight: 500;
 	}
 
-	.yoast-webinar-dashboard .notice-yoast__container{
+	.yoast-webinar-dashboard .notice-yoast__container {
 		padding: 0;
 	}
 
@@ -213,10 +213,10 @@ body.toplevel_page_wpseo_dashboard {
 				yst-text-xs
 				yst-leading-4
 				yst-px-2.5
-				yst-py-1.5
+				yst-py-1.5;
 
 				/* custom for general page */
-				yst-mt-3;
+				@apply yst-mt-3 yst-whitespace-normal;
 			}
 
 			.button-link {
@@ -237,7 +237,7 @@ body.toplevel_page_wpseo_dashboard {
 				visited:hover:yst-text-primary-400;
 			}
 
-			.ul-disc{
+			.ul-disc {
 				@apply
 				yst-list-disc
 				yst-pl-3
@@ -246,6 +246,7 @@ body.toplevel_page_wpseo_dashboard {
 			}
 		}
 	}
+
 	/* RTL */
 
 	&.rtl {

--- a/css/src/general-page.css
+++ b/css/src/general-page.css
@@ -190,7 +190,8 @@ body.toplevel_page_wpseo_dashboard {
 				yst-rounded-md
 				yst-text-sm
 				yst-font-medium
-				yst-leading-4
+				yst-leading-5
+				yst-text-center
 
 				focus:yst-outline-none
 				focus:yst-ring-2

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.5",
     "@slack/webhook": "^5.0.2",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.2",
     "@wordpress/dependency-extraction-webpack-plugin": "^4.28.0",
     "@wordpress/scripts": "^26.16.0",

--- a/packages/js/src/general/components/alerts-list.js
+++ b/packages/js/src/general/components/alerts-list.js
@@ -1,9 +1,9 @@
-import { Fragment, useContext, useCallback } from "@wordpress/element";
+import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
 import { useDispatch } from "@wordpress/data";
-import PropTypes from "prop-types";
+import { useCallback, useContext } from "@wordpress/element";
 import { Button } from "@yoast/ui-library";
-import { EyeOffIcon, EyeIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
+import PropTypes from "prop-types";
 import { AlertsContext } from "../contexts/alerts-context";
 import { STORE_NAME } from "../constants/index";
 
@@ -17,7 +17,7 @@ import { STORE_NAME } from "../constants/index";
  *
  * @returns {JSX.Element} The alert item component.
  */
-const AlertItem = ( { id, nonce, dismissed, message  } ) => {
+const AlertItem = ( { id, nonce, dismissed, message } ) => {
 	const { bulletClass = "" } = useContext( AlertsContext );
 	const { toggleAlertStatus } = useDispatch( STORE_NAME );
 	const Eye = dismissed ? EyeIcon : EyeOffIcon;
@@ -26,27 +26,28 @@ const AlertItem = ( { id, nonce, dismissed, message  } ) => {
 		toggleAlertStatus( id, nonce, dismissed );
 	}, [ id, nonce, dismissed, toggleAlertStatus ] );
 
-	return <Fragment>
-		<li key={ id } className="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0">
-			<div className="yst-flex yst-justify-between yst-gap-5 yst-items-start">
-				<div className={ classNames( "yst-mt-1",  dismissed && "yst-opacity-50" ) }>
-					<svg width="11" height="11" className={ bulletClass }>
-						<circle cx="5.5" cy="5.5" r="5.5" />
-					</svg>
-				</div>
-				<div
-					className={ classNames(
-						"yst-text-sm yst-text-slate-600 yst-grow",
-						dismissed && "yst-opacity-50" ) }
-					dangerouslySetInnerHTML={ { __html: message } }
-				/>
-
-				<Button variant="secondary" size="small" className="yst-self-center yst-h-8" onClick={ toggleAlert }>
-					<Eye className="yst-w-4 yst-h-4 yst-text-neutral-700" />
-				</Button>
+	return (
+		<li
+			key={ id }
+			className="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+		>
+			<div className={ classNames( "yst-mt-1", dismissed && "yst-opacity-50" ) }>
+				<svg width="11" height="11" className={ bulletClass }>
+					<circle cx="5.5" cy="5.5" r="5.5" />
+				</svg>
 			</div>
+			<div
+				className={ classNames(
+					"yst-text-sm yst-text-slate-600 yst-grow",
+					dismissed && "yst-opacity-50" ) }
+				dangerouslySetInnerHTML={ { __html: message } }
+			/>
+
+			<Button variant="secondary" size="small" className="yst-self-center yst-h-8" onClick={ toggleAlert }>
+				<Eye className="yst-w-4 yst-h-4 yst-text-neutral-700" />
+			</Button>
 		</li>
-	</Fragment>;
+	);
 };
 
 AlertItem.propTypes = {

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -4,8 +4,8 @@ import { Paper, Title } from "@yoast/ui-library";
 import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-list";
 import SidebarRecommendations from "../../shared-admin/components/sidebar-recommendations";
 import { Notifications, Problems } from "../components";
+import { STORE_NAME } from "../constants";
 import { useSelectGeneralPage } from "../hooks";
-import { STORE_NAME } from ".././constants";
 
 /**
  * @returns {JSX.Element} The general page content placeholder.
@@ -19,29 +19,24 @@ export const AlertCenter = () => {
 	const { isPromotionActive } = useSelect( STORE_NAME );
 
 	return <div className="yst-flex yst-gap-8 xl:yst-flex-row yst-flex-col">
-		 { /* Alert center */ }
 		<div className="yst-flex yst-flex-wrap yst-flex-grow xl:yst-flex-row yst-flex-col">
 			<Paper className="yst-grow">
-				<header className="yst-p-8">
-					<div className="yst-max-w-screen-sm">
-						<Title>{ __( "Alert center", "wordpress-seo" ) }</Title>
-						<p className="yst-text-tiny yst-mt-3">
-							{ __( "Monitor and manage potential SEO problems affecting your site and stay informed with important notifications and updates.", "wordpress-seo" ) }
-						</p>
-					</div>
+				<header className="yst-p-8 yst-max-w-screen-sm">
+					<Title>{ __( "Alert center", "wordpress-seo" ) }</Title>
+					<p className="yst-text-tiny yst-mt-3">
+						{ __( "Monitor and manage potential SEO problems affecting your site and stay informed with important notifications and updates.", "wordpress-seo" ) }
+					</p>
 				</header>
 			</Paper>
-			<div className="yst-basis-full">
-				<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
-					<Problems />
-					<Notifications />
-				</div>
-				{ ! isPremium && <PremiumUpsellList
-					premiumLink={ premiumLinkList }
-					premiumUpsellConfig={ premiumUpsellConfig }
-					isPromotionActive={ isPromotionActive }
-				/> }
+			<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
+				<Problems />
+				<Notifications />
 			</div>
+			{ ! isPremium && <PremiumUpsellList
+				premiumLink={ premiumLinkList }
+				premiumUpsellConfig={ premiumUpsellConfig }
+				isPromotionActive={ isPromotionActive }
+			/> }
 		</div>
 		{ ! isPremium &&
 			<div className="yst-min-w-[16rem] xl:yst-max-w-[16rem]">

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -18,7 +18,7 @@ export const AlertCenter = () => {
 	const academyLink = useSelectGeneralPage( "selectLink", [], "https://yoa.st/3t6" );
 	const { isPromotionActive } = useSelect( STORE_NAME );
 
-	return <div className="yst-flex yst-gap-8 xl:yst-flex-row yst-flex-col">
+	return <div className="yst-flex yst-gap-6 xl:yst-flex-row yst-flex-col">
 		<div className="yst-@container yst-flex yst-flex-wrap yst-flex-grow yst-flex-col">
 			<Paper className="yst-grow">
 				<header className="yst-p-8 yst-max-w-screen-sm">
@@ -28,7 +28,7 @@ export const AlertCenter = () => {
 					</p>
 				</header>
 			</Paper>
-			<div className="yst-grid yst-grid-cols-1 @3xl:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
+			<div className="yst-grid yst-grid-cols-1 @3xl:yst-grid-cols-2 yst-gap-6 yst-my-6 yst-grow yst-items-start">
 				<Problems />
 				<Notifications />
 			</div>

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -19,7 +19,7 @@ export const AlertCenter = () => {
 	const { isPromotionActive } = useSelect( STORE_NAME );
 
 	return <div className="yst-flex yst-gap-8 xl:yst-flex-row yst-flex-col">
-		<div className="yst-flex yst-flex-wrap yst-flex-grow xl:yst-flex-row yst-flex-col">
+		<div className="yst-@container yst-flex yst-flex-wrap yst-flex-grow yst-flex-col">
 			<Paper className="yst-grow">
 				<header className="yst-p-8 yst-max-w-screen-sm">
 					<Title>{ __( "Alert center", "wordpress-seo" ) }</Title>
@@ -28,7 +28,7 @@ export const AlertCenter = () => {
 					</p>
 				</header>
 			</Paper>
-			<div className="yst-grid lg:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
+			<div className="yst-grid yst-grid-cols-1 @3xl:yst-grid-cols-2 yst-gap-8 yst-my-8 yst-grow yst-items-start">
 				<Problems />
 				<Notifications />
 			</div>

--- a/packages/js/tests/general/components/__snapshots__/alerts-list.test.js.snap
+++ b/packages/js/tests/general/components/__snapshots__/alerts-list.test.js.snap
@@ -6,206 +6,190 @@ exports[`AlertsList should match snapshot 1`] = `
     class=""
   >
     <li
-      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+      class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
     >
       <div
-        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+        class="yst-mt-1"
       >
-        <div
-          class="yst-mt-1"
+        <svg
+          class="yst-fill-blue-500"
+          height="11"
+          width="11"
         >
-          <svg
-            class="yst-fill-blue-500"
-            height="11"
-            width="11"
-          >
-            <circle
-              cx="5.5"
-              cy="5.5"
-              r="5.5"
-            />
-          </svg>
-        </div>
-        <div
-          class="yst-text-sm yst-text-slate-600 yst-grow"
-        >
-          You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
-        </div>
-        <button
-          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="yst-w-4 yst-h-4 yst-text-neutral-700"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </button>
+          <circle
+            cx="5.5"
+            cy="5.5"
+            r="5.5"
+          />
+        </svg>
       </div>
+      <div
+        class="yst-text-sm yst-text-slate-600 yst-grow"
+      >
+        You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+      </div>
+      <button
+        class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="yst-w-4 yst-h-4 yst-text-neutral-700"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
     </li>
     <li
-      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+      class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
     >
       <div
-        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+        class="yst-mt-1"
       >
-        <div
-          class="yst-mt-1"
+        <svg
+          class="yst-fill-blue-500"
+          height="11"
+          width="11"
         >
-          <svg
-            class="yst-fill-blue-500"
-            height="11"
-            width="11"
-          >
-            <circle
-              cx="5.5"
-              cy="5.5"
-              r="5.5"
-            />
-          </svg>
-        </div>
-        <div
-          class="yst-text-sm yst-text-slate-600 yst-grow"
-        >
-          We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
-        </div>
-        <button
-          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="yst-w-4 yst-h-4 yst-text-neutral-700"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </button>
+          <circle
+            cx="5.5"
+            cy="5.5"
+            r="5.5"
+          />
+        </svg>
       </div>
+      <div
+        class="yst-text-sm yst-text-slate-600 yst-grow"
+      >
+        We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+      </div>
+      <button
+        class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="yst-w-4 yst-h-4 yst-text-neutral-700"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
     </li>
     <li
-      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+      class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
     >
       <div
-        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+        class="yst-mt-1 yst-opacity-50"
       >
-        <div
-          class="yst-mt-1 yst-opacity-50"
+        <svg
+          class="yst-fill-blue-500"
+          height="11"
+          width="11"
         >
-          <svg
-            class="yst-fill-blue-500"
-            height="11"
-            width="11"
-          >
-            <circle
-              cx="5.5"
-              cy="5.5"
-              r="5.5"
-            />
-          </svg>
-        </div>
-        <div
-          class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
-        >
-          Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
-        </div>
-        <button
-          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="yst-w-4 yst-h-4 yst-text-neutral-700"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path
-              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </button>
+          <circle
+            cx="5.5"
+            cy="5.5"
+            r="5.5"
+          />
+        </svg>
       </div>
+      <div
+        class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
+      >
+        Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+      </div>
+      <button
+        class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="yst-w-4 yst-h-4 yst-text-neutral-700"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
     </li>
     <li
-      class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+      class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
     >
       <div
-        class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+        class="yst-mt-1 yst-opacity-50"
       >
-        <div
-          class="yst-mt-1 yst-opacity-50"
+        <svg
+          class="yst-fill-blue-500"
+          height="11"
+          width="11"
         >
-          <svg
-            class="yst-fill-blue-500"
-            height="11"
-            width="11"
-          >
-            <circle
-              cx="5.5"
-              cy="5.5"
-              r="5.5"
-            />
-          </svg>
-        </div>
-        <div
-          class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
-        >
-          We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
-        </div>
-        <button
-          class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="yst-w-4 yst-h-4 yst-text-neutral-700"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path
-              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-          </svg>
-        </button>
+          <circle
+            cx="5.5"
+            cy="5.5"
+            r="5.5"
+          />
+        </svg>
       </div>
+      <div
+        class="yst-text-sm yst-text-slate-600 yst-grow yst-opacity-50"
+      >
+        We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+      </div>
+      <button
+        class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="yst-w-4 yst-h-4 yst-text-neutral-700"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <path
+            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
     </li>
   </ul>
 </div>

--- a/packages/js/tests/general/components/__snapshots__/notifications.test.js.snap
+++ b/packages/js/tests/general/components/__snapshots__/notifications.test.js.snap
@@ -40,196 +40,180 @@ exports[`AlertsList should match snapshot 1`] = `
         class=""
       >
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-blue-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-blue-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-blue-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-blue-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-blue-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-blue-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            Huge SEO Issue: You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-blue-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-blue-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
       </ul>
       <div

--- a/packages/js/tests/general/components/__snapshots__/problems.test.js.snap
+++ b/packages/js/tests/general/components/__snapshots__/problems.test.js.snap
@@ -45,199 +45,183 @@ exports[`AlertsList should match snapshot 1`] = `
         class=""
       >
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-red-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-red-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            You've added a new type of content. We recommend that you review the corresponding Search appearance settings.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-red-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-red-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            We notice that you have installed WPML. To make sure your canonical URLs are set correctly, install and activate the WPML SEO add-on as well!
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-red-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-red-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              <b>
-                Huge SEO Issue:
-              </b>
-               You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            <b>
+              Huge SEO Issue:
+            </b>
+             You're blocking access to robots. If you want search engines to show this site in their results, you must go to your Reading Settings and uncheck the box for Search Engine Visibility. I don't want this site to show in the search results.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
         <li
-          class="yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
+          class="yst-flex yst-justify-between yst-gap-x-5 yst-border-b yst-border-slate-200 last:yst-border-b-0 yst-py-6 first:yst-pt-0 last:yst-pb-0"
         >
           <div
-            class="yst-flex yst-justify-between yst-gap-5 yst-items-start"
+            class="yst-mt-1"
           >
-            <div
-              class="yst-mt-1"
+            <svg
+              class="yst-fill-red-500"
+              height="11"
+              width="11"
             >
-              <svg
-                class="yst-fill-red-500"
-                height="11"
-                width="11"
-              >
-                <circle
-                  cx="5.5"
-                  cy="5.5"
-                  r="5.5"
-                />
-              </svg>
-            </div>
-            <div
-              class="yst-text-sm yst-text-slate-600 yst-grow"
-            >
-              We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
-            </div>
-            <button
-              class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="yst-w-4 yst-h-4 yst-text-neutral-700"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
+              <circle
+                cx="5.5"
+                cy="5.5"
+                r="5.5"
+              />
+            </svg>
           </div>
+          <div
+            class="yst-text-sm yst-text-slate-600 yst-grow"
+          >
+            We need to re-analyze some of your SEO data because of a change in the visibility of your taxonomies. Please help us do that by running the SEO data optimization. We estimate this will take less than a minute.
+          </div>
+          <button
+            class="yst-button yst-button--secondary yst-button--small yst-self-center yst-h-8"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="yst-w-4 yst-h-4 yst-text-neutral-700"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
         </li>
       </ul>
       <div

--- a/packages/tailwindcss-preset/index.js
+++ b/packages/tailwindcss-preset/index.js
@@ -39,6 +39,7 @@ module.exports = {
 	},
 	important: true,
 	plugins: [
+		require( "@tailwindcss/container-queries" ),
 		require( "@tailwindcss/forms" )( {
 			strategy: "class",
 		} ),

--- a/packages/tailwindcss-preset/package.json
+++ b/packages/tailwindcss-preset/package.json
@@ -7,6 +7,7 @@
   "license": "GPL-3.0",
   "private": false,
   "peerDependencies": {
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.3",
     "tailwindcss": "^3.2.4"
   }

--- a/packages/tailwindcss-preset/readme.md
+++ b/packages/tailwindcss-preset/readme.md
@@ -6,7 +6,7 @@ This package aims to provide a Tailwind CSS preset for building Yoast packages.
 Start with installing the package and its peer dependencies from NPM:
 
 ```shell
-yarn add --dev @yoast/tailwindcss-preset tailwindcss @tailwindcss/forms
+yarn add --dev @yoast/tailwindcss-preset tailwindcss @tailwindcss/container-queries @tailwindcss/forms
 ```
 
 Then, in your `tailwind.config.js` file, extend the preset like so:

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -49,6 +49,7 @@
     "@storybook/react": "^7.6.17",
     "@storybook/react-webpack5": "^7.6.17",
     "@storybook/theming": "^7.6.17",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.3",
     "@wordpress/jest-preset-default": "^8.0.1",
     "@yoast/browserslist-config": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5305,6 +5305,11 @@
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.5.tgz#043b731d4f56a79b4897a3de1af35e75d56bc63a"
   integrity sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==
 
+"@tailwindcss/container-queries@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz#9a759ce2cb8736a4c6a0cb93aeb740573a731974"
+  integrity sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==
+
 "@tailwindcss/forms@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.5.2.tgz#4ef45f9916dcb37838cbe7fecdcc4ba7a7c2ab59"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the alert center notifications breaking out of the space.
* [@yoast/tailwindcss-preset 1.0.0 enhancement] Adds support for container queries via peer dependency `@tailwindcss/container-queries`.
* [@yoast/ui-library 0.0.1 non-user-facing] Adds support for container queries via peer dependency `@tailwindcss/container-queries` from `@yoast/tailwindcss-preset` (unreleased version).

## Relevant technical choices:

* Using container queries to test the container width instead of the screen size
  * https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries
  * https://caniuse.com/?search=container%20query
  * https://github.com/tailwindlabs/tailwindcss-container-queries
* Some unsets are used to reset WP styling on the button
  * white space; solved the most apparent breaking outside of the container problem (was nowrap)
  * for some breakpoints:
    * min height; made the button appear taller than we want
    * margin bottom; lets not
    * align; just to be sure

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use the test helper to reset your FTC progress, options and whatever is needed to get the notification with the `Start SEO data optimization` button, as show in the screenshot below
* Enable the feature flag
* Visit the General page
* Play around with the screen width!
![Kapture 2024-10-21 at 17 07 37](https://github.com/user-attachments/assets/168072d5-680b-4a14-87dd-28ea7720d9d3)
* Verify the problems/notifications stay at a reasonable width (container width > 768px to go next to eachother)
* Verify the button for the FTC progress is no longer outside
* Hide the FTC progress notification
* Play around again
* Verify the distances between and around the problems and notifications are now 24px instead of 32px
![Screenshot 2024-10-21 at 17 12 08](https://github.com/user-attachments/assets/46abc2d1-637e-4a92-9725-5fa3a1624eab)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21714
