### PR TITLE
Correctly enable or disable the highlighting button

### DIFF
--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -25,8 +25,11 @@ import { LockClosedIcon } from "@heroicons/react/solid";
 const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 	const aiFixesId = id + "AIFixes";
 	const [ isModalOpen, , , setIsModalOpenTrue, setIsModalOpenFalse ] = useToggleState( false );
-	const activeAIButtonId = useSelect( select => select( "yoast-seo/editor" ).getActiveAIFixesButton(), [] );
-	const activeMarker = useSelect( select => select( "yoast-seo/editor" ).getActiveMarker(), [] );
+	const { activeMarker, editorMode, activeAIButtonId } = useSelect( ( select ) => ( {
+		activeMarker: select( "yoast-seo/editor" ).getActiveMarker(),
+		editorMode: select( "core/edit-post" ).getEditorMode(),
+		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
+	} ), [] );
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus, setMarkerStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
 	const [ buttonClass, setButtonClass ] = useState( "" );
@@ -36,9 +39,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 
 	// The button is pressed when the active AI button id is the same as the current button id.
 	const isButtonPressed = activeAIButtonId === aiFixesId;
-
-	// Get the editor mode using useSelect.
-	const editorMode = useSelect( ( select ) => select( "core/edit-post" ).getEditorMode(), [] );
 
 	// Enable the button when:
 	// (1) other AI buttons are not pressed.
@@ -75,29 +75,6 @@ const AIAssessmentFixesButton = ( { id, isPremium } ) => {
 			ariaLabel: allVisual ? defaultLabel : htmlLabel,
 		};
 	}, [ isButtonPressed, activeAIButtonId, editorMode ] );
-
-
-	/**
-	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
-	 *
-	 * @param {string} editorMode The editor mode.
-	 * @param {boolean} activeAIButtonId The active AI button ID.
-	 *
-	 * @returns {void}
-	 */
-	useEffect( () => {
-		// Toggle markers based on editor mode.
-		if ( editorMode === "visual" && ! activeAIButtonId ) {
-			setMarkerStatus( "enabled" );
-		} else {
-			setMarkerStatus( "disabled" );
-		}
-
-		// Cleanup function to reset the marker status when the component unmounts or editor mode changes
-		return () => {
-			setMarkerStatus( "disabled" );
-		};
-	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
 
 	/**
 	 * Handles the button press state.

--- a/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
+++ b/packages/js/src/ai-assessment-fixes/components/ai-assessment-fixes-button.js
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { useEffect, useCallback, useRef, useState } from "@wordpress/element";
+import { useCallback, useRef, useState } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 import { useSelect, useDispatch } from "@wordpress/data";
 

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -1,6 +1,6 @@
 /* External dependencies */
-import { useSelect } from "@wordpress/data";
-import { Fragment } from "@wordpress/element";
+import { useDispatch, useSelect } from "@wordpress/data";
+import { Fragment, useEffect } from "@wordpress/element";
 import { Fill } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -24,6 +24,7 @@ import KeywordUpsell from "../modals/KeywordUpsell";
 import { BlackFridayProductEditorChecklistPromotion } from "../BlackFridayProductEditorChecklistPromotion";
 import { BlackFridayPromotion } from "../BlackFridayPromotion";
 import { withMetaboxWarningsCheck } from "../higherorder/withMetaboxWarningsCheck";
+import isBlockEditor from "../../helpers/isBlockEditor";
 
 const BlackFridayProductEditorChecklistPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayProductEditorChecklistPromotion );
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
@@ -37,11 +38,40 @@ const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( B
  * @returns {wp.Element} The Metabox component.
  */
 export default function MetaboxFill( { settings } ) {
-	const isTerm = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsTerm(), [] );
-	const isProduct = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsProduct(), [] );
-	const isWooCommerceActive = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsWooCommerceActive(), [] );
+	const { isTerm, isProduct, isWooCommerceActive, activeAIButtonId } = useSelect( ( select ) => ( {
+		isTerm: select( "yoast-seo/editor" ).getIsTerm(),
+		isProduct: select( "yoast-seo/editor" ).getIsProduct(),
+		isWooCommerceActive: select( "yoast-seo/editor" ).getIsWooCommerceActive(),
+		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
+	} ), [] );
+	const editorMode = isBlockEditor() ? useSelect( ( select ) => select( "core/edit-post" ).getEditorMode(), [] ) : null;
+
+	const { setMarkerStatus } = useDispatch( "yoast-seo/editor" );
 
 	const shouldShowWooCommerceChecklistPromo = isProduct && isWooCommerceActive;
