### PR TITLE
Related key phrase suggestions fix styles for RTL

### DIFF
--- a/packages/related-keyphrase-suggestions/package.json
+++ b/packages/related-keyphrase-suggestions/package.json
@@ -61,13 +61,13 @@
     "postcss-loader": "^8.1.1",
     "puppeteer": "^23.6.0",
     "storybook": "^8.3.6",
-    "tailwindcss": "^3.4.14",
-    "style-loader": "^4.0.0"
+    "style-loader": "^4.0.0",
+    "tailwindcss": "^3.4.14"
   },
   "dependencies": {
-    "classnames": "^2.5.1",
     "@heroicons/react": "^1.0.6",
     "@wordpress/i18n": "^5.10.0",
+    "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "prop-types": "^15.8.1"
   },

--- a/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/KeyphrasesTable/index.js
@@ -171,10 +171,10 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 	return <Table className={ className }>
 		<Table.Head>
 			<Table.Row>
-				<Table.Header>
+				<Table.Header className="yst-text-start">
 					{ __( "Related keyphrase", "wordpress-seo" ) }
 				</Table.Header>
-				<Table.Header>
+				<Table.Header className="yst-text-start">
 					{ __( "Intent", "wordpress-seo" ) }
 				</Table.Header>
 				<Table.Header>
