### PR TITLE
Add default to onDiscard in UnsavedChangesModal

### DIFF
--- a/packages/js/src/shared-admin/components/unsaved-changes-modal.js
+++ b/packages/js/src/shared-admin/components/unsaved-changes-modal.js
@@ -1,6 +1,6 @@
-import { __ } from "@wordpress/i18n";
-import { Modal, Button, useSvgAria } from "@yoast/ui-library";
 import { ExclamationIcon } from "@heroicons/react/outline";
+import { __ } from "@wordpress/i18n";
+import { Button, Modal, useSvgAria } from "@yoast/ui-library";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 
@@ -8,16 +8,16 @@ import PropTypes from "prop-types";
  * The unsaved changes modal.
  *
  * @param {boolean} isOpen Whether the modal is open.
- * @param {Function} onClose The function to call when the modal is closed.
+ * @param {function} [onClose] The function to call when the modal is closed.
+ * @param {function} [onDiscard] The function to call when the changes are discarded.
  * @param {string} title The title of the modal.
  * @param {string} description The description of the modal.
- * @param {Function} onDiscard The function to call when the changes are discarded.
  * @param {string} dismissLabel The label for the dismiss button.
  * @param {string} discardLabel The label for the discard button.
  *
  * @returns {JSX.Element} The unsaved changes modal.
  */
