### PR TITLE
324 tailwindify the errors and notices in the related keyphrase suggestions modal

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -116,11 +116,11 @@ export default function RelatedKeyphraseModalContent( props ) {
 				userLocale={ userLocale.split( "_" )[ 0 ] }
 			/> }
 
-			<UserMessage
+			{ ! isPending && <UserMessage
 				variant={ getUserMessage( props ) }
 				upsellLink={ window.wpseoAdminL10n[ "shortlinks.semrush.prices" ] }
 				className="yst-my-2"
-			/>
+			/> }
 
 			<KeyphrasesTable
 				relatedKeyphrases={ relatedKeyphrases }

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -105,7 +105,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 	return (
 		<Root context={ { isRtl } }>
 
-			{ ! isPremium && <SEMrushUpsellAlert /> }
+			{ ! requestLimitReached && ! isPremium && <SEMrushUpsellAlert /> }
 
 			{ ! requestLimitReached && <SEMrushCountrySelector
 				countryCode={ countryCode }

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { KeyphrasesTable, PremiumUpsell , UserMessage } from "@yoast/related-keyphrase-suggestions";
+import { KeyphrasesTable , UserMessage } from "@yoast/related-keyphrase-suggestions";
 import { Root } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -41,7 +41,6 @@ export function hasMaximumRelatedKeyphrases( relatedKeyphrases ) {
  */
 export function getUserMessage( props ) {
 	const {
-		isPending,
 		requestLimitReached,
 		isSuccess,
 		response,
@@ -60,7 +59,6 @@ export function getUserMessage( props ) {
 	if ( ! requestHasData ) {
 		return "requestEmpty";
 	}
-}
 
 	if ( hasMaximumRelatedKeyphrases( relatedKeyphrases ) ) {
 		return "maxRelatedKeyphrases";
@@ -95,7 +93,6 @@ export default function RelatedKeyphraseModalContent( props ) {
 		userLocale,
 	} = props;
 
-	const isPremium = getL10nObject().isPremium;
 	const GetMoreInsightsLink = makeOutboundLink();
 	const url = "https://www.semrush.com/analytics/keywordoverview/?q=" + encodeURIComponent( keyphrase ) +
 			"&db=" + encodeURIComponent( countryCode );

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { KeyphrasesTable , UserMessage } from "@yoast/related-keyphrase-suggestions";
+import { KeyphrasesTable, UserMessage } from "@yoast/related-keyphrase-suggestions";
 import { Root } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -25,12 +25,11 @@ export function hasError( response ) {
  * Determines whether the maximum amount of related keyphrases has been reached.
  *
  * @param {array} relatedKeyphrases The related keyphrases. Can be empty.
- * @param {boolean} [isPremium=true] Whether the user is on a premium plan or not.
  *
  * @returns {boolean} Whether or not the maximum limit has been reached.
  */
-export function hasMaximumRelatedKeyphrases( relatedKeyphrases, isPremium = true ) {
-	return isPremium && relatedKeyphrases && relatedKeyphrases.length >= 4;
+export function hasMaximumRelatedKeyphrases( relatedKeyphrases ) {
+	return relatedKeyphrases && relatedKeyphrases.length >= 4;
 }
 
 /**
@@ -48,7 +47,6 @@ export function getUserMessage( props ) {
 		response,
 		requestHasData,
 		relatedKeyphrases,
-		isPremium,
 	} = props;
 
 	if ( requestLimitReached ) {
@@ -64,7 +62,7 @@ export function getUserMessage( props ) {
 	}
 }
 
-	if ( hasMaximumRelatedKeyphrases( relatedKeyphrases, isPremium ) ) {
+	if ( hasMaximumRelatedKeyphrases( relatedKeyphrases ) ) {
 		return "maxRelatedKeyphrases";
 	}
 }

--- a/packages/js/src/containers/SEMrushRelatedKeyphrases.js
+++ b/packages/js/src/containers/SEMrushRelatedKeyphrases.js
@@ -30,6 +30,7 @@ export default compose( [
 			lastRequestKeyphrase: getSEMrushRequestKeyphrase(),
 			isRtl: getPreference( "isRtl", false ),
 			userLocale: getPreference( "userLocale", "en_US" ),
+			isPremium: getIsPremium(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/containers/SEMrushRelatedKeyphrases.js
+++ b/packages/js/src/containers/SEMrushRelatedKeyphrases.js
@@ -17,6 +17,7 @@ export default compose( [
 			getSEMrushRequestHasData,
 			getSEMrushRequestKeyphrase,
 			getPreference,
+			getIsPremium,
 		} = select( "yoast-seo/editor" );
 
 		return {

--- a/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
+++ b/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
@@ -98,16 +98,5 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 
 			expect( actual ).toBe( true );
 		} );
-
-		it( "returns that the limit has not been reached when user does not have premium", () => {
-			const actual = SEMrushRelatedKeyphrasesModalContent.hasMaximumRelatedKeyphrases( [
-				{ key: "a", keyword: "yoast seo", score: 33 },
-				{ key: "b", keyword: "yoast seo plugin", score: 33 },
-				{ key: "c", keyword: "yoast plugin", score: 33 },
-				{ key: "d", keyword: "yoast premium plugin", score: 33 },
-			], false );
-
-			expect( actual ).toBe( false );
-		} );
 	} );
 } );

--- a/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
+++ b/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
@@ -1,7 +1,4 @@
 import * as SEMrushRelatedKeyphrasesModalContent from "../../src/components/SEMrushRelatedKeyphrasesModalContent";
-import SEMrushLoading from "../../src/components/modals/SEMrushLoading";
-import SEMrushLimitReached from "../../src/components/modals/SEMrushLimitReached";
-import SEMrushRequestFailed from "../../src/components/modals/SEMrushRequestFailed";
 
 describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 	let props = {};
@@ -41,17 +38,6 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 	} );
 
 	describe( "getUserMessage", () => {
-		it( "returns the SEMrushLoading message when request is pending", () => {
-			props = {
-				...props,
-				isPending: true,
-			};
-
-			const actual = SEMrushRelatedKeyphrasesModalContent.getUserMessage( props );
-
-			expect( actual ).toEqual( <SEMrushLoading /> );
-		} );
-
 		it( "returns the SEMrushLimitReached message when request limit is reached", () => {
 			props = {
 				...props,
@@ -60,7 +46,7 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 
 			const actual = SEMrushRelatedKeyphrasesModalContent.getUserMessage( props );
 
-			expect( actual ).toEqual( <SEMrushLimitReached /> );
+			expect( actual ).toEqual( "requestLimitReached" );
 		} );
 
 		it( "returns the SEMrushRequestFailed message when request fails", () => {
@@ -75,13 +61,13 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 
 			const actual = SEMrushRelatedKeyphrasesModalContent.getUserMessage( props );
 
-			expect( actual ).toEqual( <SEMrushRequestFailed /> );
+			expect( actual ).toEqual( "requestFailed" );
 		} );
 
 		it( "returns a message when response contains no data", () => {
 			const actual = SEMrushRelatedKeyphrasesModalContent.getUserMessage( props );
 
-			expect( actual ).toEqual( <p>{ "Sorry, there's no data available for that keyphrase/country combination." }</p> );
+			expect( actual ).toEqual( "requestEmpty" );
 		} );
 	} );
 
@@ -111,6 +97,17 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 			] );
 
 			expect( actual ).toBe( true );
+		} );
+
+		it( "returns that the limit has not been reached when user does not have premium", () => {
+			const actual = SEMrushRelatedKeyphrasesModalContent.hasMaximumRelatedKeyphrases( [
+				{ key: "a", keyword: "yoast seo", score: 33 },
+				{ key: "b", keyword: "yoast seo plugin", score: 33 },
+				{ key: "c", keyword: "yoast plugin", score: 33 },
+				{ key: "d", keyword: "yoast premium plugin", score: 33 },
+			], false );
+
+			expect( actual ).toBe( false );
 		} );
 	} );
 } );

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/MaxRelatedKeyphrases.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/MaxRelatedKeyphrases.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __, sprintf } from "@wordpress/i18n";
+import { Alert } from "@yoast/ui-library";
+
+/**
+ * Display the message when reaching max related keyphrases.
+ *
+ * @param {string} [className=""] The class name for the alert.
+ *
+ * @returns {React.Component} The alert for max related keyphrases.
+ */
+export const MaxRelatedKeyphrases = ( { className = "" } ) => {
+	return (
+		<Alert variant="warning" className={ className }>
+			{ sprintf(
+				/* translators: %s: Expands to "Yoast SEO". */
+				__(
+					// eslint-disable-next-line max-len
+					"You've reached the maximum amount of 4 related keyphrases. You can change or remove related keyphrases in the %s metabox or sidebar.",
+					"wordpress-seo",
+				),
+				"Yoast SEO",
+			) }
+		</Alert>
+	);
+};
+
+MaxRelatedKeyphrases.propTypes = {
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestEmpty.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestEmpty.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
+import { Alert } from "@yoast/ui-library";
+
+/**
+ * Display the message for a empty request.
+ *
+ * @param {string} [className=""] The class name for the alert.
+ *
+ * @returns {React.Component} The message for a empty request.
+ */
+export const RequestEmpty = ( { className = "" } ) => {
+	return (
+		<Alert variant="info" className={ className }>
+			{ __( "Sorry, there's no data available for that keyphrase/country combination.", "wordpress-seo" ) }
+		</Alert>
+	);
+};
+
+RequestEmpty.propTypes = {
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestFailed.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestFailed.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
+import { Alert } from "@yoast/ui-library";
+
+/**
+ * Display the message for a failed request.
+ *
+ * @param {string} [className=""] The class name for the alert.
+ *
+ * @returns {React.Component} The message for a failed request.
+ */
+export const RequestFailed = ( { className = "" } ) => {
+	return (
+		<Alert variant="error" className={ className }>
+			{ __( "We've encountered a problem trying to get related keyphrases. Please try again later.", "wordpress-seo" ) }
+		</Alert>
+	);
+};
+
+RequestFailed.propTypes = {
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __, sprintf } from "@wordpress/i18n";
+import { Alert, Button } from "@yoast/ui-library";
+import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
+
+/**
+ * Display the message for a request that has reached the limit.
+ *
+ * @param {String} [upsellLink] The upsell link.
+ * @param {string} [className=""] The class name for the alert.
+ *
+ * @returns {React.Component} The message for limit reached.
+ */
+export const RequestLimitReached = ( { upsellLink, className = "" } ) => {
+	return (
+		<Alert variant="warning" className={ className }>
+			 <div className="yst-flex yst-flex-col yst-items-start">
+				{ sprintf(
+					/* translators: %s : Expands to "Semrush". */
+					__( "You've reached your request limit for today. Check back tomorrow or upgrade your plan over at %s.", "wordpress-seo" ),
+					"Semrush",
+				) }
+
+				{ upsellLink && <Button
+					variant="upsell"
+					className="yst-mt-3 yst-gap-1.5"
+					as="a"
+					href={ upsellLink }
+					target="_blank"
+				>
+					{
+						sprintf(
+						/* translators: %s : Expands to "Semrush". */
+							__( "Upgrade your %s plan", "wordpress-seo" ),
+							"Semrush",
+						)
+					}
+					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-text-amber-900" />
+
+				</Button> }
+			</div>
+		</Alert>
+	);
+};
+
+RequestLimitReached.propTypes = {
+	upsellLink: PropTypes.string,
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/index.js
@@ -1,0 +1,4 @@
+export { MaxRelatedKeyphrases } from "./MaxRelatedKeyphrases";
+export { RequestFailed } from "./RequestFailed";
+export { RequestEmpty } from "./RequestEmpty";
+export { RequestLimitReached } from "./RequestLimitReached";

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/docs/component.md
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/docs/component.md
@@ -1,0 +1,1 @@
+The alert to display to the user related to the related keyphrases suggestions request or action.

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/docs/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/docs/index.js
@@ -1,0 +1,1 @@
+export { default as component } from "./component.md";

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/index.js
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { RequestFailed, RequestLimitReached, RequestEmpty, MaxRelatedKeyphrases } from "./components";
+
+/**
+ * Displays the user message following a request or action.
+ *
+ * @param {string} [variant] The type of message to display.
+ * @param {string} [upsellLink=""] The link to the upsell page.
+ * @param {string} [className=""] The class name for the button.
+ *
+ * @returns {React.Component} The user message.
+ */
+export const UserMessage = ( { variant, upsellLink = "", className = "" } ) => {
+	switch ( variant ) {
+		case "requestLimitReached":
+			return <RequestLimitReached upsellLink={ upsellLink } className={ className } />;
+		case "requestFailed":
+			return <RequestFailed className={ className } />;
+		case "requestEmpty":
+			return <RequestEmpty className={ className } />;
+		case "maxRelatedKeyphrases":
+			return <MaxRelatedKeyphrases className={ className } />;
+		default:
+			return null;
+	}
+};
+
+UserMessage.propTypes = {
+	variant: PropTypes.oneOf( [ "requestLimitReached", "requestFailed", "requestEmpty", "maxRelatedKeyphrases" ] ),
+	upsellLink: PropTypes.string,
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/stories.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/stories.js
@@ -1,0 +1,24 @@
+import React from "react";
+import { UserMessage } from ".";
+import { component } from "./docs";
+
+export const Factory = {
+	parameters: {
+		controls: { disable: false },
+	},
+	render: ( args ) => <UserMessage { ...args } />,
+};
+
+export default {
+	title: "2) Elements/UserMessage",
+	component: UserMessage,
+	args: {
+		variant: "requestLimitReached",
+		upsellLink: "https://www.semrush.com/analytics/keywordoverview/?q=example&db=us",
+	},
+	parameters: {
+		docs: {
+			description: { component },
+		},
+	},
+};

--- a/packages/related-keyphrase-suggestions/src/index.js
+++ b/packages/related-keyphrase-suggestions/src/index.js
@@ -6,3 +6,4 @@ export { IntentBadge } from "./elements/IntentBadge";
 export { TableButton } from "./elements/TableButton";
 export { CountrySelector } from "./components/CountrySelector";
 export { PremiumUpsell } from "./elements/PremiumUpsell";
+export { UserMessage } from "./elements/UserMessage";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements new design for the warnings and errors in the related keyphrases suggestions modal.
* [@yoast/related-keyphrase-suggestions 0.1.0] Changes the design of the warnings and errors alerts in the related keyphrase suggestions.

## Relevant technical choices:

* The pending notice is dropped since we have the loading table.
* `relatedKeyphrases` is a prop coming from Premium, checking for `relatedKeyphrases` includes checking for premium.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check alerts for:
  * When there are more than 4 related keyphrases selected.
  * When the request failed
  * When there are no suggestions in the result
  * When the reaching the max requests for semrush:
      * The country selector should be hidden.
      * The button should have a lint to semrush upsell page.
      * Without premium, check that the premium upsell is hidden. 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Tailwindify the errors and notices in the related keyphrase suggestions modal](https://github.com/Yoast/reserved-tasks/issues/324)
