### PR TITLE
WP Tests: update install WP script

### DIFF
--- a/config/scripts/install-wp-tests.sh
+++ b/config/scripts/install-wp-tests.sh
@@ -4,8 +4,8 @@
 # Script to download and install WordPress for use in automated testing.
 #
 # Source: https://github.com/wp-cli/scaffold-command/blob/main/templates/install-wp-tests.sh
-# Last updated based on commit https://github.com/wp-cli/scaffold-command/commit/503ac569875d3665a0b28b9a5b7e8d136112b6d6
-# dated December 15 2022.
+# Last updated based on commit https://github.com/wp-cli/scaffold-command/commit/efdc0aebe792eaa7ddf6725eae45d70fe6c6ce2a
+# dated September 15 2024.
 ########################################################################
 
 if [ $# -lt 3 ]; then
@@ -30,6 +30,17 @@ download() {
 		curl -s "$1" > "$2";
 	elif [ `which wget` ]; then
 		wget -nv -O "$2" "$1"
+	else
+		echo "Error: Neither curl nor wget is installed."
+	exit 1
+	fi
+}
+
+# Check if svn is installed
+check_svn_installed() {
+	if ! command -v svn > /dev/null; then
+		echo "Error: svn is not installed. Please install svn and try again."
+		exit 1
 	fi
 }
 
@@ -72,6 +83,7 @@ install_wp() {
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 		mkdir -p $TMPDIR/wordpress-trunk
 		rm -rf $TMPDIR/wordpress-trunk/*
+		check_svn_installed
 		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
 		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
 	else
@@ -116,6 +128,7 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		rm -rf $WP_TESTS_DIR/{includes,data}
+		check_svn_installed
 		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
 		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi


### PR DESCRIPTION
## Context

* Update test tooling

## Summary

This PR can be summarized in the following changelog entry:

* Update test tooling

## Relevant technical choices:

The upstream `install-wp-tests.sh` script has been updated. This commit incorporates the upstream changes in the local copy used in this repo.

Refs:
* wp-cli/scaffold-command#345



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ If the build runs & passes, we're good.
