### PR TITLE
Updates the readability analysis when the client IDs of the blocks change

### DIFF
--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1792,6 +1792,19 @@ describe( "AnalysisWebWorker", () => {
 			worker._paper = new Paper( "This is the content.", { keyword: "dogs" } );
 			expect( worker.shouldReadabilityUpdate( paper ) ).toBe( true );
 		} );
+
+		test( "returns true when the client IDs of the blocks inside attributes changes", () => {
+			const paper = new Paper( "This is the content.", { wpBlocks: [
+				{ name: "block1", clientId: "1234" },
+				{ name: "block2", clientId: "5678" },
+			] } );
+
+			worker._paper = new Paper( "This is the content.", { wpBlocks: [
+				{ name: "block1", clientId: "6783" },
+				{ name: "block2", clientId: "0636" },
+			] } );
+			expect( worker.shouldReadabilityUpdate( paper ) ).toBe( true );
+		} );
 	} );
 
 	describe( "shouldSeoUpdate", () => {

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -2,7 +2,7 @@
 // External dependencies.
 import { enableFeatures } from "@yoast/feature-flag";
 import { __, setLocaleData, sprintf } from "@wordpress/i18n";
-import { forEach, has, includes, isEmpty, isNull, isObject, isString, isUndefined, merge, pickBy } from "lodash";
+import { forEach, has, includes, isEmpty, isEqual, isNull, isObject, isString, isUndefined, merge, pickBy } from "lodash";
 import { getLogger } from "loglevel";
 
 // Internal dependencies.
@@ -951,6 +951,12 @@ export default class AnalysisWebWorker {
 		}
 
 		if ( this._paper.getKeyword() !== paper.getKeyword() ) {
+			return true;
+		}
+
+		// Perform deep comparison between the list of Gutenberg blocks as we want to update the readability analysis
+		// if the client IDs of the blocks inside `wpBlocks` change.
+		if ( ! isEqual( this._paper._attributes.wpBlocks, paper._attributes.wpBlocks ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, after applying the AI suggestion for sentence length assessments to the editor, if the feedback still has a highlighting button and an AI Optimize button, both buttons don't work. Clicking on the highlighting button fails to highlight the relevant text in the editor. Additionally, the AI Optimize button is disabled as we could not detect blocks that contain long sentences.
* The issue was apparently we failed to retrieve the relevant blocks that contain long sentences because we have an outdated readability analysis result. In the worker, we don't update the readability analysis result when there is a change in the list of Gutenberg blocks (including their client IDs that change after the action of applying AI suggestion). As a result, attempting to retrieve relevant blocks with outdated client IDs will fail.
* The solution is to make sure that the readability analysis result is updated when there is a change in the list of Gutenberg blocks

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Updates the readability analysis result when there is a change in the list of Gutenberg blocks `wpBlocks`.
* [wordpress-seo-premium] Fixes an unreleased bug where the highlighting button and AI Optimize button for sentence length assessment didn't work after applying AI suggestion to the editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO and Yoast SEO Premium.
   * Please refer to [this page](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/2921201669/AI+Generator+how+to+test+the+functionality+with+staging+API) for guide on how to test the AI functionality
* Set the site language to English
* Create a post in Block/Gutenberg editor
* Add the following text to the post:
```
If you're a bright and restless teenager in a small town in the American Midwest, you may well have one desire, and that is to get out, to go somewhere else. Hibbing, Minnesota, is one such town, and Robert "Bob" Zimmermann was one such young man.
In 1959, at the age of 18, Zimmermann left Hibbing to study English at the University of Minnesota in Minneapolis; but formal studies were not his thing. Bob was very much into folk music, and on campus and off it, soon became a popular performer at folk clubs and folk events. "Zimmermann" was a bit of a long name for a cool folk singer, so Bob adopted the name of the popular radical Welsh poet Dylan Thomas, who had died six years previously. Robert Zimmermann became Bob Dylan.

Big though it was, compared to Hibbing, Minneapolis was not the throbbing cultural capital of the United States, and within a year Bob had dropped out of university and made up his mind to pursue a career in music instead. It was a pretty big gamble; the terms "folk singing" and "career" rarely went together, and there were hardly a dozen successful folk singers in the USA at the time; there was the ageing [Woody Guthrie](https://linguapress.com/advanced/woody-guthrie.htm), the popular Pete Seeger, and the folksy Brothers Four. But Bob, now reborn as Bob Dylan, had talent, had a particular musical style, and an ambition to go with it.

From Minneapolis, Dylan made his way to the heart of the contemporary American folk music scene, Greenwich Village in New York, reaching the city by Greyhound Bus in January 1961 with little money in his pocket and no clear career plan in his head. It was however the start of a new chapter in his life, and at once he began performing in local clubs, gaining attention for his talent and unique style.

Performing in the coffeehouses and bars of Greenwich Village, playing both popular folk songs and some of his own compositions, Dylan soon built up a following. His distinctive nasal voice and original lyrics attracted the attention of music critics and fellow musicians. And just over three months after he arrived in New York, an enthusiastic article in The New York Times by Robert Shelton helped launch Bob Dylan on the road to success. Within weeks Columbia Records had signed him up for a recording contract.

Dylan's first album, simply titled "Bob Dylan", came out in March 1962, and included a mixture of traditional folk songs such as the House of the Rising Sun, and a couple of Dylan's own compositions. The album was a success, but just a foretaste of what was to follow. It was Dylan's second album "The Freewheelin' Bob Dylan", released in 1963, that really revealed his unique genius as a songwriter. It came out at a point in time when J.F.Kennedy was President of the USA, America was getting involved in Vietnam, and people were alarmed at the prospect of nuclear war. Songs like Blowin' in the Wind and A Hard Rain's A-Gonna Fall touched on the developing issues of the day.
```

* Go to Sentence length assessment inside the Readability analysis tab
* Click on the AI optimize button next to the feedback
* When the AI request is successful, confirm that you see the AI suggestion previewed in the editor. The behavior when the suggestion is previewed should match what is described in [this doc ](https://docs.google.com/document/d/1gaM9CS3BmnlcwZ5IvFynRTJE4C_mJjnW20ZOi6Qkd4k/edit?tab=t.y5wa42xq8brg#heading=h.phz50jcv1xxc)
* When the suggestion is previewed, note the sentence length assessment score (and remember the percentage if there is any)
* Click on "Apply" inside the AI Optimize notification component in the bottom left corner
* Confirm that the suggestion is applied. The behavior when the suggestion is applied should match what is described in [this doc](https://docs.google.com/document/d/1gaM9CS3BmnlcwZ5IvFynRTJE4C_mJjnW20ZOi6Qkd4k/edit?tab=t.y5wa42xq8brg#heading=h.k228bs6hd5vm)
* After the suggestion is applied, confirm the following:
   * The sentence length assessment score is the same as when the AI suggestion is previewed
   * If the assessment feedback has highlighting button, clicking on the button should highlight relevant long sentences in the editor
   * If the assessment feedback has AI Optimize button, the button should be enabled
* Click on the AI Optimize button again
* When the AI request is successful, confirm that the AI suggestion is still previewed correctly in the editor. The behavior when the suggestion is previewed should match what is described in [this doc ](https://docs.google.com/document/d/1gaM9CS3BmnlcwZ5IvFynRTJE4C_mJjnW20ZOi6Qkd4k/edit?tab=t.y5wa42xq8brg#heading=h.phz50jcv1xxc)
* Apply the suggestion and confirm that the suggestion is applied correctly to the editor

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/~Classic~/~Elementor~/~other~)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2068
