### PR TITLE
21712 add more portuguese transition words

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/en/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/config/transitionWords.js
@@ -11,7 +11,7 @@ export const singleWords = [ "accordingly", "additionally", "afterward", "afterw
 	"shortly", "significantly", "similarly", "simultaneously", "since", "so", "soon", "specifically", "still", "straightaway",
 	"subsequently", "surely", "surprisingly", "than", "then", "thereafter", "therefore", "thereupon", "thirdly", "though",
 	"thus", "till", "undeniably", "undoubtedly", "unless", "unlike", "unquestionably", "until", "when", "whenever",
-	"whereas", "while", "whether", "if", "actually" ];
+	"whereas", "while", "whether", "if", "actually", "anyway", "anyways", "anyhow", "mostly", "namely", "including", "suddenly" ];
 export const multipleWords = [ "above all", "after all", "after that", "all in all", "all of a sudden", "all things considered",
 	"analogous to", "although this may be true", "analogous to", "another key point", "as a matter of fact", "as a result",
 	"as an illustration", "as can be seen", "as has been noted", "as I have noted", "as I have said", "as I have shown",
@@ -23,7 +23,7 @@ export const multipleWords = [ "above all", "after all", "after that", "all in a
 	"for one thing", "for that reason", "for the most part", "for the purpose of", "for the same reason", "for this purpose",
 	"for this reason", "from time to time", "given that", "given these points", "important to realize", "in a word", "in addition",
 	"in another case", "in any case", "in any event", "in brief", "in case", "in conclusion", "in contrast",
-	"in detail", "in due time", "in effect", "in either case", "in essence", "in fact", "in general", "in light of",
+	"in detail", "in due time", "in effect", "in either case", "either way", "in essence", "in fact", "in general", "in light of",
 	"in like fashion", "in like manner", "in order that", "in order to", "in other words", "in particular", "in reality",
 	"in short", "in similar fashion", "in spite of", "in sum", "in summary", "in that case", "in the event that",
 	"in the final analysis", "in the first place", "in the fourth place", "in the hope that", "in the light of",
@@ -31,16 +31,17 @@ export const multipleWords = [ "above all", "after all", "after that", "all in a
 	"in the third place", "in this case", "in this situation", "in time", "in truth", "in view of", "inasmuch as",
 	"most compelling evidence", "most important", "must be remembered", "not only", "not to mention", "note that",
 	"now that", "of course", "on account of", "on balance", "on condition that", "on one hand", "on the condition that", "on the contrary",
-	"on the negative side", "on the other hand", "on the positive side", "on the whole", "on this occasion", "once",
+	"on the negative side", "on the other hand", "on the positive side", "on the whole", "on this occasion", "all at once",
 	"once in a while", 	"only if", "owing to", "point often overlooked", "prior to", "provided that", "seeing that",
 	"so as to", "so far", "so long as", "so that", "sooner or later", "such as", "summing up", "take the case of",
 	"that is", "that is to say", "then again", "this time", "to be sure", "to begin with", "to clarify", "to conclude",
 	"to demonstrate", "to emphasize", "to enumerate", "to explain", "to illustrate", "to list", "to point out",
 	"to put it another way", "to put it differently", "to repeat", "to rephrase it", "to say nothing of", "to sum up",
 	"to summarize", "to that end", "to the end that", "to this end", "together with", "under those circumstances", "until now",
-	"up against", "up to the present time", "vis a vis", "what's more", "while it may be true", "while this may be true",
+	"up against", "up to the present time", "vis a vis", "what's more", "what is more", "while it may be true", "while this may be true",
 	"with attention to", "with the result that", "with this in mind", "with this intention", "with this purpose in mind",
-	"without a doubt", "without delay", "without doubt", "without reservation", "according to", "no sooner" ];
+	"without a doubt", "without delay", "without doubt", "without reservation", "according to", "no sooner", "at most", "at the most",
+	"from now on" ];
 
 export const allWords = singleWords.concat( multipleWords );
 

--- a/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/config/transitionWords.js
@@ -4,7 +4,6 @@ export const singleWords = [
 	"igualmente", "inegavelmente", "inesperadamente", "mas", "ocasionalmente", "outrossim", "pois", "porquanto",
 	"porque", "portanto", "posteriormente", "precipuamente", "primeiramente", "primordialmente", "principalmente",
 	"salvo", "semelhantemente", "similarmente", "sobretudo", "surpreendentemente", "todavia", "logo", "inclusive",
-	"curiosamente"
 ];
 
 export const multipleWords = [
@@ -19,14 +18,17 @@ export const multipleWords = [
 	"em suma", "em terceiro lugar", "em virtude de", "finalmente", "isto é", "já que", "juntamente com", "logo após",
 	"logo depois", "logo que", "mesmo que", "não apenas", "nesse hiato", "nesse ínterim", "nesse meio tempo", "nesse sentido",
 	"no entanto", "no momento em que", "ou por outra", "ou seja", "para que", "pelo contrário", "por analogia", "por causa de",
-	"por certo", "por conseguinte", "por consequência", "porém", "por exemplo", "por fim", "por isso", "por mais que",
+	"por certo", "por conseguinte", "por consequência", "por conseqüência", "porém", "por exemplo", "por fim", "por isso", "por mais que",
 	"por menos que", "por outro lado", "por vezes", "posto que", "se acaso", "se bem que", "seja como for", "sem dúvida",
 	"sempre que", "só para exemplificar", "só para ilustrar", "só que", "sob o mesmo ponto de vista", "talvez provavelmente",
-	"tanto quanto", "todas as vezes que", "todas as vezes em que", "uma vez que", "visto que", "de repente", "por aí",
-	"enquanto isso", "nada obstante", "por isso mesmo", "de qualquer forma", "diga-se de passagem", "de qualquer jeito",
-	"de vez em quando", "aos poucos", "diante disso", "até porque", "bom", "claro que", "quem diria", "no geral"
+	"tanto quanto", "todas as vezes que", "todas as vezes em que", "uma vez que", "visto que", "de repente",
+	"nada obstante", "não obstante", "de qualquer forma", "diga-se de passagem", "de qualquer jeito",
+	"de vez em quando", "aos poucos", "claro que", "no geral", "em geral", "geralmente", "subitamente", "a despeito de",
+	"em razão de", "em razão disso", "razão pela qual", "por essa razão", "por motivo de", "devido a", "em todo o caso", "de qualquer maneira",
+	"de todo modo", "de todo a modo", "de qualquer modo", "de forma que", "de modo que", "de tempos em tempos", "daí em diante", " daí por diante",
+	"de hoje em diante", "a partir de agora", "de agora em diante",
 ];
 
-export const allWords = singleWords.concat(multipleWords);
+export const allWords = singleWords.concat( multipleWords );
 
 export default allWords;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR expands on the PR [Add new transition words in Portuguese #21712](https://github.com/Yoast/wordpress-seo/pull/21712) submitted as a community patch by @BrunoAseff. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the _transition words_ assessment for Portuguese and English by updating the relevant lists of transitions words. Props to [BrunoAseff](https://github.com/BrunoAseff).
* [shopify-seo] Improves the _transition words_ assessment for Turkish and English by updating the relevant lists of transitions words.
* [yoastseo] Expands and updates the transition words lists for Turkish and English. Props to [BrunoAseff](https://github.com/BrunoAseff).

## Relevant technical choices:

* The community patch PR added "commonly used Portuguese transition words", along with an updated spelling version of the word "consequência".
* We reviewed the suggestions submitted by the contributor and approved most of them. There were 2 reasons for not approving a suggestion:
1. The phrase includes a word which is already part of the `singleWords` list, i.e. the sentence will be recognized as having a transition word anyway. Examples: "enquanto isso" (we already have “enquanto”), "por isso mesmo" (we have “por isso”), "até porque" (we already have “porque”).
2. It's debatable whether the word/ phrase is used as a transition word, or the word/ phrase can be used in so many contexts that adding it to the list will result in too many false positives. Examples: curiosamente, por aí, diante disso, bom, quem diria.
* We also looked up synonyms and derivates of the suggestions made by the contributor. The appropriate candidates we found were also added to the list.
* Finally, while comparing the Portuguese and English lists, we found that the English list was missing some common transition words, which were also added as part of this PR. 
* You can find the research done on each suggestion, along with some additional notes [here](https://docs.google.com/document/d/1u-JkGajY5TyfKO7nglKPrekKplYkkMAerfzDVd0neFI/edit?tab=t.0#heading=h.eshpmc5kcvcn).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

##### Portuguese transition words
* Test site language is Portuguese.
* Open a new post and paste some text in Portuguese, e.g. this one: [portuguese_text.txt](https://github.com/user-attachments/files/17632578/portuguese_text.txt).
* Open the Readability analysis (Análise de legibilidade).
* Confirm that the Transition words assessment returns an 🍊 orange traffic light, with the following feedback: 
[Palavras de transição](https://yoa.st/34z): Apenas 26.7% das suas frases contêm palavras de transição, o que é insuficiente. [Utilize mais](https://yoa.st/35a).
* Click on the eye button to confirm that none of the sentences in the first paragraph are highlighted (because none of them include a transition word).
* Add one of the new transition words to any of the sentences in the first paragraph. Here are some of the new additions: `por consequência`, `logo`, `diga-se de passagem`.
* Confirm that the assessment now returns a 🍏 green traffic light, with the following feedback: 
[Palavras de transição](https://yoa.st/34z): Muito bem!
* You can also check that the sentence you added the new transition word is now highlighted. 

##### English transition words
* Switch the test site language to English.
* Open an existing or new post with some English text, and click on the eye button of the Transition words assessment within the Readability tab to find a sentence that doesn't have transition words (that sentence won't be highlighted).
* Add one of the new transition words/ phrases to the sentence, e.g. `what is more`, `anyway`, `at the most`.
* Click again on the eye button of the Transition words assessment and confirm that the sentence is now highlighted.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/a

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #[21712](https://github.com/Yoast/wordpress-seo/pull/21712)
