### PR TITLE
Implement permanent dismiss Site Kit setup widget

### DIFF
--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -48,6 +48,7 @@ export { Dashboard } from "./components/dashboard";
  * @typedef {Object} Endpoints The endpoints.
  * @property {string} seoScores The endpoint for SEO scores.
  * @property {string} readabilityScores The endpoint for readability scores.
+ * @property {string} siteKitConfigurationDismissal The endpoint to dismiss the Site Kit configuration.
  * @property {string} siteKitConsentManagement The endpoint to manage the Site Kit consent.
  * @property {string} timeBasedSeoMetrics The endpoint to get a time based seo metrics.
  */
@@ -102,4 +103,5 @@ export { Dashboard } from "./components/dashboard";
  * @property {string} activateUrl The URL to activate Site Kit.
  * @property {string} setupUrl The URL to setup Site Kit.
  * @property {boolean} isFeatureEnabled Whether the feature is enabled.
+ * @property {boolean} isConfigurationDismissed Whether the configuration is dismissed.
  */

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -100,4 +100,15 @@ export class DataProvider {
 			isConnected,
 		};
 	}
+
+	/**
+	 * @param {boolean} isConfigurationDismissed Whether the site kit configuration is (permanently) dismissed.
+	 */
+	setSiteKitConfigurationDismissed( isConfigurationDismissed ) {
+		// This creates a new object to avoid mutation and force re-rendering.
+		this.#siteKitConfiguration = {
+			...this.#siteKitConfiguration,
+			isConfigurationDismissed,
+		};
+	}
 }

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+import { noop } from "lodash";
 import { ScoreWidget } from "../widgets/score-widget";
 import { SiteKitSetupWidget } from "../widgets/site-kit-setup-widget";
 import { TopPagesWidget } from "../widgets/top-pages-widget";
