### PR TITLE
Allow empty type/width/height via wpseo_opengraph_image_* filters

### DIFF
--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -115,6 +115,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		if ( ! empty( $image_type ) && \is_string( $image_type ) ) {
 			$image['type'] = \trim( $image_type );
 		}
+		else{
+			$image['type'] = "";
+		}
 
 		$image_width = ( $image['width'] ?? '' );
 		/**
@@ -127,6 +130,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		if ( ! empty( $image_width ) && $image_width > 0 ) {
 			$image['width'] = $image_width;
 		}
+		else{
+			$image['width'] = "";
+		}
 
 		$image_height = ( $image['height'] ?? '' );
 		/**
@@ -138,6 +144,9 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 		$image_height = (int) \apply_filters( 'wpseo_opengraph_image_height', $image_height, $this->presentation );
 		if ( ! empty( $image_height ) && $image_height > 0 ) {
 			$image['height'] = $image_height;
+		}
+		else{
+			$image['height'] = "";
 		}
 
 		return $image;


### PR DESCRIPTION
## Context

For posts with an OpenGraph Image, the width/height/type meta values cannot be removed when setting the `wpseo_opengraph_image_width`, `wpseo_opengraph_image_height` and `wpseo_opengraph_image_type` filters to empty values: these properties can only be overwritten with new values. This causes incorrect width/height/type values when overriding the image URL using the `wpseo_opengraph_image` filter as the old width/height/type values are assigned even though the width/height/type values are set to empty:

```php
add_filter( 'wpseo_opengraph_image', function($url) { return 'https://example.com/image.png'; });
add_filter( 'wpseo_opengraph_image_width', function($width) { return false; }); //The og:image:width property is still added with the old value
add_filter( 'wpseo_opengraph_image_height', function($height) { return false; }); //The og:image:height property is still added with the old value
add_filter( 'wpseo_opengraph_image_type', function($type) { return false; }); //The og:image:type property is still added with the old value
```

It is sometimes necessary to remove the meta values in order to avoid incorrect meta values: for example, when using external `og:image` URLs and you do not wish to retrieve the width/height/mime information (i.e using `getimagesize`) to prevent a slower server response time:

```php
add_filter( 'wpseo_opengraph_image', function($url) { return 'https://example.com/image.png'; });
$imagesize =getimagesize('https://example.com/image.png');
//Correct values are now displayed; however, the server is forced to retrieve the imagesize information
add_filter( 'wpseo_opengraph_image_width', function($value) use ($imagesize){ return $imagesize[0];});
add_filter( 'wpseo_opengraph_image_height', function($value)use ($imagesize){ return $imagesize[1];});
add_filter( 'wpseo_opengraph_image_type', function($value)use ($imagesize){ return $imagesize['mime'];});
```

This PR allows empty values for `wpseo_opengraph_image_width`, `wpseo_opengraph_image_height` and `wpseo_opengraph_image_type` which consequently removes the meta properties from the page so that developers can have more control over the `og:image` meta values output.

## Summary

* Allow empty values using the filters `wpseo_opengraph_image_width`, `wpseo_opengraph_image_height` and `wpseo_opengraph_image_type`.
