### PR TITLE
Only show a modified time tag if it's later than the created time

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -55,10 +55,14 @@ class Article extends Abstract_Schema_Piece {
 			],
 			'headline'         => $this->helpers->schema->html->smart_strip_tags( $this->helpers->post->get_post_title_with_fallback( $this->context->id ) ),
 			'datePublished'    => $this->helpers->date->format( $this->context->post->post_date_gmt ),
-			'dateModified'     => $this->helpers->date->format( $this->context->post->post_modified_gmt ),
-			'mainEntityOfPage' => [ '@id' => $this->context->main_schema_id ],
-			'wordCount'        => $this->word_count( $this->context->post->post_content, $this->context->post->post_title ),
 		];
+
+		if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
+			$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+		}
+			
+		$data['mainEntityOfPage'] = [ '@id' => $this->context->main_schema_id ];
+		$data['wordCount'] = $this->word_count( $this->context->post->post_content, $this->context->post->post_title );
 
 		if ( $this->context->post->comment_status === 'open' ) {
 			$data['commentCount'] = \intval( $this->context->post->comment_count, 10 );

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -58,11 +58,11 @@ class Article extends Abstract_Schema_Piece {
 		];
 
 		if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
-			$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+			$data['dateModified'] = $this->helpers->date->format( $this->context->post->post_modified_gmt );
 		}
-			
+
 		$data['mainEntityOfPage'] = [ '@id' => $this->context->main_schema_id ];
