### PR TITLE
Dashboard: UX feedback

### DIFF
--- a/packages/js/src/dashboard/scores/components/score-chart.js
+++ b/packages/js/src/dashboard/scores/components/score-chart.js
@@ -14,29 +14,24 @@ Chart.register( ArcElement, Tooltip );
  * @param {Score[]} scores The scores.
  * @returns {Object} Parsed chart data.
  */
-const transformScoresToGraphData = ( scores ) => {
-	const hexes = scores.map( ( { name } ) => SCORE_META[ name ].hex );
-
-	return {
-		labels: scores.map( ( { name } ) => SCORE_META[ name ].label ),
-		datasets: [
-			{
-				cutout: "82%",
-				data: scores.map( ( { amount } ) => amount ),
-				backgroundColor: hexes,
-				borderColor: hexes,
-				borderWidth: 1,
-				offset: 1,
-				hoverOffset: 5,
-				spacing: 1,
-				weight: 1,
-				animation: {
-					animateRotate: true,
-				},
+const transformScoresToGraphData = ( scores ) => ( {
+	labels: scores.map( ( { name } ) => SCORE_META[ name ].label ),
+	datasets: [
+		{
+			cutout: "82%",
+			data: scores.map( ( { amount } ) => amount ),
+			backgroundColor: scores.map( ( { name } ) => SCORE_META[ name ].hex ),
+			borderWidth: 0,
+			offset: 0,
+			hoverOffset: 5,
+			spacing: 1,
+			weight: 1,
+			animation: {
+				animateRotate: true,
 			},
-		],
-	};
-};
+		},
+	],
+} );
 
 const chartOptions = {
 	plugins: {
@@ -48,6 +43,9 @@ const chartOptions = {
 				label: context => `${ context.label }: ${ context?.formattedValue }`,
 			},
 		},
+	},
+	layout: {
+		padding: 5,
 	},
 };
 

--- a/packages/js/src/dashboard/scores/components/score-chart.js
+++ b/packages/js/src/dashboard/scores/components/score-chart.js
@@ -1,4 +1,6 @@
+import { SkeletonLoader } from "@yoast/ui-library";
 import { ArcElement, Chart, Tooltip } from "chart.js";
+import classNames from "classnames";
 import { Doughnut } from "react-chartjs-2";
 import { SCORE_META } from "../score-meta";
 
@@ -50,13 +52,24 @@ const chartOptions = {
 };
 
 /**
- *
+ * @param {string} [className] The class name.
+ * @returns {JSX.Element} The element.
+ */
+export const ScoreChartSkeletonLoader = ( { className } ) => (
+	<div className={ classNames( className, "yst-relative" ) }>
+		<SkeletonLoader className="yst-w-full yst-aspect-square yst-rounded-full" />
+		<div className="yst-absolute yst-inset-5 yst-aspect-square yst-bg-white yst-rounded-full" />
+	</div>
+);
+
+/**
+ * @param {string} [className] The class name.
  * @param {Score[]} scores The scores.
  * @returns {JSX.Element} The element.
  */
