### PR TITLE
Change how we retrieve rule descriptions when generating the inclusive language database

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigSpec.js
@@ -12,16 +12,6 @@ const fs = require( "fs" );
  */
 describe( "Export of the inclusive language configuration", () => {
 	/**
-	 * Retrieves the rules from a function call in a prettier format.
-	 * @param {string} str The function call.
-	 * @returns {string} The prettier formatted string.
-	 */
-	const retrieveRule = ( str ) => {
-		const matches = [ ...str.matchAll( /\.filter.*?_is(.*?)Exception.*?\[(.*?)]/g ) ];
-		return matches.map( match => "Not" + match[ 1 ] + ": " + match[ 2 ] ).join( " and " );
-	};
-
-	/**
 	 * Retrieves the href value from a string containing an anchor.
 	 * @param {string} str The string containing an anchor.
 	 * @returns {string} The href value of the anchor.
@@ -77,7 +67,7 @@ describe( "Export of the inclusive language configuration", () => {
 				nonInclusivePhrases: assessment.nonInclusivePhrases.join( ", " ),
 				inclusiveAlternatives: assessment.inclusiveAlternatives.join( ", " ).replace( /<\/?i>/g, "" ),
 				score: assessment.score === SCORES.POTENTIALLY_NON_INCLUSIVE ? "orange" : "red",
-				rule: assessment.rule.name === "includesConsecutiveWords" ? "" : retrieveRule( assessment.rule.toString() ),
+				ruleDescription: assessment.ruleDescription,
 				caseSensitive: assessment.caseSensitive ? "yes" : "no",
 				feedbackFormat: sprintf( assessment.feedbackFormat, "\"x\"", "\"y\"", "\"z\"" ).replace( /<\/?i>/g, "" ),
 				learnMoreUrl: retrieveAnchor( assessment.learnMoreUrl ),
@@ -89,25 +79,10 @@ describe( "Export of the inclusive language configuration", () => {
 		resultLines.unshift( header.join( ";" ) );
 
 		// Set doExport to true to write the results to a temporary file.
-		const doExport = false;
+		const doExport = true;
 		if ( doExport ) {
 			writeToTempFile( "inclusive-language-database.csv", resultLines.join( "\n" ) );
 		}
-	} );
-
-	it.skip( "should retrieve rules in a more pretty format", () => {
-		let assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "firemen" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).toEqual( "" );
-
-		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "binge" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).toEqual(
-			"NotFollowedBy: \"drink\", \"drinks\", \"drinking\", \"eating disorder\", \"and purge\", " +
-			"\"behavior\", \"behaviors\", \"behaviour\", \"behaviours\"" );
-
-		assessment = new InclusiveLanguageAssessment( inclusiveLanguageAssessmentsConfigs.find( obj => obj.identifier === "seniors" ) );
-		expect( retrieveRule( assessment.rule.toString() ) ).
-			toEqual( "NotPrecededBy: \"high school\", \"college\", \"graduating\", \"juniors and\"" +
-			" and NotFollowedBy: \"in high school\", \"in college\", \"who are graduating\"" );
 	} );
 
 	it( "should retrieve the href value for an anchor", () => {

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/exportInclusiveLanguageConfigSpec.js
@@ -79,7 +79,7 @@ describe( "Export of the inclusive language configuration", () => {
 		resultLines.unshift( header.join( ";" ) );
 
 		// Set doExport to true to write the results to a temporary file.
-		const doExport = true;
+		const doExport = false;
 		if ( doExport ) {
 			writeToTempFile( "inclusive-language-database.csv", resultLines.join( "\n" ) );
 		}

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/createRuleDescriptionsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/helpers/createRuleDescriptionsSpec.js
@@ -1,0 +1,16 @@
+import { isPreceded, notPreceded, notFollowed, notPrecededAndNotFollowed } from "../../../../../src/scoring/assessments/inclusiveLanguage/helpers/createRuleDescriptions";
+
+describe( "A test for creating assessment rule descriptions", function() {
+	it( "should create a rule description for phrases that should be targeted only when preceded by specific words", function() {
+		expect( isPreceded( [ "I am", "you are" ] ) ).toBe( "Targeted when preceded by 'I am', 'you are'." );
+	} );
+	it( "should create a rule description for phrases that should be targeted unless preceded by specific words", function() {
+		expect( notPreceded( [ "I am", "you are" ] ) ).toBe( "Targeted unless preceded by 'I am', 'you are'." );
+	} );
+	it( "should create a rule description for phrases that should be targeted unless followed by specific words", function() {
+		expect( notFollowed( [ "in college", "in high school" ] ) ).toBe( "Targeted unless followed by 'in college', 'in high school'." );
+	} );
+	it( "should create a rule description for phrases that should be targeted unless preceded and/or followed by specific words", function() {
+		expect( notPrecededAndNotFollowed( [ "high school", "college" ], [ "in college", "in high school" ] ) ).toBe( "Targeted unless preceded by 'high school', 'college' and/or followed by 'in college', 'in high school'." );
+	} );
+} );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
@@ -31,7 +31,9 @@ export default class InclusiveLanguageAssessment {
 	 * 									and `%2$s` (and potentially further replacements) for the suggested alternative(s).
 	 * @param {string} config.learnMoreUrl The URL to an article explaining more about this specific assessment.
 	 * @param {function} [config.rule] A potential additional rule for targeting the non-inclusive phrases.
+	 * @param {string} [config.ruleDescription] A description of the rule.
 	 * @param {boolean} [config.caseSensitive=false] If the inclusive phrase is case-sensitive, defaults to `false`.
+	 * @param {string} [config.category] The category of the assessment.
 	 *
 	 * @returns {void}
 	 */

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/InclusiveLanguageAssessment.js
@@ -36,7 +36,7 @@ export default class InclusiveLanguageAssessment {
 	 * @returns {void}
 	 */
 	constructor( { identifier, nonInclusivePhrases, inclusiveAlternatives,
-					 score, feedbackFormat, learnMoreUrl, rule, caseSensitive, category } ) {
+					 score, feedbackFormat, learnMoreUrl, rule, ruleDescription, caseSensitive, category } ) {
 		this.identifier = identifier;
 		this.nonInclusivePhrases = nonInclusivePhrases;
 		this.inclusiveAlternatives = inclusiveAlternatives;
@@ -48,6 +48,7 @@ export default class InclusiveLanguageAssessment {
 		this.learnMoreUrl = createAnchorOpeningTag( learnMoreUrl );
 
 		this.rule = rule || includesConsecutiveWords;
+		this.ruleDescription = ruleDescription;
 		this.caseSensitive = caseSensitive || false;
 		this.category = category;
 	}

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/ageAssessments.js
@@ -5,6 +5,7 @@ import { isNotFollowedByException } from "../helpers/isFollowedByException";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import { SCORES } from "./scores";
 import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
+import { nonInclusiveWhenStandalone, notPrecededAndNotFollowed } from "../helpers/createRuleDescriptions";
 
 const ageAssessments = [
 	{
@@ -60,6 +61,8 @@ const ageAssessments = [
 				.filter( isNotPrecededByException( words, [ "high school", "college", "graduating", "juniors and" ] ) )
 				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "in high school", "in college", "who are graduating" ] ) );
 		},
+		ruleDescription: notPrecededAndNotFollowed( [ "high school", "college", "graduating", "juniors and" ],
+			[ "in high school", "in college", "who are graduating" ] ),
 	},
 	{
 		identifier: "theAged",
@@ -71,6 +74,7 @@ const ageAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 ];
 

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/appearanceAssessments.js
@@ -5,6 +5,7 @@ import { redHarmful,
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
+import { nonInclusiveWhenStandalone } from "../helpers/createRuleDescriptions";
 
 const appearanceAssessments = [
 	{
@@ -24,6 +25,7 @@ const appearanceAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 	{
 		identifier: "obese",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -11,6 +11,7 @@ import {
 import {
 	orangeUnlessCultureOfOrigin,
 } from "./feedbackStrings/cultureAssessmentStrings";
+import { notFollowed } from "../helpers/createRuleDescriptions";
 
 const cultureAssessments = [
 	{
@@ -22,6 +23,7 @@ const cultureAssessments = [
 		caseSensitive: true,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "War", "war", "Assembly", "assembly" ] ) ),
+		ruleDescription: notFollowed( [ "War", "war", "Assembly", "assembly" ] ),
 	},
 	{
 		identifier: "thirdWorld",
@@ -32,6 +34,7 @@ const cultureAssessments = [
 		caseSensitive: true,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "War", "war", "Quarterly", "quarterly", "country" ] ) ),
+		ruleDescription: notFollowed( [ "War", "war", "Quarterly", "quarterly", "country" ] ),
 	},
 	{
 		identifier: "tribe",
@@ -66,6 +69,7 @@ const cultureAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "longhair", "longhairs", "shorthair", "shorthairs" ] ) );
 		},
