### PR TITLE
General page: Fix First-time configuration state and notice

### DIFF
--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -257,7 +257,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
-				window.wpseoFirstTimeConfigurationData =  { ...window.wpseoFirstTimeConfigurationData, siteRepresentation: state.siteRepresentation };
+				window.wpseoFirstTimeConfigurationData.siteRepresentation = state.siteRepresentation;
 				return true;
 			} )
 			.catch( ( e ) => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -257,7 +257,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
-				wpseoFirstTimeConfigurationData =  { ...wpseoFirstTimeConfigurationData, siteRepresentation: state.siteRepresentation };
+				wpseoFirstTimeConfigurationData.siteRepresentation = state.siteRepresentation;
 				return true;
 			} )
 			.catch( ( e ) => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -171,11 +171,11 @@ export default function FirstTimeConfigurationSteps() {
 
 	useEffect( () => {
 		saveFinishedSteps( finishedSteps );
-		window.wpseoFirstTimeConfigurationData.finishedSteps = finishedSteps;
+		wpseoFirstTimeConfigurationData.finishedSteps = finishedSteps;
 	}, [ finishedSteps ] );
 
 	const [ state, dispatch ] = useReducer( configurationReducer, {
-		...calculateInitialState( window.wpseoFirstTimeConfigurationData, isStepFinished ),
+		...calculateInitialState( wpseoFirstTimeConfigurationData, isStepFinished ),
 	} );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "already_done" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
@@ -257,7 +257,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
-				window.wpseoFirstTimeConfigurationData.siteRepresentation = state.siteRepresentation;
+				wpseoFirstTimeConfigurationData =  { ...wpseoFirstTimeConfigurationData, siteRepresentation: state.siteRepresentation };
 				return true;
 			} )
 			.catch( ( e ) => {
@@ -297,7 +297,7 @@ export default function FirstTimeConfigurationSteps() {
 				finishSteps( STEPS.socialProfiles );
 			} )
 			.then( () => {
-				window.wpseoFirstTimeConfigurationData.socialProfiles = state.socialProfiles;
+				wpseoFirstTimeConfigurationData.socialProfiles = state.socialProfiles;
 				return true;
 			} )
 			.catch(
@@ -323,7 +323,7 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {
 				removeStepError( STEPS.personalPreferences );
-				window.wpseoFirstTimeConfigurationData.tracking = state.tracking;
+				wpseoFirstTimeConfigurationData.tracking = state.tracking;
 				return true;
 			} )
 			.catch( e => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -256,7 +256,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
-				window.wpseoFirstTimeConfigurationData = { ...window.wpseoFirstTimeConfigurationData,  ...state }
+				window.wpseoFirstTimeConfigurationData = { ...window.wpseoFirstTimeConfigurationData,  ...state };
 				return true;
 			} )
 			.catch( ( e ) => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -297,7 +297,7 @@ export default function FirstTimeConfigurationSteps() {
 				finishSteps( STEPS.socialProfiles );
 			} )
 			.then( () => {
-				window.wpseoFirstTimeConfigurationData =  { ...window.wpseoFirstTimeConfigurationData, socialProfiles: state.socialProfiles };
+				window.wpseoFirstTimeConfigurationData.socialProfiles = state.socialProfiles;
 				return true;
 			} )
 			.catch(

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -1,4 +1,3 @@
-/* global wpseoFirstTimeConfigurationData */
 import apiFetch from "@wordpress/api-fetch";
 import { useCallback, useReducer, useState, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
@@ -159,7 +158,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
  * @returns {WPElement} The FirstTimeConfigurationSteps component.
  */
 export default function FirstTimeConfigurationSteps() {
-	const [ finishedSteps, setFinishedSteps ] = useState( wpseoFirstTimeConfigurationData.finishedSteps );
+	const [ finishedSteps, setFinishedSteps ] = useState( window.wpseoFirstTimeConfigurationData.finishedSteps );
 
 	const isStepFinished = useCallback( ( stepId ) => {
 		return finishedSteps.includes( stepId );
@@ -171,11 +170,11 @@ export default function FirstTimeConfigurationSteps() {
 
 	useEffect( () => {
 		saveFinishedSteps( finishedSteps );
-		wpseoFirstTimeConfigurationData.finishedSteps = finishedSteps;
+		window.wpseoFirstTimeConfigurationData.finishedSteps = finishedSteps;
 	}, [ finishedSteps ] );
 
 	const [ state, dispatch ] = useReducer( configurationReducer, {
-		...calculateInitialState( wpseoFirstTimeConfigurationData, isStepFinished ),
+		...calculateInitialState( window.wpseoFirstTimeConfigurationData, isStepFinished ),
 	} );
 	const [ indexingState, setIndexingState ] = useState( () => window.yoastIndexingData.amount === "0" ? "already_done" : "idle" );
 	const [ siteRepresentationEmpty, setSiteRepresentationEmpty ] = useState( false );
@@ -257,7 +256,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
-				wpseoFirstTimeConfigurationData.siteRepresentation = state.siteRepresentation;
+				window.wpseoFirstTimeConfigurationData = { ...window.wpseoFirstTimeConfigurationData,  ...state }
 				return true;
 			} )
 			.catch( ( e ) => {
@@ -297,7 +296,7 @@ export default function FirstTimeConfigurationSteps() {
 				finishSteps( STEPS.socialProfiles );
 			} )
 			.then( () => {
-				wpseoFirstTimeConfigurationData.socialProfiles = state.socialProfiles;
+				window.wpseoFirstTimeConfigurationData.socialProfiles = state.socialProfiles;
 				return true;
 			} )
 			.catch(
@@ -323,7 +322,7 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {
 				removeStepError( STEPS.personalPreferences );
-				wpseoFirstTimeConfigurationData.tracking = state.tracking;
+				window.wpseoFirstTimeConfigurationData.tracking = state.tracking;
 				return true;
 			} )
 			.catch( e => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -171,6 +171,7 @@ export default function FirstTimeConfigurationSteps() {
 
 	useEffect( () => {
 		saveFinishedSteps( finishedSteps );
+		window.wpseoFirstTimeConfigurationData.finishedSteps = finishedSteps;
 	}, [ finishedSteps ] );
 
 	const [ state, dispatch ] = useReducer( configurationReducer, {
@@ -256,6 +257,7 @@ export default function FirstTimeConfigurationSteps() {
 				setErrorFields( [] );
 				removeStepError( STEPS.siteRepresentation );
 				finishSteps( STEPS.siteRepresentation );
+				window.wpseoFirstTimeConfigurationData =  { ...window.wpseoFirstTimeConfigurationData, siteRepresentation: state.siteRepresentation };
 				return true;
 			} )
 			.catch( ( e ) => {
@@ -295,6 +297,7 @@ export default function FirstTimeConfigurationSteps() {
 				finishSteps( STEPS.socialProfiles );
 			} )
 			.then( () => {
+				window.wpseoFirstTimeConfigurationData =  { ...window.wpseoFirstTimeConfigurationData, socialProfiles: state.socialProfiles };
 				return true;
 			} )
 			.catch(
@@ -320,6 +323,7 @@ export default function FirstTimeConfigurationSteps() {
 			.then( () => finishSteps( STEPS.personalPreferences ) )
 			.then( () => {
 				removeStepError( STEPS.personalPreferences );
+				window.wpseoFirstTimeConfigurationData.tracking = state.tracking;
 				return true;
 			} )
 			.catch( e => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -1,6 +1,6 @@
 /* global wpseoFirstTimeConfigurationData */
 import apiFetch from "@wordpress/api-fetch";
-import { useCallback, useReducer, useState, useEffect, useRef } from "@wordpress/element";
+import { useCallback, useReducer, useState, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { uniq } from "lodash";
 
@@ -398,17 +398,6 @@ export default function FirstTimeConfigurationSteps() {
 			setStepperFinishedOnce( true );
 		}
 	}, [ isStepperFinished ] );
-
-	/* In order to refresh data in the php form, once the stepper is done, we need to reload upon haschanges triggered by the tabswitching */
-	const isStepperFinishedAtBeginning = useRef( isStep2Finished && isStep3Finished && isStep4Finished );
-	useEffect( () => {
-		if ( isStepperFinished && ! isStepperFinishedAtBeginning.current ) {
-			const firstTimeConfigurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
-			if ( firstTimeConfigurationNotice ) {
-				firstTimeConfigurationNotice.remove();
-			}
-		}
-	}, [ isStepperFinished, isStepperFinishedAtBeginning ] );
 
 	// If stepperFinishedOnce changes or isStepBeingEdited changes, evaluate edit button state.
 	useEffect( () => {

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -22,7 +22,7 @@ import { STEPS } from "./constants";
  *
  * @param {Object} state The state to save.
  *
- * @returns {Promise|bool} A promise, or false if the call fails.
+ * @returns {Promise|boolean} A promise, or false if the call fails.
  */
 async function updateSiteRepresentation( state ) {
 	// Revert emptyChoice to the actual default: "company";
@@ -52,7 +52,7 @@ async function updateSiteRepresentation( state ) {
  *
  * @param {Object} state The state to save.
  *
- * @returns {Promise|bool} A promise, or false if the call fails.
+ * @returns {Promise|boolean} A promise, or false if the call fails.
  */
 async function updateSocialProfiles( state ) {
 	const socialProfiles = {
@@ -75,7 +75,7 @@ async function updateSocialProfiles( state ) {
  *
  * @param {Object} state The state to save.
  *
- * @returns {Promise|bool} A promise, or false if the call fails.
+ * @returns {Promise|boolean} A promise, or false if the call fails.
  */
 async function updateTracking( state ) {
 	if ( state.tracking !== 0 && state.tracking !== 1 ) {
@@ -99,7 +99,7 @@ async function updateTracking( state ) {
  *
  * @param {Array} finishedSteps Array of finished steps.
  *
- * @returns {Promise|bool} A promise, or false if the call fails.
+ * @returns {Promise|boolean} A promise, or false if the call fails.
  */
 async function saveFinishedSteps( finishedSteps ) {
 	const response = await apiFetch( {
@@ -275,7 +275,7 @@ export default function FirstTimeConfigurationSteps() {
 	/**
 	 * Runs checks of finishing the social profiles step.
 	 *
-	 * @returns {void}
+	 * @returns {Promise|boolean} Returns either a Boolean for success/failure or a Promise.
 	 */
 	function updateOnFinishSocialProfiles() {
 		if ( state.companyOrPerson === "person" ) {
@@ -316,7 +316,7 @@ export default function FirstTimeConfigurationSteps() {
 	/**
 	 * Runs checks of finishing the enable tracking step.
 	 *
-	 * @returns {void}
+	 * @returns {Promise|boolean} Returns either a Boolean for success/failure or a Promise.
 	 */
 	function updateOnFinishPersonalPreferences() {
 		return updateTracking( state )

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+/* global wpseoFirstTimeConfigurationData */
 
 import { Transition } from "@headlessui/react";
 import { AdjustmentsIcon, BellIcon } from "@heroicons/react/outline";
@@ -16,6 +17,7 @@ import { getMigratingNoticeInfo, deleteMigratingNotices } from "../helpers/migra
 import Notice from "./components/notice";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
 import { shouldShowWebinarPromotionNotificationInDashboard } from "../helpers/shouldShowWebinarPromotionNotification";
+import { STEPS as FTC_STEPS } from "../first-time-configuration/constants";
 
 /**
  * @param {string} [idSuffix] Extra id suffix. Can prevent double IDs on the page.
@@ -68,7 +70,11 @@ Menu.propTypes = {
  * @returns {JSX.Element} The app component.
  */
 const App = () => {
-	const notices = useMemo( getMigratingNoticeInfo, [] );
+	// If the last step of the First-time configuration has been completed, we remove the First-time configuration notice.
+	const notices =  wpseoFirstTimeConfigurationData.finishedSteps.includes( FTC_STEPS.personalPreferences )
+		? useMemo( getMigratingNoticeInfo, [] ).filter(  notice => notice.id !== "yoast-first-time-configuration-notice" )
+		: useMemo( getMigratingNoticeInfo, [] );
+
 	useEffect( () => {
 		deleteMigratingNotices( notices );
 	}, [ notices ] );

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -71,9 +71,7 @@ Menu.propTypes = {
  */
 const App = () => {
 	// If the last step of the First-time configuration has been completed, we remove the First-time configuration notice.
-	const notices =  wpseoFirstTimeConfigurationData.finishedSteps.includes( FTC_STEPS.personalPreferences )
-		? useMemo( getMigratingNoticeInfo, [] ).filter(  notice => notice.id !== "yoast-first-time-configuration-notice" )
-		: useMemo( getMigratingNoticeInfo, [] );
+	const notices = useMemo( getMigratingNoticeInfo, [] );
 
 	useEffect( () => {
 		deleteMigratingNotices( notices );
@@ -126,16 +124,21 @@ const App = () => {
 											<WebinarPromoNotification store={ STORE_NAME } url={ webinarIntroSettingsUrl } image={ null } />
 										}
 										{ notices.length > 0 && <div className="yst-space-y-3 yoast-general-page-notices"> {
-											notices.map( ( notice, index ) => (
-												<Notice
-													key={ index }
-													id={ notice.id || "yoast-general-page-notice-" + index }
-													title={ notice.header }
-													isDismissable={ notice.isDismissable }
-												>
-													{ notice.content }
-												</Notice>
-											) )
+											notices.map( ( notice, index ) => {
+												if ( notice.id === "yoast-first-time-configuration-notice" && wpseoFirstTimeConfigurationData.finishedSteps.includes( FTC_STEPS.personalPreferences ) ) {
+													return null;
+												}
+												return (
+													<Notice
+														key={ index }
+														id={ notice.id || "yoast-general-page-notice-" + index }
+														title={ notice.header }
+														isDismissable={ notice.isDismissable }
+													>
+														{ notice.content }
+													</Notice>
+												);
+											} )
 										}
 										</div> }
 									</div> }

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -70,7 +70,6 @@ Menu.propTypes = {
  * @returns {JSX.Element} The app component.
  */
 const App = () => {
-	// If the last step of the First-time configuration has been completed, we remove the First-time configuration notice.
 	const notices = useMemo( getMigratingNoticeInfo, [] );
 
 	useEffect( () => {
@@ -125,6 +124,8 @@ const App = () => {
 										}
 										{ notices.length > 0 && <div className="yst-space-y-3 yoast-general-page-notices"> {
 											notices.map( ( notice, index ) => {
+												/* If the last step of the First-time configuration has been completed,
+												we remove the First-time configuration notice. */
 												if ( notice.id === "yoast-first-time-configuration-notice" && wpseoFirstTimeConfigurationData.finishedSteps.includes( FTC_STEPS.personalPreferences ) ) {
 													return null;
 												}

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -1,4 +1,5 @@
 import { useSelect } from "@wordpress/data";
+import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Paper, Title } from "@yoast/ui-library";
 import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-list";
@@ -17,6 +18,18 @@ export const AlertCenter = () => {
 	const premiumUpsellConfig = useSelectGeneralPage( "selectUpsellSettingsAsProps" );
 	const academyLink = useSelectGeneralPage( "selectLink", [], "https://yoa.st/3t6" );
 	const { isPromotionActive } = useSelect( STORE_NAME );
+
+	/**
+	 * Removes the first time configuration notice when the the last step has been completed.
+	 */
+	useEffect( () => {
+		if ( window.wpseoFirstTimeConfigurationData.finishedSteps.includes( "personalPreferences" ) )  {
+			const firstTimeConfigurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
+			if ( firstTimeConfigurationNotice ) {
+				firstTimeConfigurationNotice.remove();
+			}
+		}
+	}, [] );
 
 	return <div className="yst-flex yst-gap-6 xl:yst-flex-row yst-flex-col">
 		<div className="yst-@container yst-flex yst-flex-wrap yst-flex-grow yst-flex-col">

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -19,18 +19,6 @@ export const AlertCenter = () => {
 	const academyLink = useSelectGeneralPage( "selectLink", [], "https://yoa.st/3t6" );
 	const { isPromotionActive } = useSelect( STORE_NAME );
 
-	/**
-	 * Removes the first time configuration notice when the the last step has been completed.
-	 */
-	useEffect( () => {
-		if ( window.wpseoFirstTimeConfigurationData.finishedSteps.includes( "personalPreferences" ) )  {
-			const firstTimeConfigurationNotice = document.getElementById( "yoast-first-time-configuration-notice" );
-			if ( firstTimeConfigurationNotice ) {
-				firstTimeConfigurationNotice.remove();
-			}
-		}
-	}, [] );
-
 	return <div className="yst-flex yst-gap-6 xl:yst-flex-row yst-flex-col">
 		<div className="yst-@container yst-flex yst-flex-wrap yst-flex-grow yst-flex-col">
 			<Paper className="yst-grow">

--- a/packages/js/src/general/routes/alert-center.js
+++ b/packages/js/src/general/routes/alert-center.js
@@ -1,5 +1,4 @@
 import { useSelect } from "@wordpress/data";
-import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Paper, Title } from "@yoast/ui-library";
 import { PremiumUpsellList } from "../../shared-admin/components/premium-upsell-list";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the First-time configuration steps would not show updated values if switching to the Alert center.
* Fixes a bug where the First-time configuration notice wouldn't disappear even if the configuration is completed unless the user reloads the page. 

## Relevant technical choices:

* I kept the solution simple in this PR and decided to keep the window object aligned with the backend. I created a draft issue in the tech debt board to move the FTC state to the Redux store for future iterations.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Preliminary steps
* By using the `Yoast Test Helper` reset the First-time configuration progress
* Go to `Yoast SEO` -> `General` and make sure you see the following notice
<img width="745" alt="Screenshot 2024-10-25 at 14 46 57" src="https://github.com/user-attachments/assets/b87c0100-791e-450f-898d-ae111aa4302b">

#### Test the FTC retains updated values
* Go to the First-time configuration
  * Reach step 2  and make some changes
  * Click `Save and continue`
  * Switch back to the Alert center and then to the First-time configuration again
  * Click on step 3 `Go back` button 
  * Verify the changes you previously made are retained
  * Repeat this test for each step

#### Test the FTC notice goes away
* Complete the First-time configuration
* Go back to the Alert center and verify the notice is not there anymore
* By using the `Yoast Test Helper` reset the First-time configuration progress
* Go back to the Alert center and verify the notice is there

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#1933](https://github.com/Yoast/plugins-automated-testing/issues/1933)
