### PR TITLE
Declare required arguments for the site kit configuration endpoints

### DIFF
--- a/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
@@ -68,6 +68,14 @@ class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
 					'methods'             => 'POST',
 					'callback'            => [ $this, 'set_site_kit_configuration_permanent_dismissal' ],
 					'permission_callback' => [ $this, 'check_capabilities' ],
+					'args'                => [
+						'is_dismissed' => [
+							'required'          => true,
+							'type'              => 'bool',
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+
+					],
 				],
 			]
 		);

--- a/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
@@ -68,6 +68,14 @@ class Site_Kit_Consent_Management_Route implements Route_Interface {
 					'methods'             => 'POST',
 					'callback'            => [ $this, 'set_site_kit_consent' ],
 					'permission_callback' => [ $this, 'check_capabilities' ],
+					'args'                => [
+						'consent' => [
+							'required'          => true,
+							'type'              => 'bool',
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+
+					],
 				],
 			]
 		);

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Register_Routes_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Register_Routes_Test.php
@@ -31,6 +31,14 @@ final class Site_Kit_Configuration_Permanent_Dismissal_Route_Register_Routes_Tes
 						'methods'             => 'POST',
 						'callback'            => [ $this->instance, 'set_site_kit_configuration_permanent_dismissal' ],
 						'permission_callback' => [ $this->instance, 'check_capabilities' ],
+						'args'                => [
+							'is_dismissed' => [
+								'required'          => true,
+								'type'              => 'bool',
+								'sanitize_callback' => 'rest_sanitize_boolean',
+							],
+
+						],
 					],
 				]
 			);

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Register_Routes_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Register_Routes_Test.php
@@ -31,6 +31,14 @@ final class Site_Kit_Consent_Management_Route_Register_Routes_Test extends Abstr
 						'methods'             => 'POST',
 						'callback'            => [ $this->instance, 'set_site_kit_consent' ],
 						'permission_callback' => [ $this->instance, 'check_capabilities' ],
+						'args'                => [
+							'consent' => [
+								'required'          => true,
+								'type'              => 'bool',
+								'sanitize_callback' => 'rest_sanitize_boolean',
+							],
+
+						],
 					],
 				]
 			);


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure we don't throw 500 error codes when the endpoint is misused

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the configuration endpoints by declaring their arguments as required.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_manage_consent` with no body

**Without this PR:**
* You would get a 500 error code and a fatal error

**With this PR:**
* You would get a 400 error code telling you that you didnt include the required `consent` argument and no fatal error

---

* Do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_configuration_permanent_dismissal` with no body

**Without this PR:**
* You would get a 500 error code and a fatal error

**With this PR:**
* You would get a 400 error code telling you that you didnt include the required `is_dismissed` argument and no fatal error

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* In a fresh site, do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_manage_consent` with `{ "consent": true }` body
* Go to the wp_options table and confirm that your `site_kit_connected` option is `1`.
* Now do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_manage_consent` with `{ "consent": false}` body
* Go to the wp_options table and confirm that your `site_kit_connected` option is `0`.
* In a fresh site, do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_configuration_permanent_dismissal` with `{ "is_dismissed": true }` body
* Go to the wp_options table and confirm that your `site_kit_configuration_permanently_dismissed` option is `1`.
* Now do a POST request to `https://YOUR_WORDPRESS_SITE/wp-json/yoast/v1/site_kit_manage_consent` with `{ "is_dismissed": false}` body
* Go to the wp_options table and confirm that your `site_kit_configuration_permanently_dismissed` option is `0`.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/437
