### PR TITLE
class-register-capabilities.php in_array() TypeError fix

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -97,7 +97,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		}
 
 		// User must be of role wpseo_manager.
-		if ( ! in_array( 'wpseo_manager',  ( $user->roles ?? [] ), true ) ) {
+		if ( ! in_array( 'wpseo_manager', ( $user->roles ?? [] ), true ) ) {
 			return $caps;
 		}
 

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -96,8 +96,12 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 			return $caps;
 		}
 
+		if ( ! is_array( $user->roles ) ) {
+			return $caps;
+		}
+
 		// User must be of role wpseo_manager.
-		if ( ! in_array( 'wpseo_manager', ( $user->roles ?? [] ), true ) ) {
+		if ( ! in_array( 'wpseo_manager', $user->roles, true ) ) {
 			return $caps;
 		}
 

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -97,7 +97,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		}
 
 		// User must be of role wpseo_manager.
-		if ( ! in_array( 'wpseo_manager', $user->roles, true ) ) {
+		if ( ! in_array( 'wpseo_manager', $user->roles ?? [], true ) ) {
 			return $caps;
 		}
 

--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -97,7 +97,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		}
 
 		// User must be of role wpseo_manager.
-		if ( ! in_array( 'wpseo_manager', $user->roles ?? [], true ) ) {
+		if ( ! in_array( 'wpseo_manager',  ( $user->roles ?? [] ), true ) ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
Ran into a TypeError that blocks loading of the WordPress admin. Guessing it was introduced by a PHP API change (presently at 8.1.31). Simple enough fix to incorporate.

## Summary
$user->roles may be undefined, so passing it into in_array() produces a TypeError. Found this to completely block loading of the WP admin. Simple fix of adding a fallback value.
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where TypeError would occur when checking for capabilities of SEO Manager user role when the roles is not an array. Props to @kfeinUI.

## Relevant technical choices:

* Issue was produced on WordPress 6.7.1 running PHP 8.1.31.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In the `wp_config.php` add the following lines (or adjust your config):
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_DISPLAY', false );
define( 'WP_DEBUG_LOG', true );
```
* Create a privacy policy page logged in as admin user role.
* Logout and login as SEO Manager user role.
* Verify that you can edit, update and publish the privacy policy page in classic, block and Elementor editors.
* Check you don't get any TypeError in the debug.log.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* WordPress admin loading. Blocked by an error or not.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
