### PR TITLE
Add SEO scores in top pages endpoint

### DIFF
--- a/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
+++ b/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
@@ -1,0 +1,57 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Dashboard\Application\Score_Groups\SEO_Score_Groups;
+
+use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\No_SEO_Score_Group;
+use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Interface;
+
+/**
+ * The repository to get SEO score groups.
+ */
+class SEO_Score_Groups_Repository {
+
+	/**
+	 * All SEO score groups.
+	 *
+	 * @var SEO_Score_Groups_Interface[]
+	 */
+	private $seo_score_groups;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param SEO_Score_Groups_Interface ...$seo_score_groups All SEO score groups.
+	 */
+	public function __construct(
+		SEO_Score_Groups_Interface ...$seo_score_groups
+	) {
+		$this->seo_score_groups = $seo_score_groups;
+	}
+
+	/**
+	 * Returns the SEO score group that a SEO score belongs to.
+	 *
+	 * @param int $seo_score The SEO score to be assigned into a group.
+	 *
+	 * @return SEO_Score_Groups_Interface The SEO score group that the SEO score belongs to.
+	 */
+	public function get_seo_score_group( ?int $seo_score ): SEO_Score_Groups_Interface {
+		if ( $seo_score === null || $seo_score === 0 ) {
+			return new No_SEO_Score_Group();
+		}
+
+		foreach ( $this->seo_score_groups as $seo_score_group ) {
+			if ( $seo_score_group->get_max_score() === null ) {
+				continue;
+			}
+
+			if ( $seo_score >= $seo_score_group->get_min_score() && $seo_score <= $seo_score_group->get_max_score() ) {
+				return $seo_score_group;
+			}
+		}
+
+		return new No_SEO_Score_Group();
+	}
+}

--- a/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
+++ b/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
@@ -52,6 +52,7 @@ class SEO_Score_Groups_Repository {
 			}
 		}
 
+		// @TODO: Consider throwing an exception here, when we deal with error handling.
 		return new No_SEO_Score_Group();
 	}
 }

--- a/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
+++ b/src/dashboard/application/score-groups/seo-score-groups/seo-score-groups-repository.php
@@ -52,7 +52,6 @@ class SEO_Score_Groups_Repository {
 			}
 		}
 
-		// @TODO: Consider throwing an exception here, when we deal with error handling.
 		return new No_SEO_Score_Group();
 	}
 }

