### PR TITLE
Exclude post types that have false show_ui from the dashboard feature

### DIFF
--- a/src/dashboard/infrastructure/content-types/content-types-collector.php
+++ b/src/dashboard/infrastructure/content-types/content-types-collector.php
@@ -40,6 +40,10 @@ class Content_Types_Collector {
 		$post_types         = $this->post_type_helper->get_indexable_post_type_objects();
 
 		foreach ( $post_types as $post_type_object ) {
+			if ( $post_type_object->show_ui === false ) {
+				continue;
+			}
+
 			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label );
 			$content_types_list->add( $content_type );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where we would show post types with false `show_ui` in the dashboard feature, which would result into linking to non existing admin pages.

## Relevant technical choices:

* Instead of deciding whether we should fix the source of truth (aka, whether post types with false `show_ui` should be indexable-d), we do the quick fix here and [an investigation task](https://github.com/Yoast/reserved-tasks/issues/359) was created for taking care of this properly in the future.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a post type with false `show_ui` but true `public`:
```
function register_blog_post_type() {
    $args = [
		'label'              => \__( 'Blog posts', 'yoast-test-helper' ),
		'labels'             => [
			'name'          => \__( 'Blog posts', 'yoast-test-helper' ),
			'singular_name' => \__( 'Blog post', 'yoast-test-helper' ),
		],
        'public'             => true,
        'show_ui'            => false,
    ];

    register_post_type('blog-post', $args);
}
add_action('init', 'register_blog_post_type');
```
* Confirm that you dont get a dropdown in the content type filter of both scores in the dashboard:
![image](https://github.com/user-attachments/assets/b9c31071-fca1-49b6-92ee-9c16fb4e12a8)
* You can check the same if you activate BuddyPress in your site
  * Without this PR `BuddyPress Directories` is being shown in the dropdown, but if you clicked on the `View` links you used to get an error page. 
  * With this PR,  `BuddyPress Directories` is not being shown in the dropdown

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test that you still get scores for all content types that you would expect

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2020
