### PR TITLE
Dashboard: add tests for JS side

### DIFF
--- a/packages/js/tests/dashboard/components/page-title.test.js
+++ b/packages/js/tests/dashboard/components/page-title.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+import { PageTitle } from "../../../src/dashboard/components/page-title";
+import { render } from "../../test-utils";
+
+/**
+ * @param {Container} container The container.
+ * @param {Function} getByRole The getByRole function.
+ * @returns {void}
+ */
+const verifyDefaultContent = ( container, getByRole ) => {
+	expect( getByRole( "heading", { name: "Hi John," } ) ).toBeInTheDocument();
+
+	const text = {
+		description: "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities.",
+		contentAnalysisLink: "Learn more on how to improve your content with our content analysis tool",
+		contentAnalysisLinkScreenReader: "(Opens in a new browser tab)",
+	};
+
+	// The text is not retrievable with getByText due to the HTML. So below is a bit strange with the joins with and without spaces.
+	expect( container.querySelector( "p" ).textContent )
+		.toBe( [ [ text.description, text.contentAnalysisLink ].join( " " ), text.contentAnalysisLinkScreenReader, "." ].join( "" ) );
+
+	const contentAnalysisLink = getByRole( "link", {
+		name: [ text.contentAnalysisLink, text.contentAnalysisLinkScreenReader ].join( " " ),
+	} );
+	expect( contentAnalysisLink ).toHaveAttribute( "href", "https://example.com/content-analysis" );
+	expect( contentAnalysisLink ).toHaveAttribute( "target", "_blank" );
+	expect( contentAnalysisLink ).toHaveTextContent( text.contentAnalysisLink );
+};
+
+describe( "PageTitle", () => {
+	it( "should render the component", () => {
+		const { container, getByRole } = render(
+			<PageTitle
+				userName="John"
+				features={ { indexables: true, seoAnalysis: true, readabilityAnalysis: true } }
+				links={ { contentAnalysis: "https://example.com/content-analysis" } }
+			/>
+		);
+
+		verifyDefaultContent( container, getByRole );
+	} );
+
+	it( "should show a warning with SEO and readability both disabled", () => {
+		const { container, getByRole } = render(
+			<PageTitle
+				userName="Bob"
+				features={ { indexables: true, seoAnalysis: false, readabilityAnalysis: false } }
+				links={ { contentAnalysis: "https://example.com/content-analysis" } }
+			/>
+		);
+
+		expect( getByRole( "heading", { name: "Hi Bob," } ) ).toBeInTheDocument();
+
+		// The text is not retrievable with getByText due to the HTML.
+		expect( container.querySelector( "p" ).textContent )
+			.toBe( "It looks like the ‘SEO analysis’ and the ‘Readability analysis’ are currently disabled in your Site features or your user profile settings. Enable these features to start seeing all the insights you need right here!" );
+
+		const siteFeaturesLink = getByRole( "link", { name: "Site features" } );
+		expect( siteFeaturesLink ).toHaveAttribute( "href", "admin.php?page=wpseo_page_settings#/site-features" );
+		expect( siteFeaturesLink ).not.toHaveAttribute( "target", "_blank" );
+
+		const userProfileLink = getByRole( "link", { name: "user profile settings" } );
+		expect( userProfileLink ).toHaveAttribute( "href", "profile.php" );
+		expect( userProfileLink ).not.toHaveAttribute( "target", "_blank" );
+	} );
+
+	it( "should show a warning when the indexables are disabled", () => {
+		const { container, getByRole } = render(
+			<PageTitle
+				userName="John"
+				features={ { indexables: false, seoAnalysis: true, readabilityAnalysis: true } }
+				links={ { contentAnalysis: "https://example.com/content-analysis" } }
+			/>
+		);
+
+		verifyDefaultContent( container, getByRole );
+
+		const alert = getByRole( "status", { type: "info" } );
+		expect( alert )
+			.toHaveTextContent( "Oops! You can’t see the overview of your SEO scores and readability scores right now because you’re in a non-production environment." );
+	} );
+} );

