### PR TITLE
Add the Site Kit consent modal

### DIFF
--- a/packages/js/src/shared-admin/components/site-kit-consent-modal.js
+++ b/packages/js/src/shared-admin/components/site-kit-consent-modal.js
@@ -1,32 +1,88 @@
-import { Modal } from "@yoast/ui-library";
+import { ArrowSmRightIcon } from "@heroicons/react/solid";
 import { __ } from "@wordpress/i18n";
-import { PropTypes } from "prop-types";
+import { Button, Modal, useSvgAria } from "@yoast/ui-library";
+import PropTypes from "prop-types";
+import { OutboundLink } from "./outbound-link";
 
 /**
  * The Site Kit consent modal component.
  *
  * @param {boolean} isOpen Whether the modal is open.
- * @param {Function} onClose Callback to close the modal.
+ * @param {function} onClose Callback to close the modal.
+ * @param {function} onGrantConsent Callback to grant consent.
+ * @param {string} learnMoreLink The learn more link.
+ * @param {string} imageLink The image link.
  *
  * @returns {JSX.Element} The Site Kit consent modal component.
  */
-export const SiteKitConsentModal = ( { isOpen, onClose } ) => {
+export const SiteKitConsentModal = ( {
+	isOpen,
+	onClose,
+	onGrantConsent,
+	learnMoreLink = "http://yoa.st/sitekit-consent-learn-more",
+	imageLink = "",
+} ) => {
+	const svgAriaProps = useSvgAria();
+
 	return (
 		<Modal
 			isOpen={ isOpen }
 			onClose={ onClose }
 		>
-			<Modal.Panel>
-				<Modal.Title>{ __( "Connect Site Kit by Google", "wordpress-seo" ) }</Modal.Title>
-				<Modal.Description>
-					{ __( "Connect your Google account to view traffic and search rankings on your dashboard.", "wordpress-seo" ) }
-				</Modal.Description>
+			<Modal.Panel className="yst-max-w-lg yst-p-0 yst-rounded-3xl" hasCloseButton={ false }>
+				<Modal.CloseButton
+					className="yst-bg-transparent yst-text-gray-500 focus:yst-ring-offset-0"
+					onClick={ onClose }
+					screenReaderText={ __( "Close", "wordpress-seo" ) }
+				/>
+				<div className="yst-px-10 yst-pt-10 yst-bg-gradient-to-b yst-from-primary-500/25 yst-to-[80%] yst-text-center">
+					<img
+						className="yst-rounded-md yst-drop-shadow-md yst-bg-slate-100 yst-aspect-video"
+						alt=""
+						loading="lazy"
+						decoding="async"
+						src={ imageLink }
+					/>
+				</div>
+				<div className="yst-px-10 yst-pb-4 yst-flex yst-flex-col yst-items-center">
+					<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
+						<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
+							{ __( "Grant consent to connect with Site Kit by Google", "wordpress-seo" ) }
+						</h3>
+						<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
+							{ __( "Give us permission to access your Site Kit data, allowing insights from tools like Google Analytics and Search Console to be displayed directly on your dashboard.", "wordpress-seo" ) }
+							{ " " }
+							<OutboundLink
+								className="yst-no-underline yst-font-medium"
+								variant="primary"
+								href={ learnMoreLink }
+							>
+								{ __( "Learn more", "wordpress-seo" ) }
+								<ArrowSmRightIcon
+									className="yst-inline yst-h-4 yst-w-4 yst-ms-1 rtl:yst-rotate-180"
+									{ ...svgAriaProps }
+								/>
+							</OutboundLink>
+						</div>
+					</div>
+					<div className="yst-w-full yst-flex yst-mt-10">
+						<Button className="yst-grow" size="extra-large" variant="primary" onClick={ onGrantConsent || onClose }>
+							{ __( "Grant consent", "wordpress-seo" ) }
+						</Button>
+					</div>
+					<Button as="a" className="yst-mt-4" variant="tertiary" onClick={ onClose }>
+						{ __( "Close", "wordpress-seo" ) }
+					</Button>
+				</div>
 			</Modal.Panel>
 		</Modal>
 	);
 };
 
 SiteKitConsentModal.propTypes = {
-	isOpen: PropTypes.bool,
-	onClose: PropTypes.func,
+	isOpen: PropTypes.bool.isRequired,
+	onClose: PropTypes.func.isRequired,
+	onGrantConsent: PropTypes.func,
+	learnMoreLink: PropTypes.string,
+	imageLink: PropTypes.string,
 };

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -47,6 +47,49 @@ Title.defaultProps = {
 };
 
 /**
+ * @param {string} [className] Additional classname for the button.
+ * @param {function} [onClick] Function that is called when the user clicks the button. Defaults to the onClose function from the context.
+ * @param {string} [screenReaderText] The screen reader text. Used when no children are provided.
+ * @param {JSX.node} [children] Possible to override the default screen reader text and X icon.
+ * @returns {JSX.Element} The close button.
+ */
+const CloseButton = forwardRef( ( { className, onClick, screenReaderText, children, ...props }, ref ) => {
+	const { onClose } = useModalContext();
+	const svgAriaProps = useSvgAria();
+
+	return (
+		<div className="yst-modal__close">
+			<button
+				ref={ ref }
+				type="button"
+				onClick={ onClick || onClose }
+				className={ classNames( "yst-modal__close-button", className ) }
+				{ ...props }
+			>
+				{ children || <>
+					<span className="yst-sr-only">{ screenReaderText }</span>
+					<XIcon className="yst-h-6 yst-w-6" { ...svgAriaProps } />
+				</> }
+			</button>
+		</div>
+	);
+} );
+
+CloseButton.displayName = "Modal.CloseButton";
+CloseButton.propTypes = {
+	className: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+	screenReaderText: PropTypes.string,
+	children: PropTypes.node,
+};
+CloseButton.defaultProps = {
+	className: "",
+	screenReaderText: "Close",
+	// eslint-disable-next-line no-undefined
+	children: undefined,
+};
+
+/**
  * @param {JSX.node} children Contents of the modal.
  * @param {string} [className] Additional class names.
  * @param {boolean} [hasCloseButton] Whether the modal has a close button.
@@ -55,25 +98,13 @@ Title.defaultProps = {
  * @returns {JSX.Element} The panel.
  */
 const Panel = forwardRef( ( { children, className = "", hasCloseButton = true, closeButtonScreenReaderText = "Close", ...props }, ref ) => {
-	const { onClose } = useModalContext();
-	const svgAriaProps = useSvgAria();
-
 	return (
 		<Dialog.Panel
 			ref={ ref }
 			className={ classNames( "yst-modal__panel", className ) }
 			{ ...props }
 		>
-			{ hasCloseButton && <div className="yst-modal__close">
-				<button
-					type="button"
-					onClick={ onClose }
-					className="yst-modal__close-button"
-				>
-					<span className="yst-sr-only">{ closeButtonScreenReaderText }</span>
-					<XIcon className="yst-h-6 yst-w-6" { ...svgAriaProps } />
-				</button>
-			</div> }
+			{ hasCloseButton && <CloseButton screenReaderText={ closeButtonScreenReaderText } /> }
 			{ children }
 		</Dialog.Panel>
 	);
@@ -178,6 +209,7 @@ Modal.defaultProps = {
 
 Modal.Panel = Panel;
 Modal.Title = Title;
+Modal.CloseButton = CloseButton;
 Modal.Description = Dialog.Description;
 Modal.Description.displayName = "Modal.Description";
 Modal.Container = Container;

--- a/packages/ui-library/src/components/modal/stories.js
+++ b/packages/ui-library/src/components/modal/stories.js
@@ -5,8 +5,9 @@ import Modal, { classNameMap } from ".";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
 import Button from "../../elements/button";
 import TextInput from "../../elements/text-input";
+import { useModalContext } from "./hooks";
 
-const Template = ( { isOpen: initialIsOpen, onClose: _, children, ...props } ) => {
+const Template = ( { isOpen: initialIsOpen, onClose: _, children, panelProps, ...props } ) => {
 	const [ isOpen, setIsOpen ] = useState( initialIsOpen );
 	const openModal = useCallback( () => setIsOpen( true ), [] );
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
@@ -15,7 +16,7 @@ const Template = ( { isOpen: initialIsOpen, onClose: _, children, ...props } ) =
 		<>
 			<Button onClick={ openModal }>Open modal</Button>
 			<Modal { ...props } isOpen={ isOpen } onClose={ closeModal }>
-				<Modal.Panel>
+				<Modal.Panel { ...panelProps }>
 					{ children }
 				</Modal.Panel>
 			</Modal>
@@ -27,6 +28,7 @@ Template.propTypes = {
 	isOpen: PropTypes.bool,
 	onClose: PropTypes.func,
 	children: PropTypes.node.isRequired,
+	panelProps: PropTypes.object,
 };
 
 export const Factory = {
@@ -48,6 +50,57 @@ export const WithPanel = {
 	},
 	args: {
 		children: "Text inside a panel.",
+	},
+};
+
+const CustomCloseButton = ( props ) => {
+	const { onClose } = useModalContext();
+
+	return <Button { ...props } onClick={ onClose } />;
+};
+
+export const WithPanelAndAdjustedCloseButton = {
+	name: "With panel and adjusted close button",
+	parameters: {
+		controls: { disable: false },
+		docs: {
+			description: {
+				story: "Using the `Modal.Panel` component with an adjusted `Modal.CloseButton`.",
+			},
+		},
+	},
+	args: {
+		children: <>
+			<Modal.CloseButton className="yst-bg-transparent yst-text-gray-500 focus:yst-ring-offset-0" screenReaderText="Close" />
+			<p>Using the <strong>className</strong> prop to change the styling. Works nicely if the modal has a different background.</p>
+		</>,
+		panelProps: {
+			className: "yst-bg-gradient-to-b yst-from-primary-500/25 yst-to-[80%]",
+			hasCloseButton: false,
+		},
+	},
+};
+
+export const WithPanelAndCustomCloseButton = {
+	name: "With panel and custom close button",
+	parameters: {
+		controls: { disable: false },
+		docs: {
+			description: {
+				story: "Using the `Modal.Panel` component with a custom close button. The close button is a separate component and can be styled and positioned as needed.",
+			},
+		},
+	},
+	args: {
+		children: <div className="yst-flex yst-flex-col yst-gap-2">
+			<p>
+				Below is now the custom close button. It uses the <strong>useModalContext</strong> hook to get the <strong>onClose</strong> function.
+			</p>
+			<CustomCloseButton className="yst-w-fit yst-self-center" variant="primary">Close</CustomCloseButton>
+		</div>,
+		panelProps: {
+			hasCloseButton: false,
+		},
 	},
 };
 
@@ -175,7 +228,16 @@ export default {
 			description: {
 				component: "An uncontrolled modal component. For the purpose of this story, the `children`, `isOpen` and `onClose` are wrapped. So be aware that in the `Show code`, these are not reflected!",
 			},
-			page: () => <InteractiveDocsPage stories={ [ WithPanel, WithTitleAndDescription, WithContainer, InitialFocus ] } />,
+			page: () => <InteractiveDocsPage
+				stories={ [
+					WithPanel,
+					WithPanelAndAdjustedCloseButton,
+					WithPanelAndCustomCloseButton,
+					WithTitleAndDescription,
+					WithContainer,
+					InitialFocus,
+				] }
+			/>,
 		},
 	},
 	args: {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* UI only

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library 0.0.1] Exposes the `Modal.Panel`' close button as `Modal.CloseButton`. For easier styling overrides via the `className` prop.

## Relevant technical choices:

* Extracted the close button to prevent having to import the `introduction.css` for the button styling override. As there is no way to target that in JS before this patch
* Added the modal itself, and tested with https://github.com/Yoast/wordpress-seo/pull/21946 -- but now pointing to `trunk` because of force pushes and things. So lets get that merged before testing this.
* The image in the design is just a placeholder, real image coming soon ™️ 
* The shortlink should be: http://yoa.st/sitekit-consent-learn-more -- actual query params need to be added later
* Granting of consent in the backend is coming soon ™️ -- will need adjustment here
* The install flow in the widget will need to tie this together later too

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### UI library: Modal.CloseButton
* Start the storybook: `yarn workspace @yoast/ui-library storybook`
* Go to the modal story
* Check the new stories
  * With panel and adjusted close button -- this is the situation the consent modal uses it for
  * With panel and custom close button  -- this is just some extra documentation on an already pre-existing possibility
* Regression: verify the old stories work the same, especially the With panel.

#### Consent modal
* Not being able to test the actual granting of consent yet, awaiting backend
* Please verify against the design as per the issue.
  * Note that the image in the design is just a placeholder, hence me skipping that
  * Verify the learn more link without params is: http://yoa.st/sitekit-consent-learn-more

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* No need to test this PR separately. This is the initial implementation of the UI for the consent of the Site kit.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/415
