### PR TITLE
add fallback to isAiFeatureEnabled

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -242,13 +242,13 @@ export default withSelect( select => {
 		getReadabilityResults,
 		getMarkButtonStatus,
 		getIsElementorEditor,
-		getPreference,
+		getIsAiFeatureEnabled,
 	} = select( "yoast-seo/editor" );
 
 	return {
 		...getReadabilityResults(),
 		marksButtonStatus: getMarkButtonStatus(),
 		isElementor: getIsElementorEditor(),
-		isAiFeatureEnabled: getPreference( "isAiFeatureActive", false ),
+		isAiFeatureEnabled: getIsAiFeatureEnabled(),
 	};
 } )( ReadabilityAnalysis );

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -235,6 +235,7 @@ ReadabilityAnalysis.defaultProps = {
 	shouldUpsell: false,
 	shouldUpsellHighlighting: false,
 	isAiFeatureEnabled: false,
+	isElementor: false,
 };
 
 export default withSelect( select => {

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -3,7 +3,6 @@ import { withSelect } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
-import { get } from "lodash";
 import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
 import PropTypes from "prop-types";
 import styled from "styled-components";
@@ -307,6 +306,7 @@ SeoAnalysis.propTypes = {
 	shouldUpsellHighlighting: PropTypes.bool,
 	isElementor: PropTypes.bool,
 	isAiFeatureEnabled: PropTypes.bool,
+	isPremium: PropTypes.bool,
 };
 
 SeoAnalysis.defaultProps = {
@@ -319,6 +319,7 @@ SeoAnalysis.defaultProps = {
 	shouldUpsellHighlighting: false,
 	isElementor: false,
 	isAiFeatureEnabled: false,
+	isPremium: false,
 };
 
 export default withSelect( ( select, ownProps ) => {
@@ -328,7 +329,7 @@ export default withSelect( ( select, ownProps ) => {
 		getResultsForKeyword,
 		getIsElementorEditor,
 		getIsPremium,
-		getIsAiFeatureEnabled
+		getIsAiFeatureEnabled,
 	} = select( "yoast-seo/editor" );
 
 	const keyword = getFocusKeyphrase();

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -3,11 +3,11 @@ import { withSelect } from "@wordpress/data";
 import { Component, Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
+import { get } from "lodash";
 import { LocationConsumer, RootContext } from "@yoast/externals/contexts";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import getIndicatorForScore from "../../analysis/getIndicatorForScore";
-import getL10nObject from "../../analysis/getL10nObject";
 import Results from "../../containers/Results";
 import AnalysisUpsell from "../AnalysisUpsell";
 import MetaboxCollapsible from "../MetaboxCollapsible";
@@ -206,8 +206,7 @@ class SeoAnalysis extends Component {
 	 * @returns {void|JSX.Element} The AI Optimize button, or nothing if the button should not be shown.
 	 */
 	renderAIFixesButton = ( hasAIFixes, id ) => {
-		const { isElementor, isAiFeatureEnabled } = this.props;
-		const isPremium = getL10nObject().isPremium;
+		const { isElementor, isAiFeatureEnabled, isPremium } = this.props;
 
 		// Don't show the button if the AI feature is not enabled for Yoast SEO Premium users.
 		if ( isPremium && ! isAiFeatureEnabled ) {
@@ -232,7 +231,7 @@ class SeoAnalysis extends Component {
 	 */
 	render() {
 		const score = getIndicatorForScore( this.props.overallScore );
-		const isPremium = getL10nObject().isPremium;
+		const { isPremium } = this.props;
 		const highlightingUpsellLink = "shortlinks.upsell.sidebar.highlighting_seo_analysis";
 
 		if ( score.className !== "loading" && this.props.keyword === "" ) {
@@ -328,7 +327,8 @@ export default withSelect( ( select, ownProps ) => {
 		getMarksButtonStatus,
 		getResultsForKeyword,
 		getIsElementorEditor,
-		getPreference,
+		getIsPremium,
+		getIsAiFeatureEnabled
 	} = select( "yoast-seo/editor" );
 
 	const keyword = getFocusKeyphrase();
@@ -338,6 +338,7 @@ export default withSelect( ( select, ownProps ) => {
 		marksButtonStatus: ownProps.hideMarksButtons ? "disabled" : getMarksButtonStatus(),
 		keyword,
 		isElementor: getIsElementorEditor(),
-		isAiFeatureEnabled: getPreference( "isAiFeatureActive", false ),
+		isPremium: getIsPremium(),
+		isAiFeatureEnabled: getIsAiFeatureEnabled(),
 	};
 } )( SeoAnalysis );

--- a/packages/js/src/redux/reducers/preferences.js
+++ b/packages/js/src/redux/reducers/preferences.js
@@ -1,4 +1,5 @@
 import { isUndefined, get } from "lodash";
+import { getIsAiFeatureEnabled } from "../selectors/preferences";
 import isContentAnalysisActive from "../../analysis/isContentAnalysisActive";
 import isKeywordAnalysisActive from "../../analysis/isKeywordAnalysisActive";
 import isInclusiveLanguageAnalysisActive from "../../analysis/isInclusiveLanguageAnalysisActive";
@@ -33,7 +34,8 @@ function getDefaultState() {
 		isWincherIntegrationActive: isWincherIntegrationActive(),
 		isInsightsEnabled: get( window, "wpseoScriptData.metabox.isInsightsEnabled", false ),
 		isNewsEnabled: get( window, "wpseoScriptData.metabox.isNewsSeoActive", false ),
-		isAiFeatureActive: Boolean( window.wpseoAdminL10n.isAiFeatureActive ),
+		 // The check for AI feature is deprecated, used as fallback. Should be removed once we stop supporting older versions of premium.
+		isAiFeatureActive: getIsAiFeatureEnabled(),
 		isWooCommerceSeoActive: get( window, "wpseoScriptData.metabox.isWooCommerceSeoActive", false ),
 		isWooCommerceActive: get( window, "wpseoScriptData.metabox.isWooCommerceActive", false ),
 		isRtl: get( window, "wpseoScriptData.metabox.isRtl", false ),

--- a/packages/js/src/redux/selectors/preferences.js
+++ b/packages/js/src/redux/selectors/preferences.js
@@ -76,12 +76,12 @@ export const getIsWooSeoUpsellTerm = ( state ) => {
 };
 
 /**
- * @deprecated This function is deprecated and will be removed in future versions. 
+ * @deprecated This function is deprecated and will be removed in future versions.
  * Please use the getIsAiFeatureEnabled from yoast-seo-premium store instead.
- * 
+ *
  * @returns {boolean} Whether the AI feature is enabled.
  */
 export const getIsAiFeatureEnabled = () => {
-	const getIsAiFeatureEnabledFromPremium = select("yoast-seo-premium/editor")?.getIsAiFeatureEnabled;
+	const getIsAiFeatureEnabledFromPremium = select( "yoast-seo-premium/editor" )?.getIsAiFeatureEnabled;
 	return getIsAiFeatureEnabledFromPremium ? getIsAiFeatureEnabledFromPremium() : Boolean( window.wpseoAdminL10n.isAiFeatureActive );
 };

--- a/packages/js/src/redux/selectors/preferences.js
+++ b/packages/js/src/redux/selectors/preferences.js
@@ -1,4 +1,5 @@
 import { get } from "lodash";
+import { select } from "@wordpress/data";
 import { getIsProduct, getIsProductTerm } from "./editorContext";
 
 /**
@@ -72,4 +73,15 @@ export const getIsWooSeoUpsellTerm = ( state ) => {
 	const isProductTerm = getIsProductTerm( state );
 
 	return ! isWooSeoActive && isWooCommerceActive && isProductTerm;
+};
+
+/**
+ * @deprecated This function is deprecated and will be removed in future versions. 
+ * Please use the getIsAiFeatureEnabled from yoast-seo-premium store instead.
+ * 
+ * @returns {boolean} Whether the AI feature is enabled.
+ */
+export const getIsAiFeatureEnabled = () => {
+	const getIsAiFeatureEnabledFromPremium = select("yoast-seo-premium/editor")?.getIsAiFeatureEnabled;
+	return getIsAiFeatureEnabledFromPremium ? getIsAiFeatureEnabledFromPremium() : Boolean( window.wpseoAdminL10n.isAiFeatureActive );
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactor check for if AI Feature is enabled.

## Relevant technical choices:

* Moved the check from free to premium since it's a premium feature.
* Kept the original check as fallback.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Without Premium edit a post and check you have a Tab called "SEO analysis" that contain the analysis and a tab for "Premium SEO analysis" which is used as an upsell button.
* Enable Yoast Premium and check the tab label of "Premium SEO analysis" now contains the analysis and the "SEO analysis" is no longer there.
* Enable the AI feature and edit a post, check you can see the Fix assessments AI button when editing.
* Go to Yoast SEO -> Settings -> Site features and disable the AI feature.
* Edit a post and check you can't see the sparkle AI button anymore.
* Repeat test with https://github.com/Yoast/wordpress-seo-premium/pull/4529

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched of
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21632
