### PR TITLE
improve accessibility of disabled seo scores

### DIFF
--- a/packages/js/src/dashboard/components/widget-table.js
+++ b/packages/js/src/dashboard/components/widget-table.js
@@ -11,18 +11,18 @@ import { __ } from "@wordpress/i18n";
 /**
  * The disabled score component.
  *
- * @param {string} screenReaderLabel The screen reader label.
  * @param {string} tooltip The tooltip.
  *
  * @returns {JSX.Element} The element.
  */
-const DisabledScore = ( { screenReaderLabel, tooltip } ) => {
+const DisabledScore = ( { tooltip } ) => {
+	const uniqueId = `yst-disabled-score-tooltip-${Math.random().toString( 36 ).substring( 7 )}`;
 	return <TooltipContainer>
-		<TooltipTrigger>
+		<TooltipTrigger ariaDescribedby={ uniqueId }>
 			<XIcon className="yst-w-4 yst-h-4 yst-text-slate-400" />
-			<span className="yst-sr-only">{ screenReaderLabel }</span>
+			<span className="yst-sr-only">{ __( "Disabled", "wordpress-seo" ) }</span>
 		</TooltipTrigger>
-		{  tooltip && <TooltipWithContext position="left">{  tooltip }</TooltipWithContext> }
+		{  tooltip && <TooltipWithContext position="left" id={ uniqueId }>{  tooltip }</TooltipWithContext> }
 	</TooltipContainer>;
 };
 
@@ -55,21 +55,14 @@ const ScoreBullet = ( { score } ) => (
  */
 export const Score = ( { score, isIndexablesEnabled, isSeoAnalysisEnabled, isEditable } ) => {
 	if ( ! isIndexablesEnabled ) {
-		return <DisabledScore
-			tooltip={ __( "We can’t analyze your content, because you’re in a non-production environment.", "wordpress-seo" ) }
-			screenReaderLabel={ __( "Indexables are disabled", "wordpress-seo" ) }
-		/>;
+		return <DisabledScore />;
 	}
 	if ( ! isSeoAnalysisEnabled ) {
-		return <DisabledScore
-			tooltip={ __( "We can’t provide SEO scores, because the SEO analysis is disabled for your site.", "wordpress-seo" ) }
-			screenReaderLabel={ __( "SEO analysis is disabled", "wordpress-seo" ) }
-		/>;
+		return <DisabledScore />;
 	}
 	if ( ! isEditable ) {
 		return <DisabledScore
 			tooltip={ __( "We can’t provide an SEO score for this page because it can’t be edited.", "wordpress-seo" ) }
-			screenReaderLabel={ __( "Not editable", "wordpress-seo" ) }
 		/>;
 	}
 	return <ScoreBullet score={ score } />;
@@ -114,7 +107,7 @@ const TableRow = ( { children, index } ) => {
  */
 export const WidgetTable = ( { children } ) => {
 	return (
-		<div className="yst-overflow-x-auto">
+		<div className="yst-overflow-y-auto">
 			<Table variant="minimal">
 				{ children }
 			</Table>

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -75,7 +75,7 @@ export const SeoScoreHeader = ( { isIndexablesEnabled, isSeoAnalysisEnabled } ) 
 
 	return <TooltipContainer>
 		<TooltipTrigger ariaDescribedby="yst-disabled-score-header-tooltip">
-			<span className="yst-border-b yst-border-dashed yst-border-slate-900">
+			<span className="yst-underline yst-decoration-dotted">
 				Yoast
 				<br />
 				{ __( "SEO score", "wordpress-seo" ) }

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -1,13 +1,12 @@
 import { useCallback, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Alert, Button, SkeletonLoader } from "@yoast/ui-library";
+import { Alert, Button, SkeletonLoader, TooltipContainer, TooltipTrigger, TooltipWithContext } from "@yoast/ui-library";
 import { PencilIcon } from "@heroicons/react/outline";
 import { useRemoteData } from "../services/use-remote-data";
 import { WidgetTable, Score } from "../components/widget-table";
 import { Widget, WidgetTitle } from "./widget";
 import { ArrowNarrowRightIcon  } from "@heroicons/react/solid";
 import { InfoTooltip } from "../components/info-tooltip";
-
 
 /**
  * @type {import("../index").TopPageData} TopPageData
@@ -50,6 +49,43 @@ const Info = ( { url } ) => (
 	</>
 );
 
+/**
+ * The header for the SEO score column when disabled.
+ *
+ * @param {boolean} isIndexablesDisabled The indexables disabled status.
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const SeoScoreHeader = ( { isIndexablesEnabled, isSeoAnalysisEnabled } ) => {
+	if ( isIndexablesEnabled && isSeoAnalysisEnabled ) {
+		return <>
+			Yoast
+			<br />
+			{ __( "SEO score", "wordpress-seo" ) }
+		</>;
+	}
+
+	let tooltipText;
+
+	if ( ! isIndexablesEnabled ) {
+		tooltipText = __( "We can’t analyze your content, because you’re in a non-production environment.", "wordpress-seo" );
+	} else if ( ! isSeoAnalysisEnabled ) {
+		tooltipText = __( "We can’t provide SEO scores, because the SEO analysis is disabled for your site.", "wordpress-seo" );
+	}
+
+	return <TooltipContainer>
+		<TooltipTrigger ariaDescribedby="yst-disabled-score-header-tooltip">
+			<span className="yst-border-b yst-border-dashed yst-border-slate-900">
+				Yoast
+				<br />
+				{ __( "SEO score", "wordpress-seo" ) }
+			</span>
+		</TooltipTrigger>
+		<TooltipWithContext position="left" id="yst-disabled-score-header-tooltip">
+			{ tooltipText }
+		</TooltipWithContext>
+	</TooltipContainer>;
+};
 
 /**
  * @param {number} index The index.
@@ -92,8 +128,7 @@ const TopPagesTable = ( { data, children, isIndexablesEnabled = true, isSeoAnaly
 			<WidgetTable.Header className="yst-text-end">{ __( "CTR", "wordpress-seo" ) }</WidgetTable.Header>
 			<WidgetTable.Header className="yst-text-end">{ __( "Average position", "wordpress-seo" ) }</WidgetTable.Header>
 			<WidgetTable.Header className="yst-text-center">
-				<div>Yoast</div>
-				{ __( "SEO score", "wordpress-seo" ) }
+				<SeoScoreHeader isIndexablesEnabled={ isIndexablesEnabled } isSeoAnalysisEnabled={ isSeoAnalysisEnabled } />
 			</WidgetTable.Header>
 			<WidgetTable.Header className="yst-text-end">{ __( "Actions", "wordpress-seo" ) }</WidgetTable.Header>
 		</WidgetTable.Head>

--- a/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
@@ -33,7 +33,7 @@ describe( "TopPagesWidget", () => {
 		remoteDataProvider.fetchJson.mockClear();
 	} );
 
-	it( "should render the TopPagesWidget component", async() => {
+	it( "should render the component", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( data );
 		const { getByRole, getByText, getAllByRole } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
@@ -62,7 +62,7 @@ describe( "TopPagesWidget", () => {
 				expect( editButtons[ index ] ).toHaveAttribute( "href", links.edit );
 				expect( editButtons[ index ] ).toHaveAttribute( "aria-disabled", "false" );
 			} else {
-				expect( getByText( "Not editable" ) ).toBeInTheDocument();
+				expect( getByText( "Disabled" ) ).toBeInTheDocument();
 				expect( editButtons[ index ] ).not.toHaveAttribute( "href" );
 				expect( editButtons[ index ] ).toHaveAttribute( "disabled" );
 				expect( editButtons[ index ] ).toHaveAttribute( "aria-disabled", "true" );
@@ -70,7 +70,7 @@ describe( "TopPagesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopPagesWidget component without data", async() => {
+	it( "should render without data", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( [] );
 		const { getByText } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
@@ -84,7 +84,7 @@ describe( "TopPagesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopPagesWidget component with an error", async() => {
+	it( "should render with an error", async() => {
 		const message = "An error occurred.";
 		remoteDataProvider.fetchJson.mockRejectedValue( new Error( message ) );
 		const { getByText } = render( <TopPagesWidget
@@ -98,7 +98,7 @@ describe( "TopPagesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopPagesWidget component with a pending state", async() => {
+	it( "should render with a pending state", async() => {
 		// Never resolving promise to ensure it keeps loading.
 		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {
 		} ) );
@@ -118,7 +118,7 @@ describe( "TopPagesWidget", () => {
 		expect( container.getElementsByClassName( "yst-skeleton-loader" ).length ).toBe( 7 );
 	} );
 
-	it( "when the data provider has indexables disabled, should render the TopPagesWidget component with disabled tooltip", async() => {
+	it( "should render one tooltip and screen reader text for scores, when the data provider has indexables disabled", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( data );
 		dataProvider = new MockDataProvider( {
 			features: {
@@ -135,12 +135,12 @@ describe( "TopPagesWidget", () => {
 		// Verify the disabled score message is present.
 		await waitFor( () => {
 			const tooltip = getAllByText( "We can’t analyze your content, because you’re in a non-production environment." );
-			const screenReaderLabels = getAllByText( "Indexables are disabled" );
-			expect( tooltip ).toHaveLength( 5 );
+			const screenReaderLabels = getAllByText( "Disabled" );
+			expect( tooltip ).toHaveLength( 1 );
 			expect( screenReaderLabels ).toHaveLength( 5 );
 		} );
 	} );
-	it( "when the data provider has SEO analysis disabled, should render the TopPagesWidget component with disabled tooltip", async() => {
+	it( "should render one tooltip and screen reader text for scores, when the data provider has SEO analysis disabled", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( data );
 		dataProvider = new MockDataProvider( {
 			features: {
@@ -157,8 +157,8 @@ describe( "TopPagesWidget", () => {
 		// Verify the disabled score message is present.
 		await waitFor( () => {
 			const tooltip = getAllByText( "We can’t provide SEO scores, because the SEO analysis is disabled for your site." );
-			const screenReaderLabels = getAllByText( "SEO analysis is disabled" );
-			expect( tooltip ).toHaveLength( 5 );
+			const screenReaderLabels = getAllByText( "Disabled" );
+			expect( tooltip ).toHaveLength( 1 );
 			expect( screenReaderLabels ).toHaveLength( 5 );
 		} );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility for disabled SEO score in the Top 5 most popular content table of the unreleased site kit integration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the google site kit feature flag:
```
define( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE', true );
```
* Connect site kit and see the "Top 5 most popular content" table.
* Turn on the Voiceover screenreader.
* Check for urls that are not analysed, check you get the tooltip for not analysed.
* [ ] Check that the screen reader reads the tooltip.
* For urls that are not editable, check you get the not editable tooltip. 
* [ ] Check that the screen reader reads the tooltip and also mention that this score is disabled.
* Disable SEO analysis on Yoast SEO->Settings.
* [ ] Check the Yoast SEO score table header has dotted underline.
* [ ] Hover the header and check you get the tooltip for disabled SEO score.
* [ ] Check that the screen reader reads the tooltip.
* [ ] [ ] Check the screenreader read the X int he table as "Disabled".
* Disable indexable by adding the code:
```
add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
```
* [ ] Check the Yoast SEO score table header has dotted underline.
* [ ] Hover the header and check you get the tooltip for disabled indexables.
* [ ] Check that the screen reader reads the tooltip.
* [ ] Check the screenreader read the X int he table as "Disabled".


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Improve UX and accessibility of Yoast SEO scores column heading in widget table](https://github.com/Yoast/reserved-tasks/issues/451)
