### PR TITLE
Add data formatter

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cd ../.. && wp-scripts build --config config/webpack/webpack.config.js",
     "test": "jest",
-    "lint": "eslint . --max-warnings=63"
+    "lint": "eslint . --max-warnings=62"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -68,7 +68,7 @@ export { Dashboard } from "./components/dashboard";
  */
 
 /**
- * @typedef {"seoScores"|"readabilityScores"|"topPages"} WidgetType The widget type.
+ * @typedef {"seoScores"|"readabilityScores"|"topPages"|"siteKitSetup"} WidgetType The widget type.
  */
 
 /**

--- a/packages/js/src/dashboard/services/data-formatter.js
+++ b/packages/js/src/dashboard/services/data-formatter.js
@@ -1,0 +1,81 @@
+import { SCORE_META } from "../scores/score-meta";
+
+/**
+ * @param {string} url The URL.
+ * @returns {URL|null} The URL or null.
+ */
+const safeUrl = ( url ) => {
+	try {
+		return new URL( url );
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * @param {number} data The data.
+ * @param {NumberFormat} numberFormat The number formatter.
+ * @returns {string} The formatted number or number as string.
+ */
+const safeNumberFormat = ( data, numberFormat ) => {
+	try {
+		return numberFormat.format( data );
+	} catch {
+		return data.toString( 10 );
+	}
+};
+
+/**
+ * Knows how to format data.
+ */
+export class DataFormatter {
+	#numberFormat = {};
+
+	/**
+	 * @param {string} [locale] The locale.
+	 */
+	constructor( { locale = "en-US" } = {} ) {
+		this.#numberFormat.nonFractional = new Intl.NumberFormat( locale, { maximumFractionDigits: 0 } );
+		this.#numberFormat.percentage = new Intl.NumberFormat( locale, { style: "percent", minimumFractionDigits: 2, maximumFractionDigits: 2 } );
+		this.#numberFormat.twoFractions = new Intl.NumberFormat( locale, { maximumFractionDigits: 2, minimumFractionDigits: 2 } );
+	}
+
+	/**
+	 * @param {string} link The link.
+	 * @returns {string} The formatted or original link.
+	 */
+	formatLandingPage( link ) {
+		const url = safeUrl( link );
+		if ( url === null ) {
+			return link;
+		}
+
+		// Dropping: protocol, port, search and hash.
+		return [ url.hostname, url.pathname ].join( "" );
+	}
+
+	/**
+	 * @param {*} data The data.
+	 * @param {string} name The name. Used to determine how to format.
+	 * @param {Object} [context] Extra information to determine how to format.
+	 * @returns {*} The formatted or original data.
+	 */
+	// eslint-disable-next-line no-unused-vars
+	format( data, name, context = {} ) { // eslint-disable-line complexity
+		switch ( name ) {
+			case "subject":
+				return this.formatLandingPage( data );
+			case "clicks":
+			case "impressions":
+				return safeNumberFormat( data, this.#numberFormat.nonFractional );
+			case "ctr":
+				return safeNumberFormat( data, this.#numberFormat.percentage );
+			case "position":
+				return safeNumberFormat( data, this.#numberFormat.twoFractions );
+			case "seoScore":
+				return Object.keys( SCORE_META ).includes( data ) ? data : "notAnalyzed";
+			default:
+				return data;
+		}
+	}
+}

--- a/packages/js/src/dashboard/services/data-formatter.js
+++ b/packages/js/src/dashboard/services/data-formatter.js
@@ -50,8 +50,8 @@ export class DataFormatter {
 			return link;
 		}
 
-		// Dropping: protocol, port, search and hash.
-		return [ url.hostname, url.pathname ].join( "" );
+		// Dropping: hostname, protocol, port, search and hash.
+		return url.pathname;
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -14,14 +14,17 @@ import { TopPagesWidget } from "../widgets/top-pages-widget";
 export class WidgetFactory {
 	#dataProvider;
 	#remoteDataProvider;
+	#dataFormatter;
 
 	/**
 	 * @param {import("./data-provider").DataProvider} dataProvider
 	 * @param {import("./remote-data-provider").RemoteDataProvider} remoteDataProvider
+	 * @param {import("./data-formatter").DataFormatter} dataFormatter
 	 */
-	constructor( dataProvider, remoteDataProvider ) {
+	constructor( dataProvider, remoteDataProvider, dataFormatter ) {
 		this.#dataProvider = dataProvider;
 		this.#remoteDataProvider = remoteDataProvider;
+		this.#dataFormatter = dataFormatter;
 	}
 
 	/**
@@ -54,7 +57,12 @@ export class WidgetFactory {
 				}
 				return <ScoreWidget key={ widget.id } analysisType="readability" dataProvider={ this.#dataProvider } remoteDataProvider={ this.#remoteDataProvider } />;
 			case "topPages":
-				return <TopPagesWidget key={ widget.id } dataProvider={ this.#dataProvider } remoteDataProvider={ this.#remoteDataProvider } />;
+				return <TopPagesWidget
+					key={ widget.id }
+					dataProvider={ this.#dataProvider }
+					remoteDataProvider={ this.#remoteDataProvider }
+					dataFormatter={ this.#dataFormatter }
+				/>;
 			case "siteKitSetup":
 				return <SiteKitSetupWidget key={ widget.id } dataProvider={ this.#dataProvider } onRemove={ onRemove } />;
 			default:

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -1,4 +1,4 @@
-import { useCallback } from "@wordpress/element";
+import { useCallback, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Alert, SkeletonLoader } from "@yoast/ui-library";
 import { useRemoteData } from "../services/use-remote-data";
@@ -62,17 +62,40 @@ const TopPagesTable = ( { data, children } ) => {
 };
 
 /**
+ * @param {import("../services/data-formatter")} dataFormatter The data formatter.
+ * @returns {function(?TopPageData[]): TopPageData[]} Function to format the top pages data.
+ */
+export const createTopPageFormatter = ( dataFormatter ) => ( data = [] ) => data.map( ( item ) => ( {
+	subject: dataFormatter.format( item.subject, "subject", { widget: "topPages" } ),
+	clicks: dataFormatter.format( item.clicks, "clicks", { widget: "topPages" } ),
+	impressions: dataFormatter.format( item.impressions, "impressions", { widget: "topPages" } ),
+	ctr: dataFormatter.format( item.ctr, "ctr", { widget: "topPages" } ),
+	position: dataFormatter.format( item.position, "position", { widget: "topPages" } ),
+	seoScore: dataFormatter.format( item.seoScore, "seoScore", { widget: "topPages" } ),
+} ) );
+
+/**
  * @param {import("../services/data-provider")} dataProvider The data provider.
  * @param {import("../services/remote-data-provider")} remoteDataProvider The remote data provider.
+ * @param {import("../services/data-formatter")} dataFormatter The data formatter.
  * @param {number} [limit=5] The limit.
  * @returns {JSX.Element} The element.
  */
-export const TopPagesWidget = ( { dataProvider, remoteDataProvider, limit = 5 } ) => {
+export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => {
+	/**
+	 * @param {RequestInit} options The options.
+	 * @returns {Promise<TopPageData[]|Error>} The promise of TopPageData or an Error.
+	 */
 	const getTopPages = useCallback( ( options ) => {
 		return remoteDataProvider.fetchJson( dataProvider.getEndpoint( "topPages" ), { limit: limit.toString( 10 ) }, options );
 	}, [ dataProvider, limit ] );
 
-	const { data, error, isPending } = useRemoteData( getTopPages );
+	/**
+	 * @type {function(?TopPageData[]): TopPageData[]} Function to format the top pages data.
+	 */
+	const formatTopPages = useMemo( () => createTopPageFormatter( dataFormatter ), [ dataFormatter ] );
+
+	const { data, error, isPending } = useRemoteData( getTopPages, formatTopPages );
 
 	if ( isPending ) {
 		return (
@@ -94,7 +117,7 @@ export const TopPagesWidget = ( { dataProvider, remoteDataProvider, limit = 5 } 
 		);
 	}
 
-	if ( ! data || data.length === 0 ) {
+	if ( data.length === 0 ) {
 		return (
 			<Widget title={ TITLE }>
 				<p className="yst-mt-4">

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -28,7 +28,7 @@ import { ALERT_CENTER_NAME } from "./store/alert-center";
  * @type {import("../index").Endpoints} Endpoints
  */
 
-domReady( () => {
+domReady( () => { // eslint-disable-line complexity
 	const root = document.getElementById( "yoast-seo-general" );
 	if ( ! root ) {
 		return;

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -6,6 +6,7 @@ import { Root } from "@yoast/ui-library";
 import { get } from "lodash";
 import { createHashRouter, createRoutesFromElements, Navigate, Route, RouterProvider } from "react-router-dom";
 import { Dashboard } from "../dashboard";
+import { DataFormatter } from "../dashboard/services/data-formatter";
 import { DataProvider } from "../dashboard/services/data-provider";
 import { RemoteDataProvider } from "../dashboard/services/remote-data-provider";
 import { WidgetFactory } from "../dashboard/services/widget-factory";
@@ -49,6 +50,7 @@ domReady( () => {
 	const contentTypes = get( window, "wpseoScriptData.dashboard.contentTypes", [] );
 	/** @type {string} */
 	const userName = get( window, "wpseoScriptData.dashboard.displayName", "User" );
+	const userLocale = document.getElementsByTagName( "html" )?.[ 0 ]?.getAttribute( "lang" ) || "en-US";
 	/** @type {Features} */
 	const features = {
 		indexables: get( window, "wpseoScriptData.dashboard.indexablesEnabled", false ),
@@ -87,7 +89,8 @@ domReady( () => {
 
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
-	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
+	const dataFormatter = new DataFormatter( { locale: userLocale } );
+	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
 
 	const initialWidgets = [];
 

--- a/packages/js/tests/dashboard/__mocks__/data-provider.js
+++ b/packages/js/tests/dashboard/__mocks__/data-provider.js
@@ -8,7 +8,7 @@ export class MockDataProvider extends DataProvider {
 	/**
 	 * Creates an instance of MockDataProvider.
 	 *
-	 * @param {Object} options - The options to initialize the data provider.
+	 * @param {Object} [options] The options to initialize the data provider. See {@link DataProvider}.
 	 */
 	constructor( options = {} ) {
 		super( defaultsDeep( options, {

--- a/packages/js/tests/dashboard/services/data-formatter.test.js
+++ b/packages/js/tests/dashboard/services/data-formatter.test.js
@@ -3,12 +3,12 @@ import { DataFormatter } from "../../../src/dashboard/services/data-formatter";
 
 describe( "DataFormatter", () => {
 	test.each( [
-		[ "subject, dropping protocol", "subject", "http://example.com/foo", "example.com/foo" ],
+		[ "subject, dropping protocol and hostname", "subject", "http://example.com/foo", "/foo" ],
 		[
-			"subject, dropping: protocol, port, search and hash",
+			"subject, dropping: protocol, hostname, port, search and hash",
 			"subject",
 			"https://user:password@www.example.com:8080/foo?query=bar#baz",
-			"www.example.com/foo",
+			"/foo",
 		],
 		[ "subject, not a URL", "subject", "foo", "foo" ],
 		[ "clicks", "clicks", 1234, "1,234" ],

--- a/packages/js/tests/dashboard/services/data-formatter.test.js
+++ b/packages/js/tests/dashboard/services/data-formatter.test.js
@@ -1,0 +1,34 @@
+import { describe, expect } from "@jest/globals";
+import { DataFormatter } from "../../../src/dashboard/services/data-formatter";
+
+describe( "DataFormatter", () => {
+	test.each( [
+		[ "subject, dropping protocol", "subject", "http://example.com/foo", "example.com/foo" ],
+		[
+			"subject, dropping: protocol, port, search and hash",
+			"subject",
+			"https://user:password@www.example.com:8080/foo?query=bar#baz",
+			"www.example.com/foo",
+		],
+		[ "subject, not a URL", "subject", "foo", "foo" ],
+		[ "clicks", "clicks", 1234, "1,234" ],
+		[ "clicks, negative number in string", "clicks", "-10", "-10" ],
+		[ "clicks, not a number", "clicks", {}, "NaN" ],
+		[ "clicks, Dutch => different separator", "clicks", 1234, "1.234", "nl-NL" ],
+		[ "impressions", "impressions", 1_234_567, "1,234,567" ],
+		[ "ctr, rounded up", "ctr", 0.345678, "34.57%" ],
+		[ "ctr, rounded down", "ctr", 0.00144, "0.14%" ],
+		[ "ctr, zero padding", "ctr", 0, "0.00%" ],
+		[ "position, rounded up", "position", 6548.567, "6,548.57" ],
+		[ "position, rounded down", "position", 1.234, "1.23" ],
+		[ "position, zero padding", "position", 1, "1.00" ],
+		[ "position, Dutch => different separator", "position", 6548.567, "6.548,57", "nl-NL" ],
+		[ "seoScore", "seoScore", "ok", "ok" ],
+		[ "seoScore", "seoScore", "foo", "notAnalyzed" ],
+		[ "unknown name", "unknown", "foo", "foo" ],
+	] )( "should format %s", ( _, name, data, expected, locale = "en-US" ) => {
+		const formatter = new DataFormatter( { locale } );
+
+		expect( formatter.format( data, name, { widget: "topPages" } ) ).toBe( expected );
+	} );
+} );

--- a/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
@@ -1,25 +1,31 @@
 import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
 import { forEach } from "lodash";
 import { SCORE_META } from "../../../src/dashboard/scores/score-meta";
-import { TopPagesWidget } from "../../../src/dashboard/widgets/top-pages-widget";
+import { DataFormatter } from "../../../src/dashboard/services/data-formatter";
+import { createTopPageFormatter, TopPagesWidget } from "../../../src/dashboard/widgets/top-pages-widget";
 import { render, waitFor } from "../../test-utils";
 import { MockDataProvider } from "../__mocks__/data-provider";
 import { MockRemoteDataProvider } from "../__mocks__/remote-data-provider";
 
-const data = [
-	{ subject: "https://example.com/page-1", clicks: 100, impressions: 1000, ctr: 10, position: 1, seoScore: "ok" },
-	{ subject: "https://example.com/page-2", clicks: 101, impressions: 1001, ctr: 11, position: 2, seoScore: "good" },
-	{ subject: "https://example.com/page-3", clicks: 102, impressions: 1002, ctr: 12, position: 3, seoScore: "bad" },
-	{ subject: "https://example.com/page-4", clicks: 103, impressions: 1003, ctr: 13, position: 4, seoScore: "notAnalyzed" },
-];
-
 describe( "TopPagesWidget", () => {
+	const data = [
+		{ subject: "https://example.com/page-1", clicks: 100, impressions: 1000, ctr: 10, position: 1, seoScore: "ok" },
+		{ subject: "https://example.com/page-2", clicks: 101, impressions: 1001, ctr: 11, position: 2, seoScore: "good" },
+		{ subject: "https://example.com/page-3", clicks: 102, impressions: 1002, ctr: 12, position: 3, seoScore: "bad" },
+		{ subject: "https://example.com/page-4", clicks: 103, impressions: 1003, ctr: 13, position: 4, seoScore: "notAnalyzed" },
+	];
 	let dataProvider;
 	let remoteDataProvider;
+	let dataFormatter;
+	let formatter;
+	let formattedData;
 
 	beforeAll( () => {
 		dataProvider = new MockDataProvider();
 		remoteDataProvider = new MockRemoteDataProvider( {} );
+		dataFormatter = new DataFormatter();
+		formatter = createTopPageFormatter( dataFormatter );
+		formattedData = formatter( data );
 	} );
 
 	beforeEach( () => {
@@ -31,6 +37,7 @@ describe( "TopPagesWidget", () => {
 		const { getByRole, getByText } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
 		/> );
 
 		// Verify the title is present.
@@ -41,7 +48,7 @@ describe( "TopPagesWidget", () => {
 		// Verify the table is present.
 		expect( getByRole( "table" ) ).toBeInTheDocument();
 		// Verify rows are present.
-		forEach( data, ( { subject, clicks, impressions, ctr, position, seoScore } ) => {
+		forEach( formattedData, ( { subject, clicks, impressions, ctr, position, seoScore } ) => {
 			expect( getByText( subject ) ).toBeInTheDocument();
 			expect( getByText( clicks ) ).toBeInTheDocument();
 			expect( getByText( impressions ) ).toBeInTheDocument();
@@ -56,6 +63,7 @@ describe( "TopPagesWidget", () => {
 		const { getByText } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
 		/> );
 
 		// Verify no data message is present.
@@ -70,6 +78,7 @@ describe( "TopPagesWidget", () => {
 		const { getByText } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
 		/> );
 
 		await waitFor( () => {
@@ -79,10 +88,12 @@ describe( "TopPagesWidget", () => {
 
 	it( "should render the TopPagesWidget component with a pending state", async() => {
 		// Never resolving promise to ensure it keeps loading.
-		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {} ) );
+		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {
+		} ) );
 		const { getByRole, container } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
 			limit={ 1 }
 		/> );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Create a layer that formats the data for presentation

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a data formatter and implement it in the top pages widget.

## Relevant technical choices:

* Using the browser APIs for formatting: [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) and [Intl.NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat)
* Retrieving the locale from the HTML `lang` instead of the WP user locale as this seems easier. No script data transfer needed and the WP user locale uses an underscore instead of a dash.
* Using an Object for context for flexibility, more can be added as needed (opposed to the string in the issue)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the site kit feature flag
* Ensure you get Site kit data and have it connected
* Go to the dashboard
* Verify you see the widget for "Top 5 most popular content"
* Verify the format of the landing page/URL: just the pathname
* For the numbers, the formatting should adapt to the user locale (retrieved from `html` tag' `lang`). For example, in Dutch the separators are reversed (1,234.56 vs 1.234,56 in US)
  * Verify the format of the clicks and impressions: always non-fractional numbers
  * Verify the format of the CTR: as percentage and with 2 fractions, will be zero padded
  * Verify the format of the average position: 2 fractions, will be zero padded
  * Verify the SEO score is still there, will be `notAnalyzed` if fed anything else
* Change your locale to something with different number formatting and verify the above formats
* Devs: you could feed some random data to test more thoroughly. However, you could also check the tests and see if they cover all you think they should.

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/d5bfac43-ed1a-4dbe-8d38-f2318b64c8c0)

</p>
</details> 

#### Without feature flag
* Disable the site kit feature flag
* Refresh the dashboard page
* Ensure there is no errors and no top 5 pages widget

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The dashboard?

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/421