@@ -182,7 +182,7 @@ export const KeyphrasesTable = ( { columnNames = [], data, renderButton, related
 						{ __( "Volume", "wordpress-seo" ) }
 					</div>
 				</Table.Header>
-				<Table.Header>
+				<Table.Header className="yst-text-start">
 					{ __( "Trend", "wordpress-seo" ) }
 				</Table.Header>
 				<Table.Header className="yst-whitespace-nowrap">

--- a/packages/related-keyphrase-suggestions/src/components/Modal/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/Modal/index.js
@@ -46,7 +46,7 @@ export const Modal = ( { isOpen, onClose, insightsLink, learnMoreLink, children 
 							"Semrush",
 						) }
 						<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
-						<ExternalLinkIcon className="yst-link-icon" />
+						<ExternalLinkIcon className="yst-link-icon rtl:yst-rotate-270" />
 					</Link>
 					<Link
 						href={ learnMoreLink }
@@ -55,7 +55,7 @@ export const Modal = ( { isOpen, onClose, insightsLink, learnMoreLink, children 
 					>
 						{ __( "Learn more about the metrics", "wordpress-seo" ) }
 						<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
-						<ArrowNarrowRightIcon className="yst-link-icon" />
+						<ArrowNarrowRightIcon className="yst-link-icon rtl:yst-rotate-180" />
 					</Link>
 				</BaseModal.Container.Footer>
 			</BaseModal.Panel>

--- a/packages/related-keyphrase-suggestions/src/components/Modal/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/Modal/index.js
@@ -46,7 +46,7 @@ export const Modal = ( { isOpen, onClose, insightsLink, learnMoreLink, children 
 							"Semrush",
 						) }
 						<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
-						<ExternalLinkIcon className="yst-link-icon rtl:yst-rotate-270" />
+						<ExternalLinkIcon className="yst-link-icon rtl:yst-rotate-[270deg]" />
 					</Link>
 					<Link
 						href={ learnMoreLink }

--- a/packages/related-keyphrase-suggestions/src/elements/DifficultyBullet/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/DifficultyBullet/index.js
@@ -99,7 +99,7 @@ export const DifficultyBullet = ( { value } ) => {
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
 		>
-			<div className="yst-text-right yst-w-5">
+			<div className="yst-text-end yst-w-5">
 				{ value }
 			</div>
 			<div

--- a/packages/related-keyphrase-suggestions/src/elements/IntentBadge/style.css
+++ b/packages/related-keyphrase-suggestions/src/elements/IntentBadge/style.css
@@ -16,10 +16,6 @@
             &.yst-intent-badge--t {
                 @apply yst-text-green-900 yst-bg-green-200;
             }
-
-			.yst-tooltip--top {
-				@apply rtl:yst-translate-x-[58%];
-			}
         }
     }
 }

--- a/packages/related-keyphrase-suggestions/src/elements/IntentBadge/style.css
+++ b/packages/related-keyphrase-suggestions/src/elements/IntentBadge/style.css
@@ -16,6 +16,10 @@
             &.yst-intent-badge--t {
                 @apply yst-text-green-900 yst-bg-green-200;
             }
+
+			.yst-tooltip--top {
+				@apply rtl:yst-translate-x-[58%];
+			}
         }
     }
 }

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
@@ -27,10 +27,10 @@ export const PremiumUpsell = ( { url, className } ) => {
 		<Button
 			variant="upsell"
 			as="a" href={ url }
-			className="yst-mt-4"
+			className="yst-mt-4 yst-gap-2"
 			target="_blank"
 		>
-			<LockOpenIcon className="yst-w-4 yst-h-4 yst-mr-2 yst-text-amber-900" />
+			<LockOpenIcon className="yst-w-4 yst-h-4 yst-text-amber-900" />
 			{ sprintf(
 				/* translators: %s: Expands to "Yoast SEO Premium". */
 				__( "Explore %s!", "wordpress-seo" ),

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
@@ -80,7 +80,7 @@ export const TableButton = forwardRef( ( { variant = "add", className = "", ...p
 				className,
 			 ) }
 		>
-			<ButtonIcon className="yst-button-icon yst-mr-1.5 yst--ml-1 rtl:yst--mr-1 rtl:yst-ml-1.5" />
+			<ButtonIcon className="yst-button-icon yst--mx-1" />
 			{ variants[ variant ].button.label }
 		</Button>
 	);

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
@@ -80,7 +80,7 @@ export const TableButton = forwardRef( ( { variant = "add", className = "", ...p
 				className,
 			 ) }
 		>
-			<ButtonIcon className="yst-button-icon" />
+			<ButtonIcon className="yst-button-icon yst-mr-1.5 yst--ml-1 rtl:yst--mr-1 rtl:yst-ml-1.5" />
 			{ variants[ variant ].button.label }
 		</Button>
 	);

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
@@ -2,9 +2,13 @@
 	.yst-root {
 
         .yst-table-button {
+
+			.yst-button-icon {
+				@apply yst-mr-1.5 yst--ml-1 rtl:yst--mr-1 rtl:yst-ml-1.5;
+			}
             &.yst-button--secondary {
                 .yst-button-icon {
-                    @apply yst-text-slate-400 yst-w-3 yst-h-3 yst-mr-1.5 yst--ml-1;
+                    @apply yst-text-slate-400 yst-w-3 yst-h-3;
                 }
             }
     
@@ -12,7 +16,7 @@
                 @apply yst-text-red-500 hover:yst-text-red-700;
     
                 .yst-button-icon {
-                    @apply yst-w-3.5 yst-h-3.5 yst-mr-1.5 yst--ml-1;
+                    @apply yst-w-3.5 yst-h-3.5;
                 }
             }
 

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
@@ -2,6 +2,8 @@
 	.yst-root {
 
         .yst-table-button {
+			@apply yst-gap-2;
+
             &.yst-button--secondary {
                 .yst-button-icon {
                     @apply yst-text-slate-400 yst-w-3 yst-h-3;

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/style.css
@@ -2,10 +2,6 @@
 	.yst-root {
 
         .yst-table-button {
-
-			.yst-button-icon {
-				@apply yst-mr-1.5 yst--ml-1 rtl:yst--mr-1 rtl:yst-ml-1.5;
-			}
             &.yst-button--secondary {
                 .yst-button-icon {
                     @apply yst-text-slate-400 yst-w-3 yst-h-3;
@@ -19,7 +15,6 @@
                     @apply yst-w-3.5 yst-h-3.5;
                 }
             }
-
         }
 
         .yst-success-message {

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
@@ -36,7 +36,7 @@ export const RequestLimitReached = ( { upsellLink, className = "" } ) => {
 							"Semrush",
 						)
 					}
-					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-text-amber-900" />
+					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-text-amber-900 rtl:yst-rotate-180" />
 
 				</Button> }
 			</div>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/related-keyphrase-suggestions 0.1.0] Fixes a bug where styles on buttons, intent badge and modal links would not adjust to direction when on  rtl view.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate yoast premium.
* Change language to one of the rtl languages (Hebrew/Arabic)
* Edit a post with focus keyphrase
* Click on "Get related keyphrases" and log into your semrush account.
* Check you see the modal with a table
* Check the followings:
   * Check the links in the footer of the modal has icons in the right direction.
   * Check the buttons and their icons has the right space.
   * Hover over intent badges and check the tooltip are directly above the badge.
   * The semrush upsell button arrow is in the right direction ( when reaching semrush limit requests)
![Screenshot 2024-11-27 at 15 11 20](https://github.com/user-attachments/assets/7559be20-5571-45a0-b641-e97341d84812)

### Test storybook RTL
* Open the storybook,  on the top left you'll have "Direction" Button where you can change the direction of the storybook.
* Test the the table component and check the headers are in the right direction.
* Check the difficulty bullet scores are aligned to the bullet.
* Test the button icon is proper spaced from the label.
* Check the upsell component has space between the lock icon and the button label.
* Check the links in the footer of the modal has icons in the right direction
* In userMessgae check the semrush upsell button arrow is in the right direction ( when reaching semrush limit requests)

![Screenshot 2024-11-27 at 15 56 09](https://github.com/user-attachments/assets/cdb38dfc-e10c-4e1c-a0aa-19ce05ab1b83)
![Screenshot 2024-11-27 at 16 27 42](https://github.com/user-attachments/assets/88c3dfa4-fe9f-44ca-8ad5-fff4c0a7848c)

* Change site language back to English
* Smoke test the above to see it was not affected by this PR.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
