### PR TITLE
Clone the blocks array first before filtering out the invalid blocks and add block length information

### DIFF
--- a/packages/js/src/analysis/collectAnalysisData.js
+++ b/packages/js/src/analysis/collectAnalysisData.js
@@ -58,6 +58,19 @@ export default function collectAnalysisData( editorData, store, customAnalysisDa
 	let blocks = null;
 	if ( blockEditorDataModule ) {
 		blocks = blockEditorDataModule.getBlocks() || [];
+		/*
+		* We need to clone the blocks to prevent the original blocks from being modified.
+		* This is necessary because otherwise, invalid blocks will be removed from the editor.
+		* We are using JSON.parse and JSON.stringify to clone the blocks over lodash.cloneDeep or structuredClone for the following reasons:
+		* - lodash.cloneDeep cannot handle private members of classes from the blocks.
+		* - structuredClone failed in cloning invalid blocks.
+		* - Both methods will result in the analysis failing because the blocks are not cloned correctly.
+		*
+		* We are aware of the performance implications of using JSON.parse and JSON.stringify.
+		* However, considering the reasons we've mentioned above regarding the other methods, and we're running this once and not recursively,
+		* we consider the performance impact to be negligible.
+		* */
+		blocks = JSON.parse( JSON.stringify( blocks ) );
 		blocks = mapGutenbergBlocks( blocks );
 	}
 

--- a/packages/js/tests/collectAnalysisData.test.js
+++ b/packages/js/tests/collectAnalysisData.test.js
@@ -117,7 +117,8 @@ describe( "collectAnalysisData", () => {
 		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
 
 		expect( results._attributes.wpBlocks ).not.toBe( newBlocks );
-		expect( results._attributes.wpBlocks ).not.toContain( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
+		expect( newBlocks ).toContainEqual( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
+		expect( results._attributes.wpBlocks ).not.toContainEqual( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
 	} );
 
 	it( "does not add wpBlocks if no blockEditorDataModule is added", () => {

--- a/packages/js/tests/collectAnalysisData.test.js
+++ b/packages/js/tests/collectAnalysisData.test.js
@@ -105,6 +105,21 @@ describe( "collectAnalysisData", () => {
 		expect( results._attributes.wpBlocks ).toEqual( gutenbergBlocks );
 	} );
 
+	it( "should not modify the original blocks array when filtering", () => {
+		const edit = mockEdit( "<p>some content</p>" );
+		const store = mockStore( storeData );
+		const customData = mockCustomAnalysisData();
+		const pluggable = mockPluggable();
+		const newBlocks = gutenbergBlocks.concat(
+			{ isValid: false, innerBlocks: [], name: "core/paragraph" }
+		);
+		const blockEditorDataModule = mockBlockEditorDataModule( newBlocks );
+		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
+
+		expect( results._attributes.wpBlocks ).not.toBe( newBlocks );
+		expect( results._attributes.wpBlocks ).not.toContain( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
+	} );
+
 	it( "does not add wpBlocks if no blockEditorDataModule is added", () => {
 		const edit = mockEdit( "<p>some content</p>" );
 		const store = mockStore( storeData );

--- a/packages/js/tests/collectAnalysisData.test.js
+++ b/packages/js/tests/collectAnalysisData.test.js
@@ -110,15 +110,23 @@ describe( "collectAnalysisData", () => {
 		const store = mockStore( storeData );
 		const customData = mockCustomAnalysisData();
 		const pluggable = mockPluggable();
-		const newBlocks = gutenbergBlocks.concat(
-			{ isValid: false, innerBlocks: [], name: "core/paragraph" }
-		);
-		const blockEditorDataModule = mockBlockEditorDataModule( newBlocks );
-		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
 
-		expect( results._attributes.wpBlocks ).not.toBe( newBlocks );
-		expect( newBlocks ).toContainEqual( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
-		expect( results._attributes.wpBlocks ).not.toContainEqual( { isValid: false, innerBlocks: [], name: "core/paragraph" } );
+		const getFirstColumnBlocks = ( blocks ) => blocks
+			.find( block => block.name === "core/columns" ).innerBlocks
+			.find( block => block.name === "core/column" ).innerBlocks;
+		const invalidBlock = { isValid: false, innerBlocks: [], name: "core/paragraph" };
+
+		const firstColumnBlocks = getFirstColumnBlocks( gutenbergBlocks );
+		firstColumnBlocks.push( invalidBlock );
+		const blockEditorDataModule = mockBlockEditorDataModule( gutenbergBlocks );
+
+		// The original blocks array should contain the invalid block.
+		expect( getFirstColumnBlocks( gutenbergBlocks ) ).toContainEqual( invalidBlock );
+
+		// When collecting the analysis data, the invalid block should be removed from the results, but not from the original blocks array.
+		const results = collectAnalysisData( edit, store, customData, pluggable, blockEditorDataModule );
+		expect( getFirstColumnBlocks( results._attributes.wpBlocks ) ).not.toContainEqual( invalidBlock );
+		expect( getFirstColumnBlocks( gutenbergBlocks ) ).toContainEqual( invalidBlock );
 	} );
 
 	it( "does not add wpBlocks if no blockEditorDataModule is added", () => {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug where the Yoast SEO analysis removes invalid blocks that display the "Attempt recovery" message.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where invalid inner blocks would be removed when saving a post in the block editor.
 
## Relevant technical choices:

* We are fixing the problem by cloning the blocks array before making any modification to the array.
* This is necessary because otherwise, invalid blocks will be removed from the editor.
* We are using `JSON.parse` and `JSON.stringify` to clone the blocks over `lodash.cloneDeep` or `structuredClone` for the following reasons:
   * [_.cloneDeep](https://lodash.com/docs/4.17.15#cloneDeep) cannot handle private members of classes from the blocks.
   * [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) failed in cloning invalid blocks.
   * Both methods will result in the analysis failing because the blocks are not cloned correctly.
   
* We are aware of the performance implications of using `JSON.parse` and `JSON.stringify`, see [this page](https://medium.com/@pmzubar/why-json-parse-json-stringify-is-a-bad-practice-to-clone-an-object-in-javascript-b28ac5e36521).
* However, considering the reasons we've mentioned above regarding the other methods, and we're running this once and not recursively, we consider the performance impact to be negligible.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate the Yoast SEO plugin.
* Create a post in block/Gutenberg editor
* Add a `core/group` block.
* Add two `core/paragraph` blocks as inner blocks to that group.
* In the second `core/paragraph` block, edit the HTML, change the end tag to `<\/p>`
* Now the second block goes into recovery mode, as it's invalid HTML.
* Save the post
* Confirm that the broken block (the second paragraph block) is still saved and not removed

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Smoke test the highlighting function of Keyphrase density and Passive voice sentence assessment.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/21947
