### PR TITLE
Add micro caching around the score queries

### DIFF
--- a/src/dashboard/infrastructure/scores/readability-scores/readability-scores-collector.php
+++ b/src/dashboard/infrastructure/scores/readability-scores/readability-scores-collector.php
@@ -63,7 +63,7 @@ class Readability_Scores_Collector implements Scores_Collector_Interface {
 				)
 			);
 			//phpcs:enable
-			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
+			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
 			return $current_scores;
 
 		}
@@ -92,7 +92,7 @@ class Readability_Scores_Collector implements Scores_Collector_Interface {
 			)
 		);
 		//phpcs:enable
-		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
+		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
 		return $current_scores;
 	}
 

--- a/src/dashboard/infrastructure/scores/readability-scores/readability-scores-collector.php
+++ b/src/dashboard/infrastructure/scores/readability-scores/readability-scores-collector.php
@@ -3,6 +3,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Dashboard\Infrastructure\Scores\Readability_Scores;
 
+use WPSEO_Utils;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Dashboard\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Dashboard\Domain\Scores\Readability_Scores\Readability_Scores_Interface;
@@ -12,6 +13,8 @@ use Yoast\WP\SEO\Dashboard\Infrastructure\Scores\Scores_Collector_Interface;
  * Getting readability scores from the indexable database table.
  */
 class Readability_Scores_Collector implements Scores_Collector_Interface {
+
+	public const READABILITY_SCORES_TRANSIENT = 'wpseo_readability_scores';
 
 	/**
 	 * Retrieves the current readability scores for a content type.
@@ -24,13 +27,22 @@ class Readability_Scores_Collector implements Scores_Collector_Interface {
 	 */
 	public function get_current_scores( array $readability_scores, Content_Type $content_type, ?int $term_id ) {
 		global $wpdb;
+
+		$content_type_name = $content_type->get_name();
+		$transient_name    = self::READABILITY_SCORES_TRANSIENT . '_' . $content_type_name . ( ( $term_id === null ) ? '' : '_' . $term_id );
+
+		$transient = \get_transient( $transient_name );
+		if ( $transient !== false ) {
+			return \json_decode( $transient, false );
+		}
+
 		$select = $this->build_select( $readability_scores );
 
 		$replacements = \array_merge(
 			\array_values( $select['replacements'] ),
 			[
 				Model::get_table_name( 'Indexable' ),
-				$content_type->get_name(),
+				$content_type_name,
 			]
 		);
 
@@ -51,6 +63,7 @@ class Readability_Scores_Collector implements Scores_Collector_Interface {
 				)
 			);
 			//phpcs:enable
+			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
 			return $current_scores;
 
 		}
@@ -79,6 +92,7 @@ class Readability_Scores_Collector implements Scores_Collector_Interface {
 			)
 		);
 		//phpcs:enable
+		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
 		return $current_scores;
 	}
 

--- a/src/dashboard/infrastructure/scores/seo-scores/seo-scores-collector.php
+++ b/src/dashboard/infrastructure/scores/seo-scores/seo-scores-collector.php
@@ -64,7 +64,7 @@ class SEO_Scores_Collector implements Scores_Collector_Interface {
 				)
 			);
 			//phpcs:enable
-			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
+			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
 			return $current_scores;
 
 		}
@@ -94,7 +94,7 @@ class SEO_Scores_Collector implements Scores_Collector_Interface {
 			)
 		);
 		//phpcs:enable
-		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
+		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
 		return $current_scores;
 	}
 

--- a/src/dashboard/infrastructure/scores/seo-scores/seo-scores-collector.php
+++ b/src/dashboard/infrastructure/scores/seo-scores/seo-scores-collector.php
@@ -3,6 +3,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Dashboard\Infrastructure\Scores\SEO_Scores;
 
