### PR TITLE
Improves the translatability of feedback for the paragraph and sentence length assessments

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/ca/catalanPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ca/catalanPaper.js
@@ -114,7 +114,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than " +
-			"the recommended maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			"the recommended maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
@@ -115,7 +115,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 5 of the paragraphs contain more than the " +
-			"recommended maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			"recommended maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
@@ -114,7 +114,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 3 of the paragraphs contain more than the recommended " +
-			"maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			"maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
@@ -114,7 +114,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: " +
-			"1 of the paragraphs contains more than the recommended maximum of 150 words." +
+			"1 of the paragraphs contains more than the recommended maximum number of words (150)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
@@ -104,7 +104,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 8 of the paragraphs contain more than the recommended" +
-			" maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			" maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
@@ -103,7 +103,7 @@ const expectedResults = {
 	textParagraphTooLong: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 6 of the paragraphs contain more than the recommended maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 6 of the paragraphs contain more than the recommended maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ja/japanesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ja/japanesePaper.js
@@ -119,7 +119,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 4 of the paragraphs contain more " +
-			"than the recommended maximum of 300 characters. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			"than the recommended maximum number of characters (300). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -116,7 +116,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended" +
-			" maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			" maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper3.js
@@ -117,7 +117,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 10 of the paragraphs contain more than the recommended" +
-			" maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+			" maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
@@ -104,7 +104,7 @@ const expectedResults = {
 	textParagraphTooLong: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum of 150 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
+		resultText: "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains more than the recommended maximum number of words (150). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessments/readability/ParagraphTooLongAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/ParagraphTooLongAssessmentSpec.js
@@ -24,7 +24,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { countLength: 160, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
-			" contains more than the recommended maximum of 150 words." +
+			" contains more than the recommended maximum number of words (150)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -32,7 +32,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 		const assessment = paragraphTooLongAssessment.getResult( paper, Factory.buildMockResearcher( [ { countLength: 6000, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
-			" contains more than the recommended maximum of 150 words." +
+			" contains more than the recommended maximum number of words (150)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -49,7 +49,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 			{ countLength: 71, text: "" }, { countLength: 183, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
-			" contains more than the recommended maximum of 150 words." +
+			" contains more than the recommended maximum number of words (150)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -58,7 +58,7 @@ describe( "An assessment for scoring too long paragraphs.", function() {
 			{ countLength: 191, text: "" }, { countLength: 183, text: "" } ] ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs" +
-			" contain more than the recommended maximum of 150 words." +
+			" contain more than the recommended maximum number of words (150)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -77,7 +77,7 @@ describe( "An assessment for scoring too long paragraphs in Japanese in which ch
 		const assessment = paragraphTooLongAssessment.getResult( paper, new JapaneseResearcher( paper ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
-			" contains more than the recommended maximum of 300 characters." +
+			" contains more than the recommended maximum number of characters (300)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -87,7 +87,7 @@ describe( "An assessment for scoring too long paragraphs in Japanese in which ch
 		const assessment = paragraphTooLongAssessment.getResult( paper, new JapaneseResearcher( paper ) );
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 1 of the paragraphs" +
-			" contains more than the recommended maximum of 300 characters." +
+			" contains more than the recommended maximum number of characters (300)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -96,7 +96,7 @@ describe( "An assessment for scoring too long paragraphs in Japanese in which ch
 		const assessment = paragraphTooLongAssessment.getResult( paper, new JapaneseResearcher( paper ) );
 		expect( assessment.getScore() ).toBe( 6 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs" +
-			" contain more than the recommended maximum of 300 characters." +
+			" contain more than the recommended maximum number of characters (300)." +
 			" <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -318,7 +318,7 @@ describe( "A test for marking the sentences", function() {
 } );
 
 describe( "test for paragraph too long assessment when is used in product page analysis", function() {
-	it( "should assess a paper on a product page with paragraphs that contain less than 70 words", function() {
+	it( "should assess a paper on a product page with paragraphs that contain less than words (70)", function() {
 		const paper = new Paper( "" );
 		const config = {
 			parameters: {
@@ -350,7 +350,7 @@ describe( "test for paragraph too long assessment when is used in product page a
 		] ) );
 		expect( result.getScore() ).toEqual( 3 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 3 of the paragraphs contain" +
-			" more than the recommended maximum of 70 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+			" more than the recommended maximum number of words (70). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 	} );
 	it( "should assess a paper on a product page with paragraphs that contain between 70 and 100 words", function() {
 		const paper = new Paper( "" );
@@ -367,14 +367,14 @@ describe( "test for paragraph too long assessment when is used in product page a
 		] ) );
 		expect( result.getScore() ).toEqual( 6 );
 		expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 3 of the paragraphs contain " +
-			"more than the recommended maximum of 70 words. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+			"more than the recommended maximum number of words (70). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 	} );
 } );
 
 describe( "test for paragraph too long assessment for languages that have language-specific config", () => {
 	// Japanese has a language specific config for paragraph length. The config is used for the unit tests below.
 	describe( "test for non-product pages", () => {
-		it( "should assess a paper with paragraphs that contain less than 300 characters (green bullet)", function() {
+		it( "should assess a paper with paragraphs that contain less than characters (300) (green bullet)", function() {
 			const paper = new Paper( "" );
 			const mockResearcher = Factory.buildMockResearcher( [
 				{ countLength: 200, text: "" },
@@ -404,7 +404,7 @@ describe( "test for paragraph too long assessment for languages that have langua
 
 			expect( result.getScore() ).toEqual( 3 );
 			expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs contain " +
-				"more than the recommended maximum of 300 characters. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+				"more than the recommended maximum number of characters (300). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		} );
 		it( "should assess a paper with paragraphs that contain 300-400 characters (orange bullet)", function() {
 			const paper = new Paper( "" );
@@ -420,11 +420,11 @@ describe( "test for paragraph too long assessment for languages that have langua
 
 			expect( result.getScore() ).toEqual( 6 );
 			expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 2 of the paragraphs contain " +
-				"more than the recommended maximum of 300 characters. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+				"more than the recommended maximum number of characters (300). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		} );
 	} );
 	describe( "test for product pages", () => {
-		it( "should assess a paper with paragraphs that contain less than 140 characters (green bullet)", function() {
+		it( "should assess a paper with paragraphs that contain less than characters (140) (green bullet)", function() {
 			const paper = new Paper( "" );
 			const mockResearcher = Factory.buildMockResearcher( [
 				{ countLength: 100, text: "" },
@@ -454,7 +454,7 @@ describe( "test for paragraph too long assessment for languages that have langua
 
 			expect( result.getScore() ).toEqual( 3 );
 			expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 3 of the paragraphs contain " +
-				"more than the recommended maximum of 140 characters. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+				"more than the recommended maximum number of characters (140). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		} );
 		it( "should assess a paper with all paragraphs that contain 140-200 characters (orange bullet)", function() {
 			const paper = new Paper( "" );
@@ -470,7 +470,7 @@ describe( "test for paragraph too long assessment for languages that have langua
 
 			expect( result.getScore() ).toEqual( 6 );
 			expect( result.getText() ).toEqual( "<a href='https://yoa.st/35d' target='_blank'>Paragraph length</a>: 3 of the paragraphs contain " +
-				"more than the recommended maximum of 140 characters. <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
+				"more than the recommended maximum number of characters (140). <a href='https://yoa.st/35e' target='_blank'>Shorten your paragraphs</a>!" );
 		} );
 	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceLengthInTextAssessmentSpec.js
@@ -298,7 +298,7 @@ describe( "An assessment for sentence length", function() {
 describe( "A test for getting the right scoring config", function() {
 	it( "uses the default config if no language-specific config is available", function() {
 		const defaultConfig = {
-			countTextIn: "words",
+			countCharacters: false,
 			recommendedLength: 20,
 			slightlyTooMany: 25,
 			farTooMany: 30,
@@ -310,7 +310,7 @@ describe( "A test for getting the right scoring config", function() {
 	} );
 	it( "uses the default config if no language-specific config is available in cornerstone", function() {
 		const defaultConfigCornerstone = {
-			countTextIn: "words",
+			countCharacters: false,
 			recommendedLength: 20,
 			slightlyTooMany: 20,
 			farTooMany: 25,
@@ -327,7 +327,7 @@ describe( "A test for getting the right scoring config", function() {
 		const mockPaper = new Paper( "" );
 		const researcher = new ItalianResearcher( mockPaper );
 		expect( new SentenceLengthInTextAssessment().getLanguageSpecificConfig( researcher ) ).toEqual( {
-			countTextIn: "words",
+			countCharacters: false,
 			recommendedLength: 25,
 			slightlyTooMany: 25,
 			farTooMany: 30,
@@ -341,7 +341,7 @@ describe( "A test for getting the right scoring config", function() {
 			slightlyTooMany: 20,
 			farTooMany: 25,
 		}, true ).getLanguageSpecificConfig( new PolishResearcher( mockPaper ) ) ).toEqual( {
-			countTextIn: "words",
+			countCharacters: false,
 			farTooMany: 20,
 			recommendedLength: 20,
 			slightlyTooMany: 15,
@@ -352,7 +352,7 @@ describe( "A test for getting the right scoring config", function() {
 	it( "uses a combination of language-specific and default config in cornerstone if there is regular but not cornerstone config" +
 		" available", function() {
 		const expectedConfig = {
-			countTextIn: "words",
+			countCharacters: false,
 			recommendedLength: 25,
 			slightlyTooMany: 20,
 			farTooMany: 25,

--- a/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -132,7 +132,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/shopify66' target='_blank'>Paragraph length</a>: 2 of the paragraphs contain more than " +
-			"the recommended maximum of 70 words. <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
+			"the recommended maximum number of words (70). <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -144,7 +144,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/shopify66' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains " +
-			"more than the recommended maximum of 70 words. <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
+			"more than the recommended maximum number of words (70). <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -142,7 +142,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 6,
 		resultText: "<a href='https://yoa.st/shopify66' target='_blank'>Paragraph length</a>: 1 of the paragraphs contains " +
-			"more than the recommended maximum of 70 words. <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
+			"more than the recommended maximum number of words (70). <a href='https://yoa.st/shopify67' target='_blank'>Shorten your paragraphs</a>!",
 	},
 	textSentenceLength: {
 		isApplicable: true,

--- a/packages/yoastseo/src/scoring/assessments/readability/ParagraphTooLongAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/ParagraphTooLongAssessment.js
@@ -2,7 +2,7 @@ import { __, _n, sprintf } from "@wordpress/i18n";
 import { filter, map, merge } from "lodash";
 import { stripBlockTagsAtStartEnd as stripHTMLTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import marker from "../../../markers/addMark";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import { inRangeEndInclusive as inRange } from "../../helpers/assessments/inRange";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
@@ -26,7 +26,7 @@ export default class ParagraphTooLongAssessment extends Assessment {
 		const defaultConfig = {
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/35d" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/35e" ),
-			countTextIn: __( "words", "wordpress-seo" ),
+			countCharacters: false,
 			parameters: {
 				recommendedLength: 150,
 				maximumRecommendedLength: 200,
@@ -125,25 +125,34 @@ export default class ParagraphTooLongAssessment extends Assessment {
 				),
 			};
 		}
+
+		/* translators: %1$s and %5$s expand to links on yoast.com, %2$s expands to the anchor end tag,
+		%3$d expands to the number of paragraphs over the recommended limit, %4$d expands to the limit. */
+		const wordFeedback = _n(
+			"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum number of words (%4$d). %5$sShorten your paragraphs%2$s!",
+			"%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the recommended maximum number of words (%4$d). %5$sShorten your paragraphs%2$s!",
+			tooLongParagraphs.length,
+			"wordpress-seo"
+		);
+		/* translators: %1$s and %5$s expand to links on yoast.com, %2$s expands to the anchor end tag,
+		%3$d expands to the number of paragraphs over the recommended limit, %4$d expands to the limit. */
+		const characterFeedback = _n(
+			"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum number of characters (%4$d). %5$sShorten your paragraphs%2$s!",
+			"%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the recommended maximum number of characters (%4$d). %5$sShorten your paragraphs%2$s!",
+			tooLongParagraphs.length,
+			"wordpress-seo"
+		);
+
 		return {
 			score: score,
 			hasMarks: true,
 			text: sprintf(
-				/* translators: %1$s and %5$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
-			%3$d expands to the number of paragraphs over the recommended word / character limit, %4$d expands to the word / character limit,
-			%6$s expands to the word 'words' or 'characters'. */
-				_n(
-					"%1$sParagraph length%2$s: %3$d of the paragraphs contains more than the recommended maximum of %4$d %6$s. %5$sShorten your paragraphs%2$s!",
-					"%1$sParagraph length%2$s: %3$d of the paragraphs contain more than the recommended maximum of %4$d %6$s. %5$sShorten your paragraphs%2$s!",
-					tooLongParagraphs.length,
-					"wordpress-seo"
-				),
+				config.countCharacters ? characterFeedback : wordFeedback,
 				config.urlTitle,
 				"</a>",
 				tooLongParagraphs.length,
 				config.parameters.recommendedLength,
-				config.urlCallToAction,
-				this._config.countTextIn
+				config.urlCallToAction
 			),
 		};
 	}
@@ -194,10 +203,7 @@ export default class ParagraphTooLongAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		let paragraphsLength = researcher.getResearch( "getParagraphLength" );
-		const countTextInCharacters = researcher.getConfig( "countCharacters" );
-		if ( countTextInCharacters ) {
-			this._config.countTextIn = __( "characters", "wordpress-seo" );
-		}
+		this._config.countCharacters = !! researcher.getConfig( "countCharacters" );
 
 		paragraphsLength = this.sortParagraphs( paragraphsLength );
 		const config = this.getConfig( researcher );

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceLengthInTextAssessment.js
@@ -1,4 +1,4 @@
-import { __, sprintf } from "@wordpress/i18n";
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { map, merge } from "lodash";
 
 import Assessment from "../assessment";
@@ -6,7 +6,7 @@ import getTooLongSentences from "../../helpers/assessments/checkForTooLongSenten
 import formatNumber from "../../../helpers/formatNumber";
 import { inRangeEndInclusive as inRange } from "../../helpers/assessments/inRange";
 import addMark from "../../../markers/addMark";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
@@ -33,7 +33,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 			farTooMany: 30,
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/34v" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/34w" ),
-			countTextIn: __( "words", "wordpress-seo" ),
+			countCharacters: false,
 		};
 
 		// Add cornerstone and/or product-specific config if applicable.
@@ -58,10 +58,7 @@ class SentenceLengthInTextAssessment extends Assessment {
 			this._config = this.getLanguageSpecificConfig( researcher );
 		}
 
-		const countTextInCharacters = researcher.getConfig( "countCharacters" );
-		if ( countTextInCharacters ) {
-			this._config.countTextIn = __( "characters", "wordpress-seo" );
-		}
+		this._config.countCharacters = !! researcher.getConfig( "countCharacters" );
 
 		const percentage = this.calculatePercentage( sentences );
 		const score = this.calculateScore( percentage );
@@ -158,21 +155,33 @@ class SentenceLengthInTextAssessment extends Assessment {
 			);
 		}
 
+		/* translators: %1$s and %6$s expand to links on yoast.com, %2$s expands to the anchor end tag,
+		%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
+		%5$s expands to the recommended maximum percentage. */
+		const wordFeedback = _n(
+			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$d word, which is more than the recommended maximum of %5$s. %6$sTry to shorten the sentences%2$s.",
+			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$d words, which is more than the recommended maximum of %5$s. %6$sTry to shorten the sentences%2$s.",
+			this._config.recommendedLength,
+			"wordpress-seo"
+		);
+		/* translators: %1$s and %6$s expand to links on yoast.com, %2$s expands to the anchor end tag,
+		%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
+		%5$s expands to the recommended maximum percentage. */
+		const characterFeedback = _n(
+			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$d character, which is more than the recommended maximum of %5$s. %6$sTry to shorten the sentences%2$s.",
+			"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$d characters, which is more than the recommended maximum of %5$s. %6$sTry to shorten the sentences%2$s.",
+			this._config.recommendedLength,
+			"wordpress-seo"
+		);
+
 		return sprintf(
-			/* translators: %1$s and %6$s expand to a link on yoast.com, %2$s expands to the anchor end tag,
-			%3$d expands to percentage of sentences, %4$s expands to the recommended maximum sentence length,
-			%5$s expands to the recommended maximum percentage, %7$s expands to the word 'words' or 'characters'. */
-			__(
-				"%1$sSentence length%2$s: %3$s of the sentences contain more than %4$s %7$s, which is more than the recommended maximum of %5$s. %6$sTry to shorten the sentences%2$s.",
-				"wordpress-seo"
-			),
+			this._config.countCharacters ? characterFeedback : wordFeedback,
 			this._config.urlTitle,
 			"</a>",
 			percentage + "%",
 			this._config.recommendedLength,
 			this._config.slightlyTooMany + "%",
-			this._config.urlCallToAction,
-			this._config.countTextIn
+			this._config.urlCallToAction
 		);
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, the strings that contain the words 'word(s)' or 'character(s)' are not created in a way that makes it easy/possible to translate them correctly. We need to change that. See https://github.com/Yoast/wordpress-seo/issues/20478 for more detail. This PR address the paragraph length assessment and the sentence length assessment.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the translatability of feedback for the _paragraph length_ and the _sentence length_ assessments.
* [shopify-seo] Improves the translatability of feedback for the _paragraph length_ and the _sentence length_ assessments.

## Relevant technical choices:

* I did not scout the files as that will be part of upcoming PRs (e.g. https://github.com/Yoast/wordpress-seo/pull/21820).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* TBA

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR only affects the feedback strings of two assessments.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21749