-		$data['wordCount'] = $this->word_count( $this->context->post->post_content, $this->context->post->post_title );
+		$data['wordCount']        = $this->word_count( $this->context->post->post_content, $this->context->post->post_title );
 
 		if ( $this->context->post->comment_status === 'open' ) {
 			$data['commentCount'] = \intval( $this->context->post->comment_count, 10 );

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -54,7 +54,7 @@ class WebPage extends Abstract_Schema_Piece {
 			$data['datePublished'] = $this->helpers->date->format( $this->context->post->post_date_gmt );
 
 			if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
-				$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+				$data['dateModified'] = $this->helpers->date->format( $this->context->post->post_modified_gmt );
 			}
 
 			if ( $this->context->indexable->object_sub_type === 'post' ) {

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -52,7 +52,10 @@ class WebPage extends Abstract_Schema_Piece {
 
 		if ( $this->context->indexable->object_type === 'post' ) {
 			$data['datePublished'] = $this->helpers->date->format( $this->context->post->post_date_gmt );
-			$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+
+			if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
+				$data['dateModified']  = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+			}
 
 			if ( $this->context->indexable->object_sub_type === 'post' ) {
 				$data = $this->add_author( $data, $this->context->post );

--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -285,7 +285,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @return string The open graph article modified time.
 	 */
 	public function generate_open_graph_article_modified_time() {
-		if ( $this->source->post_modified_gmt !== $this->source->post_date_gmt ) {
+		if ( \strtotime( $this->source->post_modified_gmt ) > \strtotime( $this->source->post_date_gmt ) ) {
 			return $this->date->format( $this->source->post_modified_gmt );
 		}
 

--- a/tests/Unit/Generators/Schema_Generator_Test.php
+++ b/tests/Unit/Generators/Schema_Generator_Test.php
@@ -430,8 +430,8 @@ final class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
-			'post_date_gmt'     => 'date',
-			'post_modified_gmt' => 'date',
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:09',
 		];
 		$this->context->has_image                  = false;
 
@@ -448,9 +448,15 @@ final class Schema_Generator_Test extends TestCase {
 
 		$this->date
 			->expects( 'format' )
-			->twice()
-			->with( 'date' )
-			->andReturn( 'date' );
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:09' )
+			->andReturn( '2024-12-13 09:58:09' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -629,8 +635,8 @@ final class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
-			'post_date_gmt'     => 'date',
-			'post_modified_gmt' => 'date',
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:09',
 		];
 		$this->context->has_image                  = false;
 
@@ -647,9 +653,15 @@ final class Schema_Generator_Test extends TestCase {
 
 		$this->date
 			->expects( 'format' )
-			->twice()
-			->with( 'date' )
-			->andReturn( 'date' );
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:09' )
+			->andReturn( '2024-12-13 09:58:09' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -694,8 +706,8 @@ final class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
-			'post_date_gmt'     => 'date',
-			'post_modified_gmt' => 'date',
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:09',
 		];
 		$this->context->has_image                  = false;
 
@@ -712,9 +724,15 @@ final class Schema_Generator_Test extends TestCase {
 
 		$this->date
 			->expects( 'format' )
-			->twice()
-			->with( 'date' )
-			->andReturn( 'date' );
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:09' )
+			->andReturn( '2024-12-13 09:58:09' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -802,8 +820,8 @@ final class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
-			'post_date_gmt'     => 'date',
-			'post_modified_gmt' => 'date',
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:09',
 		];
 		$this->context->has_image                  = false;
 
@@ -820,9 +838,15 @@ final class Schema_Generator_Test extends TestCase {
 
 		$this->date
 			->expects( 'format' )
-			->twice()
-			->with( 'date' )
-			->andReturn( 'date' );
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:09' )
+			->andReturn( '2024-12-13 09:58:09' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -905,8 +929,8 @@ final class Schema_Generator_Test extends TestCase {
 		$this->context->indexable->object_type     = 'post';
 		$this->context->indexable->object_sub_type = 'post';
 		$this->context->post                       = (object) [
-			'post_date_gmt'     => 'date',
-			'post_modified_gmt' => 'date',
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:09',
 		];
 		$this->context->has_image                  = false;
 
@@ -917,9 +941,15 @@ final class Schema_Generator_Test extends TestCase {
 
 		$this->date
 			->expects( 'format' )
-			->twice()
-			->with( 'date' )
-			->andReturn( 'date' );
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:09' )
+			->andReturn( '2024-12-13 09:58:09' );
 
 		Monkey\Functions\expect( 'is_search' )
 			->andReturn( false );
@@ -1101,6 +1131,79 @@ final class Schema_Generator_Test extends TestCase {
 	}
 
 	/**
+	 * Tests with the generate with a post page that was published with schedule (aka, has a modified date earlier than a published date).
+	 *
+	 * @covers ::__construct
+	 * @covers ::generate
+	 * @covers ::get_graph_pieces
+	 *
+	 * @return void
+	 */
+	public function test_get_graph_pieces_on_scheduled_post() {
+		$this->stubEscapeFunctions();
+		$this->current_page->expects( 'is_paged' )->andReturns( false );
+
+		$this->context->alternate_site_name        = '';
+		$this->context->indexable->object_type     = 'post';
+		$this->context->indexable->object_sub_type = 'post';
+		$this->context->post                       = (object) [
+			'post_date_gmt'     => '2024-12-13 09:58:08',
+			'post_modified_gmt' => '2024-12-13 09:58:07',
+		];
+		$this->context->has_image                  = false;
+
+		Monkey\Functions\expect( 'post_password_required' )
+			->once()
+			->with( $this->context->post )
+			->andReturnFalse();
+
+		$this->article
+			->expects( 'is_author_supported' )
+			->twice()
+			->with( 'post' )
+			->andReturnFalse();
+
+		$this->date
+			->expects( 'format' )
+			->once()
+			->with( '2024-12-13 09:58:08' )
+			->andReturn( '2024-12-13 09:58:08' );
+
+		Monkey\Functions\expect( 'is_search' )
+			->andReturn( false );
+
+		$this->current_page
+			->expects( 'is_front_page' )
+			->andReturnTrue();
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->times( 3 )
+			->andReturnArg( 0 );
+
+		$this->replace_vars_helper
+			->expects( 'register_replace_vars' )
+			->once();
+
+		Monkey\Actions\expectDone( 'wpseo_pre_schema_block_type_yoast/faq-block' )
+			->with( $this->context->blocks['yoast/faq-block'], $this->context );
+
+		Monkey\Filters\expectApplied( 'wpseo_schema_needs_faq' )
+			->with( true );
+
+		$this->current_page->expects( 'is_home_static_page' )->andReturns( false );
+		$this->current_page->expects( 'is_home_posts_page' )->andReturns( false );
+
+		$expected_schema = $this->get_expected_schema();
+		unset( $expected_schema['@graph'][0]['dateModified'] );
+
+		$this->assertEquals(
+			$expected_schema,
+			$this->instance->generate( $this->context )
+		);
+	}
+
+	/**
 	 * The generated schema that is applicable for almost every test scenario in this file.
 	 *
 	 * @return array The schema.
@@ -1132,8 +1235,8 @@ final class Schema_Generator_Test extends TestCase {
 							'@id' => '#id-1',
 						],
 					],
-					'datePublished'   => 'date',
-					'dateModified'    => 'date',
+					'datePublished'   => '2024-12-13 09:58:08',
+					'dateModified'    => '2024-12-13 09:58:09',
 				],
 				[
 					'@type'           => 'WebSite',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the `article:modified_time` meta tag would show an earlier time than the `article:published_time` meta tag for scheduled posts.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to add a post but instead of publishing it, schedule it in the near future
* Let's say you created it at 10:00am and scheduled it to be live at 10:05am
* Once 10:05am passes, go to check the post's page source (you may need to refresh your site a couple of times, so that the scheduled post gets actually published)

**Without this PR**:
* The `article:modified_time` meta tag would appear and it would be an earlier time than the `article:published_time` meta tag, which is wrong
* In the schema, the `dateModified` attribute of the **Article** and the **Webpage** nodes would appear and it would be an earlier time than the `datePublished` attribute of those nodes. (make sure you have filled in all Site Representation info to make the `Article` node appear)

**With this PR:**
* The `article:modified_time` meta tag would not appear at all
* In the schema, there will be no `dateModified` attributes in the **Article** and the **Webpage** nodes.
* Retry the test with different timezone and time formats from your **Settings->General** page

Also:
* To check an edge case, add the following filter that will remove the modified time from a created post:
```
function filter_post_modified_gmt( $data, $postarr, $unsanitized_postarr){
    unset( $data['post_modified_gmt'] );
    return $data;
}

add_filter( 'wp_insert_post_data', 'filter_post_modified_gmt',10,3);
```
* Create a post, remove the filter and check the post's frontend
* Confirm that you don't get a PHP notice and there's no `article:modified_time` and no `dateModified` attribute of the **Article** and the **Webpage** nodes in the schema.
* That's actually an improvement from our production versions, because if you repeated this test with those, you would get an invalid/wrong `article:modified_time` tags and `dateModified` attributes equal to `-0001-11-30T00:00:00+00:00`

**Check impact in News SEO**:
* After having a post published via schedule like above, activate News SEO and go to `/sitemap_index.xml` (that post should have been published within the past 48 hours)
* Check the Last Mod. value for the `/news-sitemap.xml` entry
* Go to `/news-sitemap.xml` and confirm that the Publication Date for the most recent article is the same with the Last Mod of the `/news-sitemap.xml` entry of the above step
* Go to the frontend of that most recent article and check that the date you took note of above, is the same date with the `article:published_time` meta tag and the `datePublished` attributes in the schema

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.
*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The generation of the modified time of a post. Some things to test for regression:
  * Check that for non-scheduled posts, the meta tags and schema output is the same, both with this PR and without (make sure you fill in all Site representation settings)
    * Note: if a post has the same published and modified date in wp_post (so, same `post_date_gmt` and `post_modified_gmt`), it will stop having `datePublished` attributes in the schema
    * Which means that for posts that have been published normally and edited afterwards, meta tags and schema are exactly the same. For posts that have been published normally and not edited afterwards, they will have the same meta tags but for schema they might have `datePublished` removed with this PR. That depends on whether `post_date_gmt` and `post_modified_gmt` are the same in wp_post for that post (they might have a second difference depending how slow is your machine when saving the post)
  * Check the same for draft posts
  * Check the above for all sorts of timezones and time formats from your **Settings->General** page

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
