### PR TITLE
Update Dashboard page description

### DIFF
--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -26,10 +26,11 @@ const prepareWidgetInstance = ( type ) => {
  * @param {string} userName The user name.
  * @param {Features} features Whether features are enabled.
  * @param {Links} links The links.
+ * @param {boolean} sitekitFeatureEnabled Whether the site kit feature is enabled.
  *
  * @returns {JSX.Element} The element.
  */
-export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links } ) => {
+export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links, sitekitFeatureEnabled } ) => {
 	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
 
 	// eslint-disable-next-line no-unused-vars
@@ -43,7 +44,7 @@ export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, featu
 
 	return (
 		<>
-			<PageTitle userName={ userName } features={ features } links={ links } />
+			<PageTitle userName={ userName } features={ features } links={ links } sitekitFeatureEnabled={ sitekitFeatureEnabled } />
 			<div className="yst-grid yst-grid-cols-4 yst-gap-6 yst-my-6">
 				{ widgets.map( ( widget ) => widgetFactory.createWidget( widget, removeWidget ) ) }
 			</div>

--- a/packages/js/src/dashboard/components/page-title.js
+++ b/packages/js/src/dashboard/components/page-title.js
@@ -12,56 +12,78 @@ import { OutboundLink } from "../../shared-admin/components";
  * @param {string} userName The user name.
  * @param {Features} features Whether features are enabled.
  * @param {Links} links The links.
+ * @param {boolean} sitekitFeatureEnabled Whether the site kit feature is enabled.
  * @returns {JSX.Element} The element.
  */
-export const PageTitle = ( { userName, features, links } ) => (
-	<Paper className="yst-shadow-md">
-		<Paper.Content className="yst-flex yst-flex-col yst-gap-y-4 yst-max-w-screen-sm">
-			<Title as="h1">
-				{ sprintf(
-					__( "Hi %s,", "wordpress-seo" ),
-					userName
+export const PageTitle = ( { userName, features, links, sitekitFeatureEnabled } ) => {
+
+	const noAnalysisEnabledMessage = sitekitFeatureEnabled
+		?
+		/**
+		* translators: %1$s and %2$s expand to an opening and closing anchor tag, to the site features page.
+		* %3$s and %4$s expand to an opening and closing anchor tag, to the user profile page.
+		**/
+		 __( "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities. Get even more insights by enabling the ‘SEO analysis’ and the ‘Readability analysis’ in your %1$sSite features%2$s or your %3$suser profile settings%4$s.", "wordpress-seo" )
+		:
+		/**
+		* translators: %1$s and %2$s expand to an opening and closing anchor tag, to the site features page.
+		* %3$s and %4$s expand to an opening and closing anchor tag, to the user profile page.
+		**/
+		 __( "It looks like the ‘SEO analysis’ and the ‘Readability analysis’ are currently disabled in your %1$sSite features%2$s or your %3$suser profile settings%4$s. Enable these features to start seeing all the insights you need right here!", "wordpress-seo" );
+
+	const noIndexablesEnabledMessage = sitekitFeatureEnabled
+		?
+		__( "Oops! You can’t see the overview of your SEO insights right now because you’re in a non-production environment.", "wordpress-seo" )
+		:
+		__( "Oops! You can’t see the overview of your SEO scores and readability scores right now because you’re in a non-production environment.", "wordpress-seo" );
+
+		
+
+	return (
+		<Paper className="yst-shadow-md">
+			<Paper.Content className="yst-flex yst-flex-col yst-gap-y-4 yst-max-w-screen-sm">
+				<Title as="h1">
+					{ sprintf(
+						__( "Hi %s,", "wordpress-seo" ),
+						userName
+					) }
+				</Title>
+				<p className="yst-text-tiny">
+					{ features.indexables && ! features.seoAnalysis && ! features.readabilityAnalysis
+						? createInterpolateElement(
+							sprintf(
+								noAnalysisEnabledMessage,
+								"<link>",
+								"</link>",
+								"<profilelink>",
+								"</profilelink>"
+							),
+							{
+								// Added dummy space as content to prevent children prop warnings in the console.
+								link: <Link href="admin.php?page=wpseo_page_settings#/site-features"> </Link>,
+								profilelink: <Link href="profile.php"> </Link>,
+							}
+						)
+						: createInterpolateElement(
+							sprintf(
+								/* translators: %1$s and %2$s expand to an opening and closing anchor tag. */
+								__( "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities. %1$sLearn more about the dashboard%2$s.", "wordpress-seo" ),
+								"<link>",
+								"</link>"
+							),
+							{
+								// Added dummy space as content to prevent children prop warnings in the console.
+								link: <OutboundLink href={ links.dashboardLearnMore }> </OutboundLink>,
+							}
+						)
+					}
+				</p>
+				{ ! features.indexables && (
+					<Alert type="info">
+						{ noIndexablesEnabledMessage }
+					</Alert>
 				) }
-			</Title>
-			<p className="yst-text-tiny">
-				{ features.indexables && ! features.seoAnalysis && ! features.readabilityAnalysis
-					? createInterpolateElement(
-						sprintf(
-							/**
-							 * translators: %1$s and %2$s expand to an opening and closing anchor tag, to the site features page.
-							 * %3$s and %4$s expand to an opening and closing anchor tag, to the user profile page.
-							 **/
-							__( "It looks like the ‘SEO analysis’ and the ‘Readability analysis’ are currently disabled in your %1$sSite features%2$s or your %3$suser profile settings%4$s. Enable these features to start seeing all the insights you need right here!", "wordpress-seo" ),
-							"<link>",
-							"</link>",
-							"<profilelink>",
-							"</profilelink>"
-						),
-						{
-							// Added dummy space as content to prevent children prop warnings in the console.
-							link: <Link href="admin.php?page=wpseo_page_settings#/site-features"> </Link>,
-							profilelink: <Link href="profile.php"> </Link>,
-						}
-					)
-					: createInterpolateElement(
-						sprintf(
-							/* translators: %1$s and %2$s expand to an opening and closing anchor tag. */
-							__( "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities. %1$sLearn more about the dashboard%2$s.", "wordpress-seo" ),
-							"<link>",
-							"</link>"
-						),
-						{
-							// Added dummy space as content to prevent children prop warnings in the console.
-							link: <OutboundLink href={ links.dashboardLearnMore }> </OutboundLink>,
-						}
-					)
-				}
-			</p>
-			{ ! features.indexables && (
-				<Alert type="info">
-					{ __( "Oops! You can’t see the overview of your SEO scores and readability scores right now because you’re in a non-production environment.", "wordpress-seo" ) }
-				</Alert>
-			) }
-		</Paper.Content>
-	</Paper>
-);
+			</Paper.Content>
+		</Paper>
+	);
+};

--- a/packages/js/src/dashboard/components/page-title.js
+++ b/packages/js/src/dashboard/components/page-title.js
@@ -15,29 +15,23 @@ import { OutboundLink } from "../../shared-admin/components";
  * @param {boolean} sitekitFeatureEnabled Whether the site kit feature is enabled.
  * @returns {JSX.Element} The element.
  */
+// eslint-disable-next-line complexity
 export const PageTitle = ( { userName, features, links, sitekitFeatureEnabled } ) => {
-
 	const noAnalysisEnabledMessage = sitekitFeatureEnabled
-		?
 		/**
 		* translators: %1$s and %2$s expand to an opening and closing anchor tag, to the site features page.
 		* %3$s and %4$s expand to an opening and closing anchor tag, to the user profile page.
 		**/
-		 __( "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities. Get even more insights by enabling the ‘SEO analysis’ and the ‘Readability analysis’ in your %1$sSite features%2$s or your %3$suser profile settings%4$s.", "wordpress-seo" )
-		:
+		? __( "Welcome to your dashboard! Check your content's SEO performance, readability, and overall strengths and opportunities. Get even more insights by enabling the ‘SEO analysis’ and the ‘Readability analysis’ in your %1$sSite features%2$s or your %3$suser profile settings%4$s.", "wordpress-seo" )
 		/**
 		* translators: %1$s and %2$s expand to an opening and closing anchor tag, to the site features page.
 		* %3$s and %4$s expand to an opening and closing anchor tag, to the user profile page.
 		**/
-		 __( "It looks like the ‘SEO analysis’ and the ‘Readability analysis’ are currently disabled in your %1$sSite features%2$s or your %3$suser profile settings%4$s. Enable these features to start seeing all the insights you need right here!", "wordpress-seo" );
+		:  __( "It looks like the ‘SEO analysis’ and the ‘Readability analysis’ are currently disabled in your %1$sSite features%2$s or your %3$suser profile settings%4$s. Enable these features to start seeing all the insights you need right here!", "wordpress-seo" );
 
 	const noIndexablesEnabledMessage = sitekitFeatureEnabled
-		?
-		__( "Oops! You can’t see the overview of your SEO insights right now because you’re in a non-production environment.", "wordpress-seo" )
-		:
-		__( "Oops! You can’t see the overview of your SEO scores and readability scores right now because you’re in a non-production environment.", "wordpress-seo" );
-
-		
+		? __( "Oops! You can’t see the overview of your SEO insights right now because you’re in a non-production environment.", "wordpress-seo" )
+		: __( "Oops! You can’t see the overview of your SEO scores and readability scores right now because you’re in a non-production environment.", "wordpress-seo" );
 
 	return (
 		<Paper className="yst-shadow-md">

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -126,6 +126,7 @@ domReady( () => { // eslint-disable-line complexity
 								userName={ userName }
 								features={ features }
 								links={ links }
+								sitekitFeatureEnabled={ siteKitConfiguration.isFeatureEnabled }
 							/>
 							<ConnectedPremiumUpsellList />
 						</SidebarLayout>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates Dashboard page description.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the Google Site Kit feature flag
* The normal page title at the top of the page should be like this:
![image](https://github.com/user-attachments/assets/d9cbe70b-f85b-4c56-b402-55ea18422ee7)
* Disable indexables, by adding the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );`  filter
* Refresh the page and the page title should be like this:
![image](https://github.com/user-attachments/assets/399e9af3-a624-4d1f-80d4-d5f8e5ba71ac)
* Re-enable indexables and disable the SEO and Readability analysis from your site settings
* Refresh the page and the page title should be like this:
![image](https://github.com/user-attachments/assets/39a373c5-8fa5-4fcd-bcfe-f864b8b485a7)

* Now, disable the Google Site Kit feature flag. 
* The normal page title at the top of the page should be like this:
![image](https://github.com/user-attachments/assets/d9cbe70b-f85b-4c56-b402-55ea18422ee7)
* Disable indexables, by adding the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );`  filter
* Refresh the page and the page title should be like this:
![image](https://github.com/user-attachments/assets/436e25d3-5616-46b3-8736-95dc8f55925e)
* Re-enable indexables and disable the SEO and Readability analysis from your site settings
* Refresh the page and the page title should be like this:
![image](https://github.com/user-attachments/assets/812de0bf-0d13-40aa-a27d-30efa96886da)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
