### PR TITLE
Fixed undefine errors

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -816,8 +816,8 @@ class WPSEO_Addon_Manager {
 	 */
 	protected function map_site_information( $site_information ) {
 		return (object) [
-			'url'           => $site_information->url,
-			'subscriptions' => array_map( [ $this, 'map_subscription' ], $site_information->subscriptions ),
+			'url'           => $site_information->url ?? null,
+			'subscriptions' => array_map( [ $this, 'map_subscription' ], $site_information->subscriptions ?? [] ),
 		];
 	}
 
@@ -831,17 +831,16 @@ class WPSEO_Addon_Manager {
 	protected function map_subscription( $subscription ) {
 		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Not our properties.
 		return (object) [
-			'renewal_url' => $subscription->renewalUrl,
-			'expiry_date' => $subscription->expiryDate,
+			'renewal_url' => $subscription->renewalUrl ?? null,
+			'expiry_date' => $subscription->expiryDate ?? null,
 			'product'     => (object) [
-				'version'      => $subscription->product->version,
-				'name'         => $subscription->product->name,
-				'slug'         => $subscription->product->slug,
-				'last_updated' => $subscription->product->lastUpdated,
-				'store_url'    => $subscription->product->storeUrl,
-				// Ternary operator is necessary because download can be undefined.
-				'download'     => ( $subscription->product->download ?? null ),
-				'changelog'    => $subscription->product->changelog,
+				'version'      => $subscription->product->version ?? null,
+				'name'         => $subscription->product->name ?? null,
+				'slug'         => $subscription->product->slug ?? null,
+				'last_updated' => $subscription->product->lastUpdated ?? null,
+				'store_url'    => $subscription->product->storeUrl ?? null,
+				'download'     => $subscription->product->download ?? null,
+				'changelog'    => $subscription->product->changelog ?? null,
 			],
 		];
 		// phpcs:enable


### PR DESCRIPTION
## Context
[<!--
What do we want to achieve with this PR? Why did we write this code?
-->](https://wordpress.org/support/topic/i-am-receiving-the-below-error-kindly-check-and-confirm/#post-18100071)
Fixed warnning with assign.

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
[<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->](https://prnt.sc/Z3xo1psQthHB)
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
