### PR TITLE
Dashboard: add tooltip to not analyzed

### DIFF
--- a/packages/js/src/dashboard/scores/components/score-content.js
+++ b/packages/js/src/dashboard/scores/components/score-content.js
@@ -35,9 +35,10 @@ const ScoreContentSkeletonLoader = () => (
  * @param {Score[]} [scores=[]] The scores.
  * @param {boolean} isLoading Whether the scores are still loading.
  * @param {Object.<ScoreType,string>} descriptions The descriptions.
+ * @param {string} idSuffix The suffix for the IDs.
  * @returns {JSX.Element} The element.
  */
-export const ScoreContent = ( { scores = [], isLoading, descriptions } ) => {
+export const ScoreContent = ( { scores = [], isLoading, descriptions, idSuffix } ) => {
 	if ( isLoading ) {
 		return <ScoreContentSkeletonLoader />;
 	}
@@ -46,7 +47,7 @@ export const ScoreContent = ( { scores = [], isLoading, descriptions } ) => {
 		<>
 			<ContentStatusDescription scores={ scores } descriptions={ descriptions } />
 			<div className={ CLASSNAMES.container }>
-				{ scores && <ScoreList className={ CLASSNAMES.list } scores={ scores } /> }
+				{ scores && <ScoreList className={ CLASSNAMES.list } scores={ scores } idSuffix={ idSuffix } /> }
 				{ scores && <ScoreChart className={ CLASSNAMES.chart } scores={ scores } /> }
 			</div>
 		</>

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -1,4 +1,4 @@
-import { Badge, Button, Label, SkeletonLoader, TooltipComponent, TooltipContainer, TooltipTrigger } from "@yoast/ui-library";
+import { Badge, Button, Label, SkeletonLoader, TooltipContainer, TooltipTrigger, TooltipWithContext } from "@yoast/ui-library";
 import classNames from "classnames";
 import { SCORE_META } from "../score-meta";
 
@@ -62,9 +62,9 @@ const ScoreListItemContentWithTooltip = ( { score, idSuffix } ) => {
 			<TooltipTrigger className="yst-flex yst-items-center" ariaDescribedby={ id }>
 				<ScoreListItemContent score={ score } />
 			</TooltipTrigger>
-			<TooltipComponent id={ id }>
+			<TooltipWithContext id={ id }>
 				{ SCORE_META[ score.name ].tooltip }
-			</TooltipComponent>
+			</TooltipWithContext>
 		</TooltipContainer>
 	);
 };

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -1,4 +1,4 @@
-import { Badge, Button, Label, SkeletonLoader } from "@yoast/ui-library";
+import { Badge, Button, Label, SkeletonLoader, Tooltip, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { SCORE_META } from "../score-meta";
 
@@ -36,24 +36,40 @@ export const ScoreListSkeletonLoader = ( { className } ) => (
 );
 
 /**
+ * @param {Score} score The score.
+ * @returns {JSX.Element} The element.
+ */
+const ScoreListItem = ( { score } ) => {
+	const [ isVisible, , , show, hide ] = useToggleState( false );
+	// eslint-disable-next-line no-undefined
+	const tooltipId = SCORE_META[ score.name ].tooltip ? `tooltip__${ score.name }` : undefined;
+
+	return (
+		<li className={ CLASSNAMES.listItem }>
+			<span className="yst-relative yst-flex yst-items-center" onMouseEnter={ show } onMouseLeave={ hide } aria-describedby={ tooltipId }>
+				<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
+				<Label as="span" className={ classNames( CLASSNAMES.label, "yst-leading-4 yst-py-1.5" ) }>
+					{ SCORE_META[ score.name ].label }
+				</Label>
+				<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
+				{ SCORE_META[ score.name ].tooltip && isVisible && (
+					<Tooltip id={ tooltipId }>{ SCORE_META[ score.name ].tooltip }</Tooltip>
+				) }
+			</span>
+			{ score.links.view && (
+				<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>
+			) }
+		</li>
+	);
+};
+
+/**
  * @param {string} [className] The class name for the UL.
  * @param {Score[]} scores The scores.
  * @returns {JSX.Element} The element.
  */
 export const ScoreList = ( { className, scores } ) => (
 	<ul className={ className }>
-		{ scores.map( ( score ) => (
-			<li
-				key={ score.name }
-				className={ CLASSNAMES.listItem }
-			>
-				<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
-				<Label as="span" className={ classNames( CLASSNAMES.label, "yst-leading-4 yst-py-1.5" ) }>{ SCORE_META[ score.name ].label }</Label>
-				<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
-				{ score.links.view && (
-					<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>
-				) }
-			</li>
-		) ) }
+		{ scores.map( ( score ) => <ScoreListItem key={ score.name } score={ score } /> ) }
 	</ul>
 );

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useRef } from "@wordpress/element";
 import { Badge, Button, Label, SkeletonLoader, Tooltip, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
 import { SCORE_META } from "../score-meta";
@@ -36,26 +37,66 @@ export const ScoreListSkeletonLoader = ( { className } ) => (
 );
 
 /**
+ * @param {EventListener} onKeydown The keydown event listener.
+ * @returns {void}
+ */
+const useKeydown = ( onKeydown ) => {
+	useEffect( () => {
+		document.addEventListener( "keydown", onKeydown );
+		return () => {
+			document.removeEventListener( "keydown", onKeydown );
+		};
+	}, [ onKeydown ] );
+};
+
+/**
  * @param {Score} score The score.
+ * @param {string} idSuffix The suffix for the IDs.
  * @returns {JSX.Element} The element.
  */
-const ScoreListItem = ( { score } ) => {
+const ScoreListItem = ( { score, idSuffix } ) => {
 	const [ isVisible, , , show, hide ] = useToggleState( false );
-	// eslint-disable-next-line no-undefined
-	const tooltipId = SCORE_META[ score.name ].tooltip ? `tooltip__${ score.name }` : undefined;
+	const ref = useRef();
+
+	const TooltipTrigger = SCORE_META[ score.name ].tooltip ? "button" : "span";
+	const tooltipTriggerProps = useMemo( () => SCORE_META[ score.name ].tooltip ? {
+		onFocus: show,
+		onMouseEnter: show,
+		"aria-describedby": `tooltip--${ idSuffix }__${ score.name }`,
+		"aria-disabled": true,
+		className: "yst-rounded-md yst-cursor-default focus:yst-outline-none focus-visible:yst-ring-primary-500 focus-visible:yst-border-primary-500 focus-visible:yst-ring-2 focus-visible:yst-ring-offset-2 focus-visible:yst-bg-white focus-visible:yst-border-opacity-0",
+	} : {}, [ show ] );
+
+	useKeydown( ( event ) => {
+		if ( event.key === "Escape" ) {
+			hide();
+			ref.current?.blur();
+		}
+	} );
 
 	return (
 		<li className={ CLASSNAMES.listItem }>
-			<span className="yst-relative yst-flex yst-items-center" onMouseEnter={ show } onMouseLeave={ hide } aria-describedby={ tooltipId }>
-				<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
-				<Label as="span" className={ classNames( CLASSNAMES.label, "yst-leading-4 yst-py-1.5" ) }>
-					{ SCORE_META[ score.name ].label }
-				</Label>
-				<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
-				{ SCORE_META[ score.name ].tooltip && isVisible && (
-					<Tooltip id={ tooltipId }>{ SCORE_META[ score.name ].tooltip }</Tooltip>
+			<div className="yst-tooltip-container">
+				<TooltipTrigger
+					ref={ ref }
+					{ ...tooltipTriggerProps }
+					className={ classNames( tooltipTriggerProps.className, "yst-flex yst-items-center" ) }
+				>
+					<span className={ classNames( CLASSNAMES.score, SCORE_META[ score.name ].color ) } />
+					<Label as="span" className={ classNames( CLASSNAMES.label, "yst-leading-4 yst-py-1.5" ) }>
+						{ SCORE_META[ score.name ].label }
+					</Label>
+					<Badge variant="plain" className={ classNames( score.links.view && "yst-mr-3" ) }>{ score.amount }</Badge>
+				</TooltipTrigger>
+				{ SCORE_META[ score.name ].tooltip && (
+					<Tooltip
+						id={ tooltipTriggerProps[ "aria-describedby" ] }
+						className={ classNames( ! isVisible && "yst-hidden" ) }
+					>
+						{ SCORE_META[ score.name ].tooltip }
+					</Tooltip>
 				) }
-			</span>
+			</div>
 			{ score.links.view && (
 				<Button as="a" variant="secondary" size="small" href={ score.links.view } className="yst-ml-auto">View</Button>
 			) }
@@ -66,10 +107,11 @@ const ScoreListItem = ( { score } ) => {
 /**
  * @param {string} [className] The class name for the UL.
  * @param {Score[]} scores The scores.
+ * @param {string} idSuffix The suffix for the IDs.
  * @returns {JSX.Element} The element.
  */
-export const ScoreList = ( { className, scores } ) => (
+export const ScoreList = ( { className, scores, idSuffix } ) => (
 	<ul className={ className }>
-		{ scores.map( ( score ) => <ScoreListItem key={ score.name } score={ score } /> ) }
+		{ scores.map( ( score ) => <ScoreListItem key={ score.name } score={ score } idSuffix={ idSuffix } /> ) }
 	</ul>
 );

--- a/packages/js/src/dashboard/scores/components/score-list.js
+++ b/packages/js/src/dashboard/scores/components/score-list.js
@@ -62,7 +62,7 @@ const ScoreListItemContentWithTooltip = ( { score, idSuffix } ) => {
 			<TooltipTrigger className="yst-flex yst-items-center" ariaDescribedby={ id }>
 				<ScoreListItemContent score={ score } />
 			</TooltipTrigger>
-			<TooltipWithContext id={ id }>
+			<TooltipWithContext id={ id } className="max-[784px]:yst-max-w-full">
 				{ SCORE_META[ score.name ].tooltip }
 			</TooltipWithContext>
 		</TooltipContainer>

--- a/packages/js/src/dashboard/scores/components/scores.js
+++ b/packages/js/src/dashboard/scores/components/scores.js
@@ -133,7 +133,12 @@ export const Scores = ( { analysisType, contentTypes, endpoint, headers } ) => {
 			<div className="yst-mt-6">
 				<ErrorAlert error={ error } />
 				{ ! error && (
-					<ScoreContent scores={ scores } isLoading={ isPending } descriptions={ SCORE_DESCRIPTIONS[ analysisType ] } />
+					<ScoreContent
+						scores={ scores }
+						isLoading={ isPending }
+						descriptions={ SCORE_DESCRIPTIONS[ analysisType ] }
+						idSuffix={ analysisType }
+					/>
 				) }
 			</div>
 		</Paper>

--- a/packages/js/src/dashboard/scores/score-meta.js
+++ b/packages/js/src/dashboard/scores/score-meta.js
@@ -6,7 +6,7 @@ import { __ } from "@wordpress/i18n";
  */
 
 /**
- * @type {Object.<ScoreType,{label: string, color: string, hex: string}>} The meta data.
+ * @type {Object.<ScoreType,{label: string, color: string, hex: string, tooltip?: string}>} The meta data.
  */
 export const SCORE_META = {
 	good: {
@@ -28,6 +28,7 @@ export const SCORE_META = {
 		label: __( "Not analyzed", "wordpress-seo" ),
 		color: "yst-bg-analysis-na",
 		hex: "#cbd5e1",
+		tooltip: __( "We haven’t analyzed this content yet. Please open it and save it in your editor so we can start the analysis.", "wordpress-seo" ),
 	},
 };
 

--- a/packages/js/src/dashboard/scores/score-meta.js
+++ b/packages/js/src/dashboard/scores/score-meta.js
@@ -28,7 +28,7 @@ export const SCORE_META = {
 		label: __( "Not analyzed", "wordpress-seo" ),
 		color: "yst-bg-analysis-na",
 		hex: "#cbd5e1",
-		tooltip: __( "We haven’t analyzed this content yet. Please open it and save it in your editor so we can start the analysis.", "wordpress-seo" ),
+		tooltip: __( "We haven’t analyzed this content yet. Please open it in your editor, ensure a focus keyphrase is entered, and save it so we can start the analysis.", "wordpress-seo" ),
 	},
 };
 

--- a/packages/ui-library/.storybook/style.css
+++ b/packages/ui-library/.storybook/style.css
@@ -38,7 +38,7 @@
 @import "../src/components/text-field/style.css";
 @import "../src/components/textarea-field/style.css";
 @import "../src/components/toggle-field/style.css";
-
+@import "../src/components/tooltip-container/style.css";
 
 @tailwind base;
 @tailwind components;

--- a/packages/ui-library/src/components/tooltip-container/docs/component.md
+++ b/packages/ui-library/src/components/tooltip-container/docs/component.md
@@ -1,0 +1,24 @@
+Tooltips provide contextual information about an element when that owning element receives focus or is hovered over, but are otherwise not visible. They are displayed as small boxes containing a brief label or message. See the Tooltip elements.
+
+However, to get a fully functioning experience, with regards to accessibility, the Tooltip needs more. The following are the requirements for the Tooltip:
+* The Tooltip should be visible when the element that triggers the Tooltip is focused. And it should be hidden when the element is blurred.
+* The Tooltip should be visible when the element that triggers the Tooltip is hovered over. And it should be hidden when the element is no longer hovered over.
+* The Tooltip should be hidden when the user presses the `Escape` key, regardless of focus or hover.
+
+That is what this **TooltipContainer**, the **TooltipTrigger** and the **TooltipComponent** components are for.
+
+The **TooltipContainer** is the parent component that wraps the TooltipTrigger and the Tooltip components. It manages the visibility of the Tooltip.
+* It provides the `isVisible` boolean and `show` and `hide` functions.
+* It adds a `keydown` event listener to hide the tooltip when the user presses `Escape`.
+* It contains the styling to center and control the tooltip visibility.
+
+The **TooltipTrigger** wraps the content that should trigger the Tooltip in a focusable element.
+* It ensures that the tooltip is shown on focus and mouse enter.
+* It adds the `aria-describedby` attribute to associate the tooltip with the trigger.
+* It adds the `aria-disabled` attribute to indicate the trigger itself is not actually doing anything.
+* It has styling for keyboard focus (`focus-visible`) and none for hover.
+
+The **TooltipComponent** wraps the Tooltip element.
+* It gets the `isVisible` from the context.
+* It hides the Tooltip via the `yst-hidden` className when `isVisible` is false.
+* It forwards any props to the Tooltip element.

--- a/packages/ui-library/src/components/tooltip-container/docs/component.md
+++ b/packages/ui-library/src/components/tooltip-container/docs/component.md
@@ -22,3 +22,5 @@ The **TooltipWithContext** wraps the Tooltip element.
 * It gets the `isVisible` from the context.
 * It hides the Tooltip via the `yst-hidden` className when `isVisible` is false.
 * It forwards any props to the Tooltip element.
+
+**Note**: The tooltip is the same element, so if you want to override styling like `display`. You should add a container inside.

--- a/packages/ui-library/src/components/tooltip-container/docs/component.md
+++ b/packages/ui-library/src/components/tooltip-container/docs/component.md
@@ -5,7 +5,7 @@ However, to get a fully functioning experience, with regards to accessibility, t
 * The Tooltip should be visible when the element that triggers the Tooltip is hovered over. And it should be hidden when the element is no longer hovered over.
 * The Tooltip should be hidden when the user presses the `Escape` key, regardless of focus or hover.
 
-That is what this **TooltipContainer**, the **TooltipTrigger** and the **TooltipComponent** components are for.
+That is what this **TooltipContainer**, the **TooltipTrigger** and the **TooltipWithContext** components are for.
 
 The **TooltipContainer** is the parent component that wraps the TooltipTrigger and the Tooltip components. It manages the visibility of the Tooltip.
 * It provides the `isVisible` boolean and `show` and `hide` functions.
@@ -18,7 +18,7 @@ The **TooltipTrigger** wraps the content that should trigger the Tooltip in a fo
 * It adds the `aria-disabled` attribute to indicate the trigger itself is not actually doing anything.
 * It has styling for keyboard focus (`focus-visible`) and none for hover.
 
-The **TooltipComponent** wraps the Tooltip element.
+The **TooltipWithContext** wraps the Tooltip element.
 * It gets the `isVisible` from the context.
 * It hides the Tooltip via the `yst-hidden` className when `isVisible` is false.
 * It forwards any props to the Tooltip element.

--- a/packages/ui-library/src/components/tooltip-container/docs/index.js
+++ b/packages/ui-library/src/components/tooltip-container/docs/index.js
@@ -1,0 +1,1 @@
+export { default as component } from "./component.md";

--- a/packages/ui-library/src/components/tooltip-container/docs/index.js
+++ b/packages/ui-library/src/components/tooltip-container/docs/index.js
@@ -1,1 +1,2 @@
 export { default as component } from "./component.md";
+export { default as withFlex } from "./with-flex.md";

--- a/packages/ui-library/src/components/tooltip-container/docs/with-flex.md
+++ b/packages/ui-library/src/components/tooltip-container/docs/with-flex.md
@@ -1,0 +1,5 @@
+The TooltipWithContext renders the Tooltip element directly.
+Meaning that adding style could mean overriding the Tooltip style.
+
+For example the `display` if you want to use `diplay: flex`.
+Here is an example, that solves this by adding a container inside.

--- a/packages/ui-library/src/components/tooltip-container/index.js
+++ b/packages/ui-library/src/components/tooltip-container/index.js
@@ -106,7 +106,7 @@ TooltipTrigger.propTypes = {
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The element.
  */
-export const TooltipComponent = ( { className, children, ...props } ) => {
+export const TooltipWithContext = ( { className, children, ...props } ) => {
 	const { isVisible } = useTooltipContext();
 
 	return (
@@ -118,7 +118,7 @@ export const TooltipComponent = ( { className, children, ...props } ) => {
 		</Tooltip>
 	);
 };
-TooltipComponent.propTypes = {
+TooltipWithContext.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node,
 };

--- a/packages/ui-library/src/components/tooltip-container/index.js
+++ b/packages/ui-library/src/components/tooltip-container/index.js
@@ -1,0 +1,124 @@
+/* eslint-disable react/require-default-props */
+import classNames from "classnames";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import React, { createContext, useContext } from "react";
+import Tooltip from "../../elements/tooltip";
+import { useKeydown, useToggleState } from "../../hooks";
+
+/**
+ * @typedef {Object} TooltipContextValue
+ * @property {boolean} isVisible Whether the tooltip is visible.
+ * @property {function} show Show the tooltip.
+ * @property {function} hide Hide the tooltip.
+ */
+
+/**
+ * @type {React.Context<TooltipContextValue>}
+ */
+const TooltipContext = createContext( {
+	isVisible: false,
+	show: noop,
+	hide: noop,
+} );
+
+/**
+ * @returns {TooltipContextValue} The value of the Tooltip context.
+ */
+export const useTooltipContext = () => useContext( TooltipContext );
+
+/**
+ * Manages the visibility of the tooltip.
+ * - It provides the isVisible boolean and show and hide functions.
+ * - It adds a keydown event listener to hide the tooltip when the user presses Escape.
+ * - It contains the styling to center and control the tooltip visibility.
+ * @param {JSX.ElementClass} [as="span"] Base component.
+ * @param {string} [className] CSS class.
+ * @param {JSX.node} [children] The tooltip trigger and tooltip.
+ * @returns {JSX.Element} The element.
+ */
+export const TooltipContainer = ( { as: Component = "span", className, children } ) => {
+	const [ isVisible, , , show, hide ] = useToggleState( false );
+
+	useKeydown( ( event ) => {
+		if ( event.key === "Escape" ) {
+			hide();
+		}
+	}, document );
+
+	return (
+		<TooltipContext.Provider value={ { isVisible, show, hide } }>
+			<Component className={ classNames( "yst-tooltip-container", className ) }>
+				{ children }
+			</Component>
+		</TooltipContext.Provider>
+	);
+};
+TooltipContainer.propTypes = {
+	as: PropTypes.elementType,
+	children: PropTypes.node,
+	className: PropTypes.string,
+};
+
+/**
+ * Wraps the content that should trigger the tooltip in a focusable element.
+ * - It ensures that the tooltip is shown on focus and mouse enter.
+ * - It adds the aria-describedby attribute to associate the tooltip with the trigger.
+ * - It adds the aria-disabled attribute to indicate the trigger is not actually doing anything.
+ * - It has styling for keyboard focus and none for hover.
+ * @param {string|JSX.node} [as="button"] Base component. Needs to be focusable.
+ * @param {string} [className] CSS class.
+ * @param {JSX.node} [children] What the tooltip should center on.
+ * @param {string} [ariaDescribedby] The ID of the tooltip, so that screen readers can associate the tooltip with the trigger.
+ * @param {Object} [props] Additional props.
+ * @returns {JSX.Element} The element.
+ */
+export const TooltipTrigger = ( { as: Component = "button", className, children, ariaDescribedby, ...props } ) => {
+	const { show } = useTooltipContext();
+
+	return (
+		<Component
+			className={ classNames( "yst-tooltip-trigger", className ) }
+			onFocus={ show }
+			onMouseEnter={ show }
+			aria-describedby={ ariaDescribedby }
+			aria-disabled={ true }
+			{ ...props }
+		>
+			{ children }
+		</Component>
+	);
+};
+TooltipTrigger.propTypes = {
+	as: PropTypes.elementType,
+	children: PropTypes.node,
+	className: PropTypes.string,
+	ariaDescribedby: PropTypes.string,
+};
+
+/**
+ * Wraps the Tooltip element.
+ * - It gets the `isVisible` from the context.
+ * - It hides the Tooltip via the `yst-hidden` className when `isVisible` is false.
+ * - It forwards any props to the Tooltip element.
+ * @param {string} [className] CSS class.
+ * @param {JSX.node} [children] What the tooltip should center on.
+ * @param {Object} [props] Additional props.
+ * @returns {JSX.Element} The element.
+ */
+export const TooltipComponent = ( { className, children, ...props } ) => {
+	const { isVisible } = useTooltipContext();
+
+	return (
+		<Tooltip
+			className={ classNames( className, { "yst-hidden": ! isVisible } ) }
+			{ ...props }
+		>
+			{ children }
+		</Tooltip>
+	);
+};
+TooltipComponent.propTypes = {
+	className: PropTypes.string,
+	children: PropTypes.node,
+};

--- a/packages/ui-library/src/components/tooltip-container/stories.js
+++ b/packages/ui-library/src/components/tooltip-container/stories.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
-import { component } from "./docs";
+import { component, withFlex } from "./docs";
 import { TooltipContainer, TooltipTrigger, TooltipWithContext } from "./index";
 
 export const Factory = {
@@ -55,6 +55,35 @@ export const WithContext = {
 	],
 };
 
+export const WithFlex = {
+	name: "With display flex",
+	render: ( args ) => <TooltipWithContext { ...args } />,
+	parameters: {
+		controls: { disable: false },
+		docs: {
+			description: {
+				story: withFlex,
+			},
+		},
+	},
+	args: {
+		id: "tooltip",
+		children: <div className="yst-flex yst-flex-col">
+			<span>Row one</span>
+			<span>Row two</span>
+		</div>,
+	},
+	decorators: [
+		( Story, args ) => (
+			<TooltipContainer>
+				<TooltipTrigger ariaDescribedby={ args.id }>Element containing a tooltip.</TooltipTrigger>
+				<Story />
+			</TooltipContainer>
+		),
+	],
+};
+
+
 export default {
 	title: "2) Components/Tooltip Container",
 	component: TooltipContainer,
@@ -70,7 +99,7 @@ export default {
 			description: {
 				component,
 			},
-			page: () => <InteractiveDocsPage stories={ [ Trigger, WithContext ] } />,
+			page: () => <InteractiveDocsPage stories={ [ Trigger, WithContext, WithFlex ] } />,
 		},
 	},
 	decorators: [

--- a/packages/ui-library/src/components/tooltip-container/stories.js
+++ b/packages/ui-library/src/components/tooltip-container/stories.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
+import { component } from "./docs";
+import { TooltipComponent, TooltipContainer, TooltipTrigger } from "./index";
+
+export const Factory = {
+	parameters: {
+		controls: { disable: false },
+	},
+	args: {
+		children: <>
+			<TooltipTrigger ariaDescribedby="tooltip-factory">Element containing a tooltip.</TooltipTrigger>
+			<TooltipComponent id="tooltip-factory">I&apos;m a tooltip</TooltipComponent>
+		</>,
+	},
+};
+
+export const Trigger = {
+	name: "TooltipTrigger",
+	render: ( args ) => <TooltipTrigger { ...args } />,
+	parameters: {
+		controls: { disable: false },
+	},
+	args: {
+		children: "Element containing a tooltip.",
+		ariaDescribedby: "tooltip-trigger",
+	},
+	decorators: [
+		( Story, args ) => (
+			<TooltipContainer>
+				<Story />
+				<TooltipComponent id={ args.ariaDescribedby }>I&apos;m a tooltip</TooltipComponent>
+			</TooltipContainer>
+		),
+	],
+};
+
+export const Tooltip = {
+	name: "TooltipComponent",
+	render: ( args ) => <TooltipComponent { ...args } />,
+	parameters: {
+		controls: { disable: false },
+	},
+	args: {
+		id: "tooltip",
+		children: "I'm a tooltip",
+	},
+	decorators: [
+		( Story, args ) => (
+			<TooltipContainer>
+				<TooltipTrigger ariaDescribedby={ args.id }>Element containing a tooltip.</TooltipTrigger>
+				<Story />
+			</TooltipContainer>
+		),
+	],
+};
+
+export default {
+	title: "2) Components/Tooltip Container",
+	component: TooltipContainer,
+	argTypes: {
+		as: {
+			control: { type: "select" },
+			options: [ "span", "div" ],
+			table: { type: { summary: "span | div" }, defaultValue: { summary: "span" } },
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component,
+			},
+			page: () => <InteractiveDocsPage stories={ [ Trigger, Tooltip ] } />,
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<div className="yst-m-20">
+				<Story />
+			</div>
+		),
+	],
+};

--- a/packages/ui-library/src/components/tooltip-container/stories.js
+++ b/packages/ui-library/src/components/tooltip-container/stories.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
 import { component } from "./docs";
-import { TooltipComponent, TooltipContainer, TooltipTrigger } from "./index";
+import { TooltipContainer, TooltipTrigger, TooltipWithContext } from "./index";
 
 export const Factory = {
 	parameters: {
@@ -10,7 +10,7 @@ export const Factory = {
 	args: {
 		children: <>
 			<TooltipTrigger ariaDescribedby="tooltip-factory">Element containing a tooltip.</TooltipTrigger>
-			<TooltipComponent id="tooltip-factory">I&apos;m a tooltip</TooltipComponent>
+			<TooltipWithContext id="tooltip-factory">I&apos;m a tooltip</TooltipWithContext>
 		</>,
 	},
 };
@@ -29,15 +29,15 @@ export const Trigger = {
 		( Story, args ) => (
 			<TooltipContainer>
 				<Story />
-				<TooltipComponent id={ args.ariaDescribedby }>I&apos;m a tooltip</TooltipComponent>
+				<TooltipWithContext id={ args.ariaDescribedby }>I&apos;m a tooltip</TooltipWithContext>
 			</TooltipContainer>
 		),
 	],
 };
 
-export const Tooltip = {
-	name: "TooltipComponent",
-	render: ( args ) => <TooltipComponent { ...args } />,
+export const WithContext = {
+	name: "TooltipWithContext",
+	render: ( args ) => <TooltipWithContext { ...args } />,
 	parameters: {
 		controls: { disable: false },
 	},
@@ -70,7 +70,7 @@ export default {
 			description: {
 				component,
 			},
-			page: () => <InteractiveDocsPage stories={ [ Trigger, Tooltip ] } />,
+			page: () => <InteractiveDocsPage stories={ [ Trigger, WithContext ] } />,
 		},
 	},
 	decorators: [

--- a/packages/ui-library/src/components/tooltip-container/style.css
+++ b/packages/ui-library/src/components/tooltip-container/style.css
@@ -1,0 +1,25 @@
+@layer components {
+	.yst-root {
+		.yst-tooltip-container {
+			@apply yst-relative;
+
+			--yst-display-tooltip: none;
+
+			&:hover, &:focus-within {
+				--yst-display-tooltip: inline-block;
+			}
+		}
+
+		.yst-tooltip-trigger {
+			@apply yst-cursor-default
+			yst-rounded-md
+			focus:yst-outline-none
+			focus-visible:yst-ring-primary-500
+			focus-visible:yst-border-primary-500
+			focus-visible:yst-ring-2
+			focus-visible:yst-ring-offset-2
+			focus-visible:yst-bg-white
+			focus-visible:yst-border-opacity-0;
+		}
+	}
+}

--- a/packages/ui-library/src/elements/tooltip/style.css
+++ b/packages/ui-library/src/elements/tooltip/style.css
@@ -1,8 +1,8 @@
 @layer components {
 	.yst-root {
 		.yst-tooltip {
+			display: var(--yst-display-tooltip, inline-block);
 			@apply yst-absolute
-			yst-inline-block
 			yst-z-10
 			yst-px-2.5
 			yst-py-2
@@ -59,7 +59,7 @@
 		}
 
 		.yst-tooltip--right {
-			@apply yst--translate-x-0 
+			@apply yst--translate-x-0
 			yst--translate-y-1/2
 			yst-left-full
 			yst-top-1/2

--- a/packages/ui-library/src/elements/tooltip/style.css
+++ b/packages/ui-library/src/elements/tooltip/style.css
@@ -17,6 +17,7 @@
 
 		.yst-tooltip--top {
 			@apply yst--translate-x-1/2
+			rtl:yst-translate-x-1/2
 			yst--translate-y-full
 			yst-left-1/2
 			yst-top-0
@@ -29,6 +30,7 @@
 				yst-left-1/2
 				yst-top-full /* Arrow positioned at the bottom of the tooltip */
 				yst--translate-x-1/2
+				rtl:yst-translate-x-1/2
 				yst-translate-y-0
 				yst-border-8
 				yst-border-x-transparent
@@ -39,6 +41,7 @@
 
 		.yst-tooltip--bottom {
 			@apply yst--translate-x-1/2
+			rtl:yst-translate-x-1/2
 			yst--translate-y-0
 			yst-left-1/2
 			yst-top-full
@@ -51,6 +54,7 @@
 				yst-left-1/2
 				yst-bottom-full /* Arrow positioned at the top of the tooltip */
 				yst--translate-x-1/2
+				rtl:yst-translate-x-1/2
 				yst-border-8
 				yst-border-x-transparent
 				yst-border-t-transparent

--- a/packages/ui-library/src/hooks/index.js
+++ b/packages/ui-library/src/hooks/index.js
@@ -1,5 +1,6 @@
 export { default as useBeforeUnload } from "./use-before-unload";
 export { default as useDescribedBy } from "./use-described-by";
+export { useKeydown } from "./use-keydown";
 export { default as usePrevious } from "./use-previous";
 export { default as useRootContext } from "./use-root-context";
 export { default as useSvgAria } from "./use-svg-aria";

--- a/packages/ui-library/src/hooks/readme.md
+++ b/packages/ui-library/src/hooks/readme.md
@@ -39,6 +39,30 @@ const Component = () => {
 
     return <div />;
 };
+~~~
+
+## useKeydown
+The `useKeydown` hook adds and removes a listener to the document' `keydown` event.
+The hook accepts a callback function that is called when the event is triggered.
+The callback function receives the KeyboardEvent as an argument.
+
+### Related
+* https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event
+* https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
+
+### Usage/Examples
+~~~javascript
+import { useKeydown } from from "@yoast/ui-library";
+
+const Component = () => {
+  useKeydown( ( event ) => {
+    if ( event.key === "Escape" ) {
+      console.log( "Escape key pressed" );
+    }
+  }, document );
+
+  return <div/>;
+};
 
 ~~~
 

--- a/packages/ui-library/src/hooks/use-keydown.js
+++ b/packages/ui-library/src/hooks/use-keydown.js
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+/**
+ * @param {EventListener} onKeydown The keydown event listener.
+ * @param {EventTarget} eventTarget The target to listen on. E.g. document or window or an element.
+ * @returns {void}
+ */
+export const useKeydown = ( onKeydown, eventTarget ) => {
+	useEffect( () => {
+		eventTarget.addEventListener( "keydown", onKeydown );
+		return () => {
+			eventTarget.removeEventListener( "keydown", onKeydown );
+		};
+	}, [ onKeydown ] );
+};

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -40,6 +40,7 @@ export { default as TagField } from "./components/tag-field";
 export { default as TextField } from "./components/text-field";
 export { default as TextareaField } from "./components/textarea-field";
 export { default as ToggleField } from "./components/toggle-field";
+export { TooltipContainer, TooltipTrigger, TooltipComponent, useTooltipContext } from "./components/tooltip-container";
 
 export * from "./hooks";
 export * from "./constants";

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -40,7 +40,7 @@ export { default as TagField } from "./components/tag-field";
 export { default as TextField } from "./components/text-field";
 export { default as TextareaField } from "./components/textarea-field";
 export { default as ToggleField } from "./components/toggle-field";
-export { TooltipContainer, TooltipTrigger, TooltipComponent, useTooltipContext } from "./components/tooltip-container";
+export { TooltipContainer, TooltipTrigger, TooltipWithContext, useTooltipContext } from "./components/tooltip-container";
 
 export * from "./hooks";
 export * from "./constants";


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Wanting a tooltip as per design.
* a11y concerns regarding a tooltip: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a tooltip with information to the not analyzed scores.
* [@yoast/ui-library 0.1.0 enhancement] Adds a TooltipContainer component that handles a11y functionality around the Tooltip element.
* [@yoast/ui-library 0.1.0 enhancement] Adds a `useKeydown` hook to handle the `keydown` event listener subscription.
* [@yoast/ui-library 0.0.1 bugfix] Fixes a bug where the Tooltip would be positioned wrong when using a RTL language.

## Relevant technical choices:

* Moved the list item to its own component to be able to track the visible per item.
* Confirmed by UX: hovering over the bullet + label + badge will show the tooltip, and popping out from there too (the centering of the balloon arrow thing)
* ~~`aria-describedby` only when there is a tooltip (passing `undefined` will stop the attribute from being added)~~
* ~~The tooltip is not fully a11y compatible due to no element to focus on and our UI library needing improvements~~
* Created a UI library implementation

[Improve a11y of the tooltip](https://github.com/Yoast/wordpress-seo/pull/21870/commits/f946277b0ecb8abe54fb3d9d1a9fcd11a7b9ac05)
* add aria-describedby that needs an ID
* use button as a focusable element, this is a hacky solution
* add aria-disabled to the button to indicate that it does nothing
* show the tooltip on focus and hover
* hide the tooltip on Escape press
* move the tooltip out of the button so it does not influence the content (an alternative, less ideal would be to add aria-hidden)
* add a wrapper to still get the tooltip positioning with relative
* use focus-visible so the keyboard user still sees the focus

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the dashboard
* Hover over the `Not analyzed` scores (both SEO & readability)
* [x] Verify the tooltip shows
* [x] Verify the copy is per [the design](https://www.figma.com/design/DXKVj4tji7M65FYCYwBFUl/General-page?node-id=1893-2479&node-type=frame&t=Cf77wnLdfNW0MMju-0): `We haven’t analyzed this content yet. Please open it in your editor, ensure a focus keyphrase is entered, and save it so we can start the analysis.`
* [x] Verify that pressing escape while hovering closes the tooltip
* Navigate to the `Not analyzed` by keyboard
* [x] Verify the tooltip shows
* [x] Verify you see the focus border
* [x] Verify that pressing escape while hovering closes the tooltip
* Shrink the width of the screen
* [x] Verify the tooltip goes to a width similar to the score + label + badge and so remains visible/on the screen
* If you have access to say Safari, you could open the dashboard there and activate VoiceOver and verify that the tooltip text is spoken out loud when `Not analyzed` receives focus.
* Select the button (class: `yst-tooltip-trigger`) around the `Not analyzed` in the inspector, and open the Accessibility tab
* [x] Verify the `Name` is `Not analyzed` followed by the amount, e.g. `3`
* [x] Verify the `Description` is the contents of the tooltip
* Switch to an RTL language
* [x] Verify the tooltip is in the correct position

#### [DEV only] Storybook
* Start the storybook `yarn workspace @yoast/ui-library storybook`
* Go to Components > Tooltip container
* Does the text make sense?
* Does the story portray the components? 
* Might do a follow-up instead if you have too many comments 😁 
* For regression: go to Elements > Tooltip
* [x] Verify the tooltip still works the same there
* Switch to RTL in the `Direction` menu at the top
* [ ] Verify the tooltip is in the correct position

#### Regression
* Edit a post
* Ensure you have a keyphrase
* Click on `Get related keyphrases`
* Be sure to connect to Semrush so you get the modal with results
* Hover over the intent and difficulty percentages
* [x] Verify you get the tooltips still
* Switch to an RTL language
* [x] Verify the tooltip is in the correct position

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The tooltip in the UI library and the scores in the dashboard

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/337
