### PR TITLE
add premium upsell component

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -107,7 +107,11 @@ export default function RelatedKeyphraseModalContent( props ) {
 		<Root context={ { isRtl } }>
 			{ ! requestLimitReached && (
 				<Fragment>
-					{ ! isPremium && <SEMrushUpsellAlert /> }
+					{ ! isPremium && <PremiumUpsell
+						className="yst-my-6"
+						url={ window.wpseoAdminL10n[ "shortlinks.semrush.premium_landing_page" ] }
+					/> }
+
 					{ isPremium && hasMaximumRelatedKeyphrases( relatedKeyphrases ) && <SEMrushMaxRelatedKeyphrases /> }
 					<SEMrushCountrySelector
 						countryCode={ countryCode }
@@ -126,7 +130,6 @@ export default function RelatedKeyphraseModalContent( props ) {
 			) }
 
 			{ getUserMessage( props ) }
-
 			<KeyphrasesTable
 				relatedKeyphrases={ relatedKeyphrases }
 				columnNames={ response?.results?.columnNames }
@@ -137,7 +140,7 @@ export default function RelatedKeyphraseModalContent( props ) {
 			{ response?.results?.rows && <p className="yst-mb-0 yst-mt-2">
 				<GetMoreInsightsLink href={ url }>
 					{ sprintf(
-					/* translators: %s expands to Semrush */
+						/* translators: %s expands to Semrush */
 						__( "Get more insights at %s", "wordpress-seo" ),
 						"Semrush"
 					) }

--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -1,6 +1,6 @@
 /* External dependencies */
 import { Fragment } from "@wordpress/element";
-import { KeyphrasesTable } from "@yoast/related-keyphrase-suggestions";
+import { KeyphrasesTable, PremiumUpsell } from "@yoast/related-keyphrase-suggestions";
 import { Root } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/docs/component.md
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/docs/component.md
@@ -1,0 +1,1 @@
+The Yoast Premium upsell component can accept class name and url for the upsell button that will open the link in a new tab and has a screen reader text to indicate that.

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/docs/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/docs/index.js
@@ -1,0 +1,1 @@
+export { default as component } from "./component.md";

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
@@ -24,7 +24,7 @@ export const PremiumUpsell = ( { url, className } ) => {
 				"Yoast SEO",
 			) }
 		</p>
-		<Button 
+		<Button
 			variant="upsell"
 			as="a" href={ url }
 			className="yst-mt-4"

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
@@ -1,0 +1,49 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __, sprintf } from "@wordpress/i18n";
+import { Button } from "@yoast/ui-library";
+import { LockOpenIcon } from "@heroicons/react/outline";
+
+/**
+ * The premium upsell component.
+ *
+ * @param {string} url The URL to the premium page.
+ * @param {string} [className] The class name for the component.
+ *
+ * @returns {JSX.Element} The premium upsell component.
+ */
+export const PremiumUpsell = ( { url, className } ) => {
+	return <div className={ className }>
+		<p>
+			{ sprintf(
+				/* translators: %s: Expands to "Yoast SEO". */
+				__(
+					"You’ll reach more people with multiple keyphrases! Want to quickly add these related keyphrases to the %s analyses for even better content optimization?",
+					"wordpress-seo",
+				),
+				"Yoast SEO",
+			) }
+		</p>
+		<Button 
+			variant="upsell"
+			as="a" href={ url }
+			className="yst-mt-4"
+			target="_blank"
+		>
+			<LockOpenIcon className="yst-w-4 yst-h-4 yst-mr-2 yst-text-amber-900" />
+			{ sprintf(
+				/* translators: %s: Expands to "Yoast SEO Premium". */
+				__( "Explore %s!", "wordpress-seo" ),
+				"Yoast SEO Premium",
+			)
+			}
+			<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+		</Button>
+
+	</div>;
+};
+
+PremiumUpsell.propTypes = {
+	url: PropTypes.string.isRequired,
+	className: PropTypes.string,
+};

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/stories.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/stories.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { PremiumUpsell } from ".";
+import { component } from "./docs";
+
+export const Factory = {
+	parameters: {
+		controls: { disable: false },
+	},
+	args: {
+		url: "https://yoast.com",
+	},
+	render: ( args ) => (
+		<PremiumUpsell { ...args } />
+	),
+};
+
+export default {
+	title: "2) Elements/PremiumUpsell",
+	component: PremiumUpsell,
+	args: {
+		url: "https://yoast.com",
+	},
+	parameters: {
+		docs: {
+			description: { component },
+		},
+	},
+};

--- a/packages/related-keyphrase-suggestions/src/index.js
+++ b/packages/related-keyphrase-suggestions/src/index.js
@@ -5,3 +5,4 @@ export { DifficultyBullet } from "./elements/DifficultyBullet";
 export { IntentBadge } from "./elements/IntentBadge";
 export { TableButton } from "./elements/TableButton";
 export { CountrySelector } from "./components/CountrySelector";
+export { PremiumUpsell } from "./elements/PremiumUpsell";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements new design for the Premium upsell ad on the related keyphrase suggestions modal. 
* [@yoast/related-keyphrase-suggestions 0.1.0] Adds the premium upsell ad with new design for the related keyphrase suggestions modal.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post with focus keyphrase.
* Make sure Yoast premium in disabled or uninstalled.
* Click on "Get related keyphrases".
* Log in to semrush and return to the post to see you are getting the modal with related keyphrase suggestions.
* Check that you see the upsell ad on the top of the modal:
![Screenshot 2024-11-12 at 17 28 27](https://github.com/user-attachments/assets/53cd5203-ffbc-443a-8771-4e0e4cf04d87)
* Enable screen reader and focus on the button, check it says "Opens in a new browser tab"
* Click on the button and check the link opens in a new tab.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Tailwindify the upsell in the related keyphrase suggestions modal](https://github.com/Yoast/reserved-tasks/issues/326)
