### PR TITLE
Don't add edit links in API response if user can't edit posts

### DIFF
--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -98,6 +98,10 @@ class Top_Page_Indexable_Collector {
 	 * @return string|null The edit link for the top page.
 	 */
 	protected function get_top_page_edit_link( Indexable $indexable ): ?string {
+		if ( ! \current_user_can( 'edit_posts' ) ) {
+			return null;
+		}
+
 		if ( $indexable->object_type === 'post' ) {
 			return \get_edit_post_link( $indexable->object_id, '&' );
 		}

--- a/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
+++ b/src/dashboard/infrastructure/indexables/top-page-indexable-collector.php
@@ -98,15 +98,11 @@ class Top_Page_Indexable_Collector {
 	 * @return string|null The edit link for the top page.
 	 */
 	protected function get_top_page_edit_link( Indexable $indexable ): ?string {
-		if ( ! \current_user_can( 'edit_posts' ) ) {
-			return null;
-		}
-
-		if ( $indexable->object_type === 'post' ) {
+		if ( $indexable->object_type === 'post' && \current_user_can( 'edit_post', $indexable->object_id ) ) {
 			return \get_edit_post_link( $indexable->object_id, '&' );
 		}
 
-		if ( $indexable->object_type === 'term' ) {
+		if ( $indexable->object_type === 'term' && \current_user_can( 'edit_term', $indexable->object_id ) ) {
 			return \get_edit_term_link( $indexable->object_id );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where edit links would be shown to users that can't edit posts.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create an SEO manager and authenticate your POSTMAN requests based on that user.
* Add the following filter so that you remove the capability to edit other people's posts:
```
function remove_edit_others_posts_capability() {
    $role = get_role('wpseo_manager'); // Change 'editor' to any role you want to modify

    if ($role) {
        $role->remove_cap('edit_others_posts');
        // $role->remove_cap('edit_terms');
        // $role->remove_cap('manage_categories');
    }
}
add_action('init', 'remove_edit_others_posts_capability');
```
* Deactivate/reactivate Yoast SEO
* Do a request to the top 5 pages endpoint
* Confirm that for every post you get as a result, you see an empty array in the links array element: `"links": []`
  * If you dont get any posts in the results, in the `transform_dashboard_url_for_testing()` function of [the helper doc](https://docs.google.com/document/d/1wnUbAFtVtkGbtmuW-In02YxaUjyCaHOhzgww1eo9Kc8/edit?usp=sharing), make it return early with a post URL, with `return 'http://example.com/post-permalink';`. That way, we simulate site kit returning that URL as a top 5 page (it will actually return all 5 pages as that URL).
* Now create a post with that SEO manager and in the `transform_dashboard_url_for_testing()` function, make it return early with the URL of that post.
* Do the request again and since you're getting 5 results of that URL, confirm that you get an edit link this time in all of them, like ` "links": {  "edit": "http://example.com/wp-admin/post.php?post=5&action=edit" }` and confirm that it points you to the edit page of that post you just created and that you can actually edit that post
* In the `transform_dashboard_url_for_testing()` function, make it return early with the URL of a term
* Do the request again and since you're getting 5 results of that term URL, confirm that you get an edit link this time in all of them, like ` "links": {  "edit": "http://example.com/wp-admin/term.php?taxonomy=category&tag_ID=3&post_type=post" }` and confirm that it points you to the edit page of that term and that you can actually edit that term.
* Now, uncomment the `// $role->remove_cap('edit_terms');` and `// $role->remove_cap('manage_categories');` lines in your filter above and deactivate/reactivate Yoast SEO. That way you remove the capability of editing terms for SEO managers
* Do the request again and confirm that you dont get an edit link for those term results.
* Repeat the above tests as an admin and without the `remove_edit_others_posts_capability` filter you have added above and confirm that you get an edit button in all cases where that's possible (that is, for posts and terms). Also confirm that you can actually go to that edit pages.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/436
