### PR TITLE
exclude content types that are not indexable from sitemaps

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -94,8 +94,12 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	public function get_index_links( $max_entries ) {
 		global $wpdb;
-		$post_types          = WPSEO_Post_Type::get_accessible_post_types();
-		$post_types          = array_filter( $post_types, [ $this, 'is_valid_post_type' ] );
+		$post_types       = WPSEO_Post_Type::get_accessible_post_types();
+		$post_types       = array_filter( $post_types, [ $this, 'is_valid_post_type' ] );
+		$posts_to_exclude = YoastSEO()->helpers->post_type->get_excluded_post_types_for_indexables();
+
+		// Exclude post types that are not indexable.
+		$post_types          = array_diff( $post_types, $posts_to_exclude );
 		$last_modified_times = WPSEO_Sitemaps::get_last_modified_gmt( $post_types, true );
 		$index               = [];
 

--- a/inc/sitemaps/class-taxonomy-sitemap-provider.php
+++ b/inc/sitemaps/class-taxonomy-sitemap-provider.php
@@ -323,6 +323,12 @@ class WPSEO_Taxonomy_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			return false;
 		}
 
+		// Check if the taxonomy is indexable.
+		$indexable_taxonomies = YoastSEO()->helpers->taxonomy->get_indexable_taxonomies();
+		if ( in_array( $taxonomy_name, $indexable_taxonomies ) ) {
+			return true;
+		}
+
 		/**
 		 * Filter to exclude the taxonomy from the XML sitemap.
 		 *

--- a/src/integrations/third-party/exclude-elementor-post-types.php
+++ b/src/integrations/third-party/exclude-elementor-post-types.php
@@ -29,6 +29,6 @@ class Exclude_Elementor_Post_Types extends Abstract_Exclude_Post_Type {
 	 * @return array The names of the post types.
 	 */
 	public function get_post_type() {
-		return [ 'elementor_library' ];
+		return [ 'elementor_library', 'e-floating-buttons' ];
 	}
 }

--- a/tests/Unit/Integrations/Third_Party/Exclude_Elementor_Post_Types_Test.php
+++ b/tests/Unit/Integrations/Third_Party/Exclude_Elementor_Post_Types_Test.php
@@ -59,7 +59,7 @@ final class Exclude_Elementor_Post_Types_Test extends TestCase {
 	public function test_exclude_elementor_post_types() {
 		$excluded_post_types = [];
 
-		$expected = [ 'elementor_library' ];
+		$expected = [ 'elementor_library', 'e-floating-buttons' ];
 		$actual   = $this->instance->exclude_post_types( $excluded_post_types );
 
 		self::assertEquals( $expected, $actual );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remove post types and taxonomies that are not indexed from the sitemaps.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Elementor
* Go to sitemap and check there is no e-floating-buttons-sitemap.xml site map.
* Create a taxonomy or post type that are no index, check they are not in the sitemap
* Open Yoast Settings, check those Floating Elements are not under content types.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Noindex Elementor assets by default](https://github.com/Yoast/wordpress-seo/issues/21700)
