### PR TITLE
Stop showing zero notification bubble outside yoast pages

### DIFF
--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -111,6 +111,10 @@
   color: #f18500;
 }
 
+#wpadminbar .wpseo-no-adminbar-notifications {
+  display: none;
+}
+
 @media screen and (max-width: 782px) {
   #wp-admin-bar-wpseo-menu .wpseo-score-icon {
     margin: 16px 10px 0 2px !important;

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -359,6 +359,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		$settings_url       = '';
 		$counter            = '';
 		$notification_popup = '';
+		$notification_count = 0;
 
 		$post = $this->get_singular_post();
 		if ( $post ) {
@@ -377,7 +378,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		if ( empty( $score ) && ! is_network_admin() && $can_manage_options ) {
-			$counter            = $this->get_notification_counter();
+			$notification_center = Yoast_Notification_Center::get();
+			$notification_count  = $notification_center->get_notification_count();
+
+			$counter            = $this->get_notification_counter( $notification_count );
 			$notification_popup = $this->get_notification_popup();
 		}
 
@@ -389,7 +393,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		];
 		$wp_admin_bar->add_menu( $admin_bar_menu_args );
 
-		if ( ! empty( $counter ) ) {
+		if ( $notification_count > 0 ) {
 			$admin_bar_menu_args = [
 				'parent' => self::MENU_IDENTIFIER,
 				'id'     => 'wpseo-notifications',
@@ -849,18 +853,17 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	/**
 	 * Gets the notification counter if in a valid context.
 	 *
+	 * @param int $notification_count Number of notifications.
+	 *
 	 * @return string Notification counter markup, or empty string if not available.
 	 */
-	protected function get_notification_counter() {
-		$notification_center = Yoast_Notification_Center::get();
-		$notification_count  = $notification_center->get_notification_count();
-
+	protected function get_notification_counter( $notification_count ) {
 		/* translators: Hidden accessibility text; %s: number of notifications. */
 		$counter_screen_reader_text = sprintf( _n( '%s notification', '%s notifications', $notification_count, 'wordpress-seo' ), number_format_i18n( $notification_count ) );
 
 		return sprintf(
 			' <div class="wp-core-ui wp-ui-notification yoast-issue-counter%s"><span class="yoast-issues-count" aria-hidden="true">%d</span><span class="screen-reader-text">%s</span></div>',
-			( $notification_count ) ? '' : ' yst-hidden',
+			( $notification_count ) ? '' : ' wpseo-no-adminbar-notifications',
 			$notification_count,
 			$counter_screen_reader_text
 		);

--- a/packages/js/src/shared-admin/helpers/notifications-count.js
+++ b/packages/js/src/shared-admin/helpers/notifications-count.js
@@ -34,7 +34,7 @@ export const updateNotificationsCount = ( total ) => {
 
 	const adminBarItems = document.querySelectorAll( "#wp-admin-bar-wpseo-menu .yoast-issue-counter" );
 	for ( const adminBar of adminBarItems ) {
-		adminBar.classList.toggle( "yst-hidden", total === 0 );
+		adminBar.classList.toggle( "wpseo-no-adminbar-notifications", total === 0 );
 		updateTextContentIfElementExists( adminBar, ".yoast-issues-count", String( total ) );
 		updateTextContentIfElementExists( adminBar, ".screen-reader-text", screenReaderText );
 	}

--- a/packages/js/tests/shared-admin/helpers/__snapshots__/notifications-count.test.js.snap
+++ b/packages/js/tests/shared-admin/helpers/__snapshots__/notifications-count.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`updateNotificationsCount updates the total in the admin bar to 0 [yst-hidden class triggering hidden css] 1`] = `
+exports[`updateNotificationsCount updates the total in the admin bar to 0 [wpseo-no-adminbar-notifications class triggering hidden css] 1`] = `
 <div>
   <div
     class="no-js"
@@ -29,7 +29,7 @@ exports[`updateNotificationsCount updates the total in the admin bar to 0 [yst-h
             role="menuitem"
           >
             <div
-              class="wp-core-ui wp-ui-notification yoast-issue-counter yst-hidden"
+              class="wp-core-ui wp-ui-notification yoast-issue-counter wpseo-no-adminbar-notifications"
             >
               <span
                 aria-hidden="true"
@@ -63,7 +63,7 @@ exports[`updateNotificationsCount updates the total in the admin bar to 0 [yst-h
                 >
                   Notifications 
                   <div
-                    class="wp-core-ui wp-ui-notification yoast-issue-counter yst-hidden"
+                    class="wp-core-ui wp-ui-notification yoast-issue-counter wpseo-no-adminbar-notifications"
                   >
                     <span
                       aria-hidden="true"

--- a/packages/js/tests/shared-admin/helpers/notifications-count.test.js
+++ b/packages/js/tests/shared-admin/helpers/notifications-count.test.js
@@ -47,7 +47,7 @@ const FakeAdminMenu = ( { total = 2 } ) => (
  * @returns {JSX.Element} The admin bar count.
  */
 const AdminBarCountHtml = ( { total } ) => (
-	<div className={ `wp-core-ui wp-ui-notification yoast-issue-counter${ total === 0 ? " yst-hidden" : "" }` }>
+	<div className={ `wp-core-ui wp-ui-notification yoast-issue-counter${ total === 0 ? " wpseo-no-adminbar-notifications" : "" }` }>
 		<span className="yoast-issues-count" aria-hidden="true">${ total }</span>
 		<span className="screen-reader-text">${ total } notifications</span>
 	</div>
@@ -113,7 +113,7 @@ describe( "updateNotificationsCount", () => {
 	test.each( [
 		[ 3, "screen-reader plural in English" ],
 		[ 1, "screen-reader singular in English" ],
-		[ 0, "yst-hidden class triggering hidden css" ],
+		[ 0, "wpseo-no-adminbar-notifications class triggering hidden css" ],
 	] )( "updates the total in the admin bar to %i [%s]", ( total ) => {
 		const { container } = render( <FakeAdminBar /> );
 		updateNotificationsCount( total );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* https://github.com/Yoast/wordpress-seo/pull/21781 brought a regression of showing a bubble with zero notifications on non-Yoast pages:
![image](https://github.com/user-attachments/assets/05ce7ef8-4302-44a8-81c5-bd8e587ef722)
* We need to hide that there, as we already do in Yoast pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug, where a bubble with zero notifications would be shown outside Yoast pages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure that you have no errors/notifications in the General page
* Confirm that you see no notification bubble in the admin bar:
![image](https://github.com/user-attachments/assets/d9e74650-f51d-4052-b8bb-8f847c9b2779)
* Go to a non-Yoast page, eg. the plugins page
* Confirm again that you see no notification bubble in the admin bar.
* Go to a Yoast page, eg. the Yoast settings page
* Confirm again that you see no notification bubble in the admin bar
* Repeat the tests above, but this time while having at least one error/notification

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

**Check adminbar behavior**:
* Create an empty post with a keyphrase and visit the frrontend
* Confirm that the topbar shows the red mark, both for sites where the have zero notifications in the admin, and for sites that have at least one notification in the admin
* Go to a network admin site and confirm that there is never a notification bubble on the topbar
* Log in as a contributor and confirm that there is never a notification bubble on the topbar.
* As an admin, use the test helper to enable books and movies. Once you do, confirm that
  * a notification was added to inform users that an extra post type was added, prompting them to go to settings
  * a pop-up was also added, with the `There is a new notification` message: 
![image](https://github.com/user-attachments/assets/d7447801-e9f3-4305-88b7-a5a151c782f2)

Regression test updating counters in the new General page:
* Repeat test instructions of https://github.com/Yoast/wordpress-seo/pull/21781

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/1944
