### PR TITLE
Show alert when avif file is used in social preview

### DIFF
--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -16,9 +16,7 @@ function ImageSelect( props ) {
 	const imageSelected = props.usingFallback === false && props.imageUrl !== "";
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
 	const showWarnings = props.warnings.length > 0 && ( imageSelected || props.imageFallbackUrl !== "" );
-
-
-	let imageClassName =  previewImageUrl === ""  ? "yoast-image-select__preview yoast-image-select__preview--no-preview" : "yoast-image-select__preview";
+	const imageClassName =  previewImageUrl === ""  ? "yoast-image-select__preview yoast-image-select__preview--no-preview" : "yoast-image-select__preview";
 
 	const imageSelectButtonsProps = {
 		imageSelected: imageSelected,
@@ -89,6 +87,7 @@ export default ImageSelect;
 ImageSelect.propTypes = {
 	defaultImageUrl: PropTypes.string,
 	imageUrl: PropTypes.string,
+	imageFallbackUrl: PropTypes.string,
 	imageAltText: PropTypes.string,
 	hasPreview: PropTypes.bool.isRequired,
 	label: PropTypes.string.isRequired,
@@ -109,6 +108,7 @@ ImageSelect.propTypes = {
 ImageSelect.defaultProps = {
 	defaultImageUrl: "",
 	imageUrl: "",
+	imageFallbackUrl: "",
 	imageAltText: "",
 	onClick: () => {},
 	onMouseEnter: () => {},

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -87,7 +87,7 @@ export default ImageSelect;
 ImageSelect.propTypes = {
 	defaultImageUrl: PropTypes.string,
 	imageUrl: PropTypes.string,
-	imageFallbackUrl: PropTypes.string,
+	imageFallbackUrl: PropTypes.string.isRequired,
 	imageAltText: PropTypes.string,
 	hasPreview: PropTypes.bool.isRequired,
 	label: PropTypes.string.isRequired,
@@ -108,7 +108,6 @@ ImageSelect.propTypes = {
 ImageSelect.defaultProps = {
 	defaultImageUrl: "",
 	imageUrl: "",
-	imageFallbackUrl: "",
 	imageAltText: "",
 	onClick: () => {},
 	onMouseEnter: () => {},

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -17,10 +17,8 @@ function ImageSelect( props ) {
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
 	const showWarnings = props.warnings.length > 0 && imageSelected;
 
-	let imageClassName = showWarnings ? "yoast-image-select__preview yoast-image-select__preview-has-warnings" : "yoast-image-select__preview";
-	if ( previewImageUrl === "" ) {
-		imageClassName = "yoast-image-select__preview yoast-image-select__preview--no-preview";
-	}
+
+	let imageClassName =  previewImageUrl === ""  ? "yoast-image-select__preview yoast-image-select__preview--no-preview" : "yoast-image-select__preview";
 
 	const imageSelectButtonsProps = {
 		imageSelected: imageSelected,
@@ -72,7 +70,7 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					showWarnings && <div role="alert">
+					showWarnings && <div role="alert" className="yst-mt-4">
 						{
 							props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 								{ warning }

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import FieldGroup from "../field-group/FieldGroup";
 import Alert from "../Alert";
 
+/* eslint-disable complexity */
 /**
  * Renders ImageSelect component.
  *
@@ -88,6 +89,8 @@ function ImageSelect( props ) {
 		</div>
 	);
 }
+
+/* eslint-enable complexity */
 
 export default ImageSelect;
 

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -15,8 +15,15 @@ import Alert from "../Alert";
 function ImageSelect( props ) {
 	const imageSelected = props.usingFallback === false && props.imageUrl !== "";
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
-	const showWarnings = props.warnings.length > 0 && ( imageSelected || props.imageFallbackUrl !== "" );
-	const imageClassName =  previewImageUrl === ""  ? "yoast-image-select__preview yoast-image-select__preview--no-preview" : "yoast-image-select__preview";
+	const showWarnings = props.warnings.length > 0 && ( imageSelected || props.usingFallback );
+	const imageClassNames = [ "yoast-image-select__preview" ];
+	if ( previewImageUrl === "" ) {
+		imageClassNames.push( "yoast-image-select__preview--no-preview" );
+	}
+	if ( showWarnings ) {
+		imageClassNames.push( "yoast-image-select__preview-has-warnings" );
+	}
+
 
 	const imageSelectButtonsProps = {
 		imageSelected: imageSelected,
@@ -56,7 +63,7 @@ function ImageSelect( props ) {
 			>
 				{ props.hasPreview &&
 					<button
-						className={ imageClassName }
+						className={ imageClassNames.join( " " ) }
 						onClick={ props.onClick }
 						type="button"
 						disabled={ props.isDisabled }
@@ -68,7 +75,7 @@ function ImageSelect( props ) {
 					</button>
 				}
 				{
-					showWarnings && <div role="alert" className="yst-mt-4">
+					showWarnings && <div role="alert">
 						{
 							props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 								{ warning }
@@ -87,7 +94,6 @@ export default ImageSelect;
 ImageSelect.propTypes = {
 	defaultImageUrl: PropTypes.string,
 	imageUrl: PropTypes.string,
-	imageFallbackUrl: PropTypes.string.isRequired,
 	imageAltText: PropTypes.string,
 	hasPreview: PropTypes.bool.isRequired,
 	label: PropTypes.string.isRequired,

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -15,7 +15,7 @@ import Alert from "../Alert";
 function ImageSelect( props ) {
 	const imageSelected = props.usingFallback === false && props.imageUrl !== "";
 	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
-	const showWarnings = props.warnings.length > 0 && imageSelected;
+	const showWarnings = props.warnings.length > 0 && ( imageSelected || props.imageFallbackUrl !== "" );
 
 
 	let imageClassName =  previewImageUrl === ""  ? "yoast-image-select__preview yoast-image-select__preview--no-preview" : "yoast-image-select__preview";

--- a/packages/js/src/components/social/FacebookWrapper.js
+++ b/packages/js/src/components/social/FacebookWrapper.js
@@ -52,9 +52,15 @@ FacebookWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
-	imageFallbackUrl: PropTypes.string.isRequired,
-	imageUrl: PropTypes.string.isRequired,
-	imageWarnings: PropTypes.array.isRequired,
+	imageFallbackUrl: PropTypes.string,
+	imageUrl: PropTypes.string,
+	imageWarnings: PropTypes.array,
+};
+
+FacebookWrapper.defaultProps = {
+	imageFallbackUrl: "",
+	imageUrl: "",
+	imageWarnings: [],
 };
 
 export default FacebookWrapper;

--- a/packages/js/src/components/social/FacebookWrapper.js
+++ b/packages/js/src/components/social/FacebookWrapper.js
@@ -3,6 +3,7 @@ import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
+import { useFallbackWarning } from "./useFallbackWarning";
 
 /**
  * This wrapper is connected to the facebook container. So the data is connected to both components.
@@ -14,6 +15,8 @@ import SocialForm from "../social/SocialForm";
  */
 const FacebookWrapper = ( props ) => {
 	const [ activeMetaTabId, setActiveMetaTabId ] = useState( "" );
+
+	useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
 
 	// Set active meta tab id on window event.
 	const handleMetaTabChange = useCallback( ( event ) => {
@@ -49,6 +52,9 @@ FacebookWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
+	imageFallbackUrl: PropTypes.string.isRequired,
+	imageUrl: PropTypes.string.isRequired,
+	imageWarnings: PropTypes.array.isRequired,
 };
 
 export default FacebookWrapper;

--- a/packages/js/src/components/social/FacebookWrapper.js
+++ b/packages/js/src/components/social/FacebookWrapper.js
@@ -16,8 +16,7 @@ import { useFallbackWarning } from "./useFallbackWarning";
 const FacebookWrapper = ( props ) => {
 	const [ activeMetaTabId, setActiveMetaTabId ] = useState( "" );
 
-	useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
-
+	const warnings = useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
 	// Set active meta tab id on window event.
 	const handleMetaTabChange = useCallback( ( event ) => {
 		setActiveMetaTabId( event.detail.metaTabId );
@@ -36,10 +35,11 @@ const FacebookWrapper = ( props ) => {
 		};
 	}, [] );
 
-	const allProps = useMemo( () => ( {
+	const allProps = {
 		...props,
 		activeMetaTabId,
-	} ), [ props, activeMetaTabId ] );
+		imageWarnings: warnings,
+	};
 
 	return (
 		props.isPremium

--- a/packages/js/src/components/social/FacebookWrapper.js
+++ b/packages/js/src/components/social/FacebookWrapper.js
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from "@wordpress/element";
+import { useEffect, useState, useCallback } from "@wordpress/element";
 import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 

--- a/packages/js/src/components/social/SocialForm.js
+++ b/packages/js/src/components/social/SocialForm.js
@@ -118,6 +118,7 @@ class SocialPreviewEditor extends Component {
 			description,
 			descriptionInputPlaceholder,
 			imageUrl,
+			imageFallbackUrl,
 			alt,
 			title,
 			titleInputPlaceholder,
@@ -139,6 +140,7 @@ class SocialPreviewEditor extends Component {
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! imageUrl }
 					imageUrl={ imageUrl }
+					imageFallbackUrl={ imageFallbackUrl }
 					imageAltText={ alt }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
@@ -167,6 +169,7 @@ SocialPreviewEditor.propTypes = {
 	description: PropTypes.string.isRequired,
 	onDescriptionChange: PropTypes.func.isRequired,
 	imageUrl: PropTypes.string.isRequired,
+	imageFallbackUrl: PropTypes.string,
 	onSelectImageClick: PropTypes.func.isRequired,
 	onRemoveImageClick: PropTypes.func.isRequired,
 	socialMediumName: PropTypes.string.isRequired,
@@ -183,6 +186,7 @@ SocialPreviewEditor.propTypes = {
 
 SocialPreviewEditor.defaultProps = {
 	imageWarnings: [],
+	imageFallbackUrl: "",
 	recommendedReplacementVariables: [],
 	replacementVariables: [],
 	isPremium: false,

--- a/packages/js/src/components/social/TwitterWrapper.js
+++ b/packages/js/src/components/social/TwitterWrapper.js
@@ -14,7 +14,6 @@ import { useFallbackWarning } from "./useFallbackWarning";
  * @returns {JSX.Element} The TwitterWrapper.
  */
 const TwitterWrapper = ( props ) => {
-
 	useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
 
 	useEffect( () => {

--- a/packages/js/src/components/social/TwitterWrapper.js
+++ b/packages/js/src/components/social/TwitterWrapper.js
@@ -14,16 +14,21 @@ import { useFallbackWarning } from "./useFallbackWarning";
  * @returns {JSX.Element} The TwitterWrapper.
  */
 const TwitterWrapper = ( props ) => {
-	useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
+	const warnings = useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
 
 	useEffect( () => {
 		// Load on the next cycle because the editor inits asynchronously, and we need to load the data after the component is fully loaded.
 		setTimeout( props.onLoad );
 	}, [] );
 
+	const allProps = {
+		...props,
+		imageWarnings: warnings,
+	};
+
 	return props.isPremium
-		? <Slot name={ `YoastTwitterPremium${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }` } fillProps={ props } />
-		: <SocialForm { ...props } />;
+		? <Slot name={ `YoastTwitterPremium${ props.location.charAt( 0 ).toUpperCase() + props.location.slice( 1 ) }` } fillProps={ allProps } />
+		: <SocialForm { ...allProps } />;
 };
 
 TwitterWrapper.propTypes = {

--- a/packages/js/src/components/social/TwitterWrapper.js
+++ b/packages/js/src/components/social/TwitterWrapper.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
 import { useFallbackWarning } from "./useFallbackWarning";
+import FacebookWrapper from "./FacebookWrapper";
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.
@@ -35,9 +36,15 @@ TwitterWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
-	imageFallbackUrl: PropTypes.string.isRequired,
-	imageUrl: PropTypes.string.isRequired,
-	imageWarnings: PropTypes.array.isRequired,
+	imageFallbackUrl: PropTypes.string,
+	imageUrl: PropTypes.string,
+	imageWarnings: PropTypes.array,
+};
+
+TwitterWrapper.defaultProps = {
+	imageFallbackUrl: "",
+	imageUrl: "",
+	imageWarnings: [],
 };
 
 export default TwitterWrapper;

--- a/packages/js/src/components/social/TwitterWrapper.js
+++ b/packages/js/src/components/social/TwitterWrapper.js
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
 import { useFallbackWarning } from "./useFallbackWarning";
-import FacebookWrapper from "./FacebookWrapper";
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.

--- a/packages/js/src/components/social/TwitterWrapper.js
+++ b/packages/js/src/components/social/TwitterWrapper.js
@@ -3,6 +3,7 @@ import { Slot } from "@wordpress/components";
 import PropTypes from "prop-types";
 
 import SocialForm from "../social/SocialForm";
+import { useFallbackWarning } from "./useFallbackWarning";
 
 /**
  * This wrapper is connected to the twitter container. So the data is connected to both components.
@@ -13,6 +14,9 @@ import SocialForm from "../social/SocialForm";
  * @returns {JSX.Element} The TwitterWrapper.
  */
 const TwitterWrapper = ( props ) => {
+
+	useFallbackWarning( props.imageFallbackUrl, props.imageUrl, props.imageWarnings );
+
 	useEffect( () => {
 		// Load on the next cycle because the editor inits asynchronously, and we need to load the data after the component is fully loaded.
 		setTimeout( props.onLoad );
@@ -27,6 +31,9 @@ TwitterWrapper.propTypes = {
 	isPremium: PropTypes.bool.isRequired,
 	onLoad: PropTypes.func.isRequired,
 	location: PropTypes.string.isRequired,
+	imageFallbackUrl: PropTypes.string.isRequired,
+	imageUrl: PropTypes.string.isRequired,
+	imageWarnings: PropTypes.array.isRequired,
 };
 
 export default TwitterWrapper;

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -11,7 +11,7 @@ import { __, sprintf } from "@wordpress/i18n";
  * @returns {void}
  */
 export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) => {
-	useEffect(() => {
+	useEffect( () => {
 		if ( imageUrl === "" ) {
 			imageWarnings.length = 0;
 			if ( imageFallbackUrl.toLowerCase().endsWith( ".avif" ) ) {

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -1,4 +1,4 @@
-import { useEffect } from "@wordpress/element";
+import { useEffect, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 
 /**
@@ -8,23 +8,24 @@ import { __, sprintf } from "@wordpress/i18n";
  * @param {string} imageUrl
  * @param {array} imageWarnings
  *
- * @returns {void}
+ * @returns {array}
  */
 export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) => {
+	const [ hasFallbackWarning, setHasFallbackWarning ] = useState( false );
+	const warningMessage = sprintf(
+		/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the webp format, %s expands to the gif format. */
+		__(
+			"The image automatically added from your content isn't supported. Please use %s, %s, %s or %s formats to ensure it displays correctly on social media.",
+			"wordpress-seo"
+		),
+		"JPG", "PNG", "WEBP", "GIF"
+	);
 	useEffect( () => {
 		if ( imageUrl === "" ) {
-			imageWarnings.length = 0;
-			if ( imageFallbackUrl.toLowerCase().endsWith( ".avif" ) ) {
-				const warningMessage = sprintf(
-					/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the gif format. */
-					__(
-						"The image automatically added from your content is in an unsupported format. Supported formats are %s, %s, %s and %s. Please select or upload an image in a supported format to ensure it displays correctly on social media.",
-						"wordpress-seo"
-					),
-					"JPG", "PNG", "WEBP", "GIF"
-				);
-				imageWarnings.push( warningMessage );
-			}
+			setHasFallbackWarning(  imageFallbackUrl.toLowerCase().endsWith( ".avif" )  );
+		} else {
+			setHasFallbackWarning( false );
 		}
 	}, [ imageFallbackUrl, imageUrl ] );
+	return hasFallbackWarning ? [ warningMessage ] : imageWarnings;
 };

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -1,0 +1,30 @@
+import { useEffect } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
+
+/**
+ * Checks if the fallback image is in AVIF format and sets a warning message.
+ *
+ * @param {string} imageFallbackUrl
+ * @param {string} imageUrl
+ * @param {array} imageWarnings
+ *
+ * @returns {void}
+ */
+export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) => {
+	useEffect(() => {
+		if ( imageFallbackUrl.toLowerCase().endsWith( ".avif" ) && imageUrl === "" ) {
+			const warningMessage = sprintf(
+				/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the gif format. */
+				__(
+					"The image automatically added from your content is in an unsupported format. Supported formats are %s, %s, %s and %s. Please select or upload an image in a supported format to ensure it displays correctly on social media.",
+					"wordpress-seo"
+				),
+				"JPG", "PNG", "WEBP", "GIF"
+			);
+			imageWarnings.length = 0;
+			imageWarnings.push( warningMessage );
+		} else {
+			imageWarnings.length = 0;
+		}
+	}, [ imageFallbackUrl, imageUrl ] );
+};

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -21,11 +21,7 @@ export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) 
 		"JPG", "PNG", "WEBP", "GIF"
 	);
 	useEffect( () => {
-		if ( imageUrl === "" ) {
-			setHasFallbackWarning(  imageFallbackUrl.toLowerCase().endsWith( ".avif" )  );
-		} else {
-			setHasFallbackWarning( false );
-		}
+		setHasFallbackWarning( imageUrl === "" ? imageFallbackUrl.toLowerCase().endsWith( ".avif" ) : false );
 	}, [ imageFallbackUrl, imageUrl ] );
 	return hasFallbackWarning ? [ warningMessage ] : imageWarnings;
 };

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -12,19 +12,19 @@ import { __, sprintf } from "@wordpress/i18n";
  */
 export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) => {
 	useEffect(() => {
-		if ( imageFallbackUrl.toLowerCase().endsWith( ".avif" ) && imageUrl === "" ) {
-			const warningMessage = sprintf(
-				/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the gif format. */
-				__(
-					"The image automatically added from your content is in an unsupported format. Supported formats are %s, %s, %s and %s. Please select or upload an image in a supported format to ensure it displays correctly on social media.",
-					"wordpress-seo"
-				),
-				"JPG", "PNG", "WEBP", "GIF"
-			);
+		if ( imageUrl === "" ) {
 			imageWarnings.length = 0;
-			imageWarnings.push( warningMessage );
-		} else {
-			imageWarnings.length = 0;
+			if ( imageFallbackUrl.toLowerCase().endsWith( ".avif" ) ) {
+				const warningMessage = sprintf(
+					/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the gif format. */
+					__(
+						"The image automatically added from your content is in an unsupported format. Supported formats are %s, %s, %s and %s. Please select or upload an image in a supported format to ensure it displays correctly on social media.",
+						"wordpress-seo"
+					),
+					"JPG", "PNG", "WEBP", "GIF"
+				);
+				imageWarnings.push( warningMessage );
+			}
 		}
 	}, [ imageFallbackUrl, imageUrl ] );
 };

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -4,11 +4,11 @@ import { __, sprintf } from "@wordpress/i18n";
 /**
  * Checks if the fallback image is in AVIF format and sets a warning message.
  *
- * @param {string} imageFallbackUrl
- * @param {string} imageUrl
- * @param {array} imageWarnings
+ * @param {string} imageFallbackUrl The fallback image URL.
+ * @param {string} imageUrl The image URL.
+ * @param {array} imageWarnings The image warnings.
  *
- * @returns {array}
+ * @returns {string[]} An array of warnings.
  */
 export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) => {
 	const [ hasFallbackWarning, setHasFallbackWarning ] = useState( false );

--- a/packages/js/src/components/social/useFallbackWarning.js
+++ b/packages/js/src/components/social/useFallbackWarning.js
@@ -15,7 +15,7 @@ export const useFallbackWarning = ( imageFallbackUrl, imageUrl, imageWarnings ) 
 	const warningMessage = sprintf(
 		/* Translators: %s expands to the jpg format, %s expands to the png format, %s expands to the webp format, %s expands to the gif format. */
 		__(
-			"The image automatically added from your content isn't supported. Please use %s, %s, %s or %s formats to ensure it displays correctly on social media.",
+			"No image was found that we can automatically set as your social image. Please use %s, %s, %s or %s formats to ensure it displays correctly on social media.",
 			"wordpress-seo"
 		),
 		"JPG", "PNG", "WEBP", "GIF"

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -218,6 +218,7 @@ class SocialMetadataPreviewForm extends Component {
 			recommendedReplacementVariables,
 			imageWarnings,
 			imageUrl,
+			imageFallbackUrl,
 			imageAltText,
 			idSuffix,
 		} = this.props;
@@ -243,6 +244,7 @@ class SocialMetadataPreviewForm extends Component {
 					isActive={ activeField === "image" }
 					isHovered={ hoveredField === "image" }
 					imageUrl={ imageUrl }
+					usingFallback={ ! imageUrl && imageFallbackUrl !== "" }
 					imageAltText={ imageAltText }
 					hasPreview={ ! isPremium }
 					imageUrlInputId={ join( [ lowerCaseSocialMediumName, "url-input", idSuffix ] ) }
@@ -311,6 +313,7 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
+	imageFallbackUrl: PropTypes.string,
 	imageAltText: PropTypes.string,
 	titleInputPlaceholder: PropTypes.string,
 	descriptionInputPlaceholder: PropTypes.string,
@@ -328,6 +331,7 @@ SocialMetadataPreviewForm.defaultProps = {
 	onSelect: () => {},
 	onReplacementVariableSearchChange: null,
 	imageUrl: "",
+	imageFallbackUrl: "",
 	imageAltText: "",
 	titleInputPlaceholder: "",
 	descriptionInputPlaceholder: "",

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -174,6 +174,7 @@ class SocialPreviewEditor extends Component {
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! imageUrl }
 					imageUrl={ imageUrl }
+					imageFallbackUrl={ imageFallbackUrl }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* AVIF file are currently not supported by Facebook and X: we want to warn users when their fallback image is in that format.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Issues a warning message when the image automatically selected for a post social preview is in the unsupported AVIF format.
* [@yoast/components 0.0.1] Refactors the logic used by `ImageSelect` to determine which styling to apply.
* [@yoast/social-metadata-forms 0.0.1 other] Adds `usingFallback` prop to `SocialMetadataPreviewForm` component.
* [@yoast/social-metadata-previews 0.0.1 other] Passes `imageFallbackUrl` prop to `SocialPreviewEditor` component.

## Relevant technical choices:

* I implemented this check in the warppers (`FacebookWrapper` and `TwitterWrapper`) because it wouldn't make sense to have it in the more general `ImageSelect` component, as this limitation is specific to our implementation.
* I opted to use the already-existing warning infrastructure which is currently used to display warnings about images that are manually selected by the user
  * I directly ~manipulate~ use the `props.imageWarnings` array instead of using an action because:
  * currently there's no dedicated action to set warnings: warnings are set atomically with image selection in `selectMedia` `prepareFacebookPreviewImage` and `prepareTwitterPreviewImage` functions: refactoring this would require a non-negligible effort which is out of the scope of this PR. Moreover, the `imageWarnings` array is drilled down throughout the components' chain where it is needed.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check against [UX design](https://www.figma.com/proto/6wbzxKTteAmOXFaOz8IsvW/Avif-fallback?page-id=0%3A1&node-id=1-2&viewport=310%2C160%2C0.35&t=FRXkPMa3B7Imu2rf-1&scaling=scale-down&content-scaling=fixed&starting-point-node-id=1%3A2)
* Edit a post and make sure you did not select any image for its social previews (both Facebook and X)
* Drag and drop an AVIF image into the post, so that is being used as fallback for the social preview (you can download some sample AVIF files from [here](https://github.com/link-u/avif-sample-images))
* Go to the `Social` tab in the Metabox and verify you see the following warning:
  <img width="850" alt="Screenshot 2025-01-23 at 10 15 15" src="https://github.com/user-attachments/assets/9f7a30dc-ddf7-4ce9-8398-57fb35d6241f" />
* Check you see the same warning in the `X appearance` section, too 
* Click on `Select image` and select any image of a supported type
  * Check the warning is gone 
* Click on `Remove image` and check the warning is back
* Click on `Select image` and select an image of AVIF type (you can select the same image you used in the post)
  * Check the warning is now as follows:
  <img width="666" alt="Screenshot 2025-01-17 at 16 05 54" src="https://github.com/user-attachments/assets/9e86c708-86a8-4700-be6c-6f4ff495c903" />
* Restore the post to have no images for its social previews and an AVIF image in its body
* Open the `Social media appearance` modal from the Yoast Sidebar
  * Check the warning is present there, too
* Remove the AVIF image from the post body and use it as featured image instead
  * Perform the same checks as above
* Perform the same tests in Elementor and Classic editor
* Perform the same tests with Premium activated. To do so: 
  * Remove the folder `wordpress-seo` in your Premium's `vendor/yoast` folder 
  * in `vendor/yoast` create a symlink to the `wordpress-seo` folder installation containing this branch

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#4496](https://github.com/Yoast/wordpress-seo-premium/issues/4496)
