### PR TITLE
Creates integration test for the Filter_Pairs_Repository.

### DIFF
--- a/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
+++ b/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\Tests\WP\TestCase;
 /**
  * Integration Test Class for Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository.
  *
- * @coversDefaultClass Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository
+ * @covers Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository::get_taxonomy
  */
 final class Filter_Pairs_Repository_Test extends TestCase {
 
@@ -57,8 +57,6 @@ final class Filter_Pairs_Repository_Test extends TestCase {
 
 	/**
 	 * Tests get_taxonomy to see if it returns the correct data when a pair is found.
-	 *
-	 * @covers ::get_taxonomy
 	 *
 	 * @return void
 	 */

--- a/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
+++ b/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
@@ -34,35 +34,75 @@ final class Filter_Pairs_Repository_Test extends TestCase {
 		$taxonomy_validator = new Taxonomy_Validator();
 		$taxonomy_collector = new Taxonomies_Collector( $taxonomy_validator );
 		$this->instance     = new Filter_Pairs_Repository( $taxonomy_collector, new Product_Category_Filter_Pair() );
-
-		\register_taxonomy(
-			'product_cat',
-			'product',
-			[
-				'public'       => true,
-				'show_in_rest' => true,
-			]
-		);
-	}
-
-	/**
-	 * Remove the taxonomy after each test.
-	 *
-	 * @return void
-	 */
-	public function tear_down() {
-		\unregister_taxonomy( 'product_cat' );
-		parent::tear_down();
 	}
 
 	/**
 	 * Tests get_taxonomy to see if it returns the correct data when a pair is found.
 	 *
+	 * @dataProvider data_get_taxonomy
+	 *
+	 * @param string        $taxonomy_name    The taxonomy to register.
+	 * @param string        $object_type_name The object type that is looking.
+	 * @param bool          $is_public        If the taxonomy should be public.
+	 * @param bool          $show_in_rest     If the taxonomy should show in rest.
+	 * @param Taxonomy|null $expected         The expected result.
+	 *
 	 * @return void
 	 */
-	public function test_get_taxonomy() {
-		$product_cat_taxonomy = new Taxonomy( 'product_cat', 'Tags', 'http://example.org/index.php?rest_route=/wp/v2/product_cat' );
-		self::assertNull( $this->instance->get_taxonomy( 'post' ) );
-		self::assertEquals( $product_cat_taxonomy, $this->instance->get_taxonomy( 'product' ) );
+	public function test_get_taxonomy(
+		string $taxonomy_name,
+		string $object_type_name,
+		bool $is_public,
+		bool $show_in_rest,
+		?Taxonomy $expected
+	) {
+		\register_taxonomy(
+			$taxonomy_name,
+			$object_type_name,
+			[
+				'public'       => $is_public,
+				'show_in_rest' => $show_in_rest,
+			]
+		);
+		self::assertEquals( $expected, $this->instance->get_taxonomy( $object_type_name ) );
+		\unregister_taxonomy( $taxonomy_name );
+	}
+
+	/**
+	 * The data provider for the `get_taxonomy` test.
+	 *
+	 * @return array<array<string,bool,null,Taxonomy>> The data.
+	 */
+	public function data_get_taxonomy(): array {
+		return [
+			'Find product_cat taxonomy for product' => [
+				'product_cat',
+				'product',
+				true,
+				true,
+				new Taxonomy( 'product_cat', 'Tags', 'http://example.org/index.php?rest_route=/wp/v2/product_cat' ),
+			],
+			'Don\'t find product_cat taxonomy for product when not public' => [
+				'product_cat',
+				'product',
+				false,
+				true,
+				null,
+			],
+			'Don\'t find product_cat taxonomy for product when not in rest' => [
+				'product_cat',
+				'product',
+				true,
+				false,
+				null,
+			],
+			'Don\'t find taxonomy for a product that has no pair' => [
+				'not_found',
+				'fourofour',
+				true,
+				true,
+				null,
+			],
+		];
 	}
 }

--- a/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
+++ b/tests/WP/Dashboard/Application/Filter_Pairs/Filter_Pairs_Repository_Test.php
@@ -1,0 +1,70 @@
+<?php
+// @phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the original class.
+namespace Yoast\WP\SEO\Tests\WP\Dashboard\Application\Filter_Pairs;
+
+use Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository;
+use Yoast\WP\SEO\Dashboard\Domain\Filter_Pairs\Product_Category_Filter_Pair;
+use Yoast\WP\SEO\Dashboard\Domain\Taxonomies\Taxonomy;
+use Yoast\WP\SEO\Dashboard\Infrastructure\Taxonomies\Taxonomies_Collector;
+use Yoast\WP\SEO\Dashboard\Infrastructure\Taxonomies\Taxonomy_Validator;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration Test Class for Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository.
+ *
+ * @coversDefaultClass Yoast\WP\SEO\Dashboard\Application\Filter_Pairs\Filter_Pairs_Repository
+ */
+final class Filter_Pairs_Repository_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Filter_Pairs_Repository
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$taxonomy_validator = new Taxonomy_Validator();
+		$taxonomy_collector = new Taxonomies_Collector( $taxonomy_validator );
+		$this->instance     = new Filter_Pairs_Repository( $taxonomy_collector, new Product_Category_Filter_Pair() );
+
+		\register_taxonomy(
+			'product_cat',
+			'product',
+			[
+				'public'       => true,
+				'show_in_rest' => true,
+			]
+		);
+	}
+
+	/**
+	 * Remove the taxonomy after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		\unregister_taxonomy( 'product_cat' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests get_taxonomy to see if it returns the correct data when a pair is found.
+	 *
+	 * @covers ::get_taxonomy
+	 *
+	 * @return void
+	 */
+	public function test_get_taxonomy() {
+		$product_cat_taxonomy = new Taxonomy( 'product_cat', 'Tags', 'http://example.org/index.php?rest_route=/wp/v2/product_cat' );
+		self::assertNull( $this->instance->get_taxonomy( 'post' ) );
+		self::assertEquals( $product_cat_taxonomy, $this->instance->get_taxonomy( 'product' ) );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add integration tests for the Filter_Pairs_Repository

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an integration test to make sure the filter pairs repository returns the needed data.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