--- a/packages/js/tests/dashboard/fetch/fetch-json.test.js
+++ b/packages/js/tests/dashboard/fetch/fetch-json.test.js
@@ -1,0 +1,53 @@
+import { afterEach, beforeAll, describe, expect, it, jest } from "@jest/globals";
+import { fetchJson } from "../../../src/dashboard/fetch/fetch-json";
+
+describe( "fetchJson", () => {
+	beforeAll( () => {
+		global.fetch = jest.fn();
+	} );
+
+	afterEach( () => {
+		global.fetch.mockClear();
+	} );
+
+	it( "should wrap fetch", () => {
+		global.fetch.mockResolvedValue( {
+			ok: true,
+			json: jest.fn().mockResolvedValue( "foo" ),
+		} );
+
+		const url = "https://example.com/";
+		const options = {
+			headers: { "Content-Type": "application/json" },
+		};
+
+		expect( fetchJson( url, options ) ).resolves.toBe( "foo" );
+		expect( fetch ).toHaveBeenCalledWith( url, options );
+	} );
+
+	it( "should reject if not ok", () => {
+		global.fetch.mockResolvedValue( { ok: false } );
+
+		const url = "https://example.com/";
+		const options = {
+			headers: { "Content-Type": "application/json" },
+		};
+
+		expect( fetchJson( url, options ) ).rejects.toThrow( "not ok" );
+		expect( fetch ).toHaveBeenCalledWith( url, options );
+	} );
+
+	it( "should reject if errored", () => {
+		global.fetch.mockImplementation( () => {
+			throw new Error( "foo" );
+		} );
+
+		const url = "https://example.com/";
+		const options = {
+			headers: { "Content-Type": "application/json" },
+		};
+
+		expect( fetchJson( url, options ) ).rejects.toThrow( "foo" );
+		expect( fetch ).toHaveBeenCalledWith( url, options );
+	} );
+} );

--- a/packages/js/tests/dashboard/fetch/get-response-error.test.js
+++ b/packages/js/tests/dashboard/fetch/get-response-error.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "@jest/globals";
+import { getResponseError } from "../../../src/dashboard/fetch/get-response-error";
+
+describe( "getResponseError", () => {
+	it.each( [
+		[ 400, "Error", "not ok" ],
+		[ 404, "Error", "not ok" ],
+		[ 408, "TimeoutError", "request timed out" ],
+		[ 500, "Error", "not ok" ],
+	] )( "status %s should return %s with the message: %s", ( status, name, message ) => {
+		const actual = getResponseError( { status } );
+		expect( actual.name ).toBe( name );
+		expect( actual.message ).toBe( message );
+	} );
+} );

--- a/packages/js/tests/dashboard/fetch/timeout-error.test.js
+++ b/packages/js/tests/dashboard/fetch/timeout-error.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "@jest/globals";
+import { TimeoutError } from "../../../src/dashboard/fetch/timeout-error";
+
+describe( "TimeoutError", () => {
+	it( "should have the correct name", () => {
+		expect( new TimeoutError( "message" ).name ).toBe( "TimeoutError" );
+	} );
+
+	it( "should have the given message", () => {
+		expect( new TimeoutError( "message" ).message ).toBe( "message" );
+	} );
+} );