-export const ScoreChart = ( { scores } ) => {
+export const ScoreChart = ( { className, scores } ) => {
 	return (
-		<div className="yst-col-span-3">
+		<div className={ className }>
 			<Doughnut
 				options={ chartOptions }
 				data={ transformScoresToGraphData( scores ) }

--- a/packages/js/src/dashboard/scores/components/score-content.js
+++ b/packages/js/src/dashboard/scores/components/score-content.js
@@ -1,8 +1,7 @@
 import { SkeletonLoader } from "@yoast/ui-library";
-import { SCORE_META } from "../score-meta";
 import { ContentStatusDescription } from "./content-status-description";
-import { ScoreChart } from "./score-chart";
-import { ScoreList } from "./score-list";
+import { ScoreChart, ScoreChartSkeletonLoader } from "./score-chart";
+import { ScoreList, ScoreListSkeletonLoader } from "./score-list";
 
 /**
  * @type {import("../index").Score} Score
@@ -10,29 +9,24 @@ import { ScoreList } from "./score-list";
  */
 
 /**
+ * @type {{container: string, list: string, chart: string}}
+ */
+const CLASSNAMES = {
+	container: "yst-flex yst-flex-col @md:yst-flex-row yst-gap-12 yst-mt-6",
+	list: "yst-grow",
+	// Calculation: (line-height 1rem + py 0.375rem * 2) * 4 + (spacing 0.75rem * 2 + border 1px ) * 3 = 11.5rem + 3px.
+	chart: "yst-w-[calc(11.5rem+3px)] yst-aspect-square",
+};
+
+/**
  * @returns {JSX.Element} The element.
  */
 const ScoreContentSkeletonLoader = () => (
 	<>
 		<SkeletonLoader className="yst-w-full">&nbsp;</SkeletonLoader>
-		<div className="yst-grid yst-grid-cols-1 @md:yst-grid-cols-7 yst-gap-6 yst-mt-6">
-			<ul className="yst-col-span-4">
-				{ Object.entries( SCORE_META ).map( ( [ name, { label } ] ) => (
-					<li
-						key={ `skeleton-loader--${ name }` }
-						className="yst-flex yst-items-center yst-min-h-[1rem] yst-py-3 yst-border-b last:yst-border-b-0"
-					>
-						<SkeletonLoader className="yst-w-3 yst-h-3 yst-rounded-full" />
-						<SkeletonLoader className="yst-ml-3 yst-mr-2">{ label }</SkeletonLoader>
-						<SkeletonLoader className="yst-w-7">1</SkeletonLoader>
-						<SkeletonLoader className="yst-ml-auto yst-button yst-button--small">View</SkeletonLoader>
-					</li>
-				) ) }
-			</ul>
-			<div className="yst-col-span-3 yst-relative">
-				<SkeletonLoader className="yst-w-full yst-aspect-square yst-rounded-full" />
-				<div className="yst-absolute yst-inset-5 yst-aspect-square yst-bg-white yst-rounded-full" />
-			</div>
+		<div className={ CLASSNAMES.container }>
+			<ScoreListSkeletonLoader className={ CLASSNAMES.list } />
+			<ScoreChartSkeletonLoader className={ CLASSNAMES.chart } />
 		</div>
 	</>
 );
@@ -51,9 +45,9 @@ export const ScoreContent = ( { scores = [], isLoading, descriptions } ) => {
 	return (
 		<>
 			<ContentStatusDescription scores={ scores } descriptions={ descriptions } />
-			<div className="yst-grid yst-grid-cols-1 @md:yst-grid-cols-7 yst-gap-6 yst-mt-6">
-				{ scores && <ScoreList scores={ scores } /> }
-				{ scores && <ScoreChart scores={ scores } /> }
+			<div className={ CLASSNAMES.container }>
+				{ scores && <ScoreList className={ CLASSNAMES.list } scores={ scores } /> }
+				{ scores && <ScoreChart className={ CLASSNAMES.chart } scores={ scores } /> }
 			</div>
 		</>
 	);

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -1,4 +1,4 @@
-import { Badge, Button, SkeletonLoader } from "@yoast/ui-library";
+import { Badge, Button, Label, SkeletonLoader } from "@yoast/ui-library";
 import classNames from "classnames";
 import { SCORE_META } from "../score-meta";
 
@@ -12,6 +12,7 @@ import { SCORE_META } from "../score-meta";
 const CLASSNAMES = {
 	listItem: "yst-flex yst-items-center yst-py-3 first:yst-pt-0 last:yst-pb-0 yst-border-b last:yst-border-b-0",
 	score: "yst-shrink-0 yst-w-3 yst-aspect-square yst-rounded-full",
+	label: "yst-ml-3 yst-mr-2",
 };
 
 /**
@@ -26,7 +27,7 @@ export const ScoreListSkeletonLoader = ( { className } ) => (
 				className={ CLASSNAMES.listItem }
 			>
 				<SkeletonLoader className={ CLASSNAMES.score } />
-				<SkeletonLoader className="yst-ml-3 yst-mr-2">{ label }</SkeletonLoader>
+				<SkeletonLoader className={ CLASSNAMES.label }>{ label }</SkeletonLoader>
 				<SkeletonLoader className="yst-w-7 yst-mr-3">1</SkeletonLoader>
 				<SkeletonLoader className="yst-ml-auto yst-button yst-button--small">View</SkeletonLoader>
 			</li>
@@ -47,7 +48,7 @@ export const ScoreList = ( { className, scores } ) => (
 				className={ CLASSNAMES.listItem }
 			>
 				<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
-				<span className="yst-ml-3 yst-mr-2 yst-leading-4 yst-py-1.5">{ SCORE_META[ score.name ].label }</span>
+				<Label as="span" className={ classNames( CLASSNAMES.label, "yst-leading-4 yst-py-1.5" ) }>{ SCORE_META[ score.name ].label }</Label>
 				<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
 				{ score.links.view && (
 					<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -1,4 +1,5 @@
-import { Badge, Button } from "@yoast/ui-library";
+import { Badge, Button, SkeletonLoader } from "@yoast/ui-library";
+import classNames from "classnames";
 import { SCORE_META } from "../score-meta";
 
 /**
@@ -6,19 +7,48 @@ import { SCORE_META } from "../score-meta";
  */
 
 /**
+ * @type {{listItem: string, score: string}}
+ */
+const CLASSNAMES = {
+	listItem: "yst-flex yst-items-center yst-py-3 first:yst-pt-0 last:yst-pb-0 yst-border-b last:yst-border-b-0",
+	score: "yst-shrink-0 yst-w-3 yst-aspect-square yst-rounded-full",
+};
+
+/**
+ * @param {string} [className] The class name for the UL.
+ * @returns {JSX.Element} The element.
+ */
+export const ScoreListSkeletonLoader = ( { className } ) => (
+	<ul className={ className }>
+		{ Object.entries( SCORE_META ).map( ( [ name, { label } ] ) => (
+			<li
+				key={ `skeleton-loader--${ name }` }
+				className={ CLASSNAMES.listItem }
+			>
+				<SkeletonLoader className={ CLASSNAMES.score } />
+				<SkeletonLoader className="yst-ml-3 yst-mr-2">{ label }</SkeletonLoader>
+				<SkeletonLoader className="yst-w-7 yst-mr-3">1</SkeletonLoader>
+				<SkeletonLoader className="yst-ml-auto yst-button yst-button--small">View</SkeletonLoader>
+			</li>
+		) ) }
+	</ul>
+);
+
+/**
+ * @param {string} [className] The class name for the UL.
  * @param {Score[]} scores The scores.
  * @returns {JSX.Element} The element.
  */
-export const ScoreList = ( { scores } ) => (
-	<ul className="yst-col-span-4">
+export const ScoreList = ( { className, scores } ) => (
+	<ul className={ className }>
 		{ scores.map( ( score ) => (
 			<li
 				key={ score.name }
-				className="yst-flex yst-items-center yst-min-h-[1rem] yst-py-3 yst-border-b last:yst-border-b-0"
+				className={ CLASSNAMES.listItem }
 			>
-				<span className={ `yst-rounded-full yst-w-3 yst-h-3 ${ SCORE_META[ score.name ].color }` } />
+				<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
 				<span className="yst-ml-3 yst-mr-2 yst-leading-4 yst-py-1.5">{ SCORE_META[ score.name ].label }</span>
-				<Badge variant="plain">{ score.amount }</Badge>
+				<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
 				{ score.links.view && (
 					<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>
 				) }

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -37,37 +37,35 @@ const Menu = ( { idSuffix = "" } ) => {
 				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
 			</Link>
 		</header>
-		<div className="yst-px-0.5 yst-space-y-6">
-			<ul className="yst-mt-1 yst-space-y-1">
-				<MenuItemLink
-					to={ ROUTES.dashboard }
-					label={ <>
-						<ChartPieIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
-						{ __( "Dashboard", "wordpress-seo" ) }
-					</> }
-					idSuffix={ idSuffix }
-					className="yst-gap-3"
-				/>
-				<MenuItemLink
-					to={ ROUTES.alertCenter }
-					label={ <>
-						<BellIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
-						{ __( "Alert center", "wordpress-seo" ) }
-					</> }
-					idSuffix={ idSuffix }
-					className="yst-gap-3"
-				/>
-				<MenuItemLink
-					to={ ROUTES.firstTimeConfiguration }
-					label={ <>
-						<AdjustmentsIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
-						{ __( "First-time configuration", "wordpress-seo" ) }
-					</> }
-					idSuffix={ idSuffix }
-					className="yst-gap-3"
-				/>
-			</ul>
-		</div>
+		<ul className="yst-mt-1 yst-px-0.5 yst-space-y-4">
+			<MenuItemLink
+				to={ ROUTES.dashboard }
+				label={ <>
+					<ChartPieIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
+					{ __( "Dashboard", "wordpress-seo" ) }
+				</> }
+				idSuffix={ idSuffix }
+				className="yst-gap-3"
+			/>
+			<MenuItemLink
+				to={ ROUTES.alertCenter }
+				label={ <>
+					<BellIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
+					{ __( "Alert center", "wordpress-seo" ) }
+				</> }
+				idSuffix={ idSuffix }
+				className="yst-gap-3"
+			/>
+			<MenuItemLink
+				to={ ROUTES.firstTimeConfiguration }
+				label={ <>
+					<AdjustmentsIcon className="yst-sidebar-navigation__icon yst-w-6 yst-h-6" />
+					{ __( "First-time configuration", "wordpress-seo" ) }
+				</> }
+				idSuffix={ idSuffix }
+				className="yst-gap-3"
+			/>
+		</ul>
 	</>;
 };
 Menu.propTypes = {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Addresses some feedback from UX.

## Relevant technical choices:

All based on `Design finetune meeting` in the [document](https://docs.google.com/document/d/1aiDniY0PPvCnqemWFvQkefGJrw9zgvqcORyumDbxRwI/edit?tab=t.0#heading=h.iorg0wqrs653)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the Dashboard
* Focus on the chart

#### Document point 3
* [ ] Verify the gaps are always there and never not like it was before

#### Document point 1
* Hover your mouse over the chart and..
* [ ] Verify the edges are never cut off anymore

#### Document point 2
* [ ] Verify the gap between the score list and chart is 3 rem or 48 pixels
* Play around with the width of the screen and..
* [ ] Verify the chart goes below the list when at certain points (if the container < 28 rem (448px))

#### Document point 6
* Make the screen width 320 pixels wide
* [ ] Verify the list score icon is still as wide as tall
* [ ] Verify the label is taking two lines just fine
* [ ] Verify the distance between the amount (badge) and the view (link/button) is still at least 0.75rem (12px)
![image](https://github.com/user-attachments/assets/a5c8405a-0f99-46a9-a0a9-66a2d120bd25)

#### Document point 4
* [ ] Verify the label has the same style as the [UI library Label](https://ui-library.yoast.com/?path=/docs/1-elements-label--docs):
  * [ ] Verify the label (Good/OK/etc) has font-weight of 500
  * [ ] Verify the label has the color of slate-800 (`#1e293b`)

#### Document point 5
* Resize back to normal
* [ ] Verify the distance between the menu items is 1 rem (16px)

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The dashboard

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
