### PR TITLE
Add troubleshooting mode in score endpoints

### DIFF
--- a/src/dashboard/application/score-results/abstract-score-results-repository.php
+++ b/src/dashboard/application/score-results/abstract-score-results-repository.php
@@ -67,7 +67,11 @@ abstract class Abstract_Score_Results_Repository {
 		$score_results = $this->score_results_collector->get_score_results( $this->score_groups, $content_type, $term_id, $is_troubleshooting );
 
 		if ( $is_troubleshooting === true ) {
-			return $score_results;
+			$score_results['score_ids'] = clone $score_results['scores'];
+
+			foreach ( $score_results['scores'] as &$score ) {
+				$score = ( $score !== null ) ? \count( \explode( ',', $score ) ) : 0;
+			}
 		}
 
 		$current_scores_list = $this->current_scores_repository->get_current_scores( $this->score_groups, $score_results, $content_type, $taxonomy, $term_id );

--- a/src/dashboard/application/score-results/abstract-score-results-repository.php
+++ b/src/dashboard/application/score-results/abstract-score-results-repository.php
@@ -54,16 +54,21 @@ abstract class Abstract_Score_Results_Repository {
 	/**
 	 * Returns the score results for a content type.
 	 *
-	 * @param Content_Type  $content_type The content type.
-	 * @param Taxonomy|null $taxonomy     The taxonomy of the term we're filtering for.
-	 * @param int|null      $term_id      The ID of the term we're filtering for.
+	 * @param Content_Type  $content_type       The content type.
+	 * @param Taxonomy|null $taxonomy           The taxonomy of the term we're filtering for.
+	 * @param int|null      $term_id            The ID of the term we're filtering for.
+	 * @param bool|null     $is_troubleshooting Whether we're in troubleshooting mode.
 	 *
 	 * @return array<array<string, string|int|array<string, string>>> The scores.
 	 *
 	 * @throws Exception When getting score results from the infrastructure fails.
 	 */
-	public function get_score_results( Content_Type $content_type, ?Taxonomy $taxonomy, ?int $term_id ): array {
-		$score_results = $this->score_results_collector->get_score_results( $this->score_groups, $content_type, $term_id );
+	public function get_score_results( Content_Type $content_type, ?Taxonomy $taxonomy, ?int $term_id, ?bool $is_troubleshooting ): array {
+		$score_results = $this->score_results_collector->get_score_results( $this->score_groups, $content_type, $term_id, $is_troubleshooting );
+
+		if ( $is_troubleshooting === true ) {
+			return $score_results;
+		}
 
 		$current_scores_list = $this->current_scores_repository->get_current_scores( $this->score_groups, $score_results, $content_type, $taxonomy, $term_id );
 		$score_result_object = new Score_Result( $current_scores_list, $score_results['query_time'], $score_results['cache_used'] );

--- a/src/dashboard/application/score-results/current-scores-repository.php
+++ b/src/dashboard/application/score-results/current-scores-repository.php
@@ -50,8 +50,10 @@ class Current_Scores_Repository {
 		foreach ( $score_groups as $score_group ) {
 			$score_name          = $score_group->get_name();
 			$current_score_links = $this->get_current_score_links( $score_group, $content_type, $taxonomy, $term_id );
+			$score_amount        = (int) $score_results['scores']->$score_name;
+			$score_ids           = ( isset( $score_results['score_ids'] ) ) ? $score_results['score_ids']->$score_name : null;
 
-			$current_score = new Current_Score( $score_name, (int) $score_results['scores']->$score_name, $current_score_links );
+			$current_score = new Current_Score( $score_name, $score_amount, $score_ids, $current_score_links );
 			$current_scores_list->add( $current_score, $score_group->get_position() );
 		}
 

--- a/src/dashboard/domain/score-results/current-score.php
+++ b/src/dashboard/domain/score-results/current-score.php
@@ -22,6 +22,13 @@ class Current_Score {
 	private $amount;
 
 	/**
+	 * The ids of the current score.
+	 *
+	 * @var string
+	 */
+	private $ids;
+
+	/**
 	 * The links of the current score.
 	 *
 	 * @var array<string, string>
@@ -33,11 +40,13 @@ class Current_Score {
 	 *
 	 * @param string                $name   The name of the current score.
 	 * @param int                   $amount The amount of the current score.
+	 * @param string                $ids    The ids of the current score.
 	 * @param array<string, string> $links  The links of the current score.
 	 */
-	public function __construct( string $name, int $amount, ?array $links = null ) {
+	public function __construct( string $name, int $amount, ?string $ids = null, ?array $links = null ) {
 		$this->name   = $name;
 		$this->amount = $amount;
+		$this->ids    = $ids;
 		$this->links  = $links;
 	}
 
@@ -57,6 +66,15 @@ class Current_Score {
 	 */
 	public function get_amount(): int {
 		return $this->amount;
+	}
+
+	/**
+	 * Gets the ids of the current score.
+	 *
+	 * @return string The ids of the current score.
+	 */
+	public function get_ids(): ?string {
+		return $this->ids;
 	}
 
 	/**

--- a/src/dashboard/domain/score-results/current-scores-list.php
+++ b/src/dashboard/domain/score-results/current-scores-list.php
@@ -36,12 +36,16 @@ class Current_Scores_List {
 
 		\ksort( $this->current_scores );
 
-		foreach ( $this->current_scores as $current_score ) {
+		foreach ( $this->current_scores as $key => $current_score ) {
 			$array[] = [
 				'name'   => $current_score->get_name(),
 				'amount' => $current_score->get_amount(),
 				'links'  => $current_score->get_links_to_array(),
 			];
+
+			if ( $current_score->get_ids() !== null ) {
+				$array[ $key ]['ids'] = $current_score->get_ids();
+			}
 		}
 
 		return $array;

--- a/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/readability-score-results/readability-score-results-collector.php
@@ -23,12 +23,13 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 	 * @param Readability_Score_Groups_Interface[] $readability_score_groups All readability score groups.
 	 * @param Content_Type                         $content_type             The content type.
 	 * @param int|null                             $term_id                  The ID of the term we're filtering for.
+	 * @param bool|null                            $is_troubleshooting       Whether we're in troubleshooting mode.
 	 *
 	 * @return array<string, object|bool|float> The readability score results for a content type.
 	 *
 	 * @throws Score_Results_Not_Found_Exception When the query of getting score results fails.
 	 */
-	public function get_score_results( array $readability_score_groups, Content_Type $content_type, ?int $term_id ) {
+	public function get_score_results( array $readability_score_groups, Content_Type $content_type, ?int $term_id, ?bool $is_troubleshooting ) {
 		global $wpdb;
 		$results = [];
 
@@ -36,7 +37,7 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 		$transient_name    = self::READABILITY_SCORES_TRANSIENT . '_' . $content_type_name . ( ( $term_id === null ) ? '' : '_' . $term_id );
 
 		$transient = \get_transient( $transient_name );
-		if ( $transient !== false ) {
+		if ( $is_troubleshooting !== true && $transient !== false ) {
 			$results['scores']     = \json_decode( $transient, false );
 			$results['cache_used'] = true;
 			$results['query_time'] = 0;
@@ -44,7 +45,7 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 			return $results;
 		}
 
-		$select = $this->build_select( $readability_score_groups );
+		$select = $this->build_select( $readability_score_groups, $is_troubleshooting );
 
 		$replacements = \array_merge(
 			\array_values( $select['replacements'] ),
@@ -105,7 +106,9 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 
 		$end_time = \microtime( true );
 
-		\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
+		if ( $is_troubleshooting !== true ) {
+			\set_transient( $transient_name, WPSEO_Utils::format_json_encode( $current_scores ), \MINUTE_IN_SECONDS );
+		}
 
 		$results['scores']     = $current_scores;
 		$results['cache_used'] = false;
@@ -117,12 +120,17 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 	 * Builds the select statement for the readability scores query.
 	 *
 	 * @param Readability_Score_Groups_Interface[] $readability_score_groups All readability score groups.
+	 * @param bool|null                            $is_troubleshooting       Whether we're in troubleshooting mode.
 	 *
 	 * @return array<string, string> The select statement for the readability scores query.
 	 */
-	private function build_select( array $readability_score_groups ): array {
+	private function build_select( array $readability_score_groups, ?bool $is_troubleshooting ): array {
 		$select_fields       = [];
 		$select_replacements = [];
+
+		// When we don't troubleshoot, we're interested in the amount of posts in a group, when we troubleshoot we want to gather the actual IDs.
+		$select_operation = ( $is_troubleshooting === true ) ? 'GROUP_CONCAT' : 'COUNT';
+		$selected_info    = ( $is_troubleshooting === true ) ? 'I.object_id' : '1';
 
 		foreach ( $readability_score_groups as $readability_score_group ) {
 			$min  = $readability_score_group->get_min_score();
@@ -130,12 +138,12 @@ class Readability_Score_Results_Collector implements Score_Results_Collector_Int
 			$name = $readability_score_group->get_name();
 
 			if ( $min === null && $max === null ) {
-				$select_fields[]       = 'COUNT(CASE WHEN I.readability_score = 0 AND I.estimated_reading_time_minutes IS NULL THEN 1 END) AS %i';
+				$select_fields[]       = "{$select_operation}(CASE WHEN I.readability_score = 0 AND I.estimated_reading_time_minutes IS NULL THEN {$selected_info} END) AS %i";
 				$select_replacements[] = $name;
 			}
 			else {
 				$needs_ert             = ( $min === 1 ) ? ' OR (I.readability_score = 0 AND I.estimated_reading_time_minutes IS NOT NULL)' : '';
-				$select_fields[]       = "COUNT(CASE WHEN ( I.readability_score >= %d AND I.readability_score <= %d ){$needs_ert} THEN 1 END) AS %i";
+				$select_fields[]       = "{$select_operation}(CASE WHEN ( I.readability_score >= %d AND I.readability_score <= %d ){$needs_ert} THEN {$selected_info} END) AS %i";
 				$select_replacements[] = $min;
 				$select_replacements[] = $max;
 				$select_replacements[] = $name;

--- a/src/dashboard/infrastructure/score-results/score-results-collector-interface.php
+++ b/src/dashboard/infrastructure/score-results/score-results-collector-interface.php
@@ -14,11 +14,12 @@ interface Score_Results_Collector_Interface {
 	/**
 	 * Retrieves the score results for a content type.
 	 *
-	 * @param Score_Groups_Interface[] $score_groups All score groups.
-	 * @param Content_Type             $content_type The content type.
-	 * @param int|null                 $term_id      The ID of the term we're filtering for.
+	 * @param Score_Groups_Interface[] $score_groups       All score groups.
+	 * @param Content_Type             $content_type       The content type.
+	 * @param int|null                 $term_id            The ID of the term we're filtering for.
+	 * @param bool|null                $is_troubleshooting Whether we're in troubleshooting mode.
 	 *
 	 * @return array<string, string> The score results for a content type.
 	 */
-	public function get_score_results( array $score_groups, Content_Type $content_type, ?int $term_id );
+	public function get_score_results( array $score_groups, Content_Type $content_type, ?int $term_id, ?bool $is_troubleshooting );
 }

--- a/src/dashboard/user-interface/scores/abstract-scores-route.php
+++ b/src/dashboard/user-interface/scores/abstract-scores-route.php
@@ -150,6 +150,12 @@ abstract class Abstract_Scores_Route implements Route_Interface {
 								return \intval( $param );
 							},
 						],
+						'troubleshooting' => [
+							'required'          => false,
+							'type'              => 'bool',
+							'default'           => null,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
 					],
 				],
 			]
@@ -169,7 +175,7 @@ abstract class Abstract_Scores_Route implements Route_Interface {
 			$taxonomy     = $this->get_taxonomy( $request['taxonomy'], $content_type );
 			$term_id      = $this->get_validated_term_id( $request['term'], $taxonomy );
 
-			$results = $this->score_results_repository->get_score_results( $content_type, $taxonomy, $term_id );
+			$results = $this->score_results_repository->get_score_results( $content_type, $taxonomy, $term_id, $request['troubleshooting'] );
 		} catch ( Exception $exception ) {
 			return new WP_REST_Response(
 				[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds troubleshooting mode in score endpoints

## Relevant technical choices:

* If we're on troubleshooting mode, we bypass cache.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With POSTMAN, do the usual GET requests for seo and readability scores (see [the original PR](https://github.com/Yoast/wordpress-seo/pull/21847))
* But this time add a `&troubleshooting=1` parameter
* You should now get the same responses like before, but with an added `ids` attribute in each `good`/`ok/`bad`/notAnalyzed` score, which should represent a comma-separated list of post IDs.
* Confirm that those IDs are:
  * the same amount that the respective `amount` of the score
  * for the posts that exist in the respective `view` links
* Try for both seo and readability scores and for taxonomy filtering both enabled and disabled
* Also try to send a GET request with troubleshooting on and within a minute send the same request with troubleshooting off. You should get the same amounts but also you should get both results with `cacheUsed: false`, even if the requests happened within the cache expiration data.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Do a smoke test of the score widgets. Mainly we want to check that we keep showing the proper amounts for each score. Again, an easy way to test this is to compare the numbers that the widget show for each score and the number of posts that exist in the `View` links.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/354