--- a/packages/js/tests/dashboard/fetch/use-fetch.test.js
+++ b/packages/js/tests/dashboard/fetch/use-fetch.test.js
@@ -1,0 +1,149 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { useFetch } from "../../../src/dashboard/fetch/use-fetch";
+import { renderHook, waitFor } from "../../test-utils";
+
+describe( "useFetch", () => {
+	it( "should fetch data", async() => {
+		const fetch = jest.fn( () => Promise.resolve( "data" ) );
+		const { result } = renderHook( () => useFetch( {
+			dependencies: [],
+			url: "https://example.com",
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 0,
+		} ) );
+
+		expect( result.current.isPending ).toBe( true );
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com" );
+		expect( result.current.data ).toEqual( "data" );
+		expect( result.current.error ).toBeUndefined();
+	} );
+
+	it( "should abort the fetch on unmount", async() => {
+		// Create fetch with timeout, so that we can test the abort.
+		const fetch = jest.fn( () => new Promise( ( resolve ) => {
+			setTimeout( () => resolve( "data" ), 1000 );
+		} ) );
+		const { result, unmount } = renderHook( () => useFetch( {
+			dependencies: [],
+			url: "https://example.com",
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 0,
+		} ) );
+
+		expect( result.current.isPending ).toBe( true );
+		// Wait for the fetch to be called.
+		await waitFor( () => expect( fetch ).toHaveBeenCalledTimes( 1 ) );
+		unmount();
+
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com" );
+		expect( fetch.mock.calls[ 0 ][ 1 ].signal.aborted ).toBe( true );
+		// Abort errors should not set the error state.
+		expect( result.current.error ).toBeUndefined();
+		// The other state is not changed due to the unmount.
+		expect( result.current.data ).toBeUndefined();
+		expect( result.current.isPending ).toBe( true );
+	} );
+
+	it( "should abort the fetch on dependencies change", async() => {
+		// Create fetch with timeout, so that we can test the abort.
+		const fetch = jest.fn( () => new Promise( ( resolve ) => {
+			setTimeout( () => resolve( "data" ), 1000 );
+		} ) );
+		const { result, rerender } = renderHook( ( { url } ) => useFetch( {
+			dependencies: [ url ],
+			url,
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 0,
+		} ), { initialProps: { url: "https://example.com" } } );
+
+		expect( result.current.isPending ).toBe( true );
+		// Wait for the fetch to be called.
+		await waitFor( () => expect( fetch ).toHaveBeenCalledTimes( 1 ) );
+
+		// Rerender with a new URL to trigger the dependency change.
+		rerender( { url: "https://example.com/foo" } );
+		await waitFor( () => expect( fetch ).toHaveBeenCalledTimes( 2 ) );
+
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com" );
+		expect( fetch.mock.calls[ 0 ][ 1 ].signal.aborted ).toBe( true );
+		expect( fetch.mock.calls[ 1 ][ 0 ] ).toBe( "https://example.com/foo" );
+		// Abort errors should not set the error state.
+		expect( result.current.error ).toBeUndefined();
+		// The other state is not changed due to the unmount.
+		expect( result.current.data ).toBeUndefined();
+		expect( result.current.isPending ).toBe( true );
+	} );
+
+	it( "should handle fetch errors", async() => {
+		const fetch = jest.fn( () => Promise.reject( new Error( "error" ) ) );
+		const { result } = renderHook( () => useFetch( {
+			dependencies: [],
+			url: "https://example.com",
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 0,
+		} ) );
+
+		expect( result.current.isPending ).toBe( true );
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com" );
+		expect( result.current.data ).toBeUndefined();
+		expect( result.current.error ).toEqual( new Error( "error" ) );
+	} );
+
+	it( "should prepare data", async() => {
+		const fetch = jest.fn( () => Promise.resolve( [ { id: 1, name: "name" } ] ) );
+		const { result } = renderHook( () => useFetch( {
+			dependencies: [],
+			url: "https://example.com",
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 0,
+			prepareData: ( entry ) => entry.map( ( { id, name } ) => ( { name: String( id ), label: name } ) ),
+		} ) );
+
+		expect( result.current.isPending ).toBe( true );
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com" );
+		expect( result.current.data ).toEqual( [ { name: "1", label: "name" } ] );
+		expect( result.current.error ).toBeUndefined();
+	} );
+
+	it( "should debounce fetches", async() => {
+		const fetch = jest.fn()
+			.mockImplementationOnce( () => Promise.resolve( "one" ) )
+			.mockImplementationOnce( () => Promise.resolve( "two" ) )
+			.mockImplementationOnce( () => Promise.resolve( "three" ) );
+		const { result, rerender } = renderHook( ( { url } ) => useFetch( {
+			dependencies: [ url ],
+			url,
+			options: {},
+			doFetch: fetch,
+			fetchDelay: 100,
+		} ), { initialProps: { url: "https://example.com" } } );
+
+		expect( result.current.isPending ).toBe( true );
+		// Re-render multiple times to mimic multiple calls.
+		rerender( { url: "https://example.com/foo" } );
+		rerender( { url: "https://example.com/bar" } );
+
+		await waitFor( () => expect( result.current.isPending ).toBe( false ) );
+
+		expect( fetch ).toHaveBeenCalledTimes( 1 );
+		// Note this should be the URL for the last call, because the previous ones are debounced.
+		expect( fetch.mock.calls[ 0 ][ 0 ] ).toBe( "https://example.com/bar" );
+		// Note this should be the first call result, because we only want one call.
+		expect( result.current.data ).toBe( "one" );
+		expect( result.current.error ).toBeUndefined();
+	} );
+} );

