### PR TITLE
Return 500 error code when query fails

### DIFF
--- a/src/dashboard/application/score-results/abstract-score-results-repository.php
+++ b/src/dashboard/application/score-results/abstract-score-results-repository.php
@@ -65,10 +65,6 @@ abstract class Abstract_Score_Results_Repository {
 	public function get_score_results( Content_Type $content_type, ?Taxonomy $taxonomy, ?int $term_id ): array {
 		$score_results = $this->score_results_collector->get_score_results( $this->score_groups, $content_type, $term_id );
 
-		if ( $score_results === null ) {
-			throw new Exception( 'Error getting score results', 500 );
-		}
-
 		$current_scores_list = $this->current_scores_repository->get_current_scores( $this->score_groups, $score_results, $content_type, $taxonomy, $term_id );
 		$score_result_object = new Score_Result( $current_scores_list, $score_results['query_time'], $score_results['cache_used'] );
 

--- a/src/dashboard/application/score-results/abstract-score-results-repository.php
+++ b/src/dashboard/application/score-results/abstract-score-results-repository.php
@@ -3,6 +3,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Dashboard\Application\Score_Results;
 
+use Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\Score_Groups_Interface;
 use Yoast\WP\SEO\Dashboard\Domain\Score_Results\Score_Result;
@@ -58,9 +59,15 @@ abstract class Abstract_Score_Results_Repository {
 	 * @param int|null      $term_id      The ID of the term we're filtering for.
 	 *
 	 * @return array<array<string, string|int|array<string, string>>> The scores.
+	 *
+	 * @throws Exception When getting score results from the infrastructure fails.
 	 */
 	public function get_score_results( Content_Type $content_type, ?Taxonomy $taxonomy, ?int $term_id ): array {
 		$score_results = $this->score_results_collector->get_score_results( $this->score_groups, $content_type, $term_id );
+
+		if ( $score_results === null ) {
+			throw new Exception( 'Error getting score results', 500 );
+		}
 
 		$current_scores_list = $this->current_scores_repository->get_current_scores( $this->score_groups, $score_results, $content_type, $taxonomy, $term_id );
 		$score_result_object = new Score_Result( $current_scores_list, $score_results['query_time'], $score_results['cache_used'] );

--- a/src/dashboard/domain/score-results/score-results-not-found-exception.php
+++ b/src/dashboard/domain/score-results/score-results-not-found-exception.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Dashboard\Domain\Score_Results;
+
+use Exception;
+
+/**
+ * Exception for when score results are not found.
+ */
+class Score_Results_Not_Found_Exception extends Exception {
+
+	/**
+	 * Constructor of the exception.
+	 */
+	public function __construct() {
+		parent::__construct( 'Score results not found', 500 );
+	}
+}

--- a/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
@@ -7,6 +7,7 @@ use WPSEO_Utils;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Dashboard\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\Readability_Score_Groups\Readability_Score_Groups_Interface;
+use Yoast\WP\SEO\Dashboard\Domain\Score_Results\Score_Results_Not_Found_Exception;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Score_Results\Score_Results_Collector_Interface;
 
 /**
@@ -23,7 +24,9 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 	 * @param Content_Type                         $content_type             The content type.
 	 * @param int|null                             $term_id                  The ID of the term we're filtering for.
 	 *
-	 * @return array<string, object|bool|float>|null The readability score results for a content type, null for failure.
+	 * @return array<string, object|bool|float> The readability score results for a content type.
+	 *
+	 * @throws Score_Results_Not_Found_Exception When the query of getting score results fails.
 	 */
 	public function get_score_results( array $readability_score_groups, Content_Type $content_type, ?int $term_id ) {
 		global $wpdb;
@@ -97,7 +100,7 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 		//phpcs:enable
 
 		if ( $current_scores === null ) {
-			return null;
+			throw new Score_Results_Not_Found_Exception();
 		}
 
 		$end_time = \microtime( true );

--- a/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
@@ -23,7 +23,7 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 	 * @param Content_Type                         $content_type             The content type.
 	 * @param int|null                             $term_id                  The ID of the term we're filtering for.
 	 *
-	 * @return array<string, object|bool|float> The readability score results for a content type.
+	 * @return array<string, object|bool|float>|null The readability score results for a content type, null for failure.
 	 */
 	public function get_score_results( array $readability_score_groups, Content_Type $content_type, ?int $term_id ) {
 		global $wpdb;
@@ -52,44 +52,26 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 		);
 
 		if ( $term_id === null ) {
-			$start_time = \microtime( true );
-			//phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $select['fields'] is an array of simple strings with placeholders.
 			//phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $replacements is an array with the correct replacements.
-			//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-			//phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-			$current_scores = $wpdb->get_row(
-				$wpdb->prepare(
-					"
-					SELECT {$select['fields']}
-					FROM %i AS I
-					WHERE ( I.post_status = 'publish' OR I.post_status IS NULL )
-						AND I.object_type = 'post'
-						AND I.object_sub_type = %s",
-					$replacements
-				)
+			//phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $select['fields'] is an array of simple strings with placeholders.
+			$query = $wpdb->prepare(
+				"
+				SELECT {$select['fields']}
+				FROM %i AS I
+				WHERE ( I.post_status = 'publish' OR I.post_status IS NULL )
+					AND I.object_type = 'post'
+					AND I.object_sub_type = %s",
+				$replacements
 			);
 			//phpcs:enable
-			$end_time = \microtime( true );
-
-			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
-
-			$results['scores']     = $current_scores;
-			$results['cache_used'] = false;
-			$results['query_time'] = ( $end_time - $start_time );
-			return $results;
-
 		}
+		else {
+			$replacements[] = $wpdb->term_relationships;
+			$replacements[] = $term_id;
 
-		$replacements[] = $wpdb->term_relationships;
-		$replacements[] = $term_id;
-
-		$start_time = \microtime( true );
-		//phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $select['fields'] is an array of simple strings with placeholders.
-		//phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $replacements is an array with the correct replacements.
-		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
-		//phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
-		$current_scores = $wpdb->get_row(
-			$wpdb->prepare(
+			//phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $replacements is an array with the correct replacements.
+			//phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $select['fields'] is an array of simple strings with placeholders.
+			$query = $wpdb->prepare(
 				"
 				SELECT {$select['fields']}
 				FROM %i AS I
@@ -102,9 +84,22 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 						WHERE term_taxonomy_id = %d
 				)",
 				$replacements
-			)
-		);
+			);
+			//phpcs:enable
+		}
+
+		$start_time = \microtime( true );
+
+		//phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $query is prepared above.
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery -- Reason: Most performant way.
+		//phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching -- Reason: No relevant caches.
+		$current_scores = $wpdb->get_row( $query );
 		//phpcs:enable
+
+		if ( $current_scores === null ) {
+			return null;
+		}
+
 		$end_time = \microtime( true );
 
 		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );

--- a/src/dashboard/infrastructure/score-results/seo-score-results/seo-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/seo-score-results/seo-score-results-collector.php
@@ -7,6 +7,7 @@ use WPSEO_Utils;
 use Yoast\WP\Lib\Model;
 use Yoast\WP\SEO\Dashboard\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Interface;
+use Yoast\WP\SEO\Dashboard\Domain\Score_Results\Score_Results_Not_Found_Exception;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Score_Results\Score_Results_Collector_Interface;
 
 /**
@@ -23,7 +24,9 @@ class SEO_Score_Results_Collector implements Score_Results_Collector_Interface {
 	 * @param Content_Type                 $content_type     The content type.
 	 * @param int|null                     $term_id          The ID of the term we're filtering for.
 	 *
-	 * @return array<string, object|bool|float>|null The SEO score results for a content type, null for failure.
+	 * @return array<string, object|bool|float> The SEO score results for a content type.
+	 *
+	 * @throws Score_Results_Not_Found_Exception When the query of getting score results fails.
 	 */
 	public function get_score_results( array $seo_score_groups, Content_Type $content_type, ?int $term_id ) {
 		global $wpdb;
@@ -99,7 +102,7 @@ class SEO_Score_Results_Collector implements Score_Results_Collector_Interface {
 		//phpcs:enable
 
 		if ( $current_scores === null ) {
-			return null;
+			throw new Score_Results_Not_Found_Exception();
 		}
 
 		$end_time = \microtime( true );

--- a/src/dashboard/user-interface/scores/abstract-scores-route.php
+++ b/src/dashboard/user-interface/scores/abstract-scores-route.php
@@ -168,6 +168,8 @@ abstract class Abstract_Scores_Route implements Route_Interface {
 			$content_type = $this->get_content_type( $request['contentType'] );
 			$taxonomy     = $this->get_taxonomy( $request['taxonomy'], $content_type );
 			$term_id      = $this->get_validated_term_id( $request['term'], $taxonomy );
+
+			$results = $this->score_results_repository->get_score_results( $content_type, $taxonomy, $term_id );
 		} catch ( Exception $exception ) {
 			return new WP_REST_Response(
 				[
@@ -178,7 +180,7 @@ abstract class Abstract_Scores_Route implements Route_Interface {
 		}
 
 		return new WP_REST_Response(
-			$this->score_results_repository->get_score_results( $content_type, $taxonomy, $term_id ),
+			$results,
 			200
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances API endpoints by returning a 500 error code when queries fail.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following filter, to make the SEO score query fail:
```
add_filter( 'query', 'fail_seo_score_query' );
function fail_seo_score_query( $query ) {
	if ( strpos( $query, "SELECT COUNT(CASE WHEN I.primary_focus_keyword_score >= 0 AND I.primary_focus_keyword_score <= 40 THEN 1 END)" ) !== false ) {
        return false;
    }

    return $query;
}
```
* Do a GET request to `/wp-json/yoast/v1/seo_scores?contentType=post&taxonomy=category&term=1`
* Confirm that you get a 500 error code and a `Score results not found` error message
* Within a minute from the GET request, remove the filter and retry
* Confirm that you get correct results. Also confirm that you still get `cacheUsed: true` if you repeat the same request within a minute. 
* Do the same with readability scores:
  * The GET request should be to `/wp-json/yoast/v1/readability_scores?contentType=post&taxonomy=category&term=1`
  * The filter should be 
```
add_filter( 'query', 'fail_readability_score_query' );
function fail_readability_score_query( $query ) {
	if ( strpos( $query, "COUNT(CASE WHEN I.readability_score = 0 AND I.estimated_reading_time_minutes IS NULL THEN 1 END) AS" ) !== false ) {
        return false;
    }

    return $query;
}
```

Note: Make sure you remove those filters after you're done testing.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/roadmap/issues/536
