### PR TITLE
fix translations for ads

### DIFF
--- a/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
+++ b/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
@@ -47,8 +47,10 @@ export const InternalLinkingSuggestionsUpsell = () => {
 								"Yoast SEO Premium"
 							) }
 							benefitsTitle={
-								/* translators: %s expands to 'Yoast SEO Premium'. */
-								sprintf( "%s also gives you:", "Yoast SEO Premium" )
+								sprintf(
+									/* translators: %s expands to 'Yoast SEO Premium'. */
+									__( "%s also gives you:", "wordpress-seo" ),
+									"Yoast SEO Premium" )
 							}
 							benefits={ getPremiumBenefits() }
 							upsellButtonText={

--- a/packages/js/src/components/modals/KeywordSynonyms.js
+++ b/packages/js/src/components/modals/KeywordSynonyms.js
@@ -19,8 +19,10 @@ const KeywordSynonyms = ( props ) => (
 			"Yoast SEO Premium"
 		) }
 		benefitsTitle={
-			/* translators: %s expands to 'Yoast SEO Premium'. */
-			sprintf( "%s also gives you:", "Yoast SEO Premium" )
+			sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( "%s also gives you:", "wordpress-seo" ),
+				"Yoast SEO Premium" )
 		}
 		benefits={ getPremiumBenefits() }
 		upsellButtonText={

--- a/packages/js/src/components/modals/MultipleKeywords.js
+++ b/packages/js/src/components/modals/MultipleKeywords.js
@@ -15,8 +15,10 @@ const MultipleKeywords = ( props ) => (
 		title={ __( "Reach a wider audience", "wordpress-seo" ) }
 		description={ __( "Get help optimizing for up to 5 related keyphrases. This helps you reach a wider audience and get more traffic.", "wordpress-seo" ) }
 		benefitsTitle={
-			/* translators: %s expands to 'Yoast SEO Premium'. */
-			sprintf( "%s also gives you:", "Yoast SEO Premium" )
+			sprintf(
+				/* translators: %s expands to 'Yoast SEO Premium'. */
+				__( "%s also gives you:", "wordpress-seo" ),
+				"Yoast SEO Premium" )
 		}
 		benefits={ getPremiumBenefits() }
 		upsellButtonText={

--- a/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
+++ b/packages/js/src/components/modals/PremiumSEOAnalysisUpsell.js
@@ -26,8 +26,10 @@ const PremiumSEOAnalysisUpsell = ( props ) => {
 			title={ __( "Get more help with writing content that ranks", "wordpress-seo" ) }
 			description={ props.description }
 			benefitsTitle={
-				/* translators: %s expands to 'Yoast SEO Premium'. */
-				sprintf( "%s also gives you:", "Yoast SEO Premium" )
+				sprintf(
+					/* translators: %s expands to 'Yoast SEO Premium'. */
+					__( "%s also gives you:", "wordpress-seo" ),
+					"Yoast SEO Premium" )
 			}
 			benefits={ getPremiumBenefits() }
 			upsellButtonText={

--- a/packages/js/tests/settings/__snapshots__/search.test.js.snap
+++ b/packages/js/tests/settings/__snapshots__/search.test.js.snap
@@ -155,7 +155,7 @@ exports[`Search modal should show search results 1`] = `
     >
       <li
         aria-selected="false"
-        class="yst-group yst-block yst-no-underline yst-text-sm yst-text-slate-800 yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white yst-text-white yst-bg-primary-600"
+        class="yst-group yst-block yst-no-underline yst-text-sm  yst-select-none yst-py-3 yst-px-4 hover:yst-bg-primary-600 hover:yst-text-white focus:yst-bg-primary-600 focus:yst-text-white yst-text-white yst-bg-primary-600"
         data-headlessui-state="active"
         id="headlessui-combobox-option-:rl:"
         role="option"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Also fixes snapshot test from [Settings: fix search menu contrast](https://github.com/Yoast/wordpress-seo/pull/21929)

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjusts untranslated strings for the Yoast Premium ads modals on the editors.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Regression tests:
* Edit a post without yoast premium and check the ads for premiums contain the string "also gives you"
  *  For internal linking suggestions
  * Synonyms
  * Premium analysis
  * Multiple keyphrases

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21922