--- a/packages/js/tests/dashboard/scores/components/__data__/categories.json
+++ b/packages/js/tests/dashboard/scores/components/__data__/categories.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 22,
+    "name": "A thing"
+  },
+  {
+    "id": 32,
+    "name": "Something"
+  },
+  {
+    "id": 1,
+    "name": "Uncategorized"
+  }
+]

--- a/packages/js/tests/dashboard/scores/components/__data__/content-types.json
+++ b/packages/js/tests/dashboard/scores/components/__data__/content-types.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "post",
+    "label": "Posts",
+    "taxonomy": {
+      "name": "category",
+      "label": "Categories",
+      "links": {
+        "search": "https://example.com/categories"
+      }
+    }
+  },
+  {
+    "name": "page",
+    "label": "Pages",
+    "taxonomy": null
+  },
+  {
+    "name": "product",
+    "label": "Products",
+    "taxonomy": {
+      "name": "product_cat",
+      "label": "Product categories",
+      "links": {
+        "search": "https://example.com/product_cat"
+      }
+    }
+  }
+]

--- a/packages/js/tests/dashboard/scores/components/__data__/product_cat.json
+++ b/packages/js/tests/dashboard/scores/components/__data__/product_cat.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 18,
+    "name": "merchandise"
+  },
+  {
+    "id": 24,
+    "name": "other"
+  },
+  {
+    "id": 16,
+    "name": "Uncategorized"
+  }
+]

