### PR TITLE
Improves the Top 5 pages endpoint

### DIFF
--- a/src/dashboard/application/search-rankings/top-page-repository.php
+++ b/src/dashboard/application/search-rankings/top-page-repository.php
@@ -52,9 +52,9 @@ class Top_Page_Repository implements Dashboard_Repository_Interface {
 	 */
 	public function get_data( Parameters $parameters ): Data_Container {
 
-		$top_pages                 = $this->site_kit_search_console_adapter->get_data( $parameters );
-		$top_pages_with_seo_scores = $this->top_page_indexable_collector->get_seo_scores( $top_pages );
+		$top_pages_search_data = $this->site_kit_search_console_adapter->get_data( $parameters );
+		$top_pages_full_data   = $this->top_page_indexable_collector->get_data( $top_pages_search_data );
 
-		return $top_pages_with_seo_scores;
+		return $top_pages_full_data;
 	}
 }

--- a/src/dashboard/domain/search-console/failed-request-exception.php
+++ b/src/dashboard/domain/search-console/failed-request-exception.php
@@ -12,9 +12,10 @@ class Failed_Request_Exception extends Exception {
 	/**
 	 * Constructor of the exception.
 	 *
-	 * @param string $error The error of the request.
+	 * @param string $error_message     The error message of the request.
+	 * @param int    $error_status_code The error status code of the request.
 	 */
-	public function __construct( $error ) {
-		parent::__construct( 'The Search Console request failed: ' . $error, 500 );
+	public function __construct( $error_message, $error_status_code ) {
+		parent::__construct( 'The Search Console request failed: ' . $error_message, $error_status_code );
 	}
 }

--- a/src/dashboard/domain/search-rankings/top-page-data.php
+++ b/src/dashboard/domain/search-rankings/top-page-data.php
@@ -25,14 +25,27 @@ class Top_Page_Data implements Data_Interface {
 	private $seo_score_group;
 
 	/**
+	 * The edit link of the top page.
+	 *
+	 * @var string $edit_link
+	 */
+	private $edit_link;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param Search_Data                $search_data     The search data for the top page.
 	 * @param SEO_Score_Groups_Interface $seo_score_group The SEO score group the top page belongs to.
+	 * @param string                     $edit_link       The edit link of the top page.
 	 */
-	public function __construct( Search_Data $search_data, SEO_Score_Groups_Interface $seo_score_group ) {
+	public function __construct(
+		Search_Data $search_data,
+		SEO_Score_Groups_Interface $seo_score_group,
+		?string $edit_link = null
+	) {
 		$this->search_data     = $search_data;
 		$this->seo_score_group = $seo_score_group;
+		$this->edit_link       = $edit_link;
 	}
 
 	/**
@@ -43,6 +56,11 @@ class Top_Page_Data implements Data_Interface {
 	public function to_array(): array {
 		$top_page_data             = $this->search_data->to_array();
 		$top_page_data['seoScore'] = $this->seo_score_group->get_name();
+		$top_page_data['links']    = [];
+
+		if ( $this->edit_link !== null ) {
+			$top_page_data['links']['edit'] = $this->edit_link;
+		}
 
 		return $top_page_data;
 	}

--- a/src/dashboard/infrastructure/endpoints/search-rankings/top-query-endpoint.php
+++ b/src/dashboard/infrastructure/endpoints/search-rankings/top-query-endpoint.php
@@ -19,7 +19,7 @@ class Top_Query_Endpoint implements Endpoint_Interface {
 	 * @return string
 	 */
 	public function get_name(): string {
-		return 'topPageResults';
+		return 'topQueryResults';
 	}
 
 	/**

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -5,7 +5,9 @@ namespace Yoast\WP\SEO\Dashboard\Infrastructure\Indexables;
 
 use Yoast\WP\SEO\Dashboard\Application\Score_Groups\SEO_Score_Groups\SEO_Score_Groups_Repository;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
+use Yoast\WP\SEO\Dashboard\Domain\Score_Groups\SEO_Score_Groups\No_SEO_Score_Group;
 use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Top_Page_Data;
+use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
@@ -42,13 +44,13 @@ class Top_Page_Indexable_Collector {
 	}
 
 	/**
-	 * Gets SEO scores for top pages.
+	 * Gets full data for top pages.
 	 *
 	 * @param Data_Container $top_pages The top pages.
 	 *
 	 * @return Data_Container Data about SEO scores of top pages.
 	 */
-	public function get_seo_scores( Data_Container $top_pages ): Data_Container {
+	public function get_data( Data_Container $top_pages ): Data_Container {
 		$top_page_data_container = new Data_Container();
 
 		foreach ( $top_pages->get_data() as $top_page ) {
@@ -63,14 +65,56 @@ class Top_Page_Indexable_Collector {
 			 */
 			$url = \apply_filters( 'wpseo_transform_dashboard_url_for_testing', $url );
 
-			$indexable = $this->indexable_repository->find_by_permalink( $url );
-			$seo_score = ( $indexable ) ? $indexable->primary_focus_keyword_score : 0;
+			$indexable = $this->get_top_page_indexable( $url );
 
-			$seo_score_group = $this->seo_score_groups_repository->get_seo_score_group( $seo_score );
+			if ( $indexable instanceof Indexable ) {
+				$seo_score_group = $this->seo_score_groups_repository->get_seo_score_group( $indexable->primary_focus_keyword_score );
+				$edit_link       = $this->get_top_page_edit_link( $indexable );
 
+				$top_page_data_container->add_data( new Top_Page_Data( $top_page, $seo_score_group, $edit_link ) );
+
+				continue;
+			}
+
+			$seo_score_group = new No_SEO_Score_Group();
 			$top_page_data_container->add_data( new Top_Page_Data( $top_page, $seo_score_group ) );
 		}
 
 		return $top_page_data_container;
+	}
+
+	/**
+	 * Gets indexable for a top page URL.
+	 *
+	 * @param string $url The URL of the top page.
+	 *
+	 * @return bool|Indexable The indexable of the top page URL or false if there is none.
+	 */
+	protected function get_top_page_indexable( string $url ) {
+		// First check if the URL is the static homepage.
+		if ( \trailingslashit( $url ) === \trailingslashit( \get_home_url() ) && \get_option( 'show_on_front' ) === 'page' ) {
+			return $this->indexable_repository->find_by_id_and_type( \get_option( 'page_on_front' ), 'post' );
+		}
+
+		return $this->indexable_repository->find_by_permalink( $url );
+	}
+
+	/**
+	 * Gets edit links from a top page's indexable.
+	 *
+	 * @param Indexable $indexable The top page's indexable.
+	 *
+	 * @return string|null The edit link for the top page.
+	 */
+	protected function get_top_page_edit_link( Indexable $indexable ): ?string {
+		if ( $indexable->object_type === 'post' ) {
+			return \get_edit_post_link( $indexable->object_id, '&' );
+		}
+
+		if ( $indexable->object_type === 'term' ) {
+			return \get_edit_term_link( $indexable->object_id );
+		}
+
+		return null;
 	}
 }

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -84,7 +84,7 @@ class Top_Page_Indexable_Collector {
 	protected function get_top_page_indexable( string $url ) {
 		// First check if the URL is the static homepage.
 		if ( \trailingslashit( $url ) === \trailingslashit( \get_home_url() ) && \get_option( 'show_on_front' ) === 'page' ) {
-			return $this->indexable_repository->find_by_id_and_type( \get_option( 'page_on_front' ), 'post' );
+			return $this->indexable_repository->find_by_id_and_type( \get_option( 'page_on_front' ), 'post', false );
 		}
 
 		return $this->indexable_repository->find_by_permalink( $url );

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -56,15 +56,6 @@ class Top_Page_Indexable_Collector {
 		foreach ( $top_pages->get_data() as $top_page ) {
 			$url = $top_page->get_subject();
 
-			/**
-			 * Filter: 'wpseo_transform_dashboard_url_for_testing' - Allows overriding the URLs for the dashboard, to facilitate testing in local environments.
-			 *
-			 * @internal
-			 *
-			 * @param string $url The URL to be transformed.
-			 */
-			$url = \apply_filters( 'wpseo_transform_dashboard_url_for_testing', $url );
-
 			$indexable = $this->get_top_page_indexable( $url );
 
 			if ( $indexable instanceof Indexable ) {

--- a/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
+++ b/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
@@ -65,7 +65,16 @@ class Site_Kit_Search_Console_Adapter {
 
 		$search_data_container = new Data_Container();
 		foreach ( $data_rows as $ranking ) {
-			$search_data_container->add_data( new Search_Data( $ranking->clicks, $ranking->ctr, $ranking->impressions, $ranking->position, $ranking->keys[0] ) );
+			/**
+			 * Filter: 'wpseo_transform_dashboard_subject_for_testing' - Allows overriding subjects like URLs for the dashboard, to facilitate testing in local environments.
+			 *
+			 * @internal
+			 *
+			 * @param string $url The subject to be transformed.
+			 */
+			$subject = \apply_filters( 'wpseo_transform_dashboard_subject_for_testing', $ranking->keys[0] );
+
+			$search_data_container->add_data( new Search_Data( $ranking->clicks, $ranking->ctr, $ranking->impressions, $ranking->position, $subject ) );
 		}
 
 		return $search_data_container;

--- a/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
+++ b/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
@@ -58,7 +58,9 @@ class Site_Kit_Search_Console_Adapter {
 		$data_rows = self::$search_console_module->get_data( 'searchanalytics', $api_parameters );
 
 		if ( \is_wp_error( $data_rows ) ) {
-			throw new Failed_Request_Exception( \wp_kses_post( $data_rows->get_error_message() ) );
+			$error_data        = $data_rows->get_error_data();
+			$error_status_code = ( $error_data['status'] ?? 500 );
+			throw new Failed_Request_Exception( \wp_kses_post( $data_rows->get_error_message() ), (int) $error_status_code );
 		}
 
 		$search_data_container = new Data_Container();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the `Top 5 pages` endpoint with edit links for the URLs
* Enhances the `Top 5 pages` endpoint with better response status codes when site kit requests fail.
* Fixes the endpoints that are included in the dashboard scriptdata.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
* Prepare your local environment by following the `Using the feature in Local site with data from Production site` section in [the relevant doc](https://docs.google.com/document/d/1wnUbAFtVtkGbtmuW-In02YxaUjyCaHOhzgww1eo9Kc8/edit?usp=sharing) to connect your local site with a site with data, to facilitate the below steps.

This PR can be acceptance tested by following these steps:

**For the edit links**:
* The general rule is that you get edit links only:
  * For posts or terms or the homepage (only if the homepage is a static page)
  * When the indexable for that post/term/homepage has been created
* Use POSTMAN to do a GET request to your site's `https://example.com/wp-json/yoast/v1/top_pages?limit=5` (use the steps in [that article](https://www.oasisworkflow.com/how-to-authenticate-wp-rest-apis-with-postman) to do authenticated requests)
* Confirm you get a response like the below (the numbers might fluctuate, but the attributes should be the same):
<details>
  <summary>Response</summary>

  ```json
[
    {
        "clicks": 12,
        "ctr": 0.17910447761194029,
        "impressions": 67,
        "position": 30.895522388059703,
        "subject": "https://sitekit.local/",
        "seoScore": "notAnalyzed",
        "links": []
    },
    {
        "clicks": 1,
        "ctr": 0.055555555555555552,
        "impressions": 18,
        "position": 19.555555555555557,
        "subject": "https://sitekit.local/contact-us/",
        "seoScore": "ok",
        "links": {
            "edit": "http://sitekit.local/wp-admin/post.php?post=5&action=edit"
        }
    },
    {
        "clicks": 1,
        "ctr": 0.1111111111111111,
        "impressions": 9,
        "position": 20.222222222222221,
        "subject": "https://sitekit.local/ohrid-the-pearl-of-the-balkans/",
        "seoScore": "bad",
        "links": {
            "edit": "http://sitekit.local/wp-admin/post.php?post=2258&action=edit"
        }
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 4,
        "position": 21,
        "subject": "https://sitekit.local/a-4-day-budget-holiday-in-livorno-2/",
        "seoScore": "good",
        "links": {
            "edit": "http://sitekit.local/wp-admin/post.php?post=2713&action=edit"
        }
    },
    {
        "clicks": 0,
        "ctr": 0,
        "impressions": 8,
        "position": 2.625,
        "subject": "https://sitekit.local/page/2/",
        "seoScore": "notAnalyzed",
        "links": []
    }
]
  ```
</details>

* For the URLs that point to posts (or pages or any CPT) or terms, confirm that you get a URL in links['edit'] and that it points to the actual edit page for that post/page. Make sure to confirm that both for posts and terms. (if you dont get posts or terms in the results, use the instructions in the `change results for testing` to simulate that)
* Reset indexables and repeat the request. Confirm that you now don't get the URLs in links['edit'] 
* Now re-run the SEO optimization
* For the entry of the homepage (if you dont get the homepage in the results, use the instructions in the `change results for testing` to simulate that), confirm that
  * If in your **Settings->Reading** page you have `your homepage displays - your latest posts`, then you don't get an edit link for that entry
  * If in your **Settings->Reading** page you have `your homepage displays - A static page`, then you do get an edit link for that entry. Also confirm that the edit link actually points to the edit page for the page that's the homepage

**Change results for testing**
* Because we depend on the actual results of sitekit, we need to be able to manipulate those, in order to test what we want
* Identify the URL that you want to test (eg. if you want to test what happens with term URLs, find a URL of a category)
* Change the `wpseo_transform_dashboard_subject_for_testing()` you have in your functions.php to this:
```
add_filter( 'wpseo_transform_dashboard_subject_for_testing', 'transform_dashboard_url_for_testing' );

function transform_dashboard_url_for_testing( $url ) {
    return 'http://sitekit.local/category/category1/'; // THE URL YOU WANT TO TEST
}
```
* After doing so, the request you do will return WP data for that URL 
* Note that the sitekit data (CTR, impressions, etc.) in that response are still about the production site. The things we change are only the WP data (edit links, SEO scores)

**For the proper error status codes**:
* Test on a local site and disconnect your PC from the internet before you do the GET request
  * In that case, you would expect a 500 response with the `{ "error": "The Search Console request failed: cURL error 6: Could not resolve host: searchconsole.googleapis.com (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)" }` body
* To test a different status, another way would be to authenticate your POSTMAN requests using a user that is not the one that has granted access to sitekit.
  * Doing so, you would expect a 403 response with the `{ "error": "The Search Console request failed: Site Kit can’t access the relevant data from Search Console because you haven’t granted all permissions requested during setup." }` body

**For the endpoints**:
* Go to the dashboard page and in the console type `wpseoScriptData.dashboard.endpoints.topPageResults` and `wpseoScriptData.dashboard.endpoints.topQueryResults`
* Confirm that you get `http://example.com/wp-json/yoast/v1/top_pages` and `http://sitekit.local/wp-json/yoast/v1/top_queries` respectively

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/426