+		ruleDescription: notFollowed( [ "longhair", "longhairs", "shorthair", "shorthairs" ] ),
 	},
 	{
 		identifier: "sherpa",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -24,6 +24,13 @@ import {
 	shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
 } from "./disabilityRulesData";
 import { sprintf } from "@wordpress/i18n";
+import {
+	nonInclusiveWhenStandalone,
+	isPreceded,
+	notFollowed,
+	notPreceded,
+	notPrecededAndNotFollowed,
+} from "../helpers/createRuleDescriptions";
 
 const disabilityAssessments = [
 	{
@@ -36,6 +43,7 @@ const disabilityAssessments = [
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase,
 				[ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
+		ruleDescription: notFollowed( [ "drink", "drinks", "drinking", "eating disorder", "and purge", "behavior", "behaviors", "behaviour", "behaviours" ] ),
 	},
 	{
 		identifier: "bingeing",
@@ -47,6 +55,7 @@ const disabilityAssessments = [
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase,
 				[ "and purging", "behavior", "behaviors", "behaviour", "behaviours" ] ) ),
+		ruleDescription: notFollowed( [ "and purging", "behavior", "behaviors", "behaviour", "behaviours" ] ),
 	},
 	{
 		identifier: "binged",
@@ -57,6 +66,7 @@ const disabilityAssessments = [
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purged" ] ) ),
+		ruleDescription: notFollowed( [ "and purged" ] ),
 	},
 	{
 		identifier: "binges",
@@ -67,6 +77,7 @@ const disabilityAssessments = [
 			"If you are not referencing a symptom, consider other alternatives to describe the trait or behavior, such as %2$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "and purges" ] ) ),
+		ruleDescription: notFollowed( [ "and purges" ] ),
 	},
 	{
 		identifier: "wheelchairBound",
@@ -92,6 +103,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, [ "mentally" ] ) );
 		},
+		ruleDescription: notPreceded( [ "mentally" ] ),
 	},
 	{
 		identifier: "alcoholic",
@@ -101,6 +113,7 @@ const disabilityAssessments = [
 		feedbackFormat: orangeUnlessSomeoneWants,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "drink", "beverage" ] ) ),
+		ruleDescription: notFollowed( [ "drink", "beverage" ] ),
 	},
 	{
 		identifier: "alcoholics",
@@ -110,6 +123,7 @@ const disabilityAssessments = [
 		feedbackFormat: orangeUnlessSomeoneWants,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "anonymous" ] ) ),
