### PR TITLE
Remove breadcrumbs from mobile search preview

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -263,7 +263,7 @@ const MobilePartContainer = styled.div`
 `;
 
 const SiteName = styled.div`
-	line-height: 18x;
+	line-height: 18px;
 	font-size: 14px;
 	color: black;
 	max-width: ${ props => props.screenMode === MODE_DESKTOP ? "100%" : MOBILE_SITENAME_LIMIT };

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -64,8 +64,6 @@ const MAX_WIDTH                 = 600;
 const MAX_WIDTH_MOBILE          = 400;
 const WIDTH_PADDING             = 20;
 const DESCRIPTION_LIMIT         = 156;
-const DESKTOP_BREADCRUMBS_LIMIT = 240;
-const MOBILE_BREADCRUMBS_LIMIT  = 100;
 const MOBILE_SITENAME_LIMIT     = "300px";
 
 
@@ -139,7 +137,7 @@ const TitleBounded = styled( Title )`
 
 const BreacrumbsContainer = styled.span`
 	display: inline-block;
-	max-width: ${ props => props.screenMode === MODE_DESKTOP ? DESKTOP_BREADCRUMBS_LIMIT : MOBILE_BREADCRUMBS_LIMIT }px;
+	max-width: 240px;
 	overflow: hidden;
 	vertical-align: top;
 
@@ -674,9 +672,9 @@ export default class SnippetPreview extends PureComponent {
 					<UrlContentContainer screenMode={ mode }>
 						<SiteName screenMode={ mode }>{ siteName }</SiteName>
 						<UrlBaseContainer screenMode={ mode }>{ hostname }</UrlBaseContainer>
-						<BreacrumbsContainer screenMode={ mode }>
+						{ ! isMobileMode && <BreacrumbsContainer screenMode={ mode }>
 							{ breadcrumbs }
-						</BreacrumbsContainer>
+						</BreacrumbsContainer> }
 						{ ! isMobileMode && <VerticalDotsContainer>
 							<VerticalDots screenMode={ mode } />
 						</VerticalDotsContainer> }

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -672,7 +672,7 @@ export default class SnippetPreview extends PureComponent {
 					<UrlContentContainer screenMode={ mode }>
 						<SiteName screenMode={ mode }>{ siteName }</SiteName>
 						<UrlBaseContainer screenMode={ mode }>{ hostname }</UrlBaseContainer>
-						{ ! isMobileMode && <BreacrumbsContainer screenMode={ mode }>
+						{ ! isMobileMode && <BreacrumbsContainer>
 							{ breadcrumbs }
 						</BreacrumbsContainer> }
 						{ ! isMobileMode && <VerticalDotsContainer>

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -66,7 +66,6 @@ const WIDTH_PADDING             = 20;
 const DESCRIPTION_LIMIT         = 156;
 const MOBILE_SITENAME_LIMIT     = "300px";
 
-
 const DesktopContainer = styled( FixedWidthContainer )`
 	background-color: #fff;
 	font-family: arial, sans-serif;
@@ -137,7 +136,7 @@ const TitleBounded = styled( Title )`
 
 const BreadcrumbsContainer = styled.span`
 	display: inline-block;
-	max-width: 240px;
+	max-width: ${ ( 2 / 5 ) * MAX_WIDTH }px;
 	overflow: hidden;
 	vertical-align: top;
 

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -135,7 +135,7 @@ const TitleBounded = styled( Title )`
 	text-overflow: ellipsis;
 `;
 
-const BreacrumbsContainer = styled.span`
+const BreadcrumbsContainer = styled.span`
 	display: inline-block;
 	max-width: 240px;
 	overflow: hidden;