--- a/src/dashboard/application/search-rankings/top-page-repository.php
+++ b/src/dashboard/application/search-rankings/top-page-repository.php
@@ -42,11 +42,13 @@ class Top_Page_Repository implements Dashboard_Repository_Interface {
 	}
 
 	/**
-	 * Method to get search related data from a provider.
+	 * Gets the top pages' data.
 	 *
-	 * @param Parameters $parameters The parameter to get the search data for.
+	 * @param Parameters $parameters The parameter to use for getting the top pages.
 	 *
 	 * @return Data_Container
+	 *
+	 * @throws Exception When getting the top pages' data fails.
 	 */
 	public function get_data( Parameters $parameters ): Data_Container {
 

--- a/src/dashboard/application/search-rankings/top-page-repository.php
+++ b/src/dashboard/application/search-rankings/top-page-repository.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Dashboard\Application\Search_Rankings;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Dashboard_Repository_Interface;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Parameters;
+use Yoast\WP\SEO\Dashboard\Infrastructure\Indexables\Top_Page_Indexable_Collector;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Search_Console\Site_Kit_Search_Console_Adapter;
 
 /**
@@ -20,12 +21,24 @@ class Top_Page_Repository implements Dashboard_Repository_Interface {
 	private $site_kit_search_console_adapter;
 
 	/**
+	 * The top page indexable collector.
+	 *
+	 * @var Top_Page_Indexable_Collector $top_page_indexable_collector
+	 */
+	private $top_page_indexable_collector;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param Site_Kit_Search_Console_Adapter $site_kit_search_console_adapter The adapter.
+	 * @param Top_Page_Indexable_Collector    $top_page_indexable_collector    The top page indexable collector.
 	 */
-	public function __construct( Site_Kit_Search_Console_Adapter $site_kit_search_console_adapter ) {
+	public function __construct(
+		Site_Kit_Search_Console_Adapter $site_kit_search_console_adapter,
+		Top_Page_Indexable_Collector $top_page_indexable_collector
+	) {
 		$this->site_kit_search_console_adapter = $site_kit_search_console_adapter;
+		$this->top_page_indexable_collector    = $top_page_indexable_collector;
 	}
 
 	/**
@@ -37,6 +50,9 @@ class Top_Page_Repository implements Dashboard_Repository_Interface {
 	 */
 	public function get_data( Parameters $parameters ): Data_Container {
 
-		return $this->site_kit_search_console_adapter->get_data( $parameters );
+		$top_pages                 = $this->site_kit_search_console_adapter->get_data( $parameters );
+		$top_pages_with_seo_scores = $this->top_page_indexable_collector->get_seo_scores( $top_pages );
+
+		return $top_pages_with_seo_scores;
 	}
 }

--- a/src/dashboard/domain/data-provider/data-container.php
+++ b/src/dashboard/domain/data-provider/data-container.php
@@ -8,7 +8,7 @@ namespace Yoast\WP\SEO\Dashboard\Domain\Data_Provider;
 class Data_Container {
 
 	/**
-	 * All the search data points.
+	 * All the data points.
 	 *
 	 * @var array<Data_Interface> $data_container
 	 */
@@ -33,9 +33,18 @@ class Data_Container {
 	}
 
 	/**
-	 * Converts the list to an array.
+	 * Method to get all the data points.
 	 *
-	 * @return array<string,string> The array of endpoints.
+	 * @return Data_Interface[] All the data points.
+	 */
+	public function get_data(): array {
+		return $this->data_container;
+	}
+
+	/**
+	 * Converts the data points into an array.
+	 *
+	 * @return array<string,string> The array of the data points.
 	 */
 	public function to_array(): array {
 		$result = [];

--- a/src/dashboard/domain/search-console/failed-request-exception.php
+++ b/src/dashboard/domain/search-console/failed-request-exception.php
@@ -1,0 +1,20 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Dashboard\Domain\Search_Console;
+
+use Exception;
+
+/**
+ * Exception for when a search console request fails.
+ */
+class Failed_Request_Exception extends Exception {
+
+	/**
+	 * Constructor of the exception.
+	 *
+	 * @param string $error The error of the request.
+	 */
+	public function __construct( $error ) {
+		parent::__construct( 'The Search Console request failed: ' . $error, 500 );
+	}
+}

--- a/src/dashboard/domain/search-rankings/search-data.php
+++ b/src/dashboard/domain/search-rankings/search-data.php
@@ -10,28 +10,28 @@ use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Interface;
 class Search_Data implements Data_Interface {
 
 	/**
-	 * The amount of clicks a `key` gets.
+	 * The amount of clicks a `subject` gets.
 	 *
 	 * @var int $clicks
 	 */
 	private $clicks;
 
 	/**
-	 * The click-through rate a `key` gets.
+	 * The click-through rate a `subject` gets.
 	 *
 	 * @var float $clicks
 	 */
 	private $ctr;
 
 	/**
-	 * The amount of impressions a `key` gets.
+	 * The amount of impressions a `subject` gets.
 	 *
 	 * @var int $impressions
 	 */
 	private $impressions;
 
 	/**
-	 * The average position for the given `key`.
+	 * The average position for the given `subject`.
 	 *
 	 * @var float $position
 	 */
@@ -43,13 +43,6 @@ class Search_Data implements Data_Interface {
 	 * @var string
 	 */
 	private $subject;
-
-	/**
-	 * The seo score.
-	 *
-	 * @var int
-	 */
-	private $seo_score;
 
 	/**
 	 * The constructor.
@@ -66,7 +59,6 @@ class Search_Data implements Data_Interface {
 		$this->impressions = $impressions;
 		$this->position    = $position;
 		$this->subject     = $subject;
-		$this->seo_score   = 0;
 	}
 
 	/**
@@ -81,7 +73,15 @@ class Search_Data implements Data_Interface {
 			'impressions' => $this->impressions,
 			'position'    => $this->position,
 			'subject'     => $this->subject,
-			'seoScore'    => $this->seo_score,
 		];
+	}
+
+	/**
+	 * Gets the subject.
+	 *
+	 * @return string The subject.
+	 */
+	public function get_subject(): string {
+		return $this->subject;
 	}
 }

--- a/src/dashboard/domain/search-rankings/top-page-data.php
+++ b/src/dashboard/domain/search-rankings/top-page-data.php
@@ -1,10 +1,9 @@
 <?php
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
-namespace Yoast\WP\SEO\Dashboard\Domain\Top_Pages;
+namespace Yoast\WP\SEO\Dashboard\Domain\Search_Rankings;
 
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Interface;
 use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Interface;
-use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Search_Data;
 
 /**
  * Domain object that represents a single Top Page Data record.

--- a/src/dashboard/domain/top-pages/top-page-data.php
+++ b/src/dashboard/domain/top-pages/top-page-data.php
@@ -1,0 +1,50 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Dashboard\Domain\Top_Pages;
+
+use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Interface;
+use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Interface;
+use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Search_Data;
+
+/**
+ * Domain object that represents a single Top Page Data record.
+ */
+class Top_Page_Data implements Data_Interface {
+
+	/**
+	 * The search data for the top page.
+	 *
+	 * @var Search_Data $search_data
+	 */
+	private $search_data;
+
+	/**
+	 * The SEO score group the top page belongs to.
+	 *
+	 * @var SEO_Score_Groups_Interface
+	 */
+	private $seo_score_group;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Search_Data                $search_data     The search data for the top page.
+	 * @param SEO_Score_Groups_Interface $seo_score_group The SEO score group the top page belongs to.
+	 */
+	public function __construct( Search_Data $search_data, SEO_Score_Groups_Interface $seo_score_group ) {
+		$this->search_data     = $search_data;
+		$this->seo_score_group = $seo_score_group;
+	}
+
+	/**
+	 * The array representation of this domain object.
+	 *
+	 * @return array<string|float|int|string[]>
+	 */
+	public function to_array(): array {
+		$top_page_data             = $this->search_data->to_array();
+		$top_page_data['seoScore'] = $this->seo_score_group->get_name();
+
+		return $top_page_data;
+	}
+}

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -3,7 +3,6 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Dashboard\Infrastructure\Indexables;
 
-use WP_Error;
 use Yoast\WP\SEO\Dashboard\Application\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Repository;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
 use Yoast\WP\SEO\Dashboard\Domain\Top_Pages\Top_Page_Data;

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Dashboard\Infrastructure\Indexables;
 
 use Yoast\WP\SEO\Dashboard\Application\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Repository;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
-use Yoast\WP\SEO\Dashboard\Domain\Top_Pages\Top_Page_Data;
+use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Top_Page_Data;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -1,0 +1,77 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Dashboard\Infrastructure\Indexables;
+
+use WP_Error;
+use Yoast\WP\SEO\Dashboard\Application\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Repository;
+use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
+use Yoast\WP\SEO\Dashboard\Domain\Top_Pages\Top_Page_Data;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+
+/**
+ * The indexable collector that gets SEO scores from the indexables of top pages.
+ */
+class Top_Page_Indexable_Collector {
+
+	/**
+	 * The indexable repository.
+	 *
+	 * @var Indexable_Repository $indexable_repository
+	 */
+	private $indexable_repository;
+
+	/**
+	 * The SEO score groups repository.
+	 *
+	 * @var SEO_Score_Groups_Repository $seo_score_groups_repository
+	 */
+	private $seo_score_groups_repository;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Indexable_Repository        $indexable_repository        The indexable repository.
+	 * @param SEO_Score_Groups_Repository $seo_score_groups_repository The SEO score groups repository.
+	 */
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		SEO_Score_Groups_Repository $seo_score_groups_repository
+	) {
+		$this->indexable_repository        = $indexable_repository;
+		$this->seo_score_groups_repository = $seo_score_groups_repository;
+	}
+
+	/**
+	 * Gets SEO scores for top pages.
+	 *
+	 * @param Data_Container $top_pages The top pages.
+	 *
+	 * @return Data_Container Data about SEO scores of top pages.
+	 */
+	public function get_seo_scores( Data_Container $top_pages ): Data_Container {
+		$top_page_data_container = new Data_Container();
+
+		foreach ( $top_pages->get_data() as $top_page ) {
+			$url = $top_page->get_subject();
+
+			/**
+			 * Filter: 'wpseo_transform_dashboard_url_for_testing' - Allows overriding the URLs for the dashboard, to facilitate testing in local environments.
+			 *
+			 * @internal
+			 *
+			 * @param string $url The URL to be transformed.
+			 */
+			$url = \apply_filters( 'wpseo_transform_dashboard_url_for_testing', $url );
+
+			$indexable = $this->indexable_repository->find_by_permalink( $url );
+			$seo_score = ( $indexable ) ? $indexable->primary_focus_keyword_score : 0;
+
+			$seo_score_group = $this->seo_score_groups_repository->get_seo_score_group( $seo_score );
+
+			$top_page_data_container->add_data( new Top_Page_Data( $top_page, $seo_score_group ) );
+		}
+
+		return $top_page_data_container;
+	}
+}

--- a/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
+++ b/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
@@ -7,8 +7,8 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit\Plugin;
-use WP_Error;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
+use Yoast\WP\SEO\Dashboard\Domain\Search_Console\Failed_Request_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Search_Data;
 
 /**
@@ -41,7 +41,9 @@ class Site_Kit_Search_Console_Adapter {
 	 *
 	 * @param Search_Console_Parameters $parameters The parameters.
 	 *
-	 * @return Data_Container|WP_Error Data on success, or WP_Error on failure.
+	 * @return Data_Container The Site Kit API response.
+	 *
+	 * @throws Failed_Request_Exception When the query of getting score results fails.
 	 */
 	public function get_data( Search_Console_Parameters $parameters ): Data_Container {
 		$api_parameters = [
@@ -54,6 +56,10 @@ class Site_Kit_Search_Console_Adapter {
 		];
 
 		$data_rows = self::$search_console_module->get_data( 'searchanalytics', $api_parameters );
+
+		if ( \is_wp_error( $data_rows ) ) {
+			throw new Failed_Request_Exception( \wp_kses_post( $data_rows->get_error_message() ) );
+		}
 
 		$search_data_container = new Data_Container();
 		foreach ( $data_rows as $ranking ) {

--- a/src/dashboard/user-interface/search-rankings/abstract-ranking-route.php
+++ b/src/dashboard/user-interface/search-rankings/abstract-ranking-route.php
@@ -138,7 +138,7 @@ abstract class Abstract_Ranking_Route implements Route_Interface {
 			$this->request_parameters->set_start_date( $date->format( 'Y-m-d' ) );
 			$this->request_parameters->set_end_date( ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d' ) );
 
-			$search_data_container = $this->search_rankings_repository->get_data( $this->request_parameters );
+			$search_rankings_container = $this->search_rankings_repository->get_data( $this->request_parameters );
 
 		} catch ( Exception $exception ) {
 			return new WP_REST_Response(
@@ -150,7 +150,7 @@ abstract class Abstract_Ranking_Route implements Route_Interface {
 		}
 
 		return new WP_REST_Response(
-			$search_data_container->to_array(),
+			$search_rankings_container->to_array(),
 			200
 		);
 	}

--- a/src/dashboard/user-interface/search-rankings/abstract-ranking-route.php
+++ b/src/dashboard/user-interface/search-rankings/abstract-ranking-route.php
@@ -112,7 +112,9 @@ abstract class Abstract_Ranking_Route implements Route_Interface {
 						'limit' => [
 							'required'          => true,
 							'type'              => 'int',
-							'sanitize_callback' => 'sanitize_text_field',
+							'sanitize_callback' => static function ( $param ) {
+								return \intval( $param );
+							},
 							'default'           => 5,
 						],
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds SEO scores in the top 5 pages endpoint

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Prepare your local environment by following the `Using the feature in Local site with data from Production site` section in [the relevant doc](https://docs.google.com/document/d/1wnUbAFtVtkGbtmuW-In02YxaUjyCaHOhzgww1eo9Kc8/edit?usp=sharing) to connect your local site with a site with data, to facilitate the below steps.
  * You can use the everydayimtravelling.com site for this.
* Use POSTMAN to do a GET request to your site's `https://example.com/wp-json/yoast/v1/top_pages?limit=5` (use the steps in [that article](https://www.oasisworkflow.com/how-to-authenticate-wp-rest-apis-with-postman) to do authenticated requests)
* Confirm you get a response like the below (the numbers might fluctuate, but the attributes should be the same):
<details>
  <summary>Response</summary>

  ```json
[
    {
        "clicks": 12,
        "ctr": 0.1875,
        "impressions": 64,
        "position": 26.859375,
        "subject": "https://everydayimtravelling.com/",
        "seoScore": "notAnalyzed"
    },
    {
        "clicks": 1,
        "ctr": 0.076923076923076927,
        "impressions": 13,
        "position": 26.692307692307693,
        "subject": "https://everydayimtravelling.com/ohrid-the-pearl-of-the-balkans/",
        "seoScore": "good"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 5,
        "position": 28.600000000000001,
        "subject": "https://everydayimtravelling.com/a-4-day-budget-holiday-in-livorno-2/",
        "seoScore": "good"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 17,
        "position": 20.470588235294116,
        "subject": "https://everydayimtravelling.com/contact-us/",
        "seoScore": "ok"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 7,
        "position": 2.4285714285714288,
        "subject": "https://everydayimtravelling.com/page/2/",
        "seoScore": "notAnalyzed"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 11,
        "position": 12.181818181818182,
        "subject": "https://everydayimtravelling.com/pagina-van-hermelientje/",
        "seoScore": "notAnalyzed"
    }
]
  ```
</details>

* Go to the indexable db table for each of those pages and confirm that the `seoScore` attribute for each is what you expected based on the `primary_focus_keyword_score` column (below 40 is a bad score, between 40 and 70 it's an ok score, above 70 it's a good score and NULL or 0 is a notAnalyzed score
  * Or you can find each of those URLs in the posts/pages/etc page and check the SEO score bullets straight away
*  Find the post/page/etc of one of the listed URLs, that doesn't have a `notAnalyzed` seoScore and remove its keyword from the admin
  * Repeat the above request and confirm you now get `notAnalyzed` instead of a `bad/ok/good` score
* Try to increase/decrease the SEO score of one of the URLs listed, repeat the request and confirm you now get the updated SEO score
  * For easier testing, you can also manually tweak the SEO score in the indexable table by finding the ID of the post you want to tweak and change the `primary_focus_keyword_score` column accordingly. 
  * Just make the same change in that post's postmeta, specifically the `_yoast_wpseo_linkdex` one
* Reset your indexables and repeat the request - confirm you now get `notAnalyzed` for all URLs.

**Impact on the search queries endpoint**:
* Do a GET request to your site's `https://example.com/wp-json/yoast/v1/top_queries?limit=5`
* Confirm you get a response like the below:
<details>
  <summary>Response</summary>

```json
[
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 8,
        "position": 11.875,
        "subject": "eat travel love"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 2,
        "position": 92.5,
        "subject": "every day travel"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 1,
        "position": 11,
        "subject": "everyday travels"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 3,
        "position": 84.666666666666671,
        "subject": "i am traveling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 7,
        "position": 79.857142857142861,
        "subject": "i am travelling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 3,
        "position": 24,
        "subject": "i m traveling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 1,
        "position": 66,
        "subject": "i'm traveling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 1,
        "position": 40,
        "subject": "i'm travelling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 6,
        "position": 44.5,
        "subject": "im traveling"
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 2,
        "position": 59,
        "subject": "lake ohrid pearls"
    }
]
```
</details>

**Error handling**:
* To test errored responses, you can test on a local site and disconnect your PC from the internet before you do the GET request
  * In that case, you would expect a 500 response with the `{ "error": "The Search Console request failed: cURL error 6: Could not resolve host: searchconsole.googleapis.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)" }` body
* If you dont test on a local site, another way would be to authenticate your POSTMAN requests using a user that is not the one that has granted access to sitekit.
  * Doing so, you would expect a 500 response with the `{ "error": "The Search Console request failed: Site Kit can’t access the relevant data from Search Console because you haven’t granted all permissions requested during setup." }` body

Empty results:
* In `src\dashboard\user-interface\search-rankings\abstract-ranking-route.php`, find the following code
```
			$this->request_parameters->set_start_date( $date->format( 'Y-m-d' ) );
			$this->request_parameters->set_end_date( ( new DateTime( 'now', new DateTimeZone( 'UTC' ) ) )->format( 'Y-m-d' ) );
```
and replace it with 
```
			$this->request_parameters->set_start_date( '2020-01-01' );
			$this->request_parameters->set_end_date( '2020-01-02' );
```
* That way, you make a request for a single day 5 years ago, so the results will be no results.
* Confirm that you get an empty array as a response.
* 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/412
