### PR TITLE
541 fix data discrepancies from staging plugins

### DIFF
--- a/src/dashboard/domain/score-groups/seo-score-groups/bad-seo-score-group.php
+++ b/src/dashboard/domain/score-groups/seo-score-groups/bad-seo-score-group.php
@@ -41,7 +41,7 @@ class Bad_SEO_Score_Group extends Abstract_SEO_Score_Group {
 	 * @return int The minimum score of the SEO score group.
 	 */
 	public function get_min_score(): ?int {
-		return 0;
+		return 1;
 	}
 
 	/**

--- a/src/dashboard/infrastructure/score-results/seo-score-results/seo-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/seo-score-results/seo-score-results-collector.php
@@ -132,7 +132,7 @@ class SEO_Score_Results_Collector implements Score_Results_Collector_Interface {
 			$name = $seo_score_group->get_name();
 
 			if ( $min === null || $max === null ) {
-				$select_fields[]       = 'COUNT(CASE WHEN I.primary_focus_keyword_score IS NULL THEN 1 END) AS %i';
+				$select_fields[]       = 'COUNT(CASE WHEN I.primary_focus_keyword_score = 0 OR I.primary_focus_keyword_score IS NULL THEN 1 END) AS %i';
 				$select_replacements[] = $name;
 			}
 			else {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fix score for edge cases where the dashboard and the posts page show different results

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For when there's a keyword but SEO score is 0:
* Go and create a post with a keyword
* Go to its entry in the indexable table and set the `primary_focus_keyword_score` column into 0. Also delete its entry for the `_yoast_wpseo_linkdex` postmeta (show, search for `post_id=<POST_ID>` and `meta_key = _yoast_wpseo_linkdex`
  * We have no idea how that might happen in the wild, so that's why we have to do that manually in the db
* Check the SEO scores for that post type and confirm that each score shows the number of posts that the View links show as well
  * Most importantly, check that the post you edited, is in the `Not analyzed` group

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