-export const UnsavedChangesModal = ( { isOpen, onClose = noop, title, description, onDiscard, dismissLabel, discardLabel } ) => {
+export const UnsavedChangesModal = ( { isOpen, onClose = noop, onDiscard = noop, title, description, dismissLabel, discardLabel } ) => {
 	const svgAriaProps = useSvgAria();
 
 	return <Modal isOpen={ isOpen } onClose={ onClose }>
@@ -52,9 +52,9 @@ export const UnsavedChangesModal = ( { isOpen, onClose = noop, title, descriptio
 UnsavedChangesModal.propTypes = {
 	isOpen: PropTypes.bool.isRequired,
 	onClose: PropTypes.func,
+	onDiscard: PropTypes.func,
 	title: PropTypes.string.isRequired,
 	description: PropTypes.string.isRequired,
-	onDiscard: PropTypes.func.isRequired,
 	dismissLabel: PropTypes.string.isRequired,
 	discardLabel: PropTypes.string.isRequired,
 };

--- a/packages/js/tests/shared-admin/components/unsaved-changes-modal.test.js
+++ b/packages/js/tests/shared-admin/components/unsaved-changes-modal.test.js
@@ -1,36 +1,91 @@
-import { render, screen } from "../../test-utils";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { UnsavedChangesModal } from "../../../src/shared-admin/components";
+import { fireEvent, render, screen } from "../../test-utils";
 
 describe( "UnsavedChangesModal", () => {
+	const onClose = jest.fn();
+	const onDiscard = jest.fn();
+
 	beforeEach( () => {
+		jest.clearAllMocks();
 		render( <UnsavedChangesModal
 			isOpen={ true }
-			onClose={ jest.fn() }
+			onClose={ onClose }
+			onDiscard={ onDiscard }
 			title="Unsaved changes"
 			description="There are unsaved changes in one or more steps of the first-time configuration. Leaving means that those changes will be lost. Are you sure you want to leave this page?"
-			onDiscard={ jest.fn() }
 			dismissLabel="No, continue editing"
 			discardLabel="Yes, leave page"
 		/> );
 	} );
 
-	it( "should have dismiss and leave page buttons", () => {
-		const leaveButton = screen.queryByText( "Yes, leave page" );
-		expect( leaveButton ).toBeInTheDocument();
+	it( "should have a role of dialog", () => {
+		expect( screen.queryByRole( "dialog" ) ).toBeInTheDocument();
+	} );
 
-		expect( screen.queryByText( "Close" ) ).toBeInTheDocument();
+	it.each( [
+		[ "dismiss", "No, continue editing" ],
+		[ "discard", "Yes, leave page" ],
+	] )( "should have the %s button: %s", ( _, text ) => {
+		const button = screen.queryByText( text );
+		expect( button ).toBeInTheDocument();
+		expect( button.tagName ).toBe( "BUTTON" );
+		expect( button ).toHaveAttribute( "type", "button" );
+	} );
 
-		const dismissButton = screen.queryByText( "No, continue editing" );
-		expect( dismissButton ).toBeInTheDocument();
+	it( "should have the close button", () => {
+		const screenReaderText = screen.queryByText( "Close" );
+		expect( screenReaderText ).toBeInTheDocument();
+		expect( screenReaderText.parentElement ).toHaveAttribute( "type", "button" );
+		expect( screenReaderText.parentElement.tagName ).toBe( "BUTTON" );
 	} );
 
 	it( "should have a title", () => {
 		const title = screen.queryByText( "Unsaved changes" );
 		expect( title ).toBeInTheDocument();
+		expect( title.tagName ).toBe( "H1" );
 	} );
 
 	it( "should have a description", () => {
-		const title = screen.queryByText( "There are unsaved changes in one or more steps of the first-time configuration. Leaving means that those changes will be lost. Are you sure you want to leave this page?" );
-		expect( title ).toBeInTheDocument();
+		const description = screen.queryByText( "There are unsaved changes in one or more steps of the first-time configuration. Leaving means that those changes will be lost. Are you sure you want to leave this page?" );
+		expect( description ).toBeInTheDocument();
+		expect( description.tagName ).toBe( "P" );
+	} );
+
+	it( "should call onClose when clicking the close button", () => {
+		fireEvent.click( screen.queryByText( "Close" ) );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( "should call onClose when clicking the continue editing button", () => {
+		fireEvent.click( screen.queryByText( "No, continue editing" ) );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( "should call onDiscard when clicking the leave page button", () => {
+		fireEvent.click( screen.queryByText( "Yes, leave page" ) );
+		expect( onDiscard ).toHaveBeenCalled();
+	} );
+
+	describe( "fallback props", () => {
+		it( "should not throw an error when the onClose and onDiscard props are not passed", () => {
+			const currentImplementation = console.error;
+			console.error = jest.fn();
+
+			render( <UnsavedChangesModal
+				isOpen={ true }
+				title="Unsaved changes"
+				description="There are unsaved changes in one or more steps of the first-time configuration. Leaving means that those changes will be lost. Are you sure you want to leave this page?"
+				dismissLabel="No, continue editing"
+				discardLabel="Yes, leave page"
+			/> );
+
+			try {
+				expect( console.error ).not.toHaveBeenCalled();
+			} finally {
+				// Cleanup.
+				console.error = currentImplementation;
+			}
+		} );
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a React prop type warning would occur in the First time configuration, due to the interface of the useBlocker hook.

## Relevant technical choices:

[Add default to onDiscard in UnsavedChangesModal](https://github.com/Yoast/wordpress-seo/commit/2e552e7cb4a22e4775a6ca77dd5f83dd537001c5) 
While not necessarily useful without, it is easier to work with like this.
Mostly because the useBlocker from react-router-dom has undefined for the reset and proceed functions unless actively blocking.
We could rewrite the usage there to force not rendering this depending on the state. But that is what the isOpen is supposed to be for already.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable debug output (`SCRIPT_DEBUG`)
* Visit Yoast > General > FTC
* [ ] Verify the warning in the browser console is no longer there
> Warning: Failed prop type: The prop `onDiscard` is marked as required in `UnsavedChangesModal`, but its value is `undefined`. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Regression test going away from the FTC with unsaved changes
  * We should get the modals confirming that we want to move away from the FTC and we should also confirm that dismissing those modals works as expected.
* Regression test discarding changes in the settings page
  * We should get the modals confirming that we want to discard changes and we should also confirm that dismissing those modals works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21728