--- a/packages/js/tests/dashboard/scores/components/__data__/scores.json
+++ b/packages/js/tests/dashboard/scores/components/__data__/scores.json
@@ -1,0 +1,34 @@
+{
+  "scores": [
+    {
+      "name": "good",
+      "amount": 2,
+      "links": {
+        "view": "wp-admin/edit.php?post_status=publish&post_type=post&seo_filter=good"
+      }
+    },
+    {
+      "name": "ok",
+      "amount": 4,
+      "links": {
+        "view": "wp-admin/edit.php?post_status=publish&post_type=post&seo_filter=ok"
+      }
+    },
+    {
+      "name": "bad",
+      "amount": 3,
+      "links": {
+        "view": "wp-admin/edit.php?post_status=publish&post_type=post&seo_filter=bad"
+      }
+    },
+    {
+      "name": "notAnalyzed",
+      "amount": 3,
+      "links": {
+        "view": "wp-admin/edit.php?post_status=publish&post_type=post&seo_filter=na"
+      }
+    }
+  ],
+  "cacheUsed": false,
+  "queryTime": 0.00041222572326660156
+}

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -1,0 +1,328 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { fetchJson } from "../../../../src/dashboard/fetch/fetch-json";
+import { TimeoutError } from "../../../../src/dashboard/fetch/timeout-error";
+import { Scores } from "../../../../src/dashboard/scores/components/scores";
+import { fireEvent, render, waitFor } from "../../../test-utils";
+import categories from "./__data__/categories.json";
+import contentTypes from "./__data__/content-types.json";
+import productCategories from "./__data__/product_cat.json";
+import scores from "./__data__/scores.json";
+
+// Mock the Chart.js library. Preventing the error:
+// > Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package).
+// Note: this also prevents the canvas from being rendered.
+jest.mock( "chart.js" );
+jest.mock( "react-chartjs-2" );
+
+// Mock fetchJson, providing the data for the tests.
+jest.mock( "../../../../src/dashboard/fetch/fetch-json" );
+
+describe( "Scores", () => {
+	beforeAll( () => {
+		fetchJson.mockImplementation( ( url ) => {
+			switch ( url.pathname ) {
+				case "/error":
+					return Promise.reject( new Error( "An error" ) );
+				case "/timeout":
+					return Promise.reject( new TimeoutError( "A timeout error" ) );
+				case "/categories":
+					if ( url.searchParams.get( "search" ) === "nothing" ) {
+						return Promise.resolve( [] );
+					}
+					return Promise.resolve( categories );
+				case "/product_cat":
+					return Promise.resolve( productCategories );
+				default:
+					return Promise.resolve( scores );
+			}
+		} );
+	} );
+
+	beforeEach( () => {
+		fetchJson.mockClear();
+	} );
+
+	it( "should render the component", async() => {
+		const { container, getAllByRole, getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Verify the title is present.
+		expect( getByRole( "heading", { name: "SEO scores" } ) ).toBeInTheDocument();
+
+		// Verify the filters are present.
+		expect( getByRole( "combobox", { name: "Content type" } ) ).toBeInTheDocument();
+		expect( getByRole( "combobox", { name: "Categories" } ) ).toBeInTheDocument();
+
+		// The skeleton loader should be visible before the fetch calls succeed.
+		expect( container.querySelector( ".yst-skeleton-loader" ) ).not.toBeNull();
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/seo_scores?contentType=post" } ),
+			expect.any( Object )
+		);
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
+			expect.any( Object )
+		);
+
+		// Ensure the skeleton loader is removed.
+		expect( container.querySelector( ".yst-skeleton-loader" ) ).toBeNull();
+
+		// Verify the score content.
+		expect( getByRole( "list" ) ).toBeInTheDocument();
+
+		// Verify the score list items.
+		const listItems = getAllByRole( "listitem" );
+		expect( listItems ).toHaveLength( 4 );
+		expect( listItems[ 0 ] ).toHaveTextContent( "Good" );
+		expect( listItems[ 1 ] ).toHaveTextContent( "OK" );
+		expect( listItems[ 2 ] ).toHaveTextContent( "Needs improvement" );
+		expect( listItems[ 3 ] ).toHaveTextContent( "Not analyzed" );
+	} );
+
+	it( "should show an error with a link to the support page", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/error"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Verify the error is present.
+		expect( getByRole( "status" ) )
+			.toHaveTextContent( "Something went wrong. In case you need further help, please take a look at our Support page." );
+
+		// Verify a link to the support page is present.
+		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
+	} );
+
+	it( "should show a timeout error with a link to the support page", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/timeout"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Verify the error is present.
+		expect( getByRole( "status" ) )
+			.toHaveTextContent( "A timeout occurred, possibly due to a large number of posts or terms. In case you need further help, please take a look at our Support page." );
+
+		// Verify a link to the support page is present.
+		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
+	} );
+
+	it( "should not show the categories filter without taxonomies", async() => {
+		const { getByRole, queryByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Click the content type filter to show the options.
+		const contentTypeFilter = getByRole( "combobox", { name: "Content type" } );
+		fireEvent.click( contentTypeFilter );
+
+		// Double check all the options are present.
+		expect( getByRole( "option", { name: "Posts" } ) ).toBeInTheDocument();
+		expect( getByRole( "option", { name: "Pages" } ) ).toBeInTheDocument();
+		const pagesOption = getByRole( "option", { name: "Pages" } );
+		expect( pagesOption ).toBeInTheDocument();
+
+		// Select the "Pages" option.
+		fireEvent.click( pagesOption );
+
+		// Await new fetch call for the scores.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+		expect( fetchJson )
+			.toHaveBeenCalledWith( expect.objectContaining( { href: "https://example.com/seo_scores?contentType=page" } ), expect.any( Object ) );
+
+		// Verify the categories filter is not there.
+		expect( queryByRole( "combobox", { name: "Categories" } ) ).toBeNull();
+	} );
+
+	it( "should request the (readability) scores for a specific term", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="readability"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/readability_scores"
+			/>
+		);
+
+		// Verify the title is present.
+		expect( getByRole( "heading", { name: "Readability scores" } ) ).toBeInTheDocument();
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+		// Verify the `readability_scores` part.
+		expect( fetchJson )
+			.toHaveBeenCalledWith( expect.objectContaining( { href: "https://example.com/readability_scores?contentType=post" } ), expect.any( Object ) );
+
+		// Select the content type: "Products".
+		fireEvent.click( getByRole( "combobox", { name: "Content type" } ) );
+		fireEvent.click( getByRole( "option", { name: "Products" } ) );
+
+		// Await new fetch call for the scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 4 ) );
+		expect( fetchJson )
+			.toHaveBeenCalledWith( expect.objectContaining( { href: "https://example.com/readability_scores?contentType=product" } ), expect.any( Object ) );
+		expect( fetchJson ).toHaveBeenCalledWith( expect.objectContaining( { pathname: "/product_cat" } ), expect.any( Object ) );
+
+		// Select the product term: "merchandise".
+		fireEvent.click( getByRole( "combobox", { name: "Product categories" } ) );
+		fireEvent.click( getByRole( "option", { name: "merchandise" } ) );
+
+		// Await new fetch call for the scores.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 5 ) );
+		// Verify the taxonomy is "product_cat" and the term is the ID of "merchandise" (see data JSON).
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/readability_scores?contentType=product&taxonomy=product_cat&term=18" } ),
+			expect.any( Object )
+		);
+	} );
+
+	it( "should filter the content types", async() => {
+		const { getAllByRole, getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Search for the content type "pr".
+		fireEvent.change( getByRole( "combobox", { name: "Content type" } ), { target: { value: "pr" } } );
+
+		// Verify "Products" is in the list.
+		expect( getByRole( "option", { name: "Products" } ) ).toBeInTheDocument();
+		// Verify that is the only option.
+		expect( getAllByRole( "option" ) ).toHaveLength( 1 );
+	} );
+
+	it( "should search for terms", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="readability"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/readability_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Search for the term "thing".
+		fireEvent.change( getByRole( "combobox", { name: "Categories" } ), { target: { value: "thing" } } );
+
+		// Await the new fetch call for the terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/categories?search=thing&_fields=id%2Cname" } ),
+			expect.any( Object )
+		);
+	} );
+
+	it( "should show a loading indicator when searching for terms", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Search for a term.
+		fireEvent.change( getByRole( "combobox", { name: "Categories" } ), { target: { value: "foo" } } );
+
+		// Verify the loading indicator is present.
+		const list = getByRole( "listbox" );
+		expect( list ).toBeInTheDocument();
+		expect( list.querySelector( ".yst-animate-spin" ) ).not.toBeNull();
+
+		// Await the fetch call for terms, or the request might come through after the mock clear between tests.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+	} );
+
+	it( "should show a message when no terms are found", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Search for the term "nothing": which has a mock that yields no results.
+		fireEvent.change( getByRole( "combobox", { name: "Categories" } ), { target: { value: "nothing" } } );
+
+		// Await the new fetch call for the terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/categories?search=nothing&_fields=id%2Cname" } ),
+			expect.any( Object )
+		);
+
+		// Verify the "Nothing found" message is present.
+		expect( getByRole( "listbox" ) ).toHaveTextContent( "Nothing found" );
+	} );
+
+	it( "should be possible to clear the term filter", async() => {
+		const { getByRole } = render(
+			<Scores
+				analysisType="seo"
+				contentTypes={ contentTypes }
+				endpoint="https://example.com/seo_scores"
+			/>
+		);
+
+		// Await the fetch calls: scores and terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
+
+		// Search for the term "nothing": which has a mock that yields no results.
+		fireEvent.change( getByRole( "combobox", { name: "Categories" } ), { target: { value: "foo" } } );
+
+		// Await the new fetch call for the terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+
+		// Clear the term filter.
+		fireEvent.click( getByRole( "button", { name: "Clear filter" } ) );
+
+		// Await the new fetch call for the terms.
+		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
+		// Verify the search is empty.
+		expect( fetchJson ).toHaveBeenCalledWith(
+			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
+			expect.any( Object )
+		);
+	} );
+} );