+use WPSEO_Utils;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Dashboard\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Dashboard\Domain\Scores\SEO_Scores\SEO_Scores_Interface;
@@ -12,6 +13,8 @@ use Yoast\WP\SEO\Dashboard\Infrastructure\Scores\Scores_Collector_Interface;
  * Getting SEO scores from the indexable database table.
  */
 class SEO_Scores_Collector implements Scores_Collector_Interface {
+
+	public const SEO_SCORES_TRANSIENT = 'wpseo_seo_scores';
 
 	/**
 	 * Retrieves the current SEO scores for a content type.
@@ -24,13 +27,22 @@ class SEO_Scores_Collector implements Scores_Collector_Interface {
 	 */
 	public function get_current_scores( array $seo_scores, Content_Type $content_type, ?int $term_id ) {
 		global $wpdb;
+
+		$content_type_name = $content_type->get_name();
+		$transient_name    = self::SEO_SCORES_TRANSIENT . '_' . $content_type_name . ( ( $term_id === null ) ? '' : '_' . $term_id );
+
+		$transient = \get_transient( $transient_name );
+		if ( $transient !== false ) {
+			return \json_decode( $transient, false );
+		}
+
 		$select = $this->build_select( $seo_scores );
 
 		$replacements = \array_merge(
 			\array_values( $select['replacements'] ),
 			[
 				Model::get_table_name( 'Indexable' ),
-				$content_type->get_name(),
+				$content_type_name,
 			]
 		);
 
@@ -52,6 +64,7 @@ class SEO_Scores_Collector implements Scores_Collector_Interface {
 				)
 			);
 			//phpcs:enable
+			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
 			return $current_scores;
 
 		}
@@ -81,6 +94,7 @@ class SEO_Scores_Collector implements Scores_Collector_Interface {
 			)
 		);
 		//phpcs:enable
+		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), ( \MINUTE_IN_SECONDS ) );
 		return $current_scores;
 	}
 

--- a/src/dashboard/infrastructure/taxonomies/taxonomies-collector.php
+++ b/src/dashboard/infrastructure/taxonomies/taxonomies-collector.php
@@ -39,6 +39,8 @@ class Taxonomies_Collector {
 		/**
 		 * Filter: 'wpseo_{$content_type}_filtering_taxonomy' - Allows overriding which taxonomy filters the content type.
 		 *
+		 * @internal
+		 *
 		 * @param string $filtering_taxonomy The taxonomy that filters the content type.
 		 */
 		$filtering_taxonomy = \apply_filters( "wpseo_{$content_type}_filtering_taxonomy", '' );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds micro caching around the score queries

## Relevant technical choices:

* A small change in the visibility of the unrelated `wpseo_{$content_type}_filtering_taxonomy` query is included.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `src\dashboard\infrastructure\scores\seo-scores\seo-scores-collector.php` and in `src\dashboard\infrastructure\scores\readability-scores\readability-scores-collector.php` there are two lines that read as `$current_scores = $wpdb->get_row(` in each file. Add a `error_log('QUERY STARTED');` line right before them.
* Within the span of 1 minute, perform GET requests to:
  * `/wp-json/yoast/v1/seo_scores?contentType=post`
  * `/wp-json/yoast/v1/seo_scores?contentType=post&taxonomy=category&term=<TERM_ID>` where <TERM_ID> is the id of an existing term
  * `/wp-json/yoast/v1/seo_scores?contentType=post&taxonomy=category&term=<TERM_ID>` where <TERM_ID> is the id of a different existing term
  * `/wp-json/yoast/v1/seo_scores?contentType=page`
  * An additional GET request to each of those endpoints
* Confirm that:
  * You get the expected amounts in every request you do
  * In your debug.log you get only 4 `QUERY STARTED` entries
  * After one minute, if you repeat a request out of the above, you will get an additional `QUERY STARTED` entry in the debug.log
* Do the same but with the `/wp-json/yoast/v1/readability_scores` endpoint

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/roadmap/issues/531