@@ -74,6 +75,11 @@ export class WidgetFactory {
 					dataFormatter={ this.#dataFormatter }
 				/>;
 			case "siteKitSetup":
+				// This check here makes sure we don't render the setup anymore if the user connected and then switches away from the dashboard.
+				// Then switches back to the dashboard, but does not refresh.
+				if ( this.#dataProvider.getSiteKitConfiguration().isConnected ) {
+					return null;
+				}
 				return <SiteKitSetupWidget
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-import { noop } from "lodash";
 import { ScoreWidget } from "../widgets/score-widget";
 import { SiteKitSetupWidget } from "../widgets/site-kit-setup-widget";
 import { TopPagesWidget } from "../widgets/top-pages-widget";

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -76,7 +76,8 @@ export class WidgetFactory {
 			case "siteKitSetup":
 				// This check here makes sure we don't render the setup anymore if the user connected and then switches away from the dashboard.
 				// Then switches back to the dashboard, but does not refresh.
-				if ( this.#dataProvider.getSiteKitConfiguration().isConnected ) {
+				if ( this.#dataProvider.getSiteKitConfiguration().isConnected ||
+				this.#dataProvider.getSiteKitConfiguration().isConfigurationDismissed ) {
 					return null;
 				}
 				return <SiteKitSetupWidget

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -3,6 +3,7 @@ import { CheckCircleIcon } from "@heroicons/react/solid";
 import { useCallback, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button, DropdownMenu, Paper, Stepper, Title, useToggleState } from "@yoast/ui-library";
+import { noop } from "lodash";
 import { ReactComponent as YoastConnectSiteKit } from "../../../images/yoast-connect-google-site-kit.svg";
 import { SiteKitConsentModal } from "../../shared-admin/components";
 
@@ -21,9 +22,16 @@ const steps = [
 ];
 
 /**
+ * @typedef {Object} UseSiteKitConfiguration
+ * @property {SiteKitConfiguration} config The site kit configuration.
+ * @property {function(RequestInit?)} grantConsent The grant consent function.
+ * @property {function(RequestInit?)} dismissPermanently The dismiss permanently function.
+ */
+
+/**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @returns {{config: SiteKitConfiguration, grantConsent: function(RequestInit)}} The site kit configuration and the grant consent function.
+ * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
 const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
@@ -38,10 +46,21 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 				dataProvider.setSiteKitConnected( true );
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
-		} ).catch( () => {} );
+		} ).catch( noop );
 	}, [ dataProvider, remoteDataProvider, setConfig ] );
 
-	return { config, grantConsent };
+	const dismissPermanently = useCallback( ( options ) => {
+		remoteDataProvider.fetchJson(
+			dataProvider.getEndpoint( "siteKitConfigurationDismissal" ),
+			// eslint-disable-next-line camelcase
+			{ is_dismissed: String( true ) },
+			{ ...options, method: "POST" }
+		).catch( noop );
+		// There is no point in waiting for the response, just remove the widget.
+		dataProvider.setSiteKitConfigurationDismissed( true );
+	}, [ remoteDataProvider, dataProvider ] );
+
+	return { config, grantConsent, dismissPermanently };
 };
 
 /**
@@ -54,16 +73,17 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
  * @returns {JSX.Element} The widget.
  */
 export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, onRemove } ) => {
-	const { config, grantConsent } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
+	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleOnRemove = useCallback( () => {
 		onRemove( "siteKitSetup" );
 	}, [ onRemove ] );
+
 	const handleRemovePermanently = useCallback( () => {
-		// Implement the remove permanently functionality.
+		dismissPermanently();
 		handleOnRemove();
-	}, [ handleOnRemove ] );
+	}, [ handleOnRemove, dismissPermanently ] );
 
 	const learnMoreLink = dataProvider.getLink( "siteKitLearnMore" );
 	const consentLearnMoreLink = dataProvider.getLink( "siteKitConsentLearnMore" );
@@ -153,7 +173,7 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, onRemove
 		<div className="yst-flex yst-gap-1 yst-mt-6 yst-items-center">
 			{ overallCompleted
 				? <>
-					<Button onClick={ handleRemovePermanently }>
+					<Button onClick={ handleOnRemove }>
 						{ __( "Got it!", "wordpress-seo" ) }
 					</Button>
 				</>

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -63,6 +63,7 @@ domReady( () => { // eslint-disable-line complexity
 		seoScores: get( window, "wpseoScriptData.dashboard.endpoints.seoScores", "" ),
 		readabilityScores: get( window, "wpseoScriptData.dashboard.endpoints.readabilityScores", "" ),
 		timeBasedSeoMetrics: get( window, "wpseoScriptData.dashboard.endpoints.timeBasedSeoMetrics", "" ),
+		siteKitConfigurationDismissal: get( window, "wpseoScriptData.dashboard.endpoints.siteKitConfigurationDismissal", "" ),
 		siteKitConsentManagement: get( window, "wpseoScriptData.dashboard.endpoints.siteKitConsentManagement", "" ),
 	};
 	/** @type {Object<string,string>} */
@@ -88,6 +89,7 @@ domReady( () => { // eslint-disable-line complexity
 		activateUrl: "",
 		setupUrl: "",
 		isFeatureEnabled: false,
+		isConfigurationDismissed: false,
 	} );
 
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
@@ -98,7 +100,7 @@ domReady( () => { // eslint-disable-line complexity
 	const initialWidgets = [];
 
 	// If site kit feature is enabled, add the site kit setup widget.
-	if ( siteKitConfiguration.isFeatureEnabled && ! siteKitConfiguration.isConnected ) {
+	if ( siteKitConfiguration.isFeatureEnabled && ! siteKitConfiguration.isConfigurationDismissed && ! siteKitConfiguration.isConnected ) {
 		initialWidgets.push( "siteKitSetup" );
 	}
 

--- a/packages/js/tests/dashboard/__mocks__/data-provider.js
+++ b/packages/js/tests/dashboard/__mocks__/data-provider.js
@@ -52,6 +52,7 @@ export class MockDataProvider extends DataProvider {
 				readabilityScores: "https://example.com/readability-scores",
 				topPages: "https://example.com/top-pages",
 				siteKitConsentManagement: "https://example.com/site-kit-consent-management",
+				siteKitConfigurationDismissal: "https://example.com/site-kit-configuration-dismissal",
 			},
 			headers: {
 				"X-Wp-Nonce": "123",
@@ -72,6 +73,7 @@ export class MockDataProvider extends DataProvider {
 				isFeatureEnabled: false,
 			},
 		} ) );
+		this.setSiteKitConfigurationDismissed = jest.fn();
 	}
 }
 

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -172,19 +172,25 @@ describe( "SiteKitSetupWidget", () => {
 		expect( onRemove ).toHaveBeenCalled();
 	} );
 
-	it( "opens the menu and calls onRemove when 'Remove until next visit' is clicked", () => {
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
-		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
-		const removeButton = screen.getByRole( "menuitem", { name: /Remove until next visit/i, type: "button" } );
-		fireEvent.click( removeButton );
-		expect( onRemove ).toHaveBeenCalled();
-	} );
-
-	it( "opens the menu and calls onRemovePermanently when 'Remove permanently' is clicked", () => {
+	it( "opens the menu and calls dismissPermanently and onRemove when 'Remove permanently' is clicked", async() => {
+		dataProvider = new MockDataProvider( {
+			siteKitConfiguration: {
+				isInstalled: true,
+				isActive: true,
+				isSetupCompleted: true,
+			},
+		} );
 		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
 		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
 		const removeButton = screen.getByRole( "menuitem", { name: /Remove permanently/i, type: "button" } );
 		fireEvent.click( removeButton );
 		expect( onRemove ).toHaveBeenCalled();
+		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
+			"https://example.com/site-kit-configuration-dismissal",
+			// eslint-disable-next-line camelcase
+			{ is_dismissed: "true" },
+			expect.objectContaining( { method: "POST" } )
+		);
+		expect( dataProvider.setSiteKitConfigurationDismissed ).toHaveBeenCalledWith( true );
 	} );
 } );

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Dashboard\Infrastructure\Integrations;
 
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Interface;
 use Yoast\WP\SEO\Editors\Domain\Integrations\Integration_Data_Provider_Interface;
 
@@ -21,12 +22,34 @@ class Site_Kit implements Integration_Data_Provider_Interface {
 	private $site_kit_consent_repository;
 
 	/**
+	 * The Site Kit consent repository.
+	 *
+	 * @var Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface
+	 */
+	private $permanently_dismissed_site_kit_configuration_repository;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param Site_Kit_Consent_Repository_Interface $site_kit_consent_repository The Site Kit consent repository.
+	 * @param Site_Kit_Consent_Repository_Interface                             $site_kit_consent_repository                             The
+	 *                                                                                                                                   Site
+	 *                                                                                                                                   Kit
+	 *                                                                                                                                   consent
+	 *                                                                                                                                   repository.
+	 * @param Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface $permanently_dismissed_site_kit_configuration_repository The
+	 *                                                                                                                                   Site
+	 *                                                                                                                                   Kit
+	 *                                                                                                                                   permanently
+	 *                                                                                                                                   dismissed
+	 *                                                                                                                                   configuration
+	 *                                                                                                                                   repository.
 	 */
-	public function __construct( Site_Kit_Consent_Repository_Interface $site_kit_consent_repository ) {
-		$this->site_kit_consent_repository = $site_kit_consent_repository;
+	public function __construct(
+		Site_Kit_Consent_Repository_Interface $site_kit_consent_repository,
+		Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface $permanently_dismissed_site_kit_configuration_repository
+	) {
+		$this->site_kit_consent_repository                             = $site_kit_consent_repository;
+		$this->permanently_dismissed_site_kit_configuration_repository = $permanently_dismissed_site_kit_configuration_repository;
 	}
 
 	/**
@@ -61,14 +84,15 @@ class Site_Kit implements Integration_Data_Provider_Interface {
 		$site_kit_setup_url = \self_admin_url( 'admin.php?page=googlesitekit-splash' );
 
 		return [
-			'isInstalled'      => \file_exists( \WP_PLUGIN_DIR . '/' . self::SITE_KIT_FILE ),
-			'isActive'         => \is_plugin_active( self::SITE_KIT_FILE ),
-			'isSetupCompleted' => \get_option( 'googlesitekit_has_connected_admins', false ) === '1',
-			'isConnected'      => $this->site_kit_consent_repository->is_consent_granted(),
-			'isFeatureEnabled' => ( new Google_Site_Kit_Feature_Conditional() )->is_met(),
-			'installUrl'       => $site_kit_install_url,
-			'activateUrl'      => $site_kit_activate_url,
-			'setupUrl'         => $site_kit_setup_url,
+			'isInstalled'              => \file_exists( \WP_PLUGIN_DIR . '/' . self::SITE_KIT_FILE ),
+			'isActive'                 => \is_plugin_active( self::SITE_KIT_FILE ),
+			'isSetupCompleted'         => \get_option( 'googlesitekit_has_connected_admins', false ) === '1',
+			'isConnected'              => $this->site_kit_consent_repository->is_consent_granted(),
+			'isFeatureEnabled'         => ( new Google_Site_Kit_Feature_Conditional() )->is_met(),
+			'installUrl'               => $site_kit_install_url,
+			'activateUrl'              => $site_kit_activate_url,
+			'setupUrl'                 => $site_kit_setup_url,
+			'isConfigurationDismissed' => $this->permanently_dismissed_site_kit_configuration_repository->is_site_kit_configuration_dismissed(),
 		];
 	}
 

--- a/tests/Unit/Integrations/Admin/Integrations_Page_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Integrations_Page_Integration_Test.php
@@ -170,14 +170,15 @@ final class Integrations_Page_Integration_Test extends TestCase {
 		$this->elementor_conditional->expects( 'is_met' )->andReturnFalse();
 		$this->jetpack_conditional->expects( 'is_met' )->andReturnFalse();
 		$site_kit_config = [
-			'isInstalled'      => false,
-			'isActive'         => false,
-			'isSetupCompleted' => false,
-			'isConnected'      => false,
-			'isFeatureEnabled' => false,
-			'installUrl'       => 'example.com',
-			'activateUrl'      => 'example.com',
-			'setupUrl'         => 'example.com',
+			'isInstalled'              => false,
+			'isActive'                 => false,
+			'isSetupCompleted'         => false,
+			'isConnected'              => false,
+			'isFeatureEnabled'         => false,
+			'installUrl'               => 'example.com',
+			'activateUrl'              => 'example.com',
+			'setupUrl'                 => 'example.com',
+			'isConfigurationDismissed' => false,
 		];
 		$this->site_kit_configuration->expects( 'to_array' )->andReturn( $site_kit_config );
 		$this->site_kit_consent_management_endpoint->expects( 'get_url' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Decision on when to hide etc, see the [Specific behaviors section](https://docs.google.com/document/d/1BkN2qKkM8sPiNzcoH8eTQv-hcnzfZNfIlPv-SSes1Ug/edit?tab=t.0#heading=h.jm6hr9n0su8l)
* To be implemented in another PR: adding the widgets on granting consent

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*  Implements Site Kit setup widget' `Remove permanently` functionality.

## Relevant technical choices:

* adds the current value to the site kit configuration
* don't show the setup widget if permanently dismissed
* clicking on "Got it!" is non-permanent: so if a user disconnects again, the setup widget should return
* clicking on "Got it!" should still keep hiding the widget on tab change: so I added a cheat in the widget factory

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

> [!TIP] 
> To restore widget after permanently dismissal update option `wpseo` value of `site_kit_configuration_permanently_dismissed` to 0.
> Or use the following in `site-kit.php` `to_array` to undo connected and/or dismissed:
```php
$this->site_kit_consent_repository->set_site_kit_consent( false );
$this->permanently_dismissed_site_kit_configuration_repository->set_site_kit_configuration_dismissal( false );
``` 

* Enable google site kit feature flag.
```
define( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE', true );
```
* Go to the dashboard on Yoast SEO->General.
* Make sure site kit is not connected ( if connected, you can disconnect from integrations page ).
* Once the site kit set up widget is visible again on the dashboard, connect site kit and click on "Got it".
* Navigate to the First time configuration tab (do not refresh the page) and return to the dashboard.
* Check that site kit set up widget is not visible.
* Disconnect site kit integration on the integration page.
* Go back to the dashboard and click on the three dots menu and dismiss permanently
* Navigate to other tabs and return to dashboard 
* Check that the set up widget is not visible.
* Refresh and check it is still not visible. 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/450
