### PR TITLE
21724 new general page updating counters properly new

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -855,14 +855,15 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$notification_center = Yoast_Notification_Center::get();
 		$notification_count  = $notification_center->get_notification_count();
 
-		if ( ! $notification_count ) {
-			return '';
-		}
-
 		/* translators: Hidden accessibility text; %s: number of notifications. */
 		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
-		return sprintf( ' <div class="wp-core-ui wp-ui-notification yoast-issue-counter"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>', $notification_count, $counter_screen_reader_text );
+		return sprintf(
+			' <div class="wp-core-ui wp-ui-notification yoast-issue-counter%s"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>',
+			( $notification_count ) ? '' : ' yst-hidden',
+			$notification_count,
+			$counter_screen_reader_text
+		);
 	}
 
 	/**

--- a/packages/js/src/first-time-configuration/first-time-configuration-steps.js
+++ b/packages/js/src/first-time-configuration/first-time-configuration-steps.js
@@ -1,8 +1,9 @@
 import apiFetch from "@wordpress/api-fetch";
+import { useDispatch } from "@wordpress/data";
 import { useCallback, useReducer, useState, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { uniq } from "lodash";
-
+import { STORE_NAME } from "../general/constants";
 import { configurationReducer } from "./tailwind-components/helpers/index.js";
 import SocialProfilesStep from "./tailwind-components/steps/social-profiles/social-profiles-step";
 import Stepper, { Step } from "./tailwind-components/stepper";
@@ -158,6 +159,7 @@ function calculateInitialState( windowObject, isStepFinished ) {
  * @returns {WPElement} The FirstTimeConfigurationSteps component.
  */
 export default function FirstTimeConfigurationSteps() {
+	const { removeAlert } = useDispatch( STORE_NAME );
 	const [ finishedSteps, setFinishedSteps ] = useState( window.wpseoFirstTimeConfigurationData.finishedSteps );
 
 	const isStepFinished = useCallback( ( stepId ) => {
@@ -192,32 +194,10 @@ export default function FirstTimeConfigurationSteps() {
 	without triggering a reload, whereas the window variable remains stale. */
 	useEffect( () => {
 		if ( indexingState === "completed" ) {
-			const indexationNotice = document.getElementById( "wpseo-reindex" );
-			if ( indexationNotice ) {
-				const allCounters = document.querySelectorAll( ".yoast-issue-counter, #toplevel_page_wpseo_dashboard .update-plugins" );
-
-				// Update the notification counters if there are any (non-zero ones).
-				if ( allCounters.length > 0 && allCounters[ 0 ].firstChild.textContent !== "0" ) {
-					// Get the oldCount for easier targeting.
-					const oldCount = allCounters[ 0 ].firstChild.textContent;
-					const newCount = ( parseInt( oldCount, 10 ) - 1 ).toString();
-					allCounters.forEach( ( counterNode => {
-						// The classList replace will return false if the class was not present (and thus an adminbar counter).
-						const isAdminBarCounter = ! counterNode.classList.replace( "count-" + oldCount, "count-" + newCount );
-						// If the count reaches zero because of this, remove the red dot alltogether.
-						if ( isAdminBarCounter && newCount === "0" ) {
-							counterNode.style.display = "none";
-						} else {
-							counterNode.firstChild.textContent = counterNode.firstChild.textContent.replace( oldCount, newCount );
-							counterNode.lastChild.textContent = counterNode.lastChild.textContent.replace( oldCount, newCount );
-						}
-					} ) );
-				}
-				indexationNotice.remove();
-			}
+			removeAlert( "wpseo-reindex" );
 			window.yoastIndexingData.amount = "0";
 		}
-	}, [ indexingState ] );
+	}, [ indexingState, removeAlert ] );
 
 	const isStep2Finished = isStepFinished( STEPS.siteRepresentation );
 	const isStep3Finished = isStepFinished( STEPS.socialProfiles );

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -17,6 +17,7 @@ import { getMigratingNoticeInfo, deleteMigratingNotices } from "../helpers/migra
 import Notice from "./components/notice";
 import WebinarPromoNotification from "../components/WebinarPromoNotification";
 import { shouldShowWebinarPromotionNotificationInDashboard } from "../helpers/shouldShowWebinarPromotionNotification";
+import { useNotificationCountSync } from "./hooks/use-notification-count-sync";
 import { STEPS as FTC_STEPS } from "../first-time-configuration/constants";
 
 /**
@@ -79,6 +80,7 @@ const App = () => {
 	const { pathname } = useLocation();
 	const alertToggleError = useSelectGeneralPage( "selectAlertToggleError", [], [] );
 	const { setAlertToggleError } = useDispatch( STORE_NAME );
+	useNotificationCountSync();
 
 	const handleDismiss = useCallback( () => {
 		setAlertToggleError( null );

--- a/packages/js/src/general/hooks/index.js
+++ b/packages/js/src/general/hooks/index.js
@@ -1,2 +1,2 @@
-
+export { useNotificationCountSync } from "./use-notification-count-sync";
 export { default as useSelectGeneralPage } from "./use-select-general-page";

--- a/packages/js/src/general/hooks/use-notification-count-sync.js
+++ b/packages/js/src/general/hooks/use-notification-count-sync.js
@@ -1,0 +1,16 @@
+import { useSelect } from "@wordpress/data";
+import { useEffect } from "@wordpress/element";
+import { updateNotificationsCount } from "../../shared-admin/helpers";
+import { STORE_NAME } from "../constants";
+
+/**
+ * Sync the notification count with the Yoast menu and admin bar.
+ * @returns {void}
+ */
+export const useNotificationCountSync = () => {
+	const activeAlertCount = useSelect( ( select ) => select( STORE_NAME ).selectActiveAlertsCount(), [] );
+
+	useEffect( () => {
+		updateNotificationsCount( activeAlertCount );
+	}, [ activeAlertCount ] );
+};

--- a/packages/js/src/general/store/alert-center.js
+++ b/packages/js/src/general/store/alert-center.js
@@ -68,6 +68,14 @@ const slice = createSlice( {
 	reducers: {
 		toggleAlert,
 		setAlertToggleError,
+		/**
+		 * @param {Object} state The state of the slice.
+		 * @param {string} id The ID of the alert to remove.
+		 * @returns {void}
+		 */
+		removeAlert( state, { payload: id } ) {
+			state.alerts = state.alerts.filter( ( alert ) => alert.id !== id );
+		},
 	},
 	extraReducers: ( builder ) => {
 		builder.addCase( `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload: { id } } ) => {

--- a/packages/js/src/general/store/alert-center.js
+++ b/packages/js/src/general/store/alert-center.js
@@ -14,7 +14,7 @@ const TOGGLE_ALERT_VISIBILITY = "toggleAlertVisibility";
  * @param {boolean} hidden The hidden state of the alert.
  * @returns {Object} Success or error action object.
  */
-export function* toggleAlertStatus( id, nonce, hidden = false ) {
+function* toggleAlertStatus( id, nonce, hidden = false ) {
 	yield{ type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.request }` };
 	try {
 		yield{

--- a/packages/js/src/general/store/alert-center.js
+++ b/packages/js/src/general/store/alert-center.js
@@ -1,8 +1,8 @@
-import { createSlice, createSelector } from "@reduxjs/toolkit";
-import { ASYNC_ACTION_NAMES } from "../../shared-admin/constants";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { select } from "@wordpress/data";
-import { STORE_NAME } from "../constants";
 import { get } from "lodash";
+import { ASYNC_ACTION_NAMES } from "../../shared-admin/constants";
+import { STORE_NAME } from "../constants";
 
 export const ALERT_CENTER_NAME = "alertCenter";
 
@@ -90,7 +90,12 @@ export const getInitialAlertCenterState = slice.getInitialState;
  * @param {object} state The state.
  * @returns {array} The alerts.
  */
-const selectAlerts = ( state ) => get( state, `${ALERT_CENTER_NAME}.alerts`, [] );
+const selectAlerts = ( state ) => get( state, `${ ALERT_CENTER_NAME }.alerts`, [] );
+
+const selectActiveAlerts = createSelector(
+	[ selectAlerts ],
+	( alerts ) => alerts.filter( ( alert ) => ! alert.dismissed )
+);
 
 /**
  * Selector to get the alert toggle error.
@@ -98,26 +103,37 @@ const selectAlerts = ( state ) => get( state, `${ALERT_CENTER_NAME}.alerts`, [] 
  * @param {object} state The state.
  * @returns {string}  id The id of the alert which caused the error..
  */
-const selectAlertToggleError = ( state ) => get( state, `${ALERT_CENTER_NAME}.alertToggleError`, null );
+const selectAlertToggleError = ( state ) => get( state, `${ ALERT_CENTER_NAME }.alertToggleError`, null );
 
 export const alertCenterSelectors = {
 	selectActiveProblems: createSelector(
-		[ selectAlerts ],
-		( alerts ) => alerts.filter( ( alert ) => alert.type === "error" && ! alert.dismissed )
+		[ selectActiveAlerts ],
+		( alerts ) => alerts.filter( ( alert ) => alert.type === "error" )
 	),
 	selectDismissedProblems: createSelector(
 		[ selectAlerts ],
 		( alerts ) => alerts.filter( ( alert ) => alert.type === "error" && alert.dismissed )
 	),
 	selectActiveNotifications: createSelector(
-		[ selectAlerts ],
-		( alerts ) => alerts.filter( ( alert ) => alert.type === "warning" && ! alert.dismissed )
+		[ selectActiveAlerts ],
+		( alerts ) => alerts.filter( ( alert ) => alert.type === "warning" )
 	),
 	selectDismissedNotifications: createSelector(
 		[ selectAlerts ],
 		( alerts ) => alerts.filter( ( alert ) => alert.type === "warning" && alert.dismissed )
 	),
 	selectAlertToggleError,
+	selectAlert: createSelector(
+		[
+			selectAlerts,
+			( state, id ) => id,
+		],
+		( alerts, id ) => alerts.find( ( alert ) => alert.id === id )
+	),
+	selectActiveAlertsCount: createSelector(
+		[ selectActiveAlerts ],
+		( alerts ) => alerts.length
+	),
 };
 
 export const alertCenterActions = {

--- a/packages/js/src/general/store/alert-center.js
+++ b/packages/js/src/general/store/alert-center.js
@@ -17,13 +17,14 @@ const TOGGLE_ALERT_VISIBILITY = "toggleAlertVisibility";
 export function* toggleAlertStatus( id, nonce, hidden = false ) {
 	yield{ type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.request }` };
 	try {
-		yield{ type: TOGGLE_ALERT_VISIBILITY,
+		yield{
+			type: TOGGLE_ALERT_VISIBILITY,
 			payload: {
 				id,
 				nonce,
 				hidden,
 			},
-		    };
+		};
 		return { type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.success }`, payload: { id } };
 	} catch ( error ) {
 		return { type: `${ TOGGLE_ALERT_VISIBILITY }/${ ASYNC_ACTION_NAMES.error }`, payload: { id } };
@@ -172,4 +173,4 @@ export const alertCenterControls = {
 	},
 };
 
-export default slice.reducer;
+export const alertCenterReducer = slice.reducer;

--- a/packages/js/src/general/store/index.js
+++ b/packages/js/src/general/store/index.js
@@ -6,7 +6,7 @@ import { STORE_NAME } from "../constants";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
 import { reducers, selectors, actions } from "@yoast/externals/redux";
 import * as dismissedAlertsControls from "../../redux/controls/dismissedAlerts";
-import alertCenter, { alertCenterActions, alertCenterSelectors, getInitialAlertCenterState, alertCenterControls, ALERT_CENTER_NAME } from "./alert-center";
+import { alertCenterReducer, alertCenterActions, alertCenterSelectors, getInitialAlertCenterState, alertCenterControls, ALERT_CENTER_NAME } from "./alert-center";
 
 const { currentPromotions, dismissedAlerts, isPremium  } = reducers;
 const { isAlertDismissed, getIsPremium, isPromotionActive } = selectors;
@@ -50,7 +50,7 @@ const createStore = ( { initialState } ) => {
 		reducer: combineReducers( {
 			[ LINK_PARAMS_NAME ]: linkParamsReducer,
 			preferences,
-			[ ALERT_CENTER_NAME ]: alertCenter,
+			[ ALERT_CENTER_NAME ]: alertCenterReducer,
 			currentPromotions,
 			dismissedAlerts,
 			isPremium,

--- a/packages/js/src/shared-admin/helpers/index.js
+++ b/packages/js/src/shared-admin/helpers/index.js
@@ -1,1 +1,2 @@
 export { fixWordPressMenuScrolling } from "./fix-wordpress-menu-scrolling";
+export { updateNotificationsCount } from "./notifications-count";

--- a/packages/js/src/shared-admin/helpers/notifications-count.js
+++ b/packages/js/src/shared-admin/helpers/notifications-count.js
@@ -1,0 +1,41 @@
+import { _n, sprintf } from "@wordpress/i18n";
+
+/**
+ * Update the text content of an element if it exists.
+ * @param {HTMLElement} root The root element.
+ * @param {string} selector The selector.
+ * @param {string} text The text.
+ * @returns {HTMLElement|null} The element or null.
+ */
+const updateTextContentIfElementExists = ( root, selector, text ) => {
+	const element = root.querySelector( selector );
+	if ( element ) {
+		element.textContent = text;
+	}
+	return element;
+};
+
+/**
+ * Update the notification total in the Yoast SEO menu and the admin bar badges.
+ * @param {number} total The total number of notifications.
+ * @returns {void}
+ */
+export const updateNotificationsCount = ( total ) => {
+	// Note: these translation is the same as on the server side.
+	/* translators: Hidden accessibility text; %s: number of notifications. */
+	const screenReaderText = sprintf( _n( "%s notification", "%s notifications", total, "wordpress-seo" ), total );
+
+	const menuItems = document.querySelectorAll( "#toplevel_page_wpseo_dashboard .update-plugins" );
+	for ( const menuItem of menuItems ) {
+		menuItem.className = `update-plugins count-${ total }`;
+		updateTextContentIfElementExists( menuItem, ".plugin-count", String( total ) );
+		updateTextContentIfElementExists( menuItem, ".screen-reader-text", screenReaderText );
+	}
+
+	const adminBarItems = document.querySelectorAll( "#wp-admin-bar-wpseo-menu .yoast-issue-counter" );
+	for ( const adminBar of adminBarItems ) {
+		adminBar.classList.toggle( "yst-hidden", total === 0 );
+		updateTextContentIfElementExists( adminBar, ".yoast-issues-count", String( total ) );
+		updateTextContentIfElementExists( adminBar, ".screen-reader-text", screenReaderText );
+	}
+};

--- a/packages/js/tests/general/store/alert-center.test.js
+++ b/packages/js/tests/general/store/alert-center.test.js
@@ -1,59 +1,179 @@
-import { toggleAlertStatus, alertCenterActions, alertCenterSelectors } from "../../../src/general/store/alert-center";
+import { describe, expect, it } from "@jest/globals";
+import { ALERT_CENTER_NAME, alertCenterActions, alertCenterReducer, alertCenterSelectors } from "../../../src/general/store/alert-center";
 
-describe( "toggleAlertStatus", () => {
-	it( "should dispatch the request action", () => {
-		const id = "alertId";
-		const nonce = "alertNonce";
-		const hidden = false;
+it( "ALERT_CENTER_NAME is alertCenter", () => {
+	expect( ALERT_CENTER_NAME ).toBe( "alertCenter" );
+} );
 
-		const generator = toggleAlertStatus( id, nonce, hidden );
+describe( "actions", () => {
+	describe( "removeAlert", () => {
+		it( "should exist", () => {
+			expect( alertCenterActions.removeAlert ).toBeDefined();
+		} );
 
-		expect( generator.next().value ).toEqual( {
-			type: "toggleAlertVisibility/request",
+		it( "should return the action", () => {
+			expect( alertCenterActions.removeAlert( "alertId" ) ).toEqual( { type: "alertCenter/removeAlert", payload: "alertId" } );
 		} );
 	} );
 
-	it( "should dispatch the success action with the correct payload", () => {
-		const id = "alertId";
-		const nonce = "alertNonce";
-		const hidden = false;
-
-		const generator = toggleAlertStatus( id, nonce, hidden );
-
-		generator.next();
-
-		const successAction = generator.next().value;
-
-		expect( successAction.type ).toEqual( "toggleAlertVisibility" );
-		expect( successAction.payload.id ).toEqual( id );
-		expect( successAction.payload.nonce ).toEqual( nonce );
-		expect( successAction.payload.hidden ).toEqual( hidden );
-	} );
-} );
-
-describe( "alertCenterActions", () => {
 	it( "should have the toggleAlert action", () => {
 		expect( alertCenterActions.toggleAlert ).toBeDefined();
-		expect( alertCenterActions.toggleAlertStatus ).toBeDefined();
+	} );
+
+	describe( "toggleAlertStatus", () => {
+		it( "should exist", () => {
+			expect( alertCenterActions.toggleAlertStatus ).toBeDefined();
+		} );
+
+		it( "should dispatch the request action", () => {
+			const id = "alertId";
+			const nonce = "alertNonce";
+			const hidden = false;
+
+			const generator = alertCenterActions.toggleAlertStatus( id, nonce, hidden );
+
+			expect( generator.next().value ).toEqual( {
+				type: "toggleAlertVisibility/request",
+			} );
+		} );
+
+		it( "should dispatch the success action with the correct payload", () => {
+			const id = "alertId";
+			const nonce = "alertNonce";
+			const hidden = false;
+
+			const generator = alertCenterActions.toggleAlertStatus( id, nonce, hidden );
+
+			generator.next();
+
+			const successAction = generator.next().value;
+
+			expect( successAction.type ).toEqual( "toggleAlertVisibility" );
+			expect( successAction.payload.id ).toEqual( id );
+			expect( successAction.payload.nonce ).toEqual( nonce );
+			expect( successAction.payload.hidden ).toEqual( hidden );
+		} );
 	} );
 } );
 
-describe( "alertCenterSelectors", () => {
-	it( "should have the selectActiveNotifications selector", () => {
-		expect( alertCenterSelectors.selectActiveNotifications ).toBeDefined();
-	} );
-
-	it( "should have the selectDismissedNotifications selector", () => {
-		expect( alertCenterSelectors.selectDismissedNotifications ).toBeDefined();
-	} );
-
-	it( "should have the selectActiveProblems selector", () => {
-		expect( alertCenterSelectors.selectActiveProblems ).toBeDefined();
-	} );
-
-	it( "should have the selectDismissedProblems selector", () => {
-		expect( alertCenterSelectors.selectDismissedProblems ).toBeDefined();
+describe( "initial state", () => {
+	it( "should have an empty alerts array and no error", () => {
+		expect( alertCenterReducer( undefined, { type: "" } ) ).toEqual( { alerts: [], alertToggleError: null } );
 	} );
 } );
 
+describe( "reducer", () => {
+	describe( "removeAlert", () => {
+		it( "should remove the alert", () => {
+			const state = {
+				alerts: [
+					{ id: "alertId" },
+				],
+			};
+			const newState = alertCenterReducer( state, alertCenterActions.removeAlert( "alertId" ) );
+			expect( newState ).toEqual( { alerts: [] } );
+		} );
 
+		it( "should not change if trying to remove an unknown alert", () => {
+			const state = {
+				alerts: [
+					{ id: "alertId" },
+				],
+			};
+			const newState = alertCenterReducer( state, alertCenterActions.removeAlert( "unknown" ) );
+			expect( newState ).toEqual( state );
+		} );
+	} );
+} );
+
+describe( "selectors", () => {
+	const state = {
+		[ ALERT_CENTER_NAME ]: {
+			alerts: [
+				{ id: "foo", type: "error", dismissed: false },
+				{ id: "bar", type: "warning", dismissed: false },
+				{ id: "baz", type: "error", dismissed: true },
+				{ id: "qux", type: "warning", dismissed: true },
+			],
+			alertToggleError: "qux",
+		},
+	};
+
+	describe( "selectActiveNotifications", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectActiveNotifications ).toBeDefined();
+		} );
+
+		it( "should return the active notifications", () => {
+			expect( alertCenterSelectors.selectActiveNotifications( state ) ).toEqual( [
+				{ id: "bar", type: "warning", dismissed: false },
+			] );
+		} );
+	} );
+
+	describe( "selectActiveProblems", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectActiveProblems ).toBeDefined();
+		} );
+
+		it( "should return the active problems", () => {
+			expect( alertCenterSelectors.selectActiveProblems( state ) ).toEqual( [
+				{ id: "foo", type: "error", dismissed: false },
+			] );
+		} );
+	} );
+
+	describe( "selectActiveAlertsCount", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectActiveAlertsCount ).toBeDefined();
+		} );
+
+		it( "should return the active alerts count", () => {
+			expect( alertCenterSelectors.selectActiveAlertsCount( state ) ).toEqual( 2 );
+		} );
+	} );
+
+	describe( "selectAlert", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectAlert ).toBeDefined();
+		} );
+
+		it( "should return the alert with the given id", () => {
+			expect( alertCenterSelectors.selectAlert( state, "foo" ) ).toEqual( { id: "foo", type: "error", dismissed: false } );
+		} );
+	} );
+
+	describe( "selectAlertToggleError", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectAlertToggleError ).toBeDefined();
+		} );
+
+		it( "should return the alert toggle error", () => {
+			expect( alertCenterSelectors.selectAlertToggleError( state ) ).toEqual( "qux" );
+		} );
+	} );
+
+	describe( "selectDismissedNotifications", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectDismissedNotifications ).toBeDefined();
+		} );
+
+		it( "should return the dismissed notifications", () => {
+			expect( alertCenterSelectors.selectDismissedNotifications( state ) ).toEqual( [
+				{ id: "qux", type: "warning", dismissed: true },
+			] );
+		} );
+	} );
+
+	describe( "selectDismissedProblems", () => {
+		it( "should exist", () => {
+			expect( alertCenterSelectors.selectDismissedProblems ).toBeDefined();
+		} );
+
+		it( "should return the dismissed problems", () => {
+			expect( alertCenterSelectors.selectDismissedProblems( state ) ).toEqual( [
+				{ id: "baz", type: "error", dismissed: true },
+			] );
+		} );
+	} );
+} );

