### PR TITLE
Add draft yoastseo package overview

### DIFF
--- a/packages/yoastseo/GLOSSARY.md
+++ b/packages/yoastseo/GLOSSARY.md
@@ -8,31 +8,31 @@ A comprehensive glossary of terms and concepts used in YoastSEO.js.
 A value object that encapsulates all content and metadata to be analyzed. The Paper object is immutable and serves as the primary input for all analyses.
 
 **Properties include:**
-- text: The main content to analyze
-- title: The SEO title or page title
+- text: The main content to analyze. We assume the content follows a standard HTML format, and consists of the elements that would be part of the `<body>` (so no `<head>` or `<footer>` elements.
+- title: The SEO title
 - keyword: The focus keyphrase
 - description: Meta description
-- url: The slug/URL of the page
+- slug: The slug/URL of the page
 - locale: Language code (e.g., en_US)
 - permalink: Full URL
 
 **Example:**
 ```javascript
-const paper = new Paper("This is the main content", {
+const paper = new Paper("<p>This is the <strong>main</strong> content<p>", {
     title: "Example Title",
     keyword: "example",
     description: "This is a meta description",
-    url: "example-page",
+    slug: "example-page",
     locale: "en_US"
 });
 ```
 
 ### <a name="assessment"></a>Assessment
 A single analysis unit that evaluates one specific aspect of content. Each assessment:
-- Has a specific purpose (e.g., keyword density analysis)
+- Has a specific purpose (e.g., the _keyword density_ assessment evaluates the number of keywords used in the content)
 - Produces a score (0-100)
-- Can generate improvement suggestions
 - May include text markers for visual feedback
+- Can generate improvement suggestions (through Yoast AI)
 
 **Example Assessment Structure:**
 ```javascript
@@ -58,6 +58,8 @@ Types of assessors include:
 - SEOAssessor: Focuses on search engine optimization
 - ReadabilityAssessor: Analyzes text readability
 - CornerStoneAssessor: Applies stricter rules for important content
+
+The diagram below shows an example hierarchy of assessors and assessments. 
 
 ```mermaid
 graph TD
@@ -101,7 +103,6 @@ Score ranges:
 A system to highlight relevant parts of text for specific assessments. Markers:
 - Help visualize assessment results
 - Provide inline feedback
-- Support multiple marking types (error, warning, good)
 
 **Example Marker Output:**
 ```html
@@ -157,10 +158,7 @@ These are crucial for:
 - Content quality assessment
 
 ### <a name="keyphrase"></a>Keyphrase
-The main search term or topic being targeted. Can be:
-- Single word ("SEO")
-- Multiple words ("WordPress SEO plugin")
-- Contains function words ("how to bake bread")
+The main search term or topic being targeted. We use `keyphrase` and `keyword` interchangeably, but primarily the former, as a keyphrase can be a single word ("SEO") or consist of multiple words ("WordPress SEO plugin"), and even contain function words ("how to bake bread").
 
 **Keyphrase Analysis:**
 ```mermaid

--- a/packages/yoastseo/GLOSSARY.md
+++ b/packages/yoastseo/GLOSSARY.md
@@ -30,7 +30,7 @@ const paper = new Paper("<p>This is the <strong>main</strong> content<p>", {
 ### <a name="assessment"></a>Assessment
 A single analysis unit that evaluates one specific aspect of content. Each assessment:
 - Has a specific purpose (e.g., the _keyword density_ assessment evaluates the number of keywords used in the content)
-- Produces a score (0-100)
+- Produces a score (0-9)
 - May include text markers for visual feedback
 - Can generate improvement suggestions (through Yoast AI)
 

--- a/packages/yoastseo/GLOSSARY.md
+++ b/packages/yoastseo/GLOSSARY.md
@@ -1,0 +1,184 @@
+# YoastSEO.js Glossary
+
+A comprehensive glossary of terms and concepts used in YoastSEO.js.
+
+## Core Concepts
+
+### <a name="paper"></a>Paper
+A value object that encapsulates all content and metadata to be analyzed. The Paper object is immutable and serves as the primary input for all analyses.
+
+**Properties include:**
+- text: The main content to analyze
+- title: The SEO title or page title
+- keyword: The focus keyphrase
+- description: Meta description
+- url: The slug/URL of the page
+- locale: Language code (e.g., en_US)
+- permalink: Full URL
+
+**Example:**
+```javascript
+const paper = new Paper("This is the main content", {
+    title: "Example Title",
+    keyword: "example",
+    description: "This is a meta description",
+    url: "example-page",
+    locale: "en_US"
+});
+```
+
+### <a name="assessment"></a>Assessment
+A single analysis unit that evaluates one specific aspect of content. Each assessment:
+- Has a specific purpose (e.g., keyword density analysis)
+- Produces a score (0-100)
+- Can generate improvement suggestions
+- May include text markers for visual feedback
+
+**Example Assessment Structure:**
+```javascript
+class KeywordDensityAssessment extends Assessment {
+    getResult(paper, researcher) {
+        const density = researcher.getResearch("keywordDensity");
+        return {
+            score: this.calculateScore(density),
+            text: this.translateScore(density)
+        };
+    }
+}
+```
+
+### <a name="assessor"></a>Assessor
+A collection manager that:
+- Coordinates multiple assessments
+- Determines which assessments to run
+- Aggregates assessment results
+- Calculates overall scores
+
+Types of assessors include:
+- SEOAssessor: Focuses on search engine optimization
+- ReadabilityAssessor: Analyzes text readability
+- CornerStoneAssessor: Applies stricter rules for important content
+
+```mermaid
+graph TD
+    A[Assessor] --> B[SEOAssessor]
+    A --> C[ReadabilityAssessor]
+    A --> D[CornerStoneAssessor]
+    B --> E[KeywordAssessment]
+    B --> F[URLAssessment]
+    C --> G[SentenceLengthAssessment]
+    C --> H[ParagraphLengthAssessment]
+```
+
+### <a name="researcher"></a>Researcher
+The research component that:
+- Performs linguistic analysis
+- Caches research results
+- Provides research data to assessments
+
+Common research types:
+- Word count
+- Sentence detection
+- Keyword presence
+- Morphological analysis
+
+**Example Research Usage:**
+```javascript
+const researcher = new Researcher(paper);
+const wordCount = researcher.getResearch("wordCountInText");
+const sentences = researcher.getResearch("sentences");
+```
+
+### <a name="score"></a>Score
+A numeric representation (0-100) of content quality for a specific aspect.
+
+Score ranges:
+- 0-40: Bad (Red)
+- 41-70: Needs Improvement (Orange)
+- 71-100: Good (Green)
+
+### <a name="marker"></a>Marker
+A system to highlight relevant parts of text for specific assessments. Markers:
+- Help visualize assessment results
+- Provide inline feedback
+- Support multiple marking types (error, warning, good)
+
+**Example Marker Output:**
+```html
+<mark class="yoast-text-mark">This sentence is too long</mark>
+```
+
+## Linguistic Concepts
+
+### <a name="morphology"></a>Morphology
+The study of word forms and their variations. In YoastSEO.js, morphology is used to:
+- Recognize different forms of keywords
+- Improve keyword matching
+- Support language-specific word variations
+
+**Example:**
+```
+Base word: teach
+Morphological forms: teaches, teaching, taught, teacher, teachers
+```
+
+### <a name="stem"></a>Stem
+The base form of a word before any affixes. Stemming helps in:
+- Keyword matching
+- Word form recognition
+- Content analysis
+
+**Example:**
+```
+Word: running
+Stem: run
+Related forms: runs, ran
+```
+
+### <a name="function-words"></a>Function Words
+Words that serve grammatical purposes but carry little meaning:
+- Articles (the, a, an)
+- Prepositions (in, on, at)
+- Conjunctions (and, or, but)
+- Auxiliary verbs (is, has, will)
+
+These are often filtered out during analysis to focus on meaningful content.
+
+### <a name="content-words"></a>Content Words
+Words that carry semantic meaning:
+- Nouns (book, house)
+- Main verbs (run, write)
+- Adjectives (big, red)
+- Adverbs (quickly, well)
+
+These are crucial for:
+- Keyword analysis
+- Topic detection
+- Content quality assessment
+
+### <a name="keyphrase"></a>Keyphrase
+The main search term or topic being targeted. Can be:
+- Single word ("SEO")
+- Multiple words ("WordPress SEO plugin")
+- Contains function words ("how to bake bread")
+
+**Keyphrase Analysis:**
+```mermaid
+graph LR
+    A[Keyphrase] --> B[Extract Words]
+    B --> C[Remove Function Words]
+    C --> D[Find Word Forms]
+    D --> E[Match in Content]
+```
+
+### <a name="synonym"></a>Synonym
+Alternative words or phrases with similar meaning to the keyphrase. Used to:
+- Prevent keyword stuffing
+- Allow natural writing
+- Improve content quality
+
+**Example:**
+```
+Keyphrase: "car"
+Synonyms: "automobile", "vehicle", "motor vehicle"
+``` 

--- a/packages/yoastseo/OVERVIEW.md
+++ b/packages/yoastseo/OVERVIEW.md
@@ -6,21 +6,21 @@ YoastSEO.js is a text analysis and SEO assessment library that helps improve con
 
 ### Core Concepts
 
-- **Paper**: A value object representing the text content to be analyzed, including metadata like title, meta description, keyword, etc.
-- **Assessment**: An individual analysis that evaluates a specific aspect of content (e.g., keyword density, sentence length)
-- **Assessor**: A collection of assessments that work together to analyze content from a specific angle (SEO, readability, etc.)
-- **Researcher**: Performs linguistic research on text content (e.g., sentence detection, word counting)
-- **Score**: A numeric value (0-100) indicating how well content performs for a specific assessment
-- **Marker**: Highlights relevant portions of text for specific assessments
+- **[Paper](./GLOSSARY.md#paper)**: A value object representing the text content to be analyzed, including metadata like title, meta description, keyword, etc.
+- **[Assessment](./GLOSSARY.md#assessment)**: An individual analysis that evaluates a specific aspect of content (e.g., keyword density, sentence length)
+- **[Assessor](./GLOSSARY.md#assessor)**: A collection of assessments that work together to analyze content from a specific angle (SEO, readability, etc.)
+- **[Researcher](./GLOSSARY.md#researcher)**: Performs linguistic research on text content (e.g., sentence detection, word counting)
+- **[Score](./GLOSSARY.md#score)**: A numeric value (0-100) indicating how well content performs for a specific assessment
+- **[Marker](./GLOSSARY.md#marker)**: Highlights relevant portions of text for specific assessments
 
 ### Linguistic Concepts
 
-- **Morphology**: Study of word forms and structure (stems, affixes, etc.)
-- **Stem**: The base form of a word before any affixes are added
-- **Function Words**: Words with little semantic meaning that primarily serve grammatical purposes (e.g., articles, prepositions)
-- **Content Words**: Words that carry semantic meaning (nouns, verbs, adjectives, etc.)
-- **Keyphrase**: The main topic or search term being targeted in the content
-- **Synonym**: Alternative words or phrases with similar meaning to the keyphrase
+- **[Morphology](./GLOSSARY.md#morphology)**: Study of word forms and structure (stems, affixes, etc.)
+- **[Stem](./GLOSSARY.md#stem)**: The base form of a word before any affixes are added
+- **[Function Words](./GLOSSARY.md#function-words)**: Words with little semantic meaning that primarily serve grammatical purposes (e.g., articles, prepositions)
+- **[Content Words](./GLOSSARY.md#content-words)**: Words that carry semantic meaning (nouns, verbs, adjectives, etc.)
+- **[Keyphrase](./GLOSSARY.md#keyphrase)**: The main topic or search term being targeted in the content
+- **[Synonym](./GLOSSARY.md#synonym)**: Alternative words or phrases with similar meaning to the keyphrase
 
 ## Architecture Diagrams
 

--- a/packages/yoastseo/OVERVIEW.md
+++ b/packages/yoastseo/OVERVIEW.md
@@ -1,0 +1,141 @@
+# YoastSEO.js Overview
+
+YoastSEO.js is a text analysis and SEO assessment library that helps improve content readability and search engine optimization. This document provides an overview of the main concepts and components.
+
+## Domain Glossary
+
+### Core Concepts
+
+- **Paper**: A value object representing the text content to be analyzed, including metadata like title, meta description, keyword, etc.
+- **Assessment**: An individual analysis that evaluates a specific aspect of content (e.g., keyword density, sentence length)
+- **Assessor**: A collection of assessments that work together to analyze content from a specific angle (SEO, readability, etc.)
+- **Researcher**: Performs linguistic research on text content (e.g., sentence detection, word counting)
+- **Score**: A numeric value (0-100) indicating how well content performs for a specific assessment
+- **Marker**: Highlights relevant portions of text for specific assessments
+
+### Linguistic Concepts
+
+- **Morphology**: Study of word forms and structure (stems, affixes, etc.)
+- **Stem**: The base form of a word before any affixes are added
+- **Function Words**: Words with little semantic meaning that primarily serve grammatical purposes (e.g., articles, prepositions)
+- **Content Words**: Words that carry semantic meaning (nouns, verbs, adjectives, etc.)
+- **Keyphrase**: The main topic or search term being targeted in the content
+- **Synonym**: Alternative words or phrases with similar meaning to the keyphrase
+
+## Architecture Diagrams
+
+### High-level Component Interaction
+```mermaid
+graph TD
+    Paper[Paper] --> Researcher
+    Paper --> Assessor
+    Researcher --> Assessor
+    Assessor --> SEOAssessor
+    Assessor --> ReadabilityAssessor
+    SEOAssessor --> Assessment1[Keyword Density]
+    SEOAssessor --> Assessment2[Meta Description]
+    ReadabilityAssessor --> Assessment3[Sentence Length]
+    ReadabilityAssessor --> Assessment4[Paragraph Length]
+```
+
+### Analysis Flow
+```mermaid
+sequenceDiagram
+    Client->>Worker: Initialize(config)
+    Client->>Worker: Analyze(paper)
+    Worker->>Researcher: Research(paper)
+    Worker->>Assessor: Assess(research)
+    Assessor->>Worker: Results
+    Worker->>Client: Analysis Complete
+```
+
+## Usage Examples
+
+### Basic Usage with Web Worker
+
+```javascript
+import { AnalysisWorkerWrapper, createWorker, Paper } from "yoastseo";
+
+// Create and initialize the worker
+const worker = new AnalysisWorkerWrapper(createWorker("path-to-worker.js"));
+
+await worker.initialize({
+    locale: "en_US",
+    contentAnalysisActive: true,
+    keywordAnalysisActive: true,
+});
+
+// Create a paper with content to analyze
+const paper = new Paper("Text to analyze", {
+    keyword: "analysis",
+    title: "My First Analysis",
+    locale: "en_US"
+});
+
+// Run the analysis
+const results = await worker.analyze(paper);
+console.log(results);
+```
+
+### Direct Usage (Without Worker)
+
+```javascript
+import { AbstractResearcher, Paper, ContentAssessor } from "yoastseo";
+
+// Create a paper with content
+const paper = new Paper("Text to analyze", {
+    keyword: "analysis",
+    title: "My Analysis" 
+});
+
+// Create researcher and run research
+const researcher = new AbstractResearcher(paper);
+const wordCount = researcher.getResearch("wordCountInText");
+
+// Create assessor and run assessments
+const assessor = new ContentAssessor(researcher);
+assessor.assess(paper);
+const results = assessor.getValidResults();
+```
+
+## Key Features
+
+1. **Multilingual Support**: Supports analysis in multiple languages with language-specific rules and assessments
+
+2. **Extensible Architecture**: 
+   - Custom assessments can be added
+   - Research can be extended
+   - Markers can be customized
+
+3. **SEO Analysis**:
+   - Keyword usage and density
+   - Meta description optimization
+   - URL structure
+   - Internal linking
+   - Image alt attributes
+
+4. **Readability Analysis**:
+   - Sentence length
+   - Paragraph length
+   - Transition words
+   - Passive voice
+   - Flesch Reading Ease
+
+5. **Performance**:
+   - Web Worker support for non-blocking analysis
+   - Memoization of research results
+   - Configurable analysis depth
+
+## Integration Points
+
+The library can be integrated in several ways:
+
+1. **Web Worker**: Recommended approach for browser environments to prevent UI blocking
+2. **Direct Usage**: For server-side analysis or simpler implementations
+3. **WordPress Integration**: Primary use case through the Yoast SEO plugin
+4. **Custom CMS Integration**: Can be integrated into any CMS or editing environment
+
+For more detailed documentation on specific topics, see:
+- [Assessments Documentation](./src/scoring/assessments/README.md)
+- [Morphology Documentation](./MORPHOLOGY.md)
+- [Design Decisions](./DESIGN%20DECISIONS.md) 


### PR DESCRIPTION
## Context
As discussed in [internal Slack](https://yoast.slack.com/archives/C03PRESAXMJ/p1732877907666479), it would be useful to have an overview for engineers who want to interact with the code. Given that a lot of the terminology comes from the linguistic domain, an engineer new to the domain has a hard time following the code itself.

This PR adds an initial draft for such a document.

## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Adds an overview and glossary for the terminology used throughout the package.

## Relevant technical choices:

* This was entirely AI-generated for now and needs review by domain specialists

## QA 
No testing needed as this is just documentation. 