### PR TITLE
Tests: fix block type notices

### DIFF
--- a/tests/WP/bootstrap.php
+++ b/tests/WP/bootstrap.php
@@ -16,22 +16,16 @@ require_once \dirname( __DIR__, 2 ) . '/vendor/yoast/wp-test-utils/src/WPIntegra
 /* *****[ Ensure a couple of required files are present ]***** */
 
 /**
- * Creates asset files.
+ * Creates asset and block files.
+ *
+ * @return void
  *
  * @throws RuntimeException If the directory or file creation failed.
  */
-$yoast_seo_create_asset_files = static function () {
-	$target_dir = \dirname( __DIR__, 2 ) . '/src/generated/assets';
-
-	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- Silencing warnings when function fails.
-	if ( @\is_dir( $target_dir ) === false ) {
-		if ( @\mkdir( $target_dir, 0777, true ) === false ) {
-			throw new RuntimeException( \sprintf( 'Failed to create the %s directory.', $target_dir ) );
-		}
-	} // phpcs:enable WordPress
-
+function yoast_seo_create_asset_files_for_tests() {
+	$base_dir       = \dirname( __DIR__, 2 );
 	$required_files = [
-		'plugin.php'    => "<?php
+		'src/generated/assets/plugin.php'                 => "<?php
 return [
 	'post-edit.js' => [
 		'dependencies' => [],
@@ -47,21 +41,34 @@ return [
 	],
 ];
 ",
-		'externals.php' => '<?php return [];',
-		'languages.php' => '<?php return [];',
+		'src/generated/assets/externals.php'              => '<?php return [];',
+		'src/generated/assets/languages.php'              => '<?php return [];',
+		'blocks/dynamic-blocks/breadcrumbs/block.json'    => '{}',
+		'blocks/structured-data-blocks/faq/block.json'    => '{}',
+		'blocks/structured-data-blocks/how-to/block.json' => '{}',
 	];
 
-	foreach ( $required_files as $file_name => $contents ) {
-		$target_file = $target_dir . '/' . $file_name;
-		if ( \file_exists( $target_file ) === false ) {
-			if ( \file_put_contents( $target_file, $contents ) === false ) {
-				throw new RuntimeException( \sprintf( 'Failed to write to target location: %s', $target_file ) );
+	foreach ( $required_files as $file_path => $contents ) {
+		$file_path = $base_dir . '/' . $file_path;
+		if ( \file_exists( $file_path ) === true ) {
+			continue;
+		}
+
+		// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged -- Silencing warnings when function fails.
+		$target_dir = \dirname( $file_path );
+		if ( @\is_dir( $target_dir ) === false ) {
+			if ( @\mkdir( $target_dir, 0777, true ) === false ) {
+				throw new RuntimeException( \sprintf( 'Failed to create the %s directory.', $target_dir ) );
 			}
+		} // phpcs:enable WordPress
+
+		if ( \file_put_contents( $file_path, $contents ) === false ) {
+			throw new RuntimeException( \sprintf( 'Failed to write to target location: %s', $file_path ) );
 		}
 	}
-};
+}
 
-$yoast_seo_create_asset_files();
+namespace\yoast_seo_create_asset_files_for_tests();
 
 
 /* *****[ Wire in the integration ]***** */


### PR DESCRIPTION
## Context

* Improve test setup

## Summary

This PR can be summarized in the following changelog entry:

* Improve test setup

## Relevant technical choices:

When running the tests, three notices along the lines of the below are shown at the top of the test run:
```
PHP Notice:  Function WP_Block_Type_Registry::register was called <strong>incorrectly</strong>. Block type names must contain a namespace prefix. Example: my-plugin/my-custom-block-type Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.0.0.) in /tmp/wordpress/wp-includes/functions.php on line 6114
```

The reason these notices show is that the `blocks/*/*/block.json` files for the Yoast custom blocks do not exist in a plain PHP based test environment in which no `npm install` (etc) has been run.

Now why does that cause these notices ?

* The test bootstrap initializes the plugin with WordPress.
* As part of the activation/initialization of the plugin, the custom blocks are being registered using the `register_block_type()` function.
* The first parameter of the `register_block_type()` function is one of those monstrosities you find in WP - it can be various different data types:
    > Block type name including namespace, or alternatively a path to the JSON file with metadata definition for the block, or a path to the folder where the block.json file is located, or a complete WP_Block_Type instance
* The YoastSEO plugin uses the "path to the JSON file with metadata definition for the block" variant, but the files referenced in the parameter do not exist in a plain PHP test environment.
* If WordPress can't find the file and the parameter is a string, it presumes the parameter was a "block type name including namespace", but a file path (as passed by YoastSEO) doesn't comply with the regex WP uses to validate the block type name, which cause the error notice.

To fix this, I've updated the `yoast_seo_create_asset_files` closure which was originally used to only create the `src/generated/assets` files to also handle creation of mocks for the missing `block.json` files.

As the PHP tests don't contain tests which are dependent on the _real_ `block.json` files being in place and valid, this "hack" will side-step the notices from WP without diminishing the value of the tests.

Also note that if a dev-user already has (real) copies of these files in their development setup, those files will not be overwritten by this fix, so this shouldn't break anyone's dev environment.

Ref:
* https://developer.wordpress.org/reference/functions/register_block_type/
* https://developer.wordpress.org/reference/classes/wp_block_type_registry/register/

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check that the above mentioned notices no longer appear when running the WP tests.