--- a/packages/js/tests/shared-admin/helpers/__snapshots__/notifications-count.test.js.snap
+++ b/packages/js/tests/shared-admin/helpers/__snapshots__/notifications-count.test.js.snap
@@ -1,0 +1,463 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`updateNotificationsCount updates the total in the admin bar to 0 [yst-hidden class triggering hidden css] 1`] = `
+<div>
+  <div
+    class="no-js"
+    id="wpadminbar"
+  >
+    <div
+      aria-label="Toolbar"
+      class="quicklinks"
+      id="wp-toolbar"
+      role="navigation"
+    >
+      <ul
+        class="ab-top-menu"
+        id="wp-admin-bar-root-default"
+        role="menu"
+      >
+        <li
+          class="menupop"
+          id="wp-admin-bar-wpseo-menu"
+          role="group"
+        >
+          <a
+            aria-expanded="false"
+            class="ab-item"
+            href="/wp-admin/admin.php?page=wpseo_dashboard"
+            role="menuitem"
+          >
+            <div
+              class="wp-core-ui wp-ui-notification yoast-issue-counter yst-hidden"
+            >
+              <span
+                aria-hidden="true"
+                class="yoast-issues-count"
+              >
+                0
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                0 notifications
+              </span>
+            </div>
+          </a>
+          <div
+            class="ab-sub-wrapper"
+          >
+            <ul
+              class="ab-submenu"
+              id="wp-admin-bar-wpseo-menu-default"
+              role="menu"
+            >
+              <li
+                id="wp-admin-bar-wpseo-notifications"
+                role="group"
+              >
+                <a
+                  class="ab-item"
+                  href="/wp-admin/admin.php?page=wpseo_dashboard"
+                  role="menuitem"
+                >
+                  Notifications 
+                  <div
+                    class="wp-core-ui wp-ui-notification yoast-issue-counter yst-hidden"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="yoast-issues-count"
+                    >
+                      0
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      0 notifications
+                    </span>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`updateNotificationsCount updates the total in the admin bar to 1 [screen-reader singular in English] 1`] = `
+<div>
+  <div
+    class="no-js"
+    id="wpadminbar"
+  >
+    <div
+      aria-label="Toolbar"
+      class="quicklinks"
+      id="wp-toolbar"
+      role="navigation"
+    >
+      <ul
+        class="ab-top-menu"
+        id="wp-admin-bar-root-default"
+        role="menu"
+      >
+        <li
+          class="menupop"
+          id="wp-admin-bar-wpseo-menu"
+          role="group"
+        >
+          <a
+            aria-expanded="false"
+            class="ab-item"
+            href="/wp-admin/admin.php?page=wpseo_dashboard"
+            role="menuitem"
+          >
+            <div
+              class="wp-core-ui wp-ui-notification yoast-issue-counter"
+            >
+              <span
+                aria-hidden="true"
+                class="yoast-issues-count"
+              >
+                1
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                1 notification
+              </span>
+            </div>
+          </a>
+          <div
+            class="ab-sub-wrapper"
+          >
+            <ul
+              class="ab-submenu"
+              id="wp-admin-bar-wpseo-menu-default"
+              role="menu"
+            >
+              <li
+                id="wp-admin-bar-wpseo-notifications"
+                role="group"
+              >
+                <a
+                  class="ab-item"
+                  href="/wp-admin/admin.php?page=wpseo_dashboard"
+                  role="menuitem"
+                >
+                  Notifications 
+                  <div
+                    class="wp-core-ui wp-ui-notification yoast-issue-counter"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="yoast-issues-count"
+                    >
+                      1
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      1 notification
+                    </span>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`updateNotificationsCount updates the total in the admin bar to 3 [screen-reader plural in English] 1`] = `
+<div>
+  <div
+    class="no-js"
+    id="wpadminbar"
+  >
+    <div
+      aria-label="Toolbar"
+      class="quicklinks"
+      id="wp-toolbar"
+      role="navigation"
+    >
+      <ul
+        class="ab-top-menu"
+        id="wp-admin-bar-root-default"
+        role="menu"
+      >
+        <li
+          class="menupop"
+          id="wp-admin-bar-wpseo-menu"
+          role="group"
+        >
+          <a
+            aria-expanded="false"
+            class="ab-item"
+            href="/wp-admin/admin.php?page=wpseo_dashboard"
+            role="menuitem"
+          >
+            <div
+              class="wp-core-ui wp-ui-notification yoast-issue-counter"
+            >
+              <span
+                aria-hidden="true"
+                class="yoast-issues-count"
+              >
+                3
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                3 notifications
+              </span>
+            </div>
+          </a>
+          <div
+            class="ab-sub-wrapper"
+          >
+            <ul
+              class="ab-submenu"
+              id="wp-admin-bar-wpseo-menu-default"
+              role="menu"
+            >
+              <li
+                id="wp-admin-bar-wpseo-notifications"
+                role="group"
+              >
+                <a
+                  class="ab-item"
+                  href="/wp-admin/admin.php?page=wpseo_dashboard"
+                  role="menuitem"
+                >
+                  Notifications 
+                  <div
+                    class="wp-core-ui wp-ui-notification yoast-issue-counter"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="yoast-issues-count"
+                    >
+                      3
+                    </span>
+                    <span
+                      class="screen-reader-text"
+                    >
+                      3 notifications
+                    </span>
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`updateNotificationsCount updates the total in the admin menu to 0 [count-0 class triggering hidden css] 1`] = `
+<div>
+  <div
+    id="adminmenuwrap"
+  >
+    <ul
+      id="adminmenu"
+    >
+      <li
+        id="toplevel_page_wpseo_dashboard"
+      >
+        <a
+          href="admin.php?page=wpseo_dashboard"
+        >
+          <div
+            class="wp-menu-name"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-0"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                0
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                0 notifications
+              </span>
+            </span>
+          </div>
+        </a>
+        <ul
+          class="wp-submenu wp-submenu-wrap"
+        >
+          <li
+            aria-hidden="true"
+            class="wp-submenu-head"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-0"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                0
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                0 notifications
+              </span>
+            </span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`updateNotificationsCount updates the total in the admin menu to 1 [screen-reader singular in English] 1`] = `
+<div>
+  <div
+    id="adminmenuwrap"
+  >
+    <ul
+      id="adminmenu"
+    >
+      <li
+        id="toplevel_page_wpseo_dashboard"
+      >
+        <a
+          href="admin.php?page=wpseo_dashboard"
+        >
+          <div
+            class="wp-menu-name"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-1"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                1
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                1 notification
+              </span>
+            </span>
+          </div>
+        </a>
+        <ul
+          class="wp-submenu wp-submenu-wrap"
+        >
+          <li
+            aria-hidden="true"
+            class="wp-submenu-head"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-1"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                1
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                1 notification
+              </span>
+            </span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`updateNotificationsCount updates the total in the admin menu to 3 [screen-reader plural in English] 1`] = `
+<div>
+  <div
+    id="adminmenuwrap"
+  >
+    <ul
+      id="adminmenu"
+    >
+      <li
+        id="toplevel_page_wpseo_dashboard"
+      >
+        <a
+          href="admin.php?page=wpseo_dashboard"
+        >
+          <div
+            class="wp-menu-name"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-3"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                3
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                3 notifications
+              </span>
+            </span>
+          </div>
+        </a>
+        <ul
+          class="wp-submenu wp-submenu-wrap"
+        >
+          <li
+            aria-hidden="true"
+            class="wp-submenu-head"
+          >
+            Yoast SEO 
+            <span
+              class="update-plugins count-3"
+            >
+              <span
+                aria-hidden="true"
+                class="plugin-count"
+              >
+                3
+              </span>
+              <span
+                class="screen-reader-text"
+              >
+                3 notifications
+              </span>
+            </span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/packages/js/tests/shared-admin/helpers/notifications-count.test.js
+++ b/packages/js/tests/shared-admin/helpers/notifications-count.test.js
@@ -1,0 +1,122 @@
+/* eslint-disable react/prop-types */
+import { describe, expect, it } from "@jest/globals";
+import { updateNotificationsCount } from "../../../src/shared-admin/helpers";
+import { render } from "../../test-utils";
+
+/**
+ * Simplified version of the admin bar count. With incorrect singular/plural.
+ * @param {number} total The total number of notifications.
+ * @returns {JSX.Element} The admin menu count.
+ */
+const AdminMenuCountHtml = ( { total } ) => (
+	<span className={ `update-plugins count-${ total }` }>
+		<span className="plugin-count" aria-hidden="true">{ total }</span>
+		<span className="screen-reader-text">{ total } notifications</span>
+	</span>
+);
+
+/**
+ * Creates a fake admin menu.
+ * The content is a simplified copy of the admin menu structure from the WordPress admin.
+ * But with only the Yoast SEO list item in the menu.
+ * @param {number} total The total number of notifications.
+ * @returns {JSX.Element} The element.
+ */
+const FakeAdminMenu = ( { total = 2 } ) => (
+	<div id="adminmenuwrap">
+		<ul id="adminmenu">
+			<li id="toplevel_page_wpseo_dashboard">
+				<a href="admin.php?page=wpseo_dashboard">
+					<div className="wp-menu-name">
+						Yoast SEO <AdminMenuCountHtml total={ total } />
+					</div>
+				</a>
+				<ul className="wp-submenu wp-submenu-wrap">
+					<li className="wp-submenu-head" aria-hidden="true">
+						Yoast SEO <AdminMenuCountHtml total={ total } />
+					</li>
+				</ul>
+			</li>
+		</ul>
+	</div>
+);
+
+/**
+ * Simplified version of the admin bar count. With incorrect singular/plural.
+ * @param {number} total The total number of notifications.
+ * @returns {JSX.Element} The admin bar count.
+ */
+const AdminBarCountHtml = ( { total } ) => (
+	<div className={ `wp-core-ui wp-ui-notification yoast-issue-counter${ total === 0 ? " yst-hidden" : "" }` }>
+		<span className="yoast-issues-count" aria-hidden="true">${ total }</span>
+		<span className="screen-reader-text">${ total } notifications</span>
+	</div>
+);
+
+/**
+ * Creates a fake admin bar.
+ * The content is a simplified copy of the admin bar structure from the WordPress admin.
+ * But with only the Yoast SEO section in the first menu.
+ * @param {number} total The total number of notifications.
+ * @returns {JSX.Element} The element.
+ */
+const FakeAdminBar = ( { total = 2 } ) => (
+	<div id="wpadminbar" className="no-js">
+		<div className="quicklinks" id="wp-toolbar" role="navigation" aria-label="Toolbar">
+			<ul role="menu" id="wp-admin-bar-root-default" className="ab-top-menu">
+				<li role="group" id="wp-admin-bar-wpseo-menu" className="menupop">
+					<a className="ab-item" role="menuitem" aria-expanded="false" href="/wp-admin/admin.php?page=wpseo_dashboard">
+						<AdminBarCountHtml total={ total } />
+					</a>
+					<div className="ab-sub-wrapper">
+						<ul role="menu" id="wp-admin-bar-wpseo-menu-default" className="ab-submenu">
+							<li role="group" id="wp-admin-bar-wpseo-notifications">
+								<a className="ab-item" role="menuitem" href="/wp-admin/admin.php?page=wpseo_dashboard">
+									Notifications <AdminBarCountHtml total={ total } />
+								</a>
+							</li>
+						</ul>
+					</div>
+				</li>
+			</ul>
+		</div>
+	</div>
+);
+
+describe( "updateNotificationsCount", () => {
+	it( "does not throw an error when the elements are not there", () => {
+		expect( updateNotificationsCount ).not.toThrow();
+	} );
+
+	it( "does not throw an error when the inner elements are not there", () => {
+		render( <>
+			<div id="toplevel_page_wpseo_dashboard">
+				<div className="update-plugins" />
+			</div>
+			<div id="wp-admin-bar-wpseo-menu">
+				<div className="yoast-issue-counter" />
+			</div>
+		</> );
+		expect( updateNotificationsCount ).not.toThrow();
+	} );
+
+	test.each( [
+		[ 3, "screen-reader plural in English" ],
+		[ 1, "screen-reader singular in English" ],
+		[ 0, "count-0 class triggering hidden css" ],
+	] )( "updates the total in the admin menu to %i [%s]", ( total ) => {
+		const { container } = render( <FakeAdminMenu /> );
+		updateNotificationsCount( total );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	test.each( [
+		[ 3, "screen-reader plural in English" ],
+		[ 1, "screen-reader singular in English" ],
+		[ 0, "yst-hidden class triggering hidden css" ],
+	] )( "updates the total in the admin bar to %i [%s]", ( total ) => {
+		const { container } = render( <FakeAdminBar /> );
+		updateNotificationsCount( total );
+		expect( container ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Update our notification count (badges) in the Yoast menu and admin bar
* Created from https://github.com/Yoast/wordpress-seo/pull/21747, after a botched rebase.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the notification count in the admin menu and bar would not update when interacting with the show/hide functionality on the general page.
* Fixes an unreleased bug where completing the SEO data optimization from within the First time configuration would not result in automatically dismissing the respective notification in the general page.

## Relevant technical choices:

* I was doubting where to place the side-effect for the updates. The action is the correct place in time. But the store reducer/control seems like a bad place to add side-effects. So at first I added it to where you call the action. But then I needed the remove too, which needs the same sync after. So instead I ended up creating a sync hook and selector.
* The new helper fixes a pre-existing issue where the screen-reader text would be removed instead of updated. 
* The PHP change fixes a pre-existing issue where if the initial count is 0, no count update would be possible.
* The FTC change fixes a pre-existing issue where the count would decrement even if the reindex notice would be hidden.
* Refactored the selectors a bit to use the selectActive I used for the count selector. Improved the test coverage while at it.
* About the tests, that is a bit of strange one with the JSX and React component mimicking the menus. But that is just the easiest for me to get a snapshot situation going that I could at least check a bit. Otherwise I'm just writing the same selectors again in the test, which seemed redundant.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have some problem and notification. I used the site no-index under Settings > Reading and resetting the indexables/migrations with our test helper (which is needed anyway for the FTC check)
* Go to the new general page
* Verify the counts are correct: the sum of the problems and notifications should be reflected in the Yoast admin and menu bar badges.
![Screenshot 2024-10-24 at 14 30 48](https://github.com/user-attachments/assets/ec516d0f-88b8-4a84-b4a0-dbede2d6fec8)
* Play around with hiding/showing problems and notifications:
  * Go to 0, the badges should be gone
* Verify the count updates correctly each time
* Hide all the problems/notifications
* Reload the page
* Make the problems/notifications visible again
* Verify the badges appeared again
* Ensure you have the re-index notification (resetting the indexables) and that is not hidden
* Go to the first time configuration
* Run the SEO data optimization from the first step
* Verify the count went down by 1
* Without reloading, go to the alert center
* Verify the notification is totally gone
* Reset your indexables again
* Go back to the alert center
* Hide the re-index notification
* Go to the first time configuration
* Run the SEO data optimization from the first step
* Verify the count did not go down
* Without reloading, go to the alert center
* Verify the notification is totally gone

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The new general page, and the SEO data optimization complete on the FTC

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21724
