### PR TITLE
Fixes issue #31963: Added space at end of the input fields

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -219,18 +219,18 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 
 			<?php if ( $which === 'top' ) { ?>
 			<form id="posts-filter" action="" method="get">
-				<input type="hidden" name="nonce" value="<?php echo esc_attr( $this->nonce ); ?>"/>
-				<input type="hidden" name="page" value="wpseo_tools"/>
-				<input type="hidden" name="tool" value="bulk-editor"/>
-				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>"/>
+				<input type="hidden" name="nonce" value="<?php echo esc_attr( $this->nonce ); ?>" />
+				<input type="hidden" name="page" value="wpseo_tools" />
+				<input type="hidden" name="tool" value="bulk-editor" />
+				<input type="hidden" name="type" value="<?php echo esc_attr( $this->page_type ); ?>" />
 				<input type="hidden" name="orderby"
-					value="<?php echo esc_attr( $order_by ); ?>"/>
+					value="<?php echo esc_attr( $order_by ); ?>" />
 				<input type="hidden" name="order"
-					value="<?php echo esc_attr( $order ); ?>"/>
+					value="<?php echo esc_attr( $order ); ?>" />
 				<input type="hidden" name="post_type_filter"
-					value="<?php echo esc_attr( $post_type_filter ); ?>"/>
+					value="<?php echo esc_attr( $post_type_filter ); ?>" />
 				<?php if ( ! empty( $post_status ) ) { ?>
-					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>"/>
+					<input type="hidden" name="post_status" value="<?php echo esc_attr( $post_status ); ?>" />
 				<?php } ?>
 				<?php } ?>
 

--- a/admin/class-premium-popup.php
+++ b/admin/class-premium-popup.php
@@ -90,7 +90,7 @@ class WPSEO_Premium_Popup {
 
 		$popup = <<<EO_POPUP
 <div id="wpseo-{$this->identifier}-popup" class="wpseo-premium-popup wp-clearfix$classes">
-	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}packages/js/images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO"/>
+	<img class="alignright wpseo-premium-popup-icon" src="{$assets_uri}packages/js/images/Yoast_SEO_Icon.svg" width="150" height="150" alt="Yoast SEO" />
 	<{$this->heading_level} id="wpseo-contact-support-popup-title" class="wpseo-premium-popup-title">{$this->title}</{$this->heading_level}>
 	{$this->content}
 	<a id="wpseo-{$this->identifier}-popup-button" class="yoast-button-upsell" href="{$this->url}" target="_blank">

--- a/admin/views/tabs/tool/import-seo.php
+++ b/admin/views/tabs/tool/import-seo.php
@@ -85,7 +85,7 @@ function wpseo_import_external_select( $name, $plugins ) {
 
 		?>
 		<input type="submit" class="button button-primary" name="import_external"
-			value="<?php esc_attr_e( 'Import', 'wordpress-seo' ); ?>"/>
+			value="<?php esc_attr_e( 'Import', 'wordpress-seo' ); ?>" />
 	</form>
 </div>
 

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -25,7 +25,7 @@ $wpseo_no_index_author_label = sprintf(
 	<?php if ( ! WPSEO_Options::get( 'disable-author' ) ) : ?>
 	<label for="wpseo_author_title"><?php esc_html_e( 'Title to use for Author page', 'wordpress-seo' ); ?></label>
 	<input class="yoast-settings__text regular-text" type="text" id="wpseo_author_title" name="wpseo_author_title"
-		value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>"/><br>
+		value="<?php echo esc_attr( get_the_author_meta( 'wpseo_title', $user->ID ) ); ?>" /><br>
 
 	<label for="wpseo_author_metadesc"><?php esc_html_e( 'Meta description to use for Author page', 'wordpress-seo' ); ?></label>
 	<textarea rows="5" cols="30" id="wpseo_author_metadesc"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Added space at end of the input fields and It is good as per the standard coding format.
* File Path: /wordpress-seo/admin/views/user-profile.php - Will see the space meessing at end of the input filed at line number: 28
* File Path: /wordpress-seo/admin/class-bulk-editor-list-table.php - Same issue at multiple lines. Please review the .diff file.
* File Path: /wordpress-seo/admin/class-premium-popup.php - Same issue at multiple lines. Please review the .diff file.
* File Path: /wordpress-seo/admin/views/tabs/tool/import-seo.php - Same issue at multiple lines. Please review the .diff file.


## Summary
* Space is missing at end of the input field

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds space before the closing slash in self-closing HTML tags to comply with recommended coding standards. Props to @laxman1192 .

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Open above listed file and see as the space was missing at end of input fields so we have added.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No any impect at any but It is good as per the standard coding format.  

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21963 