+		ruleDescription: notFollowed( [ "anonymous" ] ),
 	},
 	{
 		identifier: "cripple",
@@ -148,6 +162,7 @@ const disabilityAssessments = [
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase,
 				[ "toilet", "toilets", "parking", "bathroom", "bathrooms", "stall", "stalls" ] ) ),
+		ruleDescription: notFollowed( [ "toilet", "toilets", "parking", "bathroom", "bathrooms", "stall", "stalls" ] ),
 	},
 	{
 		identifier: "insane",
@@ -195,6 +210,7 @@ const disabilityAssessments = [
 			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "autism" ] ) ),
+		ruleDescription: notFollowed( [ "autism" ] ),
 	},
 	{
 		identifier: "autismHigh",
@@ -327,6 +343,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, [ "deaf and" ] ) );
 		},
+		ruleDescription: notPreceded( [ "deaf and" ] ),
 	},
 	{
 		identifier: "deaf",
@@ -395,6 +412,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isPrecededByException( words, formsOfToBeNotWithOptionalIntensifier ) );
 		},
+		ruleDescription: "Targeted when preceded by a negated form of 'to be' or 'to get' and an optional intensifier.",
 	},
 	{
 		identifier: "to be crazy about",
@@ -407,6 +425,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
 		},
+		ruleDescription: "Targeted when preceded by a form of 'to be' or 'to get' and an optional intensifier.",
 	},
 	{
 		identifier: "crazy in love",
@@ -427,6 +446,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isPrecededByException( words, formsOfToGo ) );
 		},