--- a/packages/js/tests/dashboard/scores/score-meta.test.js
+++ b/packages/js/tests/dashboard/scores/score-meta.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "@jest/globals";
+import { SCORE_DESCRIPTIONS, SCORE_META } from "../../../src/dashboard/scores/score-meta";
+
+describe( "SCORE_META", () => {
+	it.each( [
+		"good",
+		"ok",
+		"bad",
+		"notAnalyzed",
+	] )( "score type \"%s\" should contain a label, color, hex and an optional tooltip", ( scoreType ) => {
+		expect( SCORE_META[ scoreType ] ).toBeDefined();
+		expect( SCORE_META[ scoreType ] ).toEqual( expect.any( Object ) );
+		expect( SCORE_META[ scoreType ].label ).toEqual( expect.any( String ) );
+		expect( SCORE_META[ scoreType ].color ).toEqual( expect.any( String ) );
+		expect( SCORE_META[ scoreType ].hex ).toEqual( expect.any( String ) );
+		if ( SCORE_META[ scoreType ].tooltip !== undefined ) {
+			// When present, the tooltip should be a string.
+			expect( SCORE_META[ scoreType ].tooltip ).toEqual( expect.any( String ) );
+		}
+	} );
+} );
+
+describe( "SCORE_DESCRIPTIONS", () => {
+	it.each( [
+		"seo",
+		"readability",
+	] )( "analysis type \"%s\" should contain descriptions for good, ok, bad and notAnalyzed", ( analysisType ) => {
+		expect( SCORE_DESCRIPTIONS[ analysisType ] ).toBeDefined();
+		expect( SCORE_DESCRIPTIONS[ analysisType ] ).toEqual( expect.any( Object ) );
+		expect( SCORE_DESCRIPTIONS[ analysisType ].good ).toEqual( expect.any( String ) );
+		expect( SCORE_DESCRIPTIONS[ analysisType ].ok ).toEqual( expect.any( String ) );
+		expect( SCORE_DESCRIPTIONS[ analysisType ].bad ).toEqual( expect.any( String ) );
+		expect( SCORE_DESCRIPTIONS[ analysisType ].notAnalyzed ).toEqual( expect.any( String ) );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tests for the Dashboard frontend.

## Relevant technical choices:

* I didn't write tests for `src/dashboard/components/dashboard.js`, the main component that renders the "widgets". This is because:
  * it will change when more widgets are added
  * the subcomponents are tested already
* Reversed situation for scores, where I did not test individual components, but just Scores.
* Due to not wanting to spend time testing the chart library I opted to just mock that out. Hence the lack of coverage for `score-chart.js` -- We would need to render it properly and test the tooltip on hover.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the code to see if it makes sense
* Run the tests in the `dashboard` folder with coverage: `yarn workspace @yoast/wordpress-seo test tests/dashboard/ --coverage`
* Verify they pass and the coverage is up-to-par
  * Note: see tech choices: I skipped `dashboard.js` and `score-chart.js`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* CI should test it for you, though you are free to check the code if you want 😉 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/342
