### PR TITLE
fix add keyphrase direction and width and loading table storybook

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -10,7 +10,6 @@ import { isEmpty } from "lodash";
 import SEMrushLoading from "./modals/SEMrushLoading";
 import SEMrushLimitReached from "./modals/SEMrushLimitReached";
 import SEMrushCountrySelector from "./modals/SEMrushCountrySelector";
-import SEMrushUpsellAlert from "./modals/SEMrushUpsellAlert";
 import SEMrushRequestFailed from "./modals/SEMrushRequestFailed";
 import SEMrushMaxRelatedKeyphrases from "./modals/SEMrushMaxRelatedKeyphrases";
 import getL10nObject from "../analysis/getL10nObject";

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -76,8 +76,8 @@ KeyphrasesTableRow.propTypes = {
 const LoadingKeyphrasesTableRow = ( { withButton = false } ) => {
 	return (
 		<Table.Row>
-			<Table.Cell className="yst-w-56">
-				<SkeletonLoader className="yst-w-44 yst-h-5" />
+			<Table.Cell className="yst-w-44">
+				<SkeletonLoader className="yst-w-36 yst-h-5" />
 			</Table.Cell>
 			<Table.Cell>
 				<SkeletonLoader className="yst-w-5 yst-h-5" />
@@ -96,8 +96,10 @@ const LoadingKeyphrasesTableRow = ( { withButton = false } ) => {
 					<SkeletonLoader className="yst-w-3 yst-h-5" />
 				</div>
 			</Table.Cell>
-			{ withButton && <Table.Cell>
-				<SkeletonLoader className="yst-w-16 yst-h-7" />
+			{ withButton && <Table.Cell className="yst-w-32">
+				<div className="yst-flex yst-justify-end">
+					<SkeletonLoader className="yst-w-16 yst-h-7" />
+				</div>
 			</Table.Cell>
 			}
 		</Table.Row>
@@ -188,8 +190,9 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 						{ __( "Difficulty %", "wordpress-seo" ) }
 					</div>
 				</Table.Header>
-				{ renderButton && <Table.Header className="yst-min-w-28">
-					<div className="yst-flex yst-justify-end">
+
+				{ renderButton && <Table.Header className="yst-w-32">
+					<div className="yst-flex yst-justify-end yst-text-right rtl:yst-text-left">
 						{ __( "Add keyphrase", "wordpress-seo" ) }
 					</div>
 				</Table.Header> }
@@ -198,7 +201,7 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 		</Table.Head>
 
 		<Table.Body>
-			{ rows && rows.map( ( rowData, index ) => (
+			{ ! isPending && rows && rows.map( ( rowData, index ) => (
 				<KeyphrasesTableRow
 					key={ `related-keyphrase-${ index }` }
 					renderButton={ renderButton }

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/stories.js
@@ -11,6 +11,7 @@ export const Factory = {
 	args: {
 		renderButton: ButtonFactory.render,
 		relatedKeyphrases: [],
+		isPending: false,
 		columnNames: [ "Keyword", "Search Volume", "Trends", "Keyword Difficulty Index", "Intent" ],
 		userLocale: "en",
 		data: [
@@ -94,7 +95,7 @@ export const Factory = {
 	render: ( args ) => <KeyphrasesTable { ...args } />,
 };
 
-export const LoadingTable = () => <KeyphrasesTable renderButton={ noop } />;
+export const LoadingTable = () => <KeyphrasesTable renderButton={ noop } isPending={ true } />;
 
 export const WithoutButtons = () => <KeyphrasesTable data={ Factory.args.data } columnNames={ Factory.args.columnNames } />;
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The direction of "Add keyphrase" header title should we the opposite of the text direction. 
* The width should be fixed since the success message/remove button are of different width and we don't want that to affect the table/column width when switching the buttons.
* We want to fix the storybook for loading table and prevent rendering data when table is loading.  

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/related-keyphrase-suggestions 0.1.0] Fixes "Add keyphrase" title direction and width.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast Premium
* Edit a post with focus keyphrase
* Click on "Get related keyphrases"
* After logging into Semrush check the table header for get related keyphrase is in one line and when removing or adding related keyphrase the width of the columns doesn't change.
* When the table is loading, check that the loading button is closer to the end of the cell and that the header title is still in one line.

[Edit Post “Hello world!” ‹ wordpress.test — WordPress (2).webm](https://github.com/user-attachments/assets/4aad5f13-9c98-4b50-8700-9a1fb10d5d9a)

### Test storybook

* Activate storybook by:
```
cd packages/related-keyphrase-suggestions
yarn install
yarn storybook
```
* Play with the control prop `isPending` and check the table is changing to the pending design.
* Go to the Keyphrase table component and check that the Loading table is rendered.
 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