+		ruleDescription: isPreceded( formsOfToGo ),
 	},
 	{
 		identifier: "to drive crazy",
@@ -440,6 +460,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
 		},
+		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
 	},
 	{
 		identifier: "crazy",
@@ -457,6 +478,8 @@ const disabilityAssessments = [
 					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
 					shouldNotFollowStandaloneCrazyWhenPrecededByToBe ) );
 		},
+		ruleDescription: "Not targeted with this feedback when part of a more specific phrase that we target ('to drive crazy', " +
+			"to go crazy', 'to (not) be crazy about', 'crazy in love').",
 	},
 	{
 		identifier: "crazier",
@@ -489,6 +512,7 @@ const disabilityAssessments = [
 		feedbackFormat: orangeUnlessMedicalCondition,
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "disorder" ] ) ),
+		ruleDescription: notFollowed( [ "disorder" ] ),
 	},
 	{
 		identifier: "paranoid",
@@ -499,6 +523,7 @@ const disabilityAssessments = [
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase,
 				[ "personality disorder", "delusion", "delusions", "ideation" ] ) ),
+		ruleDescription: notFollowed( [ "personality disorder", "delusion", "delusions", "ideation" ] ),
 	},
 	{
 		identifier: "manic",
@@ -509,6 +534,7 @@ const disabilityAssessments = [
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase,
 				[ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic" ] ) ),
+		ruleDescription: notFollowed( [ "episode", "episodes", "state", "states", "symptoms", "and depressive episodes", "and hypomanic", "or hypomanic" ] ),
 	},
 	{
 		identifier: "hysterical",
@@ -562,6 +588,7 @@ const disabilityAssessments = [
 			" If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
 		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
 			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "personality disorder" ] ) ),
+		ruleDescription: notFollowed( [ "personality disorder" ] ),
 	},
 	{
 		identifier: "OCD",
@@ -577,6 +604,8 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, inclusivePhrases )
 				.filter( isPrecededByException( words, formsOfToBeAndToBeNotWithOptionalIntensifier ) );
 		},
