### PR TITLE
show site kit tabular widget on connecting

### DIFF
--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -32,7 +32,7 @@ const prepareWidgetInstance = ( type ) => {
 export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links } ) => {
 	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
 
-	// eslint-disable-next-line no-unused-vars
+
 	const addWidget = useCallback( ( type ) => {
 		setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
 	}, [] );
@@ -45,7 +45,7 @@ export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, featu
 		<>
 			<PageTitle userName={ userName } features={ features } links={ links } />
 			<div className="yst-flex yst-flex-col @7xl:yst-flex-row yst-gap-6 yst-my-6">
-				{ widgets.map( ( widget ) => widgetFactory.createWidget( widget, removeWidget ) ) }
+				{ widgets.map( ( widget ) => widgetFactory.createWidget( widget, removeWidget, addWidget ) ) }
 			</div>
 		</>
 	);

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -31,12 +31,19 @@ const prepareWidgetInstance = ( type ) => {
  * @returns {JSX.Element} The element.
  */
 export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links, sitekitFeatureEnabled } ) => {
-	const [ widgets, setWidgets ] = useState( () => widgetFactory.sortWidgetsByRenderPriority( initialWidgets.map( prepareWidgetInstance ) ) );
+	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
 
-	const addWidget = useCallback( ( type ) => {
+
+	const addWidget = useCallback( ( type, index = null ) => {
+		if ( typeof index !== "number" ) {
+			setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
+			return;
+		}
+
 		setWidgets( ( currentWidgets ) => {
-			const newWidgets = [ ...currentWidgets, prepareWidgetInstance( type ) ];
-			return widgetFactory.sortWidgetsByRenderPriority( newWidgets );
+			const newWidgets = [ ...currentWidgets ];
+			newWidgets.splice( index, 0, prepareWidgetInstance( type ) );
+			return newWidgets;
 		} );
 	}, [] );
 

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -33,8 +33,17 @@ export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, featu
 	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
 
 
-	const addWidget = useCallback( ( type ) => {
-		setWidgets( ( currentWidgets ) => [ prepareWidgetInstance( type ), ...currentWidgets ] );
+	const addWidget = useCallback( ( type, index = null ) => {
+		if ( typeof index !== "number" ) {
+			setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
+			return;
+		}
+
+		setWidgets( ( currentWidgets ) => {
+			const newWidgets = [ ...currentWidgets ];
+			newWidgets.splice( index, 0, prepareWidgetInstance( type ) );
+			return newWidgets;
+		} );
 	}, [] );
 
 	const removeWidget = useCallback( ( type ) => {

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -34,17 +34,8 @@ export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, featu
 	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
 
 
-	const addWidget = useCallback( ( type, index = null ) => {
-		if ( typeof index !== "number" ) {
-			setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
-			return;
-		}
-
-		setWidgets( ( currentWidgets ) => {
-			const newWidgets = [ ...currentWidgets ];
-			newWidgets.splice( index, 0, prepareWidgetInstance( type ) );
-			return newWidgets;
-		} );
+	const addWidget = useCallback( ( type ) => {
+		setWidgets( ( currentWidgets ) => [ prepareWidgetInstance( type ), ...currentWidgets ] );
 	}, [] );
 
 	const removeWidget = useCallback( ( type ) => {

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -34,7 +34,7 @@ export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, featu
 
 
 	const addWidget = useCallback( ( type ) => {
-		setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
+		setWidgets( ( currentWidgets ) => [ prepareWidgetInstance( type ), ...currentWidgets ] );
 	}, [] );
 
 	const removeWidget = useCallback( ( type ) => {

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -31,19 +31,12 @@ const prepareWidgetInstance = ( type ) => {
  * @returns {JSX.Element} The element.
  */
 export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links, sitekitFeatureEnabled } ) => {
-	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
+	const [ widgets, setWidgets ] = useState( () => widgetFactory.sortWidgetsByRenderPriority( initialWidgets.map( prepareWidgetInstance ) ) );
 
-
-	const addWidget = useCallback( ( type, index = null ) => {
-		if ( typeof index !== "number" ) {
-			setWidgets( ( currentWidgets ) => [ ...currentWidgets, prepareWidgetInstance( type ) ] );
-			return;
-		}
-
+	const addWidget = useCallback( ( type ) => {
 		setWidgets( ( currentWidgets ) => {
-			const newWidgets = [ ...currentWidgets ];
-			newWidgets.splice( index, 0, prepareWidgetInstance( type ) );
-			return newWidgets;
+			const newWidgets = [ ...currentWidgets, prepareWidgetInstance( type ) ];
+			return widgetFactory.sortWidgetsByRenderPriority( newWidgets );
 		} );
 	}, [] );
 

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -85,6 +85,7 @@ export { Dashboard } from "./components/dashboard";
 /**
  * @typedef {Object} WidgetTypeInfo The widget info. Should hold what the UI needs to let the user pick a widget.
  * @property {WidgetType} type The widget type.
+ * @property {number} priority The priority of the widget.
  */
 
 /**

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -85,7 +85,6 @@ export { Dashboard } from "./components/dashboard";
 /**
  * @typedef {Object} WidgetTypeInfo The widget info. Should hold what the UI needs to let the user pick a widget.
  * @property {WidgetType} type The widget type.
- * @property {number} priority The priority of the widget.
  */
 
 /**

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -83,8 +83,11 @@ export { Dashboard } from "./components/dashboard";
  */
 
 /**
- * @typedef {Object} WidgetTypeInfo The widget info. Should hold what the UI needs to let the user pick a widget.
- * @property {WidgetType} type The widget type.
+ * @typedef {Object} WidgetTypes The widget info. Should hold what the UI needs to let the user pick a widget.
+ * @property {string} seoScores The seoScores widget type.
+ * @property {string} readabilityScores The readabilityScores widget type.
+ * @property {string} topPages The topPages widget type.
+ * @property {string} siteKitSetup The siteKitSetup widget type.
  */
 
 /**

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -83,14 +83,6 @@ export { Dashboard } from "./components/dashboard";
  */
 
 /**
- * @typedef {Object} WidgetTypes The widget info. Should hold what the UI needs to let the user pick a widget.
- * @property {string} seoScores The seoScores widget type.
- * @property {string} readabilityScores The readabilityScores widget type.
- * @property {string} topPages The topPages widget type.
- * @property {string} siteKitSetup The siteKitSetup widget type.
- */
-
-/**
  * @typedef {Object} WidgetInstance The widget instance. Should hold what the UI needs to render the widget.
  * @property {string} id The unique identifier.
  * @property {WidgetType} type The widget type.

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -87,7 +87,7 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 					removeWidget={ onRemove }
 					addWidget={ onAdd }
-					siteKitWidgets={ [ WidgetFactory.types.topPages ] }
+					siteKitWidgets={ [ widget.type, WidgetFactory.types.topPages ] }
 				/>;
 			default:
 				return null;

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -5,7 +5,7 @@ import { TopPagesWidget } from "../widgets/top-pages-widget";
 
 /**
  * @type {import("../index").WidgetType} WidgetType
- * @type {import("../index").WidgetTypeInfo} WidgetTypeInfo
+ * @type {import("../index").WidgetTypes} WidgetTypes
  */
 
 /**
@@ -28,15 +28,15 @@ export class WidgetFactory {
 	}
 
 	/**
-	 * @returns {WidgetTypeInfo[]}
+	 * @returns {WidgetTypes} The widget types.
 	 */
-	static get widgetTypes() {
-		return [
-			{ type: "seoScores" },
-			{ type: "readabilityScores" },
-			{ type: "topPages" },
-			{ type: "siteKitSetup" },
-		];
+	static get types() {
+		return {
+			seoScores: "seoScores",
+			readabilityScores: "readabilityScores",
+			topPages: "topPages",
+			siteKitSetup: "siteKitSetup",
+		};
 	}
 
 	/**
@@ -47,7 +47,7 @@ export class WidgetFactory {
 	 */
 	createWidget( widget, onRemove, onAdd ) {
 		switch ( widget.type ) {
-			case "seoScores":
+			case WidgetFactory.types.seoScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
 					return null;
 				}
@@ -57,7 +57,7 @@ export class WidgetFactory {
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
-			case "readabilityScores":
+			case WidgetFactory.types.readabilityScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "readabilityAnalysis" ) ) ) {
 					return null;
 				}
@@ -67,14 +67,14 @@ export class WidgetFactory {
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
-			case "topPages":
+			case WidgetFactory.types.topPages:
 				return <TopPagesWidget
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatter }
 				/>;
-			case "siteKitSetup":
+			case WidgetFactory.types.siteKitSetup:
 				// This check here makes sure we don't render the setup anymore if the user connected and then switches away from the dashboard.
 				// Then switches back to the dashboard, but does not refresh.
 				if ( this.#dataProvider.getSiteKitConfiguration().isConnected ||
@@ -87,6 +87,7 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 					removeWidget={ onRemove }
 					addWidget={ onAdd }
+					siteKitWidgets={ [ WidgetFactory.types.topPages ] }
 				/>;
 			default:
 				return null;

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -6,6 +6,7 @@ import { TopPagesWidget } from "../widgets/top-pages-widget";
 /**
  * @type {import("../index").WidgetType} WidgetType
  * @type {import("../index").WidgetTypeInfo} WidgetTypeInfo
+ * @type {import("../index").WidgetInstance} WidgetInstance
  */
 
 /**
@@ -32,11 +33,26 @@ export class WidgetFactory {
 	 */
 	static get widgetTypes() {
 		return [
-			{ type: "seoScores" },
-			{ type: "readabilityScores" },
-			{ type: "topPages" },
-			{ type: "siteKitSetup" },
+			{ type: "seoScores", renderPriority: 1 },
+			{ type: "readabilityScores", renderPriority: 2 },
+			{ type: "topPages", renderPriority: 0 },
+			{ type: "siteKitSetup", renderPriority: 0 },
 		];
+	}
+
+	/**
+	 * Sort by render priority.
+	 *
+	 * @param {WidgetInstance[]} widgets The first widget.
+	 * @returns {WidgetInstance[]} The sort value.
+	 */
+	sortWidgetsByRenderPriority( widgets ) {
+		return widgets.sort( ( a, b ) => {
+			const aType = WidgetFactory.widgetTypes.find( ( widget ) => widget.type === a.type );
+			const bType = WidgetFactory.widgetTypes.find( ( widget ) => widget.type === b.type );
+
+			return aType.renderPriority - bType.renderPriority;
+		} );
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -5,7 +5,6 @@ import { TopPagesWidget } from "../widgets/top-pages-widget";
 
 /**
  * @type {import("../index").WidgetType} WidgetType
- * @type {import("../index").WidgetTypes} WidgetTypes
  */
 
 /**
@@ -28,7 +27,7 @@ export class WidgetFactory {
 	}
 
 	/**
-	 * @returns {WidgetTypes} The widget types.
+	 * @returns {Object} The widget types.
 	 */
 	static get types() {
 		return {
@@ -87,7 +86,6 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 					removeWidget={ onRemove }
 					addWidget={ onAdd }
-					siteKitWidgets={ [ widget.type, WidgetFactory.types.topPages ] }
 				/>;
 			default:
 				return null;

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -6,7 +6,6 @@ import { TopPagesWidget } from "../widgets/top-pages-widget";
 /**
  * @type {import("../index").WidgetType} WidgetType
  * @type {import("../index").WidgetTypeInfo} WidgetTypeInfo
- * @type {import("../index").WidgetInstance} WidgetInstance
  */
 
 /**
@@ -33,26 +32,11 @@ export class WidgetFactory {
 	 */
 	static get widgetTypes() {
 		return [
-			{ type: "seoScores", renderPriority: 1 },
-			{ type: "readabilityScores", renderPriority: 2 },
-			{ type: "topPages", renderPriority: 0 },
-			{ type: "siteKitSetup", renderPriority: 0 },
+			{ type: "seoScores" },
+			{ type: "readabilityScores" },
+			{ type: "topPages" },
+			{ type: "siteKitSetup" },
 		];
-	}
-
-	/**
-	 * Sort by render priority.
-	 *
-	 * @param {WidgetInstance[]} widgets The first widget.
-	 * @returns {WidgetInstance[]} The sort value.
-	 */
-	sortWidgetsByRenderPriority( widgets ) {
-		return widgets.sort( ( a, b ) => {
-			const aType = WidgetFactory.widgetTypes.find( ( widget ) => widget.type === a.type );
-			const bType = WidgetFactory.widgetTypes.find( ( widget ) => widget.type === b.type );
-
-			return aType.renderPriority - bType.renderPriority;
-		} );
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -42,9 +42,10 @@ export class WidgetFactory {
 	/**
 	 * @param {WidgetInstance} widget The widget to create.
 	 * @param {function} onRemove The remove handler.
+	 * @param {function} onAdd The add handler.
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
-	createWidget( widget, onRemove ) {
+	createWidget( widget, onRemove, onAdd ) {
 		switch ( widget.type ) {
 			case "seoScores":
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
@@ -84,7 +85,8 @@ export class WidgetFactory {
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
-					onRemove={ onRemove }
+					removeWidget={ onRemove }
+					addWidget={ onAdd }
 				/>;
 			default:
 				return null;

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -21,11 +21,6 @@ const steps = [
 	__( "CONNECT", "wordpress-seo" ),
 ];
 
-/** @type {string[]} */
-const siteKitWidgets = [
-	"topPages",
-];
-
 /**
  * @typedef {Object} UseSiteKitConfiguration
  * @property {SiteKitConfiguration} config The site kit configuration.
@@ -50,7 +45,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) 
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				siteKitWidgets.map( widget => addWidget( widget ) );
+				addWidget( "topPages", 0 );
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -21,6 +21,11 @@ const steps = [
 	__( "CONNECT", "wordpress-seo" ),
 ];
 
+/** @type {string[]} */
+const siteKitWidgets = [
+	"topPages",
+];
+
 /**
  * @typedef {Object} UseSiteKitConfiguration
  * @property {SiteKitConfiguration} config The site kit configuration.
@@ -45,7 +50,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) 
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				addWidget( "topPages", 0 );
+				siteKitWidgets.map( widget => addWidget( widget ) );
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -31,10 +31,10 @@ const steps = [
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} addWidget The function to call when a new widget is added.
+ * @param {function} addSiteKitWidgets The function add the site kit widgets.
  * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
-const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) => {
+const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWidgets ) => {
 	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
 
 	const grantConsent = useCallback( ( options ) => {
@@ -45,7 +45,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) 
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				addWidget( "topPages", 0 );
+				addSiteKitWidgets();
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );
@@ -72,11 +72,16 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) 
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
  * @param {function} removeWidget The function to call when the widget is removed.
  * @param {function} addWidget The function to call when a new widget is added.
+ * @param {WidgetType[]} siteKitWidgets The site kit widgets.
  *
  * @returns {JSX.Element} The widget.
  */
-export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget } ) => {
-	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, addWidget );
+export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget, siteKitWidgets } ) => {
+	const handleAddSiteKitWidgets = useCallback( () => {
+		siteKitWidgets.forEach( ( type ) => addWidget( type ) );
+	}, [ siteKitWidgets, addWidget ] );
+
+	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleAddSiteKitWidgets );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleOnRemove = useCallback( () => {

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -70,9 +70,9 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWi
  *
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} removeWidget The function to call when the widget is removed.
- * @param {function} addWidget The function to call when a new widget is added.
- * @param {WidgetType[]} siteKitWidgets The site kit widgets.
+ * @param {function} removeWidget The function to remove a widget.
+ * @param {function} addWidget The function to add a widget.
+ * @param {WidgetType[]} siteKitWidgets The site kit widgets to add once connected.
  *
  * @returns {JSX.Element} The widget.
  */

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -45,7 +45,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) 
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				addWidget( "topPages" );
+				addWidget( "topPages", 0 );
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -6,6 +6,7 @@ import { Button, DropdownMenu, Paper, Stepper, Title, useToggleState } from "@yo
 import { noop } from "lodash";
 import { ReactComponent as YoastConnectSiteKit } from "../../../images/yoast-connect-google-site-kit.svg";
 import { SiteKitConsentModal } from "../../shared-admin/components";
+import { WidgetFactory } from "../services/widget-factory";
 
 /**
  * @type {import("../index").SiteKitConfiguration} SiteKitConfiguration
@@ -72,23 +73,19 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWi
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
  * @param {function} removeWidget The function to remove a widget.
  * @param {function} addWidget The function to add a widget.
- * @param {WidgetType[]} siteKitWidgets The site kit widgets to add once connected.
  *
  * @returns {JSX.Element} The widget.
  */
-export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget, siteKitWidgets } ) => {
-	const currentWidgetType = siteKitWidgets[ 0 ];
+export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget } ) => {
 	const handleAddSiteKitWidgets = useCallback( () => {
-		const widgetsAfterConnecting = [ ...siteKitWidgets ];
-		widgetsAfterConnecting.shift();
-		widgetsAfterConnecting.forEach( ( type ) => addWidget( type ) );
-	}, [ siteKitWidgets, addWidget ] );
+		[ WidgetFactory.types.topPages ].forEach( ( type ) => addWidget( type ) );
+	}, [ addWidget ] );
 
 	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleAddSiteKitWidgets );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleOnRemove = useCallback( () => {
-		removeWidget( currentWidgetType );
+		removeWidget( WidgetFactory.types.siteKitSetup );
 	}, [ removeWidget ] );
 
 	const handleRemovePermanently = useCallback( () => {

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -31,9 +31,10 @@ const steps = [
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {function} addWidget The function to call when a new widget is added.
  * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
-const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
+const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addWidget ) => {
 	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
 
 	const grantConsent = useCallback( ( options ) => {
@@ -44,6 +45,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
+				addWidget( "topPages" );
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );
@@ -68,17 +70,18 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
  *
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} onRemove The function to call when the widget is removed.
+ * @param {function} removeWidget The function to call when the widget is removed.
+ * @param {function} addWidget The function to call when a new widget is added.
  *
  * @returns {JSX.Element} The widget.
  */
-export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, onRemove } ) => {
-	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
+export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget } ) => {
+	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, addWidget );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleOnRemove = useCallback( () => {
-		onRemove( "siteKitSetup" );
-	}, [ onRemove ] );
+		removeWidget( "siteKitSetup" );
+	}, [ removeWidget ] );
 
 	const handleRemovePermanently = useCallback( () => {
 		dismissPermanently();

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -77,15 +77,18 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWi
  * @returns {JSX.Element} The widget.
  */
 export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget, siteKitWidgets } ) => {
+	const currentWidgetType = siteKitWidgets[ 0 ];
 	const handleAddSiteKitWidgets = useCallback( () => {
-		siteKitWidgets.forEach( ( type ) => addWidget( type ) );
+		const widgetsAfterConnecting = [ ...siteKitWidgets ];
+		widgetsAfterConnecting.shift();
+		widgetsAfterConnecting.forEach( ( type ) => addWidget( type ) );
 	}, [ siteKitWidgets, addWidget ] );
 
 	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleAddSiteKitWidgets );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleOnRemove = useCallback( () => {
-		removeWidget( "siteKitSetup" );
+		removeWidget( currentWidgetType );
 	}, [ removeWidget ] );
 
 	const handleRemovePermanently = useCallback( () => {

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -104,13 +104,13 @@ domReady( () => { // eslint-disable-line complexity
 		initialWidgets.push( "siteKitSetup" );
 	}
 
-	initialWidgets.push( "seoScores" );
-	initialWidgets.push( "readabilityScores" );
-
 	// If site kit feature is enabled and connected: add the top pages widget.
 	if ( siteKitConfiguration.isFeatureEnabled && siteKitConfiguration.isConnected ) {
 		initialWidgets.push( "topPages" );
 	}
+
+	initialWidgets.push( "seoScores" );
+	initialWidgets.push( "readabilityScores" );
 
 	const router = createHashRouter(
 		createRoutesFromElements(

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -101,16 +101,16 @@ domReady( () => { // eslint-disable-line complexity
 
 	// If site kit feature is enabled, add the site kit setup widget.
 	if ( siteKitConfiguration.isFeatureEnabled && ! siteKitConfiguration.isConfigurationDismissed && ! siteKitConfiguration.isConnected ) {
-		initialWidgets.push( "siteKitSetup" );
+		initialWidgets.push( WidgetFactory.types.siteKitSetup );
 	}
 
 	// If site kit feature is enabled and connected: add the top pages widget.
 	if ( siteKitConfiguration.isFeatureEnabled && siteKitConfiguration.isConnected ) {
-		initialWidgets.push( "topPages" );
+		initialWidgets.push( WidgetFactory.types.topPages );
 	}
 
-	initialWidgets.push( "seoScores" );
-	initialWidgets.push( "readabilityScores" );
+	initialWidgets.push( WidgetFactory.types.seoScores );
+	initialWidgets.push( WidgetFactory.types.readabilityScores );
 
 	const router = createHashRouter(
 		createRoutesFromElements(

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -104,14 +104,13 @@ domReady( () => { // eslint-disable-line complexity
 		initialWidgets.push( "siteKitSetup" );
 	}
 
+	initialWidgets.push( "seoScores" );
+	initialWidgets.push( "readabilityScores" );
+
 	// If site kit feature is enabled and connected: add the top pages widget.
 	if ( siteKitConfiguration.isFeatureEnabled && siteKitConfiguration.isConnected ) {
 		initialWidgets.push( "topPages" );
 	}
-
-	initialWidgets.push( "seoScores" );
-	initialWidgets.push( "readabilityScores" );
-
 
 	const router = createHashRouter(
 		createRoutesFromElements(

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -27,7 +27,7 @@ describe( "WidgetFactory", () => {
 		[ "readabilityScores" ],
 		[ "topPages" ],
 	] )( "should have the widget type: %s", async( type ) => {
-		expect( WidgetFactory.widgetTypes.map( info => info?.type ) ).toContain( type );
+		expect( WidgetFactory.types[ type ] ).toBe( type );
 	} );
 
 	test.each( [

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -10,7 +10,7 @@ describe( "SiteKitSetupWidget", () => {
 	const removeWidget = jest.fn();
 	const addWidget = jest.fn();
 	const props = {
-		siteKitWidgets: [ "topPages" ],
+		siteKitWidgets: [ "siteKitSetup", "topPages" ],
 		removeWidget,
 		addWidget,
 	};

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -10,7 +10,6 @@ describe( "SiteKitSetupWidget", () => {
 	const removeWidget = jest.fn();
 	const addWidget = jest.fn();
 	const props = {
-		siteKitWidgets: [ "siteKitSetup", "topPages" ],
 		removeWidget,
 		addWidget,
 	};

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -7,23 +7,34 @@ import { MockRemoteDataProvider } from "../__mocks__/remote-data-provider";
 describe( "SiteKitSetupWidget", () => {
 	let dataProvider;
 	const remoteDataProvider = new MockRemoteDataProvider( {} );
-	const onRemove = jest.fn();
+	const removeWidget = jest.fn();
+	const addWidget = jest.fn();
 
 	beforeEach( () => {
 		dataProvider = new MockDataProvider();
 		remoteDataProvider.fetchJson.mockClear();
-		onRemove.mockClear();
+		removeWidget.mockClear();
 	} );
 
 	it( "renders the widget with install button", () => {
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const installLink = screen.getByRole( "link", { name: /Install Site Kit by Google/i } );
 		expect( installLink ).toBeInTheDocument();
 		expect( installLink ).toHaveAttribute( "href", "https://example.com/install" );
 	} );
 
 	it( "renders the widget with learn more link", () => {
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const learnMoreLink = screen.getByRole( "link", { name: /Learn more/i } );
 		expect( learnMoreLink ).toBeInTheDocument();
 		expect( learnMoreLink ).toHaveAttribute( "href", "https://example.com/google-site-kit-learn-more" );
@@ -35,7 +46,12 @@ describe( "SiteKitSetupWidget", () => {
 				isInstalled: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const activateLink = screen.getByRole( "link", { name: /Activate Site Kit by Google/i } );
 		expect( activateLink ).toBeInTheDocument();
 		expect( activateLink ).toHaveAttribute( "href", "https://example.com/activate" );
@@ -48,7 +64,12 @@ describe( "SiteKitSetupWidget", () => {
 				isActive: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const setupLink = screen.getByRole( "link", { name: /Set up Site Kit by Google/i } );
 		expect( setupLink ).toBeInTheDocument();
 		expect( setupLink ).toHaveAttribute( "href", "https://example.com/isSetup" );
@@ -62,7 +83,12 @@ describe( "SiteKitSetupWidget", () => {
 				isSetupCompleted: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		expect( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) ).toBeInTheDocument();
 	} );
 
@@ -74,7 +100,12 @@ describe( "SiteKitSetupWidget", () => {
 				isSetupCompleted: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const connectButton = screen.getByRole( "button", { name: /Connect Site Kit by Google/i } );
 		fireEvent.click( connectButton );
 		expect( screen.getByRole( "button", { name: /Grant consent/i } ) ).toBeInTheDocument();
@@ -89,7 +120,12 @@ describe( "SiteKitSetupWidget", () => {
 			},
 		} );
 		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: true } );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
 		fireEvent.click( screen.getByRole( "button", { name: /Grant consent/i } ) );
@@ -113,7 +149,12 @@ describe( "SiteKitSetupWidget", () => {
 			},
 		} );
 		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: false } );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
 		const grantConsentButton = screen.getByRole( "button", { name: /Grant consent/i } );
@@ -139,7 +180,12 @@ describe( "SiteKitSetupWidget", () => {
 			},
 		} );
 		remoteDataProvider.fetchJson.mockRejectedValueOnce( new Error( "Failed to fetch" ) );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
 		const grantConsentButton = screen.getByRole( "button", { name: /Grant consent/i } );
@@ -165,14 +211,20 @@ describe( "SiteKitSetupWidget", () => {
 				isConnected: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		const dismissButton = screen.getByRole( "button", { name: /Got it/i } );
 		expect( dismissButton ).toBeInTheDocument();
 		fireEvent.click( dismissButton );
-		expect( onRemove ).toHaveBeenCalled();
+		expect( removeWidget ).toHaveBeenCalledWith( "siteKitSetup" );
+		expect( addWidget ).toHaveBeenCalledWith( "topPages" );
 	} );
 
-	it( "opens the menu and calls dismissPermanently and onRemove when 'Remove permanently' is clicked", async() => {
+	it( "opens the menu and calls dismissPermanently and removeWidget when 'Remove permanently' is clicked", async() => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {
 				isInstalled: true,
@@ -180,11 +232,16 @@ describe( "SiteKitSetupWidget", () => {
 				isSetupCompleted: true,
 			},
 		} );
-		render( <SiteKitSetupWidget dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } onRemove={ onRemove } /> );
+		render( <SiteKitSetupWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			removeWidget={ removeWidget }
+			addWidget={ addWidget }
+		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
 		const removeButton = screen.getByRole( "menuitem", { name: /Remove permanently/i, type: "button" } );
 		fireEvent.click( removeButton );
-		expect( onRemove ).toHaveBeenCalled();
+		expect( removeWidget ).toHaveBeenCalled();
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-configuration-dismissal",
 			// eslint-disable-next-line camelcase

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -9,6 +9,11 @@ describe( "SiteKitSetupWidget", () => {
 	const remoteDataProvider = new MockRemoteDataProvider( {} );
 	const removeWidget = jest.fn();
 	const addWidget = jest.fn();
+	const props = {
+		siteKitWidgets: [ "topPages" ],
+		removeWidget,
+		addWidget,
+	};
 
 	beforeEach( () => {
 		dataProvider = new MockDataProvider();
@@ -20,8 +25,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const installLink = screen.getByRole( "link", { name: /Install Site Kit by Google/i } );
 		expect( installLink ).toBeInTheDocument();
@@ -32,8 +36,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const learnMoreLink = screen.getByRole( "link", { name: /Learn more/i } );
 		expect( learnMoreLink ).toBeInTheDocument();
@@ -49,8 +52,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const activateLink = screen.getByRole( "link", { name: /Activate Site Kit by Google/i } );
 		expect( activateLink ).toBeInTheDocument();
@@ -67,8 +69,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const setupLink = screen.getByRole( "link", { name: /Set up Site Kit by Google/i } );
 		expect( setupLink ).toBeInTheDocument();
@@ -86,8 +87,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		expect( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) ).toBeInTheDocument();
 	} );
@@ -103,8 +103,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const connectButton = screen.getByRole( "button", { name: /Connect Site Kit by Google/i } );
 		fireEvent.click( connectButton );
@@ -121,10 +120,9 @@ describe( "SiteKitSetupWidget", () => {
 		} );
 		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: true } );
 		render( <SiteKitSetupWidget
+			{ ...props }
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -152,8 +150,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -163,6 +160,7 @@ describe( "SiteKitSetupWidget", () => {
 			expect( grantConsentButton ).toBeInTheDocument();
 		} );
 		expect( screen.queryByRole( "button", { name: /Got it!/i } ) ).not.toBeInTheDocument();
+		expect( addWidget ).toHaveBeenCalledWith( "topPages" );
 
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-consent-management",
@@ -183,8 +181,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -203,6 +200,7 @@ describe( "SiteKitSetupWidget", () => {
 	} );
 
 	it( "renders the widget with dismiss button when connected", () => {
+		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: true } );
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {
 				isInstalled: true,
@@ -214,14 +212,12 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		const dismissButton = screen.getByRole( "button", { name: /Got it/i } );
 		expect( dismissButton ).toBeInTheDocument();
 		fireEvent.click( dismissButton );
 		expect( removeWidget ).toHaveBeenCalledWith( "siteKitSetup" );
-		expect( addWidget ).toHaveBeenCalledWith( "topPages" );
 	} );
 
 	it( "opens the menu and calls dismissPermanently and removeWidget when 'Remove permanently' is clicked", async() => {
@@ -235,8 +231,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
-			addWidget={ addWidget }
+			{ ...props }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
 		const removeButton = screen.getByRole( "menuitem", { name: /Remove permanently/i, type: "button" } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows the "Top 5 most popular content" table on the dashboard on connecting to site kit, replacing the set up widget.

## Relevant technical choices:

* The table should appear instead of the setup widget. I didn't consider priority, widgets are added from the top.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable feature branch for site kit integration:
```
define( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE', true );
```
* Complete the site kit setup on the dashboard.
* [ ] Check the "Top 5 most popular content" widget appears immediately before the scores widgets.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [show site kit widgets immediately after site kit is connected on dashboard](https://github.com/Yoast/roadmap/issues/573)
