### PR TITLE
Improve handling of the inclusive language feedback string for 'tribe'

### DIFF
--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -9,7 +9,7 @@ import {
 	orangeUnlessAnimalsObjects,
 } from "./feedbackStrings/generalFeedbackStrings";
 import {
-	orangeUnlessCultureOfOrigin,
+	orangeUnlessCultureOfOrigin, orangeUnlessCultureUsesTerm,
 } from "./feedbackStrings/cultureAssessmentStrings";
 
 const cultureAssessments = [
@@ -38,22 +38,14 @@ const cultureAssessments = [
 		nonInclusivePhrases: [ "tribe" ],
 		inclusiveAlternatives: "<i>group, cohort, crew, league, guild, team, union</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		/*
-		 * Replace 'the culture in which this term originated' with 'a culture that uses this term' in the 'unless you are
-		 * referring to...' part of the orangeUnlessCultureOfOrigin string.
-		 */
-		feedbackFormat: orangeUnlessCultureOfOrigin.slice( 0, -42 ) + "a culture that uses this term.",
+		feedbackFormat: orangeUnlessCultureUsesTerm,
 	},
 	{
 		identifier: "tribes",
 		nonInclusivePhrases: [ "tribes" ],
 		inclusiveAlternatives: "<i>groups, cohorts, crews, leagues, guilds, teams, unions</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		/*
-		 * Replace 'the culture in which this term originated' with 'a culture that uses this term' in the 'unless you are
-		 * referring to...' part of the orangeUnlessCultureOfOrigin string.
-		 */
-		feedbackFormat: orangeUnlessCultureOfOrigin.slice( 0, -42 ) + "a culture that uses this term.",
+		feedbackFormat: orangeUnlessCultureUsesTerm,
 	},
 	{
 		identifier: "exotic",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/cultureAssessmentStrings.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/cultureAssessmentStrings.js
@@ -12,7 +12,7 @@ import { beCarefulHarmful } from "./generalFeedbackStrings";
  * the culture in which this term originated."
  */
 export const orangeUnlessCultureOfOrigin = [ beCarefulHarmful, "Consider using an alternative, such as %2$s instead," +
-" unless you are referring to the culture in which this term originated." ].join( "" );
+" unless you are referring to the culture in which this term originated." ].join( " " );
 
 /*
  * Used for culturally appropriative terms, such as 'tribe'.
@@ -21,4 +21,4 @@ export const orangeUnlessCultureOfOrigin = [ beCarefulHarmful, "Consider using a
  * a culture that uses this term."
  */
 export const orangeUnlessCultureUsesTerm = [ beCarefulHarmful, "Consider using an alternative, such as %2$s instead," +
-" unless you are referring to a culture that uses this term." ].join( "" );
+" unless you are referring to a culture that uses this term." ].join( " " );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/cultureAssessmentStrings.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/cultureAssessmentStrings.js
@@ -1,14 +1,24 @@
+import { beCarefulHarmful } from "./generalFeedbackStrings";
+
 // Guidelines for adding feedback strings:
 // 1) This file is for strings that can only be used for culture assessments. If a string can be also used for other
 // assessments, add it to the generalFeedbackStrings.js file instead.
 // 2) Before adding a new string, check whether a similar string that can be used instead already exists (also in generalFeedbackStrings.js).
 
 /*
- * Used for culturally appropriative terms, such as 'tribe' or 'spirit animal'.
+ * Used for culturally appropriative terms, such as 'spirit animal'.
  *
  * "Be careful when using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, such as %2$s instead, unless you are referring to
  * the culture in which this term originated."
  */
-export const orangeUnlessCultureOfOrigin = "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
-	"Consider using an alternative, such as %2$s instead, unless you are referring to the culture " +
-	"in which this term originated.";
+export const orangeUnlessCultureOfOrigin = [ beCarefulHarmful, "Consider using an alternative, such as %2$s instead," +
+" unless you are referring to the culture in which this term originated." ].join( "" );
+
+/*
+ * Used for culturally appropriative terms, such as 'tribe'.
+ *
+ * "Be careful when using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, such as %2$s instead, unless you are referring to
+ * a culture that uses this term."
+ */
+export const orangeUnlessCultureUsesTerm = [ beCarefulHarmful, "Consider using an alternative, such as %2$s instead," +
+" unless you are referring to a culture that uses this term." ].join( "" );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The way the feedback string for 'tribe' was created was not readable. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the handling of the feedback string for the potentially non-inclusive phrase 'tribe'.
* [shopify-seo] Improves the handling of the feedback string for the potentially non-inclusive phrase 'tribe'.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post and add the phrase `tribe` to it.
* Confirm that the inclusive language analysis shows the following feedback:
     * Be careful when using tribe as it is potentially harmful. Consider using an alternative, such as group, cohort, crew, league, guild, team, union instead, unless you are referring to a culture that uses this term. [Learn more.](https://yoa.st/inclusive-language-culture?php_version=8.1&platform=wordpress&platform_version=6.6.2&software=free&software_version=23.8-RC4&days_active=546&user_language=en_US)
 * Change the word to `tribes` and confirm that the inclusive language analysis shows the following feedback:
      * Be careful when using tribes as it is potentially harmful. Consider using an alternative, such as groups, cohorts, crews, leagues, guilds, teams, unions instead, unless you are referring to a culture that uses this term. [Learn more.](https://yoa.st/inclusive-language-culture?php_version=8.1&platform=wordpress&platform_version=6.6.2&software=free&software_version=23.8-RC4&days_active=546&user_language=en_US)
 * Change the word to `guru` and confirm that the inclusive language analysis shows the following feedback:
      * Be careful when using guru as it is potentially harmful. Consider using an alternative, such as mentor, doyen, coach, mastermind, virtuoso, expert instead, unless you are referring to the culture in which this term originated. [Learn more.](https://yoa.st/inclusive-language-culture?php_version=8.1&platform=wordpress&platform_version=6.6.2&software=free&software_version=23.8-RC4&days_active=546&user_language=en_US) 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Inclusive language: Improve handling of the feedback string for 'tribe'/'tribes'](https://github.com/Yoast/lingo-other-tasks/issues/146)