@@ -672,9 +672,9 @@ export default class SnippetPreview extends PureComponent {
 					<UrlContentContainer screenMode={ mode }>
 						<SiteName screenMode={ mode }>{ siteName }</SiteName>
 						<UrlBaseContainer screenMode={ mode }>{ hostname }</UrlBaseContainer>
-						{ ! isMobileMode && <BreacrumbsContainer>
+						{ ! isMobileMode && <BreadcrumbsContainer>
 							{ breadcrumbs }
-						</BreacrumbsContainer> }
+						</BreadcrumbsContainer> }
 						{ ! isMobileMode && <VerticalDotsContainer>
 							<VerticalDots screenMode={ mode } />
 						</VerticalDotsContainer> }

--- a/packages/search-metadata-previews/tests/SnippetPreviewTest.js
+++ b/packages/search-metadata-previews/tests/SnippetPreviewTest.js
@@ -12,16 +12,15 @@ const baseArgs = {
 
 describe( "SnippetPreview", () => {
 	describe( "breadcrumbs", () => {
-		it( "properly renders multiple breadcrumbs in mobile view", () => {
+		it( "should not render breadcrumbs in mobile view", () => {
 			render( <SnippetPreview { ...baseArgs } url={ "http://www.google.nl/about" } mode={ MODE_MOBILE } /> );
 			const baseURL = screen.getByText( "www.google.nl" );
-			const subFolder = screen.getByText( "› about" );
 			expect( baseURL ).toBeInTheDocument();
-			expect( subFolder ).toBeInTheDocument();
+			expect( screen.queryByText( "› about" ) ).toBeNull();
 		} );
 
-		it( "doesn't percent encode characters that are percent encoded by node's url.parse in mobile view", () => {
-			render( <SnippetPreview { ...baseArgs } url={ "http://www.google.nl/`^ {}" } mode={ MODE_MOBILE } /> );
+		it( "doesn't percent encode characters that are percent encoded by node's url.parse in desktop view", () => {
+			render( <SnippetPreview { ...baseArgs } url={ "http://www.google.nl/`^ {}" } mode={ MODE_DESKTOP } /> );
 			const baseURL = screen.getByText( "www.google.nl" );
 			const subFolder = screen.getByText( "› `^ {}" );
 			expect( baseURL ).toBeInTheDocument();
@@ -44,26 +43,6 @@ describe( "SnippetPreview", () => {
 			expect( baseURL ).toBeInTheDocument();
 			expect( subFolder ).toBeInTheDocument();
 			expect( subFolderWithTrailingSlash ).not.toBeInTheDocument();
-		} );
-
-		it( "strips http protocol in mobile view", () => {
-			render( <SnippetPreview { ...baseArgs } url={ "http://www.google.nl/subdir" } mode={ MODE_MOBILE } /> );
-			const baseURL = screen.getByText( "www.google.nl" );
-			const baseUrlWithProtocol = screen.queryByText( "http://www.google.nl" );
-			const subFolder = screen.getByText( "› subdir" );
-			expect( baseURL ).toBeInTheDocument();
-			expect( baseUrlWithProtocol ).not.toBeInTheDocument();
-			expect( subFolder ).toBeInTheDocument();
-		} );
-
-		it( "strips https protocol in mobile view", () => {
-			render( <SnippetPreview { ...baseArgs } url={ "https://www.google.nl/subdir" } mode={ MODE_MOBILE } /> );
-			const baseURL = screen.getByText( "www.google.nl" );
-			const baseUrlWithProtocol = screen.queryByText( "https://www.google.nl" );
-			const subFolder = screen.getByText( "› subdir" );
-			expect( baseURL ).toBeInTheDocument();
-			expect( baseUrlWithProtocol ).not.toBeInTheDocument();
-			expect( subFolder ).toBeInTheDocument();
 		} );
 
 		it( "strips http protocol in desktop view", () => {

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -213,7 +213,7 @@ exports[`SnippetEditor Desktop mode and should switch to mobile 1`] = `
 }
 
 .c13 {
-  line-height: 18x;
+  line-height: 18px;
   font-size: 14px;
   color: black;
   max-width: 100%;
@@ -475,7 +475,7 @@ exports[`SnippetEditor Desktop mode and should switch to mobile 1`] = `
 `;
 
 exports[`SnippetEditor Mobile mode 1`] = `
-.c27 {
+.c26 {
   width: 16px;
   height: 16px;
   -webkit-flex: none;
@@ -483,24 +483,24 @@ exports[`SnippetEditor Mobile mode 1`] = `
   flex: none;
 }
 
-.c20 {
+.c19 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
   box-shadow: 0 1px 0 rgba( 204,204,204,1 );
 }
 
-.c21:active {
+.c20:active {
   color: #000;
   background-color: #f7f7f7;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c22::-moz-focus-inner {
+.c21::-moz-focus-inner {
   border-width: 0;
 }
 
-.c22:focus {
+.c21:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -508,13 +508,13 @@ exports[`SnippetEditor Mobile mode 1`] = `
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c23:hover {
+.c22:hover {
   color: #000;
   background-color: #fff;
   border-color: var(--yoast-color-border--default);
 }
 
-.c24 {
+.c23 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -545,7 +545,7 @@ exports[`SnippetEditor Mobile mode 1`] = `
   transition: var(--yoast-transition-default);
 }
 
-.c24 svg {
+.c23 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -561,12 +561,12 @@ exports[`SnippetEditor Mobile mode 1`] = `
   font-size: 14px;
 }
 
-.c15 {
+.c14 {
   cursor: pointer;
   position: relative;
 }
 
-.c16 {
+.c15 {
   color: #1558d6;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -581,22 +581,13 @@ exports[`SnippetEditor Mobile mode 1`] = `
   text-overflow: ellipsis;
 }
 
-.c17 {
+.c16 {
   max-width: 600px;
   vertical-align: top;
   text-overflow: ellipsis;
 }
 
-.c14 {
-  display: inline-block;
-  max-width: 100px;
-  overflow: hidden;
-  vertical-align: top;
-  text-overflow: ellipsis;
-  margin-left: 4px;
-}
-
-.c18 {
+.c17 {
   display: inline-block;
   max-height: 52px;
   padding-top: 1px;
@@ -673,7 +664,7 @@ exports[`SnippetEditor Mobile mode 1`] = `
   min-width: 28px;
 }
 
-.c19 {
+.c18 {
   color: #3c4043;
   font-size: 14px;
   cursor: pointer;
@@ -682,7 +673,7 @@ exports[`SnippetEditor Mobile mode 1`] = `
   max-width: 600px;
 }
 
-.c19:after {
+.c18:after {
   display: table;
   content: "";
   clear: both;
@@ -697,7 +688,7 @@ exports[`SnippetEditor Mobile mode 1`] = `
 }
 
 .c12 {
-  line-height: 18x;
+  line-height: 18px;
   font-size: 14px;
   color: black;
   max-width: 300px;
@@ -747,25 +738,25 @@ exports[`SnippetEditor Mobile mode 1`] = `
   font-weight: 300;
 }
 
-.c25 {
+.c24 {
   height: 33px;
   border: 1px solid #dbdbdb;
   box-shadow: none;
   font-family: Arial,Roboto-Regular,HelveticaNeue,sans-serif;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0 0 4px;
   fill: #555;
   padding-left: 8px;
 }
 
-.c26 svg {
+.c25 svg {
   margin-right: 7px;
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c24::after {
+  .c23::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -859,11 +850,6 @@ exports[`SnippetEditor Mobile mode 1`] = `
                 >
                   example.org
                 </span>
-                <span
-                  class="c14"
-                >
-                   › test-slug
-                </span>
               </span>
               <svg
                 fill="#70757a"
@@ -884,13 +870,13 @@ exports[`SnippetEditor Mobile mode 1`] = `
             SEO title preview:
           </span>
           <div
-            class="c15"
+            class="c14"
           >
             <div
-              class="c16 c17"
+              class="c15 c16"
             >
               <span
-                class="c18"
+                class="c17"
               >
                 Test title
               </span>
@@ -907,10 +893,10 @@ exports[`SnippetEditor Mobile mode 1`] = `
             Meta description preview:
           </span>
           <div
-            class="c19"
+            class="c18"
           >
             <div
-              class="c19"
+              class="c18"
             >
               Test description, %%replacement_variable%%
             </div>
@@ -920,12 +906,12 @@ exports[`SnippetEditor Mobile mode 1`] = `
     </section>
     <button
       aria-expanded="false"
-      class="c20 c21 c22 c23 c24 c25 c26"
+      class="c19 c20 c21 c22 c23 c24 c25"
       type="button"
     >
       <svg
         aria-hidden="true"
-        class="c27 yoast-svg-icon yoast-svg-icon-edit"
+        class="c26 yoast-svg-icon yoast-svg-icon-edit"
         fill="currentColor"
         focusable="false"
         role="img"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Google doesn't show breadcrumbs in mobile search results anymore (see this [article](https://developers.google.com/search/blog/2025/01/simplifying-breadcrumbs)). This PR makes sure that the breadcrumbs is not rendered in the search snippet preview in mobile mode.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] Removes the breadcrumbs container from the Search snippet preview in Mobile mode.
* Removes the breadcrumbs from the Search snippet preview in Mobile mode.
* [shopify-seo] Removes the breadcrumbs from the Search snippet preview in Mobile mode.

## Relevant technical choices:

* I also do some girl scouting in the `packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js` file, fixing some typos.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### WordPress
* Install and activate Yoast SEO
* Create a post in Block editor
   * Also test in other editors, and in other content types
* Add some content to your post
* When the slug field is empty, the breadcrumbs should not be previewed inside Search appearance for both Mobile and Desktop result, in the sidebar and in the metabox. However, the base URL should still be previewed See the examples below:
<details><summary>Mobile view</summary>
<p>In the example below, the base URL is `basic.wordpress.test`. Please also note that the base URL should not be followed by > </p>
<img width="554" alt="Screenshot 2025-02-11 at 16 25 55" src="https://github.com/user-attachments/assets/bb4cd0a0-4d08-41eb-915d-008e4bd7bfe4" />
</details>    

<details><summary>Desktop view</summary>
<p>In the example below, the base URL is `basic.wordpress.test`</p>
<img width="619" alt="Screenshot 2025-02-11 at 16 27 27" src="https://github.com/user-attachments/assets/b16aeb4c-de61-4295-8cfd-b3a1e70ec350" />
</details>   

* Fill in the slug field. 
* Confirm that the slug is NOT shown inside Search appearance for Mobile result both in the sidebar and in the metabox
   * ⚠️ New behavior. Previously, the slug will also be added to the breadcrumbs inside Search appearance for Mobile result 
* Confirm that the slug is added as the breadcrumbs inside Search appearance for Desktop result both in the sidebar and in the metabox. See screenshot below for an example:
<details><summary>Desktop view</summary>
<p>In the example below, the slug is "ai-revolution".</p>
<img width="571" alt="Screenshot 2025-02-11 at 16 35 30" src="https://github.com/user-attachments/assets/c7ccc54e-ab09-4f84-99d9-9a8ee060b6fc" />
</details> 

* Please smoke test in other content types and in other editors.

##### Shopify
* Install and activate Yoast SEO for shopify 
* Repeat the steps under **WordPress** above and confirm that you get the same result
* Please smoke test in different content types
   
#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Should not have further impact other than what is covered in the testing instruction.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/431
