### PR TITLE
21811 hide semrush loading table when user needs to upgrade

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -132,7 +132,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 					isPending={ isPending }
 					renderButton={ renderAction }
 				/>
-				{ response?.results?.rows && ! isPending && <p className="yst-mb-0 yst-mt-2">
+				{ response?.results?.rows && <p className="yst-mb-0 yst-mt-2">
 					<GetMoreInsightsLink href={ url }>
 						{ sprintf(
 						/* translators: %s expands to Semrush */
@@ -162,6 +162,7 @@ RelatedKeyphraseModalContent.propTypes = {
 	response: PropTypes.object,
 	lastRequestKeyphrase: PropTypes.string,
 	isRtl: PropTypes.bool,
+	isPending: PropTypes.bool,
 };
 
 RelatedKeyphraseModalContent.defaultProps = {
@@ -172,4 +173,5 @@ RelatedKeyphraseModalContent.defaultProps = {
 	response: {},
 	lastRequestKeyphrase: "",
 	isRtl: false,
+	isPending: false,
 };

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -93,6 +93,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 		relatedKeyphrases,
 		setRequestSucceeded,
 		setRequestLimitReached,
+		isPending,
 		isRtl,
 	} = props;
 
@@ -128,6 +129,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 					relatedKeyphrases={ relatedKeyphrases }
 					columnNames={ response?.results?.columnNames }
 					data={ response?.results?.rows }
+					isPending={ isPending }
 					renderButton={ renderAction }
 				/>
 				<p className="yst-mb-0 yst-mt-2">

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -132,7 +132,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 					isPending={ isPending }
 					renderButton={ renderAction }
 				/>
-				<p className="yst-mb-0 yst-mt-2">
+				{ response?.results?.rows && ! isPending && <p className="yst-mb-0 yst-mt-2">
 					<GetMoreInsightsLink href={ url }>
 						{ sprintf(
 						/* translators: %s expands to Semrush */
@@ -140,7 +140,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 							"Semrush"
 						) }
 					</GetMoreInsightsLink>
-				</p>
+				</p> }
 			</Root>
 
 		</Fragment>

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -146,7 +146,7 @@ const prepareRow = ( columnNames, row ) => {
  * @param {Function} [renderButton] The render button function.
  * @param {Object[]} [relatedKeyphrases=[]] The related keyphrases.
  * @param {string} [className=""] The class name for the table.
- * @param {boolean} [isPending] Whether the data is still pending.
+ * @param {boolean} [isPending=false] Whether the data is still pending.
  *
  * @returns {JSX.Element} The keyphrases table.
  */

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -146,10 +146,11 @@ const prepareRow = ( columnNames, row ) => {
  * @param {Function} [renderButton] The render button function.
  * @param {Object[]} [relatedKeyphrases=[]] The related keyphrases.
  * @param {string} [className=""] The class name for the table.
+ * @param {boolean} [isPending] Whether the data is still pending.
  *
  * @returns {JSX.Element} The keyphrases table.
  */
-export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "" } ) => {
+export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", isPending } ) => {
 	const rows = data?.map( row => prepareRow(  columnNames, row ) );
 
 	return <Table className={ className }>
@@ -184,18 +185,17 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 		</Table.Head>
 
 		<Table.Body>
+			{ rows && ! isPending && rows.map( ( rowData, index ) => (
+				<KeyphrasesTableRow
+					key={ `related-keyphrase-${ index }` }
+					renderButton={ renderButton }
+					relatedKeyphrases={ relatedKeyphrases }
+					{ ...rowData }
+				/> ) )
+			}
 
-			{ rows
-				? rows.map( ( rowData, index ) => (
-					<KeyphrasesTableRow
-						key={ `related-keyphrase-${ index }` }
-						renderButton={ renderButton }
-						relatedKeyphrases={ relatedKeyphrases }
-						{ ...rowData }
-					/> ) )
-				// Show 10 loading rows when there are no rows.
-				: Array.from( { length: 10 }, ( _, index ) => (
-					<LoadingKeyphrasesTableRow key={ `loading-row-${ index }` } withButton={ isFunction( renderButton ) }  /> ) )
+			{ isPending && Array.from( { length: 10 }, ( _, index ) => (
+				<LoadingKeyphrasesTableRow key={ `loading-row-${ index }` } withButton={ isFunction( renderButton ) }  /> ) )
 			}
 		</Table.Body>
 	</Table>;
@@ -212,6 +212,7 @@ KeyphrasesTable.propTypes = {
 	} ) ),
 	renderButton: PropTypes.func,
 	className: PropTypes.string,
+	isPending: PropTypes.bool,
 };
 
 KeyphrasesTable.displayName = "KeyphrasesTable";

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -189,7 +189,7 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 		</Table.Head>
 
 		<Table.Body>
-			{ rows.length && rows.map( ( rowData, index ) => (
+			{ rows && rows.map( ( rowData, index ) => (
 				<KeyphrasesTableRow
 					key={ `related-keyphrase-${ index }` }
 					renderButton={ renderButton }

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -150,7 +150,7 @@ const prepareRow = ( columnNames, row ) => {
  *
  * @returns {JSX.Element} The keyphrases table.
  */
-export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", isPending } ) => {
+export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", isPending = false } ) => {
 	const rows = data?.map( row => prepareRow(  columnNames, row ) );
 
 	if ( ( ! rows || rows.length === 0 ) && ! isPending ) {

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -153,6 +153,10 @@ const prepareRow = ( columnNames, row ) => {
 export const KeyphrasesTable = ( { columnNames = [], data, renderButton, relatedKeyphrases = [], className = "", isPending } ) => {
 	const rows = data?.map( row => prepareRow(  columnNames, row ) );
 
+	if ( ( ! rows || rows.length === 0 ) && ! isPending ) {
+		return null;
+	}
+
 	return <Table className={ className }>
 		<Table.Head>
 			<Table.Row>
@@ -185,7 +189,7 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 		</Table.Head>
 
 		<Table.Body>
-			{ rows && ! isPending && rows.map( ( rowData, index ) => (
+			{ rows.length && rows.map( ( rowData, index ) => (
 				<KeyphrasesTableRow
 					key={ `related-keyphrase-${ index }` }
 					renderButton={ renderButton }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Show the loading table only when the request status is loading.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/related-keyphrase-suggestions 0.1.0] Adds isLoading prop to related keyphrase table.
* Hides "Get more insights..." link when there are no results.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*  Edit a post with focus leyphrase.
* Click on "Get related keyphrases"
* Check you see the loading table before the results appear in the table.
* Change the focus keyphrase and repeat the request until you you see the semrush upsell button.
* Make sure the table is not there and so is the link for getting more insights. 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Hide semrush loading table when user needs to upgrade](https://github.com/Yoast/wordpress-seo/issues/21811)