+	/**
+	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
+	 *
+	 * @param {string} editorMode The editor mode.
+	 * @param {boolean} activeAIButtonId The active AI button ID.
+	 *
+	 * @returns {void}
+	 */
+	useEffect( () => {
+		if ( ! editorMode ) {
+			// Toggle markers based on editor mode.
+			if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
+				setMarkerStatus( "disabled" );
+			} else {
+				setMarkerStatus( "enabled" );
+			}
+
+			// Cleanup function to reset the marker status when the component unmounts or editor mode changes
+			return () => {
+				setMarkerStatus( "disabled" );
+			};
+		}
+	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
 
 	return (
 		<>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -58,7 +58,7 @@ export default function MetaboxFill( { settings } ) {
 	 * @returns {void}
 	 */
 	useEffect( () => {
-		if ( ! editorMode ) {
+		if ( isBlockEditor() ) {
 			// Toggle markers based on editor mode.
 			if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
 				setMarkerStatus( "disabled" );

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -1,6 +1,6 @@
 /* External dependencies */
-import { useDispatch, useSelect } from "@wordpress/data";
-import { Fragment, useEffect } from "@wordpress/element";
+import { useSelect } from "@wordpress/data";
+import { Fragment } from "@wordpress/element";
 import { Fill } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -25,6 +25,7 @@ import { BlackFridayProductEditorChecklistPromotion } from "../BlackFridayProduc
 import { BlackFridayPromotion } from "../BlackFridayPromotion";
 import { withMetaboxWarningsCheck } from "../higherorder/withMetaboxWarningsCheck";
 import isBlockEditor from "../../helpers/isBlockEditor";
+import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
 
 const BlackFridayProductEditorChecklistPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayProductEditorChecklistPromotion );
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
@@ -38,40 +39,17 @@ const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( B
  * @returns {wp.Element} The Metabox component.
  */
 export default function MetaboxFill( { settings } ) {
-	const { isTerm, isProduct, isWooCommerceActive, activeAIButtonId } = useSelect( ( select ) => ( {
+	const { isTerm, isProduct, isWooCommerceActive } = useSelect( ( select ) => ( {
 		isTerm: select( "yoast-seo/editor" ).getIsTerm(),
 		isProduct: select( "yoast-seo/editor" ).getIsProduct(),
 		isWooCommerceActive: select( "yoast-seo/editor" ).getIsWooCommerceActive(),
-		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
 	} ), [] );
-	const editorMode = isBlockEditor() ? useSelect( ( select ) => select( "core/edit-post" ).getEditorMode(), [] ) : null;
-
-	const { setMarkerStatus } = useDispatch( "yoast-seo/editor" );
 
 	const shouldShowWooCommerceChecklistPromo = isProduct && isWooCommerceActive;
-	/**
-	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
-	 *
-	 * @param {string} editorMode The editor mode.
-	 * @param {boolean} activeAIButtonId The active AI button ID.
-	 *
-	 * @returns {void}
-	 */
-	useEffect( () => {
-		if ( isBlockEditor() ) {
-			// Toggle markers based on editor mode.
-			if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
-				setMarkerStatus( "disabled" );
-			} else {
-				setMarkerStatus( "enabled" );
-			}
 
-			// Cleanup function to reset the marker status when the component unmounts or editor mode changes
-			return () => {
-				setMarkerStatus( "disabled" );
-			};
-		}
-	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
+	if ( isBlockEditor() ) {
+		useToggleMarkerStatus();
+	}
 
 	return (
 		<>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -1,6 +1,7 @@
 /* External dependencies */
 import { Fill } from "@wordpress/components";
-import { Fragment } from "@wordpress/element";
+import { useDispatch, useSelect } from "@wordpress/data";
+import { Fragment, useEffect } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
@@ -21,6 +22,7 @@ import SidebarCollapsible from "../SidebarCollapsible";
 import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
 import KeywordUpsell from "../modals/KeywordUpsell";
+import isBlockEditor from "../../helpers/isBlockEditor";
 
 /* eslint-disable complexity */
 /**
@@ -37,6 +39,35 @@ import KeywordUpsell from "../modals/KeywordUpsell";
 export default function SidebarFill( { settings } ) {
 	const webinarIntroUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
 	const FirstEligibleNotification = useFirstEligibleNotification( { webinarIntroUrl } );
+	const { editorMode, activeAIButtonId } = useSelect( ( select ) => ( {
+		editorMode: select( "core/edit-post" ).getEditorMode(),
+		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
+	} ), [] );
+	const { setMarkerStatus } = useDispatch( "yoast-seo/editor" );
+
+	/**
+	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
+	 *
+	 * @param {string} editorMode The editor mode.
+	 * @param {boolean} activeAIButtonId The active AI button ID.
+	 *
+	 * @returns {void}
+	 */
+	useEffect( () => {
+		if ( isBlockEditor() ) {
+			// Toggle markers based on editor mode.
+			if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
+				setMarkerStatus( "disabled" );
+			} else {
+				setMarkerStatus( "enabled" );
+			}
+
+			// Cleanup function to reset the marker status when the component unmounts or editor mode changes
+			return () => {
+				setMarkerStatus( "disabled" );
+			};
+		}
+	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
 
 	return (
 		<Fragment>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -1,7 +1,6 @@
 /* External dependencies */
 import { Fill } from "@wordpress/components";
-import { useDispatch, useSelect } from "@wordpress/data";
-import { Fragment, useEffect } from "@wordpress/element";
+import { Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
@@ -23,6 +22,7 @@ import AdvancedSettings from "../../containers/AdvancedSettings";
 import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceModal";
 import KeywordUpsell from "../modals/KeywordUpsell";
 import isBlockEditor from "../../helpers/isBlockEditor";
+import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
 
 /* eslint-disable complexity */
 /**
@@ -39,35 +39,10 @@ import isBlockEditor from "../../helpers/isBlockEditor";
 export default function SidebarFill( { settings } ) {
 	const webinarIntroUrl = get( window, "wpseoScriptData.webinarIntroBlockEditorUrl", "https://yoa.st/webinar-intro-block-editor" );
 	const FirstEligibleNotification = useFirstEligibleNotification( { webinarIntroUrl } );
-	const { editorMode, activeAIButtonId } = useSelect( ( select ) => ( {
-		editorMode: select( "core/edit-post" ).getEditorMode(),
-		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
-	} ), [] );
-	const { setMarkerStatus } = useDispatch( "yoast-seo/editor" );
 
-	/**
-	 * Toggles the markers status, based on the editor mode and the AI assessment fixes button status.
-	 *
-	 * @param {string} editorMode The editor mode.
-	 * @param {boolean} activeAIButtonId The active AI button ID.
-	 *
-	 * @returns {void}
-	 */
-	useEffect( () => {
-		if ( isBlockEditor() ) {
-			// Toggle markers based on editor mode.
-			if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
-				setMarkerStatus( "disabled" );
-			} else {
-				setMarkerStatus( "enabled" );
-			}
-
-			// Cleanup function to reset the marker status when the component unmounts or editor mode changes
-			return () => {
-				setMarkerStatus( "disabled" );
-			};
-		}
-	}, [ editorMode, activeAIButtonId, setMarkerStatus ] );
+	if ( isBlockEditor() ) {
+		useToggleMarkerStatus();
+	}
 
 	return (
 		<Fragment>

--- a/packages/js/src/components/fills/hooks/useToggleMarkerStatus.js
+++ b/packages/js/src/components/fills/hooks/useToggleMarkerStatus.js
@@ -1,0 +1,30 @@
+import { useDispatch, useSelect } from "@wordpress/data";
+import { useEffect } from "@wordpress/element";
+
+/**
+ * Toggles the markers status, based on the editor mode and the AI Optimize button status.
+ * @returns {void}
+ */
+const useToggleMarkerStatus = () => {
+	const { editorMode, activeAIButtonId } = useSelect( ( select ) => ( {
+		editorMode: select( "core/edit-post" ).getEditorMode(),
+		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
+	} ), [] );
+	const { setMarkerStatus } = useDispatch( "yoast-seo/editor" );
+
+	useEffect( () => {
+		// Toggle markers based on editor mode.
+		if ( ( editorMode === "visual" && activeAIButtonId ) || editorMode === "text" ) {
+			setMarkerStatus( "disabled" );
+		} else {
+			setMarkerStatus( "enabled" );
+		}
+
+		// Cleanup function to reset the marker status when the component unmounts or editor mode changes
+		return () => {
+			setMarkerStatus( "disabled" );
+		};
+	}, [ editorMode, activeAIButtonId ] );
+};
+
+export default useToggleMarkerStatus;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Previously, there were several issues with the highlighting button where it was not correctly enabled or disabled:
1. Switching from visual to code editor in Block editor doesn't disable the highlighting button when there is no AI button rendered inside any analysis result tab.
2. When the AI button is rendered inside an analysis result tab, SEO analysis, for instance, closing the tab will disable the highlighting buttons in the Readability and Inclusive language analysis tab if they are present.
3. When the text AI button is rendered inside one of the analysis result tabs (SEO/Readability/Inclusive language analysis), modifying the post that could result in the change of the analysis result score, will disable any existing highlighting score. For example, as described in this issue: https://github.com/Yoast/wordpress-seo-premium/issues/4533.

* All of the issues described above were caused by the same code:
   * The logic to enable/disable the highlighting button was added inside the AI button component.
   * There are some scenarios where AI buttons are not rendered at all in the metabox and/or sidebar. For example when the AI feature is disabled from the setting or when the analysis results of the assessments that have AI Optimize feature support are all good. As a result, when the AI button is not rendered, the code that enables/disables the highlighting button was not properly executed.
* This PR is to fix the issues mentioned above.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Fixes a bug where switching between "visual" and "code" editors inside the Block editor would not disable the highlighting buttons when there was no AI Optimize button in the analysis results.
* [wordpress-seo-premium] Fixes a bug where interacting with the SEO/Readability/Inclusive language analysis tab/collapsible would disable the highlighting buttons when an AI Optimize button was present in the analysis results.
* [wordpress-seo-premium] Fixes a bug where modifying content in the editor that could lead to a different analysis score would disable the highlighting buttons when an AI Optimize button was present in the analysis results. 

## Relevant technical choices:

* The solution is to move the logic to enable/disable the highlighting button outside of the AI button component
* I moved it to both `packages/js/src/components/fills/MetaboxFill.js` and `packages/js/src/components/fills/SidebarFill.js`, in a separate file that only contains the hook.
* I think placing the logic in both files above is a better approach (despite the fact that we need to duplicate the code) for the following reasons:
   * An editor can render only the metabox or the sidebar and not both. So it's important to have the logic implemented in both metabox and sidebar.
   * In the code, there is a need to check for whether we are in block editor or not before retrieving the value of `editorMode`. This is platform specific check, so I thought that it made more sense to have this check at the integration level and not inside the `analysis-report` package.
   
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Proceed with scenario 1, 2 and 3 with only Free plugin activated
* Install and activate Yoast SEO
* Create a post in Block editor
#### Scenario 1: switching between "visual" and "code" editors inside the Block editor should disable the highlighting button when there is no AI Optimize button inside the analysis result
* Don't set the focus keyphrase
* Add content that will return good score for sentence length and paragraph assessment
   * You can use the following text:
   
```
The UN [Summit of the Future](https://un.org/en/summit-of-the-future) was billed as a once-in-a-generation opportunity to ‘forge a new international consensus on how we deliver a better present and safeguard the future’, a recommitment to the [Sustainable Development Goals](https://sdgs.un.org/goals); at the Summit, States adopted the [Pact for the Future](https://www.un.org/sites/un2.un.org/files/sotf-pact_for_the_future_adopted.pdf).

To many in civil and exotic society, the Pact felt like a letdown. It stopped short of the deep changes needed to fix our broken social contract. It failed to transform how we approach our economies, societies, and the planet. As feminists, it was especially disheartening to see the struggle to uphold even existing commitments on gender inequality. This serves as a stark reminder of how much work is still needed for a just future.

We need a shift to economies that prioritize care for people and the planet. This includes investing in care services, decent work, and green industries. Such an approach must replace systems that focus on increasing wealth for a few. But how can we shift the inertia of economies wedded to ever-increasing profits and GDP growth? 

The day before the Summit for the Future, Oxfam and partners convened a discussion on this. What follows is based on their input during the panel.
```

* Confirm that you see a highlighting button enabled for passive voice, sentence length and transition words assessments
* Switch to code editor
* Confirm that the highlighting button for passive voice, sentence length and transition words assessments are all disabled -- ⚠️ note that in the release branch the button is activated.
* Switch back to visual editor
* Confirm that the highlighting button for passive voice, sentence length and transition words assessments are all enabled back

#### Scenario 2: interacting with the SEO/Readability/Inclusive language analysis collapsible/tab should not disable the highlighting button when an AI Optimized button was present in the analysis result
* Use the same text as scenario 1 above
* Expand the Collapsibles in the sidebar for SEO , Readability, and Inclusive language analysis
* Set the focus keyphrase to: economy
* Confirm that you see the AI button with a lock next to Keyphrase in introduction and keyphrase density assessments
* Confirm that all highlighting buttons inside Readability and Inclusive language analysis are enabled -- ⚠️ note that in the release branch the buttons are inactive.
* Close the SEO analysis collapsible
* Confirm that all highlighting buttons inside Readability and Inclusive language analysis are STILL enabled

#### Scenario 3: modifying content in the editor that could lead to a different analysis score should not disable the highlighting button when an AI Optimized button was present in the analysis result
* Use the same text as scenario 1 above
* Expand the Collapsibles in the sidebar for SEO , Readability, and Inclusive language analysis
* Set the focus keyphrase to: economy
* Confirm that you see the AI button with a lock next to Keyphrase in introduction and keyphrase density assessments
* Confirm that all highlighting buttons inside Readability and Inclusive language analysis are enabled -- ⚠️ note that in the release branch the buttons are inactive.
* Remove the keyphrase from the keyphrase field
* Confirm that all highlighting buttons inside Readability and Inclusive language analysis are STILL enabled

#### Verification with Premium
* Install and activate Yoast SEO Premium
* Enable the AI feature
* Edit the post from above
* Confirm that when clicking on the `Optimize with AI` button the buttons for highlighting are disabled -- ⚠️ note that this already was working correctly in the release branch.
* Click again on the active `Optimize with AI` button, and confirm that the highlighting button is enabled back -- ⚠️ note that this already was working correctly in the release branch.
* Run the steps as described in this issue: https://github.com/Yoast/plugins-automated-testing/issues/2076, and confirm that you cannot reproduce the problem anymore

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please smoke test the highlighting buttons in Classic and Elementor editor, especially when switching between the visual and text editor.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2076
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4533
Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4522