+		ruleDescription: "Targeted when preceded by a form of 'to be' or 'to get' (including their negated forms)" +
+			"and an optional intensifier",
 	},
 	{
 		identifier: "theMentallyIll",
@@ -588,6 +617,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 	{
 		identifier: "theDisabled",
@@ -599,6 +629,7 @@ const disabilityAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 ];
 

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -29,7 +29,6 @@ import {
 	isPreceded,
 	notFollowed,
 	notPreceded,
-	notPrecededAndNotFollowed,
 } from "../helpers/createRuleDescriptions";
 
 const disabilityAssessments = [

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
@@ -16,6 +16,7 @@ import { orangeExclusionaryUnless,
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
+import { nonInclusiveWhenStandalone } from "../helpers/createRuleDescriptions";
 
 const genderAssessments = [
 	{
@@ -281,6 +282,7 @@ const genderAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 ];
 

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/otherAssessments.js
@@ -7,6 +7,7 @@ import {
 } from "./feedbackStrings/generalFeedbackStrings";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import { isNotPrecededByException } from "../helpers/isPrecededByException";
+import { notPreceded } from "../helpers/createRuleDescriptions";
 
 const otherAssessments = [
 	{
@@ -30,6 +31,7 @@ const otherAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
 		},
+		ruleDescription: notPreceded( [ "mentally", "behaviorally", "behaviourally" ] ),
 	},
 	{
 		identifier: "normalPeople",
@@ -43,6 +45,7 @@ const otherAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotPrecededByException( words, [ "mentally", "behaviorally", "behaviourally" ] ) );
 		},
+		ruleDescription: notPreceded( [ "mentally", "behaviorally", "behaviourally" ] ),
 	},
 	{
 		identifier: "mentallyNormal",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/sesAssessments.js
@@ -2,6 +2,7 @@ import { redHarmful, orangeUnlessSomeoneWants } from "./feedbackStrings/generalF
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
 import notInclusiveWhenStandalone from "../helpers/notInclusiveWhenStandalone";
+import { nonInclusiveWhenStandalone } from "../helpers/createRuleDescriptions";
 
 const sesAssessments = [
 	{
@@ -98,6 +99,7 @@ const sesAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 	{
 		identifier: "theUndocumented",
@@ -109,6 +111,7 @@ const sesAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 	{
 		identifier: "thePoor",
@@ -120,6 +123,7 @@ const sesAssessments = [
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( notInclusiveWhenStandalone( words, nonInclusivePhrase ) );
 		},
+		ruleDescription: nonInclusiveWhenStandalone,
 	},
 ];
 

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/createRuleDescriptions.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/helpers/createRuleDescriptions.js
@@ -1,0 +1,46 @@
+export const nonInclusiveWhenStandalone = "Targeted when followed by a participle, a function word (other than a noun), or punctuation.";
+
+/**
+ * Creates a rule description for phrases that are only targeted when preceded by specific words.
+ *
+ * @param {string[]} precedenceExceptionList The list of words that should precede the non-inclusive phrase.
+ *
+ * @returns {string} The rule description.
+ */
+export function isPreceded( precedenceExceptionList ) {
+	return "Targeted when preceded by '" + precedenceExceptionList.join( "', '" ) + "'.";
+}
+
+/**
+ * Creates a rule description for phrases that are targeted unless preceded by specific words.
+ *
+ * @param {string[]} precedenceExceptionList  The list of words that shouldn't precede the non-inclusive phrase.
+ *
+ * @returns {string} The rule description.
+ */
+export function notPreceded( precedenceExceptionList ) {
+	return "Targeted unless preceded by '" + precedenceExceptionList.join( "', '" ) + "'.";
+}
+
+/**
+ * Creates a rule description for phrases that are targeted unless followed by specific words.
+ *
+ * @param {string[]} followingExceptionList  The list of words that shouldn't follow the non-inclusive phrase.
+ *
+ * @returns {string} The rule description.
+ */
+export function notFollowed( followingExceptionList ) {
+	return "Targeted unless followed by '" + followingExceptionList.join( "', '" ) + "'.";
+}
+
+/**
+ * Creates a rule description for phrases that are targeted unless followed or preceded by specific words.
+ *
+ * @param {string[]} precedenceExceptionList  The list of words that shouldn't precede the non-inclusive phrase.
+ * @param {string[]} followingExceptionList  The list of words that shouldn't follow the non-inclusive phrase.
+ *
+ * @returns {string} The rule description.
+ */
+export function notPrecededAndNotFollowed( precedenceExceptionList, followingExceptionList ) {
+	return "Targeted unless preceded by '" + precedenceExceptionList.join( "', '" ) + "' and/or followed by '" + followingExceptionList.join( "', '" ) + "'.";
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, we retrieved the inclusive language assessment rule descriptions by using a regex to extract them from the functions used to apply the rule. This method was unreliable and didn't work for all rules. Instead, in this PR, a new property is added to each inclusive language assessment with a rule that contains the rule description.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a rule description property to each inclusive language assessment that has a rule.
* [shopify-seo] Adds a rule description property to each inclusive language assessment that has a rule.

## Relevant technical choices:

* I chose to duplicate the list of precedence/following exceptions that are passed to the functions that apply the rules, and to the function that generates the rule description. Rather than extracting them to a separate variable. I thought that the benefit of avoiding duplication doesn't outweigh the benefit of being able to see the exception lists next to the other assessment data, rather than somewhere else. This way, we can find the information quicker, as well as more easily spot any mistakes or missing exceptions. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Generate the inclusive language database following these instructions: [How to generate the inclusive language database](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2477621286/Inclusive+language+database).
* Confirm that the rules for the assessments are outputted correctly. They should be the same as in this file: [Inclusive language database test](https://docs.google.com/spreadsheets/d/1uTgmQNuzHd2EnkZunjv0Nhe9qbsHSXe6nkEr0fDH4dA/edit?usp=sharing).
* Smoke test the inclusive language analysis
     * Create a post and add some phrases that have rules, for example: `seniors`, `I'm so OCD`, `alcoholics`, `normal person`.
     * Confirm that the inclusive language analysis returns feedback for all those phrases.
     * Change some of the phrases so that they are considered inclusive according to the rules, for example: `high school seniors`, `I have OCD`, `alcoholics anonymous`.
     * Confirm that no feedback shows for these phrases.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Use the same steps as above, except for the first two steps which do not need to be tested by QA.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Improve script for generating inclusive language database so that all rules are outputted](https://github.com/Yoast/lingo-other-tasks/issues/155)
