### PR TITLE
Remove cache around changing link

### DIFF
--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 /**
  * WordPress dependencies
  */
-import { useMemo, useState, useCallback } from "@wordpress/element";
+import { useMemo, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { withSpokenMessages, Popover } from "@wordpress/components";
 import { prependHTTP } from "@wordpress/url";
@@ -190,7 +190,12 @@ function InlineLinkUI( {
 		}
 	};
 
-	const onChangeLink = useCallback( ( nextValue ) =>{
+	/**
+	 * Handles the change of the link.
+	 * @param {Object} nextValue The next link URL.
+	 * @returns {void}
+	 */
+	const onChangeLink = ( nextValue ) => {
 		/*
 		 * Merge with values from state, both for the purpose of assigning the next state value, and for use in constructing the new link format if
 		 * the link is ready to be applied.
@@ -256,7 +261,7 @@ function InlineLinkUI( {
 		}
 
 		actionCompleteMessage( newUrl );
-	}, [] );
+	};
 
 	const NoFollowHelpLink = <HelpLink
 		href={ window.wpseoAdminL10n[ "shortlinks.nofollow_sponsored" ] }
@@ -333,6 +338,7 @@ function InlineLinkUI( {
 		>
 			<LinkControl
 				value={ linkValue }
+				// eslint-disable-next-line react/jsx-no-bind
 				onChange={ onChangeLink }
 				forceIsEditingLink={ addingLink }
 				settings={ settings }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug from https://github.com/Yoast/wordpress-seo/pull/20270

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where editing a link in the block editor would have unexpected consequences when using undo.

## Relevant technical choices:

The cache via useCallback is too greedy.
Everything is re-created already (no useCallback around all other functions). Therefore, opting to remove the cache (useCallback) here for an easy fix.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Setup
* Edit a post in the block editor
* Add the native gutenberg table block: 2×2 table ( the default size )
* Add some text
* Change the text in the 2nd column to be a link
![image](https://github.com/user-attachments/assets/52a59fbb-ea28-4e4c-b529-49e183547649)

#### Test
In order for focus reasons:
* Change the link in the 2nd column
* Remove the text in the 1st column
* With the keyboard click on CTRL + Z or Command + Z to undo the added text
* The focus should shift back to the link
* Edit the link again
* [ ] Verify the text in the 1st column is back as before and _not_ the link as before this fix


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The link control

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21926
