### PR TITLE
Dashboard: clear category in case another post type was selected

### DIFF
--- a/packages/js/src/dashboard/scores/components/term-filter.js
+++ b/packages/js/src/dashboard/scores/components/term-filter.js
@@ -25,6 +25,24 @@ const createQueryUrl = ( baseUrl, query ) => new URL( "?" + new URLSearchParams(
 const transformTerm = ( term ) => ( { name: term.slug, label: term.name } );
 
 /**
+ * Renders either a list of terms or a message that nothing was found.
+ * @param {Term[]} terms The terms.
+ * @returns {JSX.Element} The element.
+ */
+const Content = ( { terms } ) => terms.length === 0
+	? (
+		<div className="yst-autocomplete__option">
+			{ __( "Nothing found", "wordpress-seo" ) }
+		</div>
+	)
+	: terms.map( ( { name, label } ) => (
+		<AutocompleteField.Option key={ name } value={ name }>
+			{ label }
+		</AutocompleteField.Option>
+	) )
+;
+
+/**
  * @param {string} idSuffix The suffix for the ID.
  * @param {Taxonomy} taxonomy The taxonomy.
  * @param {Term?} selected The selected term.
@@ -72,16 +90,7 @@ export const TermFilter = ( { idSuffix, taxonomy, selected, onChange } ) => {
 					<Spinner />
 				</div>
 			) }
-			{ ! isPending && terms.length === 0 && (
-				<div className="yst-autocomplete__option">
-					{ __( "Nothing found", "wordpress-seo" ) }
-				</div>
-			) }
-			{ ! isPending && terms.length > 0 && terms.map( ( { name, label } ) => (
-				<AutocompleteField.Option key={ name } value={ name }>
-					{ label }
-				</AutocompleteField.Option>
-			) ) }
+			{ ! isPending && <Content terms={ terms } /> }
 		</AutocompleteField>
 	);
 };

--- a/packages/js/src/dashboard/scores/seo/seo-scores.js
+++ b/packages/js/src/dashboard/scores/seo/seo-scores.js
@@ -1,4 +1,4 @@
-import { useState } from "@wordpress/element";
+import { useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Paper, Title } from "@yoast/ui-library";
 import { useFetch } from "../../hooks/use-fetch";
@@ -40,6 +40,11 @@ export const SeoScores = ( { contentTypes } ) => {
 			}
 		},
 	} );
+
+	useEffect( () => {
+		// Reset the selected term when the selected content type changes.
+		setSelectedTerm( undefined ); // eslint-disable-line no-undefined
+	}, [ selectedContentType.name ] );
 
 	return (
 		<Paper className="yst-@container yst-grow yst-max-w-screen-sm yst-p-8">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Clears the selected term when a content type is selected.

## Relevant technical choices:

* Added a `useEffect` in the outer layer instead of in the TermFilter because the TermFilter does not always get rendered and thus might not get the `useEffect` trigger? 🤷 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the dashboard
* Select a term
* Select a different content type (that also has a connected taxonomy, like product)
* [ ] Verify there is no more selected term

#### Regression
* Search for a term
* [ ] Verify you see the spinner when you typed
* [ ] Verify you see no content when you search for something that has no terms

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/338
