### PR TITLE
Change search volume format

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -174,6 +174,6 @@ RelatedKeyphraseModalContent.defaultProps = {
 	response: {},
 	lastRequestKeyphrase: "",
 	isRtl: false,
-	userLocale: null,
+	userLocale: "en_US",
 	isPending: false,
 };

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -37,7 +37,7 @@ function getDefaultState() {
 		isWooCommerceSeoActive: get( window, "wpseoScriptData.metabox.isWooCommerceSeoActive", false ),
 		isWooCommerceActive: get( window, "wpseoScriptData.metabox.isWooCommerceActive", false ),
 		isRtl: get( window, "wpseoScriptData.metabox.isRtl", false ),
-		userLocale: get( window, "wpseoScriptData.metabox.userLocale", "en_US" ),
+		userLocale: get( window, "wpseoScriptData.metabox.userLocale", "en-US" ),
 	};
 }
 

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -114,10 +114,10 @@ const intentMapping = [ "i", "n", "t", "c" ];
  * Prepare the row data.
  * @param {string[]} columnNames The column names.
  * @param {string[]} row The row data.
- * @param {string} [userLocale] The user locale.
+ * @param {Object} searchVolumeFormat The search volume format object.
  * @returns {object} The prepared row.
  */
-const prepareRow = ( columnNames, row, userLocale ) => {
+const prepareRow = ( columnNames, row, searchVolumeFormat ) => {
 	const rowData = {};
 	columnNames.forEach( ( columnName, index ) => {
 		switch ( columnName ) {
@@ -131,17 +131,7 @@ const prepareRow = ( columnNames, row, userLocale ) => {
 				rowData.keywordDifficultyIndex = Number( row[ index ] );
 				break;
 			case "Search Volume":
-				try {
-					rowData.searchVolume = new Intl.NumberFormat( userLocale, {
-						notation: "compact",
-						compactDisplay: "short",
-					} ).format( row[ index ] );
-				} catch ( e ) {
-					rowData.searchVolume = new Intl.NumberFormat( "en", {
-						notation: "compact",
-						compactDisplay: "short",
-					} ).format( row[ index ] );
-				}
+				rowData.searchVolume = searchVolumeFormat.format( row[ index ] );
 				break;
 			default:
 				rowData[ columnName.toLowerCase() ] = row[ index ];
@@ -163,7 +153,13 @@ const prepareRow = ( columnNames, row, userLocale ) => {
  * @returns {JSX.Element} The keyphrases table.
  */
 export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", userLocale, isPending = false } ) => {
-	const rows = data?.map( row => prepareRow(  columnNames, row, userLocale ) );
+	let searchVolumeFormat;
+	try {
+		searchVolumeFormat  = new Intl.NumberFormat( userLocale, { notation: "compact", compactDisplay: "short" } );
+	} catch ( e ) {
+		searchVolumeFormat  = new Intl.NumberFormat( "en", { notation: "compact", compactDisplay: "short" } );
+	}
+	const rows = data?.map( row => prepareRow(  columnNames, row, searchVolumeFormat ) );
 
 	if ( ( ! rows || rows.length === 0 ) && ! isPending ) {
 		return null;

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -112,11 +112,12 @@ const intentMapping = [ "i", "n", "t", "c" ];
 
 /**
  * Prepare the row data.
- * @param {array} columnNames The column names.
- * @param {array} row The row data.
+ * @param {string[]} columnNames The column names.
+ * @param {string[]} row The row data.
+ * @param {string} [userLocale] The user locale.
  * @returns {object} The prepared row.
  */
-const prepareRow = ( columnNames, row ) => {
+const prepareRow = ( columnNames, row, userLocale ) => {
 	const rowData = {};
 	columnNames.forEach( ( columnName, index ) => {
 		switch ( columnName ) {
@@ -130,7 +131,17 @@ const prepareRow = ( columnNames, row ) => {
 				rowData.keywordDifficultyIndex = Number( row[ index ] );
 				break;
 			case "Search Volume":
-				rowData.searchVolume = row[ index ];
+				try {
+					rowData.searchVolume = new Intl.NumberFormat( userLocale, {
+						notation: "compact",
+						compactDisplay: "short",
+					} ).format( row[ index ] );
+				} catch ( e ) {
+					rowData.searchVolume = new Intl.NumberFormat( "en", {
+						notation: "compact",
+						compactDisplay: "short",
+					} ).format( row[ index ] );
+				}
 				break;
 			default:
 				rowData[ columnName.toLowerCase() ] = row[ index ];
@@ -147,11 +158,12 @@ const prepareRow = ( columnNames, row ) => {
  * @param {Object[]} [relatedKeyphrases=[]] The related keyphrases.
  * @param {string} [className=""] The class name for the table.
  * @param {boolean} [isPending=false] Whether the data is still pending.
+ * @param {string} [userLocale] The user locale, only the first part, for example "en" not "en_US".
  *
  * @returns {JSX.Element} The keyphrases table.
  */
-export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", isPending = false } ) => {
-	const rows = data?.map( row => prepareRow(  columnNames, row ) );
+export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", userLocale, isPending = false } ) => {
+	const rows = data?.map( row => prepareRow(  columnNames, row, userLocale ) );
 
 	if ( ( ! rows || rows.length === 0 ) && ! isPending ) {
 		return null;
@@ -217,6 +229,7 @@ KeyphrasesTable.propTypes = {
 	renderButton: PropTypes.func,
 	className: PropTypes.string,
 	isPending: PropTypes.bool,
+	userLocale: PropTypes.string,
 };
 
 KeyphrasesTable.displayName = "KeyphrasesTable";

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -155,9 +155,10 @@ const prepareRow = ( columnNames, row, searchVolumeFormat ) => {
 export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", userLocale, isPending = false } ) => {
 	let searchVolumeFormat;
 	try {
-		searchVolumeFormat  = new Intl.NumberFormat( userLocale, { notation: "compact", compactDisplay: "short" } );
+		searchVolumeFormat = new Intl.NumberFormat( userLocale, { notation: "compact", compactDisplay: "short" } );
 	} catch ( e ) {
-		searchVolumeFormat  = new Intl.NumberFormat( "en", { notation: "compact", compactDisplay: "short" } );
+		// Fallback to the browser language.
+		searchVolumeFormat = new Intl.NumberFormat( navigator.language.split( "-" )[ 0 ], { notation: "compact", compactDisplay: "short" } );
 	}
 	const rows = data?.map( row => prepareRow(  columnNames, row, searchVolumeFormat ) );
 

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
@@ -115,7 +115,7 @@ export default {
 	],
 	argTypes: {
 		userLocale: {
-			description: "The locale used for formatting the search volume. Should be only the first part, for example 'en' not 'en_US'.",
+			description: "The locale used for formatting the search volume. Should be without country code, for example 'en' not 'en_US'. Fallback to the browser language.",
 		},
 	},
 };

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
@@ -12,6 +12,7 @@ export const Factory = {
 		renderButton: ButtonFactory.render,
 		relatedKeyphrases: [],
 		columnNames: [ "Keyword", "Search Volume", "Trends", "Keyword Difficulty Index", "Intent" ],
+		userLocale: "en",
 		data: [
 			[
 				"speed test",

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
@@ -113,4 +113,9 @@ export default {
 			</div>
 		),
 	],
+	argTypes: {
+		userLocale: {
+			description: "The locale used for formatting the search volume. Should be only the first part, for example 'en' not 'en_US'.",
+		},
+	},
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/related-keyphrase-suggestions 0.1.0] Changes the format of the search volume in the related keyphrase suggestions table.
* Changes the format of the search volume in the related keyphrase suggestions table.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with. focus key phrase.
* Click on `Get related keyphrases`
* Login to semrush and check you get the table.
* Check the volume has the short format:
![Screenshot 2024-11-07 at 15 02 04](https://github.com/user-attachments/assets/9925285e-d6b8-46f7-a52c-7fd4b406bb61)
* Go to user profile and change the language to Arabic or Hindi and check the Search volume in the table has short format for the specific language.
![Screenshot 2024-11-07 at 15 50 48](https://github.com/user-attachments/assets/8178c105-8a36-44e4-9f9e-ca0d77cab761)


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Change the search volume to short format based on locale](https://github.com/Yoast/reserved-tasks/issues/315)
