### PR TITLE
Fix PHP warning when errors where dismissed in the alert center

### DIFF
--- a/admin/views/partial-notifications-errors.php
+++ b/admin/views/partial-notifications-errors.php
@@ -17,8 +17,13 @@ $yoast_seo_active_total    = count( $yoast_seo_active );
 $yoast_seo_dismissed_total = count( $yoast_seo_dismissed );
 $yoast_seo_total           = $notifications_data['metrics']['errors'];
 
-$yoast_seo_i18n_title     = __( 'Problems', 'wordpress-seo' );
-$yoast_seo_i18n_issues    = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
-$yoast_seo_i18n_no_issues = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
+$yoast_seo_i18n_title              = __( 'Problems', 'wordpress-seo' );
+$yoast_seo_i18n_issues             = __( 'We have detected the following issues that affect the SEO of your site.', 'wordpress-seo' );
+$yoast_seo_i18n_no_issues          = __( 'Good job! We could detect no serious SEO problems.', 'wordpress-seo' );
+$yoast_seo_i18n_muted_issues_title = sprintf(
+	/* translators: %d expands the amount of hidden notifications. */
+	_n( 'You have %d hidden notification:', 'You have %d hidden notifications:', $yoast_seo_dismissed_total, 'wordpress-seo' ),
+	$yoast_seo_dismissed_total
+);
 
 require WPSEO_PATH . 'admin/views/partial-notifications-template.php';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a PHP notice (warning in PHP 8+) would be thrown when an error was dismissed in the new general page's alert center

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the new general page, but make sure you have at least one error there
  * To do so, mark the site as discouraged to be indexed by search engines in the site's settings
* Confirm that you get an error in the alert center
* Go and hide/dismiss the error
* Confirm that you dont get a PHP notice (or warning) like: `PHP Notice:  Undefined variable: yoast_seo_i18n_muted_issues_title` in the debug.log
  * Without this PR/RC, you would get one
* Now create another error on top of the one you already have
  * To do so, activate Premium but don't activate a subscription for this website
* Hide both and restore both and play around a bit with those errors
* Confirm that you still didnt get any PHP notice 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/310
