### PR TITLE
GitHub Action for enforcing PR Validation for Changelog Labels and Milestones

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,43 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, milestoned, demilestoned]
+
+jobs:
+  validate-pr:
+    name: Validate PR Labels & Milestone
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for changelog label
+        id: changelog-check
+        run: |
+          LABELS="${{ join(github.event.pull_request.labels.*.name, ' ') }}"
+          if [[ "$LABELS" != *"changelog:"* ]]; then
+            echo "❌ Missing required changelog label!"
+            echo "changelog_status=failed" >> "$GITHUB_ENV"
+          else
+            echo "✅ Changelog label found."
+            echo "changelog_status=success" >> "$GITHUB_ENV"
+          fi
+
+      - name: Check for milestone
+        id: milestone-check
+        run: |
+          if [[ -z "${{ github.event.pull_request.milestone }}" ]]; then
+            echo "❌ Missing milestone!"
+            echo "milestone_status=failed" >> "$GITHUB_ENV"
+          else
+            echo "✅ Milestone assigned."
+            echo "milestone_status=success" >> "$GITHUB_ENV"
+          fi
+
+      - name: Final Validation
+        run: |
+          if [[ "$changelog_status" == "failed" || "$milestone_status" == "failed" ]]; then
+            echo "❌ PR is missing required attributes. Please add a milestone and a changelog label before merging."
+            exit 1
+          else
+            echo "✅ PR validation passed."
+          fi
+ 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

To improve PR tracking and ensure proper release management, we want to prevent merging PRs unless they have:

1. A **changelog label** that starts with `changelog:`
2. A **milestone assigned**

This PR introduces a **GitHub Action** that enforces these rules, making sure PRs are properly labeled before merging.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds validation to a PR, checking if it has a proper changelog label and milestone attached.

## Relevant technical choices:

- The GitHub Action runs on all PR updates (`opened`, `edited`, `labeled`, `unlabeled`, etc.).
- It checks for a **changelog label** and **milestone**, failing if either is missing.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Open a new PR **without a changelog label or milestone**.
- ❌ The check should fail.

2. Add a changelog label (e.g., `changelog: enhancement`).
- ❌ The check should still fail (since milestone is missing).

3. Assign a milestone to the PR.
- ✅ The check should now pass.

Additional Scenarios

-  Test with different changelog labels (e.g., `changelog: bugfix`).
-  Remove the milestone after adding it → PR should fail validation again.
-  Test on a PR with multiple labels, ensuring only one `changelog:` label is required.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects:

- Pull request validation and merging process
- GitHub Actions workflow

## UI changes
No UI changes in the plugin itself.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
