### PR TITLE
Allow transpiling all js files inside yoastseo/src and allow import with asterisk *

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -28,7 +28,7 @@
     "build": "yarn clean && yarn build:js && yarn build:types",
     "build:js": "babel src --copy-files --source-maps --out-dir build",
     "build:types": "tsc",
-    "clean": "rm -rf build",
+    "clean": "rm -rf build types",
     "pretest": "grunt get-premium-configuration",
     "test": "jest",
     "lint": "eslint . --max-warnings 26"

--- a/packages/yoastseo/tsconfig.json
+++ b/packages/yoastseo/tsconfig.json
@@ -10,7 +10,7 @@
     "checkJs": false,
     "outDir": "./types",
     "module": "esnext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "strict": true,
     "skipLibCheck": true,
   }

--- a/packages/yoastseo/tsconfig.json
+++ b/packages/yoastseo/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "src/**.js",
+    "src/**/*",
   ],
   "compilerOptions": {
     "declaration": true,

--- a/packages/yoastseo/tsconfig.json
+++ b/packages/yoastseo/tsconfig.json
@@ -9,7 +9,8 @@
     "allowJs": true,
     "checkJs": false,
     "outDir": "./types",
-    "module": "es2022",
+    "module": "esnext",
+    "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
   }

--- a/packages/yoastseo/tsconfig.json
+++ b/packages/yoastseo/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "include": [
     "src/**/*.js",
+    "vendor"
   ],
   "compilerOptions": {
     "declaration": true,

--- a/packages/yoastseo/tsconfig.json
+++ b/packages/yoastseo/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "src/**/*",
+    "src/**/*.js",
   ],
   "compilerOptions": {
     "declaration": true,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to miss any files when preparing the types.
* We also want to explicitly allow imports with asterisks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Allows transpiling all JavaScript files inside `src` and `vendor` into TypeScript and allows importing modules with an asterisk `*`.

## Relevant technical choices:

* Adding the `moduleResolution` option in the config allows using import statement with an asterisk `*`. For example, `import * as assessments from "./scoring/assessments";`. Reference: [moduleResolution](https://www.typescriptlang.org/tsconfig/#moduleResolution)
*  Changing `"src/**.js"` to `"src/**/*.js"` in `include` allows the transpiling of all Javascript files inside the `src` folder. Previously, not all JS files were transpiled. By using `**/` now we should be able to match nested directory to any level. Reference: [include](https://www.typescriptlang.org/tsconfig/#include)
* `vendor` is added to the `include` array inside `tsconfig.json`. This is because the Turkish external stemmer is stored in this folder. We also need to transpile the stemmer since we also use it inside `src` folder
* The `yarn clean` script has also been changed to clean the generated `types` folder.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set `checkJs` option inside `packages/yoastseo/tsconfig.json` to `true` to be able to build types (⚠️ don't commit this change)
* Run `yarn build:types` inside `yoastseo` package
##### Allows transpiling all JavaScript files inside `src` and `vendor` into TypeScript
* Confirm that you have `types` folder inside the root of `yoastseo` directory
* Confirm that inside `types` folder, you see both `src` and `vendor` folders
* Confirm that all js files inside `src` are transpiled

##### Allows importing modules with an asterisk `*`
* Open this file `packages/yoastseo/src/index.js` . This file previously had errors in the import syntax with an asterisk
* Confirm that now you don't see that error anymore for all imports that are using an asterisk
* Go to `packages/yoastseo/types/src/index.d.ts` and confirm that the following modules are imported correctly:
   * AnalysisWebWorker, AnalysisWorkerWrapper, createWorker, assessments, assessors, bundledPlugins, config, helpers, markers, interpreters, languageProcessing, values 

##### Removes `types` folder when `yarn clean` is executed
* Remove the `types` folder inside `yoastseo` with `rm -rf types`
* Inside `yoastseo` package, run `yarn build`
* Confirm that you see `build` and `types` folder inside `yoastseo`
* Run `yarn clean`
* Confirm that both `build` and `types` folder inside `yoastseo` are removed

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No user-facing changes, no need to test this as QA.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/510
