### PR TITLE
GH Actions: add merge-conflict check

### DIFF
--- a/.github/workflows/merge-conflict-check.yml
+++ b/.github/workflows/merge-conflict-check.yml
@@ -1,0 +1,24 @@
+name: Check PRs for merge conflicts
+
+on:
+  # Check for new conflicts due to merges.
+  push:
+    branches:
+      - main
+      - trunk
+      - 'release/**'
+      - 'hotfix/[0-9]+.[0-9]+*'
+      - 'feature/**'
+  # Check conflicts in new PRs and for resolved conflicts due to an open PR being updated.
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  check-prs:
+    if: github.repository_owner == 'Yoast'
+
+    name: Check PRs for merge conflicts
+    uses: Yoast/.github/.github/workflows/reusable-merge-conflict-check.yml@main


### PR DESCRIPTION
## Context

* Improve dev experience

## Summary

This PR can be summarized in the following changelog entry:

* Improve dev experience

## Relevant technical choices:

This commit adds a new workflow which runs on pushes (merges) to any of the long-running branches and whenever the contents of a pull requests changes.

It will check whether any open PRs are in a "conflict state" (after the push) and if so, will add a "merge conflict" label and leave a comment on the PR asking the OP to solve the conflict. The workflow will automatically remove the label again when the conflict is resolved.

This workflow uses a reusable action stored in the `.github` repository which takes care of the default settings, though a number of settings can still be overruled for an individual repo.

For now, it has not been deemed necessary to overrule these though.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_ Tested via https://github.com/Yoast/duplicate-post/pull/391