### PR TITLE
Dashboard: implement descriptions scores 

### DIFF
--- a/packages/js/src/dashboard/hooks/use-fetch.js
+++ b/packages/js/src/dashboard/hooks/use-fetch.js
@@ -44,7 +44,7 @@ const fetchJson = async( url, options ) => {
  * @returns {FetchResult} The fetch result.
  */
 export const useFetch = ( { dependencies, url, options, prepareData = identity, doFetch = fetchJson, fetchDelay = FETCH_DELAY } ) => {
-	const [ isPending, setIsPending ] = useState( false );
+	const [ isPending, setIsPending ] = useState( true );
 	const [ error, setError ] = useState();
 	const [ data, setData ] = useState();
 	/** @type {MutableRefObject<AbortController>} */

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -22,8 +22,16 @@ export { Dashboard } from "./components/dashboard";
  */
 
 /**
+ * @typedef {"seo"|"readability"} AnalysisType The analysis type.
+ */
+
+/**
+ * @typedef {"ok"|"good"|"bad"|"notAnalyzed"} ScoreType The score type.
+ */
+
+/**
  * @typedef {Object} Score A score.
- * @property {string} name The name of the score. Can be "ok", "good", "bad" or "notAnalyzed".
+ * @property {ScoreType} name The name of the score.
  * @property {number} amount The amount of content for this score.
  * @property {Object} links The links.
  * @property {string} [links.view] The view link, might not exist.

--- a/packages/js/src/dashboard/scores/components/content-status-description.js
+++ b/packages/js/src/dashboard/scores/components/content-status-description.js
@@ -1,16 +1,17 @@
-import { __ } from "@wordpress/i18n";
+import { maxBy } from "lodash";
 
 /**
  * @type {import("../index").Score} Score
+ * @type {import("../index").ScoreType} ScoreType
  */
 
 /**
- * @param {Score[]|null} scores The SEO scores.
+ * @param {Score[]} scores The SEO scores.
+ * @param {Object.<ScoreType,string>} descriptions The descriptions.
  * @returns {JSX.Element} The element.
  */
-export const ContentStatusDescription = ( { scores } ) => {
-	if ( ! scores ) {
-		return <p className="yst-my-6">{ __( "No scores could be retrieved Or maybe loading??", "wordpress-seo" ) }</p>;
-	}
-	return <p className="yst-my-6">{ __( "description placeholder", "wordpress-seo" ) }</p>;
+export const ContentStatusDescription = ( { scores, descriptions } ) => {
+	const maxScore = maxBy( scores, "amount" );
+
+	return <p className="yst-my-6">{ descriptions[ maxScore.name ] || "" }</p>;
 };

--- a/packages/js/src/dashboard/scores/components/score-content.js
+++ b/packages/js/src/dashboard/scores/components/score-content.js
@@ -6,6 +6,7 @@ import { ScoreList } from "./score-list";
 
 /**
  * @type {import("../index").Score} Score
+ * @type {import("../index").ScoreType} ScoreType
  */
 
 /**
@@ -39,16 +40,17 @@ const ScoreContentSkeletonLoader = () => (
 /**
  * @param {Score[]} [scores=[]] The scores.
  * @param {boolean} isLoading Whether the scores are still loading.
+ * @param {Object.<ScoreType,string>} descriptions The descriptions.
  * @returns {JSX.Element} The element.
  */
-export const ScoreContent = ( { scores = [], isLoading } ) => {
+export const ScoreContent = ( { scores = [], isLoading, descriptions } ) => {
 	if ( isLoading ) {
 		return <ScoreContentSkeletonLoader />;
 	}
 
 	return (
 		<>
-			<ContentStatusDescription scores={ scores } />
+			<ContentStatusDescription scores={ scores } descriptions={ descriptions } />
 			<div className="yst-grid yst-grid-cols-1 @md:yst-grid-cols-7 yst-gap-6">
 				{ scores && <ScoreList scores={ scores } /> }
 				{ scores && <ScoreChart scores={ scores } /> }

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -19,7 +19,9 @@ export const ScoreList = ( { scores } ) => (
 				<span className={ `yst-rounded-full yst-w-3 yst-h-3 ${ SCORE_META[ score.name ].color }` } />
 				<span className="yst-ml-3 yst-mr-2 yst-leading-4 yst-py-1.5">{ SCORE_META[ score.name ].label }</span>
 				<Badge variant="plain">{ score.amount }</Badge>
-				{ score.links.view && <Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button> }
+				{ score.links.view && (
+					<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>
+				) }
 			</li>
 		) ) }
 	</ul>

--- a/packages/js/src/dashboard/scores/readability/readability-scores.js
+++ b/packages/js/src/dashboard/scores/readability/readability-scores.js
@@ -5,6 +5,7 @@ import { useFetch } from "../../hooks/use-fetch";
 import { ContentTypeFilter } from "../components/content-type-filter";
 import { ScoreContent } from "../components/score-content";
 import { TermFilter } from "../components/term-filter";
+import { SCORE_DESCRIPTIONS } from "../score-meta";
 
 /**
  * @type {import("../index").ContentType} ContentType
@@ -59,7 +60,7 @@ export const ReadabilityScores = ( { contentTypes } ) => {
 					/>
 				}
 			</div>
-			<ScoreContent scores={ scores } isLoading={ isPending } />
+			<ScoreContent scores={ scores } isLoading={ isPending } descriptions={ SCORE_DESCRIPTIONS.readability } />
 		</Paper>
 	);
 };

--- a/packages/js/src/dashboard/scores/readability/readability-scores.js
+++ b/packages/js/src/dashboard/scores/readability/readability-scores.js
@@ -28,6 +28,12 @@ export const ReadabilityScores = ( { contentTypes } ) => {
 		fetchDelay: 0,
 		doFetch: async( url, options ) => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+			return [ "good", "ok", "bad", "notAnalyzed" ].map( ( name ) => ( {
+				name,
+				amount: Math.ceil( Math.random() * 10 ),
+				links: Math.random() > 0.5 ? {} : { view: `edit.php?readability_filter=${ name }` },
+			} ) );
+			// eslint-disable-next-line no-unreachable
 			try {
 				const response = await fetch( url, options );
 				if ( ! response.ok ) {

--- a/packages/js/src/dashboard/scores/score-meta.js
+++ b/packages/js/src/dashboard/scores/score-meta.js
@@ -1,5 +1,13 @@
 import { __ } from "@wordpress/i18n";
 
+/**
+ * @type {import("../index").AnalysisType} AnalysisType
+ * @type {import("../index").ScoreType} ScoreType
+ */
+
+/**
+ * @type {Object.<ScoreType,{label: string, color: string, hex: string}>} The meta data.
+ */
 export const SCORE_META = {
 	good: {
 		label: __( "Good", "wordpress-seo" ),
@@ -20,5 +28,23 @@ export const SCORE_META = {
 		label: __( "Not analyzed", "wordpress-seo" ),
 		color: "yst-bg-analysis-na",
 		hex: "#cbd5e1",
+	},
+};
+
+/**
+ * @type {Object.<AnalysisType,Object.<ScoreType,string>>} The descriptions.
+ */
+export const SCORE_DESCRIPTIONS = {
+	seo: {
+		good: __( "Most of your content has a good SEO score. Well done!", "wordpress-seo" ),
+		ok: __( "Your content has an average SEO score. Find opportunities for enhancement.", "wordpress-seo" ),
+		bad: __( "Some of your content needs attention. Identify and address areas for improvement.", "wordpress-seo" ),
+		notAnalyzed: __( "Some of your content hasn't been analyzed yet. Please open it in your editor so we can analyze it.", "wordpress-seo" ),
+	},
+	readability: {
+		good: __( "Most of your content has a good Readability score. Well done!", "wordpress-seo" ),
+		ok: __( "Your content has an average Readability score. Find opportunities for enhancement.", "wordpress-seo" ),
+		bad: __( "Some of your content needs attention. Identify and address areas for improvement.", "wordpress-seo" ),
+		notAnalyzed: __( "Some of your content hasn't been analyzed yet. Please open it in your editor so we can analyze it.", "wordpress-seo" ),
 	},
 };

--- a/packages/js/src/dashboard/scores/seo/seo-scores.js
+++ b/packages/js/src/dashboard/scores/seo/seo-scores.js
@@ -5,6 +5,7 @@ import { useFetch } from "../../hooks/use-fetch";
 import { ContentTypeFilter } from "../components/content-type-filter";
 import { ScoreContent } from "../components/score-content";
 import { TermFilter } from "../components/term-filter";
+import { SCORE_DESCRIPTIONS } from "../score-meta";
 
 /**
  * @type {import("../index").ContentType} ContentType
@@ -60,7 +61,7 @@ export const SeoScores = ( { contentTypes } ) => {
 					/>
 				}
 			</div>
-			<ScoreContent scores={ scores } isLoading={ isPending } />
+			<ScoreContent scores={ scores } isLoading={ isPending } descriptions={ SCORE_DESCRIPTIONS.seo } />
 		</Paper>
 	);
 };

--- a/packages/js/src/dashboard/scores/seo/seo-scores.js
+++ b/packages/js/src/dashboard/scores/seo/seo-scores.js
@@ -29,6 +29,12 @@ export const SeoScores = ( { contentTypes } ) => {
 		fetchDelay: 0,
 		doFetch: async( url, options ) => {
 			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+			return [ "good", "ok", "bad", "notAnalyzed" ].map( ( name ) => ( {
+				name,
+				amount: Math.ceil( Math.random() * 10 ),
+				links: Math.random() > 0.5 ? {} : { view: `edit.php?seo_filter=${ name }` },
+			} ) );
+			// eslint-disable-next-line no-unreachable
 			try {
 				const response = await fetch( url, options );
 				if ( ! response.ok ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Reflect the description based on the widget and which score has the highest amount

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows description based on which score has the highest amount, in both the SEO and Readability widget of the dashboard.

## Relevant technical choices:

[Implement descriptions](https://github.com/Yoast/wordpress-seo/commit/933ff1048143c9e8515370f631a99c12ec022bb4) 
Descriptions are based on the analysis type and the score "type"
* I made them hardcoded with lookup on Widget level for SEO/Readability and score in the description. This seemed the most flexible without introducing context or a store or a complicated nested switch if/else. If you have better ideas, please let me know 😄 

[Change the initial isPending to true](https://github.com/Yoast/wordpress-seo/commit/231c22862fd491852a7c292ec5f9e2d273e2f4c6) 
This prevents the initial rendering of the descriptions without any score
As the useFetch has a useEffect which should trigger on rending anyway, this makes sense

[For testing](https://github.com/Yoast/wordpress-seo/commit/c0888c2572061f2e6e08d9ed24d5177ee2403b0e) 
Add random amounts (and links) for now (ignoring the actual JSON content)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the dashboard
* Ensure you have different amounts so you can check that each description is shown
  * Devs: either change the code or keep refreshing for now 
  * QA: change the environment once this is actually hooked up to valid requests
* Note: copy is subject to change still at the time of writing this PR. [Here is a link that contains the copy](https://docs.google.com/document/d/1aiDniY0PPvCnqemWFvQkefGJrw9zgvqcORyumDbxRwI/edit?tab=t.0#heading=h.lnrvziv4xamd), hoping that will be updated.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The dashboard

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/336
