### PR TITLE
restore the add more insights link

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -130,7 +130,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 					data={ response?.results?.rows }
 					renderButton={ renderAction }
 				/>
-				<p style={ { marginBottom: 0 } }>
+				<p className="yst-mb-0 yst-mt-2">
 					<GetMoreInsightsLink href={ url }>
 						{ sprintf(
 						/* translators: %s expands to Semrush */

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -2,7 +2,7 @@
 import { Fragment } from "@wordpress/element";
 import { KeyphrasesTable } from "@yoast/related-keyphrase-suggestions";
 import { Root } from "@yoast/ui-library";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import { isEmpty } from "lodash";
 
@@ -14,6 +14,7 @@ import SEMrushUpsellAlert from "./modals/SEMrushUpsellAlert";
 import SEMrushRequestFailed from "./modals/SEMrushRequestFailed";
 import SEMrushMaxRelatedKeyphrases from "./modals/SEMrushMaxRelatedKeyphrases";
 import getL10nObject from "../analysis/getL10nObject";
+import { makeOutboundLink } from "@yoast/helpers";
 
 /**
  * Determines whether the error property is present in the passed response object.
@@ -96,6 +97,9 @@ export default function RelatedKeyphraseModalContent( props ) {
 	} = props;
 
 	const isPremium = getL10nObject().isPremium;
+	const GetMoreInsightsLink = makeOutboundLink();
+	const url = "https://www.semrush.com/analytics/keywordoverview/?q=" + encodeURIComponent( keyphrase ) +
+			"&db=" + encodeURIComponent( countryCode );
 
 	return (
 		<Fragment>
@@ -126,7 +130,17 @@ export default function RelatedKeyphraseModalContent( props ) {
 					data={ response?.results?.rows }
 					renderButton={ renderAction }
 				/>
+				<p style={ { marginBottom: 0 } }>
+					<GetMoreInsightsLink href={ url }>
+						{ sprintf(
+						/* translators: %s expands to Semrush */
+							__( "Get more insights at %s", "wordpress-seo" ),
+							"Semrush"
+						) }
+					</GetMoreInsightsLink>
+				</p>
 			</Root>
+
 		</Fragment>
 	);
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When we replace the SEMrushKeyphraseTable component we lost the link that was included in that component, this PR restores it. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes unreleased bug where the "Get more insights..." link was missing from the related keyphrase suggestions modal. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with focus key phrase.
* Click on the "Get related keyphrases" button.
* Log in to Semrush and return to the post, check you are getting a modal with a table of keyphrase suggestions and below a link "Get more insights at Semrush" check the link is "https://www.semrush.com/analytics/keywordoverview/" and contain 2 params q={the focus keuphrase} & db={the country code}

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
