### PR TITLE
Fix deprecation notices in PHP >= 8.1

### DIFF
--- a/src/presenters/canonical-presenter.php
+++ b/src/presenters/canonical-presenter.php
@@ -46,6 +46,6 @@ class Canonical_Presenter extends Abstract_Indexable_Tag_Presenter {
 		 * @param string                 $canonical    The canonical URL.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		return \urldecode( (string) \trim( \apply_filters( 'wpseo_canonical', $this->presentation->canonical, $this->presentation ) ) );
+		return \urldecode( \trim( (string) \apply_filters( 'wpseo_canonical', $this->presentation->canonical, $this->presentation ) ) );
 	}
 }

--- a/src/presenters/open-graph/title-presenter.php
+++ b/src/presenters/open-graph/title-presenter.php
@@ -38,7 +38,7 @@ class Title_Presenter extends Abstract_Indexable_Tag_Presenter {
 		 * @param string                 $title        The title.
 		 * @param Indexable_Presentation $presentation The presentation of an indexable.
 		 */
-		$title = (string) \trim( \apply_filters( 'wpseo_opengraph_title', $title, $this->presentation ) );
+		$title = \trim( (string) \apply_filters( 'wpseo_opengraph_title', $title, $this->presentation ) );
 		return $this->helpers->string->strip_all_tags( $title );
 	}
 }


### PR DESCRIPTION
## Context
* Fixes #21455

## Summary

This PR can be summarized in the following changelog entry:

* Fixes deprecation notice thrown by the canonical presenter in environments running PHP >= 8.1. Props to [aanduque](https://github.com/aanduque).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* add the following snippet in your theme's functions.php:
```
add_filter( 'wpseo_canonical', function() { return null; } );
add_filter( 'wpseo_opengraph_title', function() { return null; } );
```
* make sure you are running PHP >= 8.1
* make sure `WP_DEBUG` is `true`
* visit a post in the frontend
* without this patch:
  * you get two `trim(): Passing null to parameter #1 ($string) of type string is deprecated` warnings
* with this patch:
  * you don´t  get the warning above

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21455
