### PR TITLE
Use Google library for parsing GSC responses

### DIFF
--- a/src/dashboard/domain/analytics-4/unexpected-response-exception.php
+++ b/src/dashboard/domain/analytics-4/unexpected-response-exception.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Dashboard\Domain\Analytics_4;
+
+use Exception;
+
+/**
+ * Exception for when a search console request returns with an unexpected response.
+ */
+class Unexpected_Response_Exception extends Exception {
+
+	/**
+	 * Constructor of the exception.
+	 */
+	public function __construct() {
+		parent::__construct( 'The response from Google Site Kit did not have an expected format.', 400 );
+	}
+}

--- a/src/dashboard/domain/analytics-4/unexpected-response-exception.php
+++ b/src/dashboard/domain/analytics-4/unexpected-response-exception.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Dashboard\Domain\Analytics_4;
 use Exception;
 
 /**
- * Exception for when a search console request returns with an unexpected response.
+ * Exception for when an Analytics 4 request returns with an unexpected response.
  */
 class Unexpected_Response_Exception extends Exception {
 

--- a/src/dashboard/domain/search-console/unexpected-response-exception.php
+++ b/src/dashboard/domain/search-console/unexpected-response-exception.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Dashboard\Domain\Search_Console;
+
+use Exception;
+
+/**
+ * Exception for when a search console request returns with an unexpected response.
+ */
+class Unexpected_Response_Exception extends Exception {
+
+	/**
+	 * Constructor of the exception.
+	 */
+	public function __construct() {
+		parent::__construct( 'The response from Google Site Kit did not have an expected format.', 400 );
+	}
+}

--- a/src/dashboard/domain/search-console/unexpected-response-exception.php
+++ b/src/dashboard/domain/search-console/unexpected-response-exception.php
@@ -5,7 +5,7 @@ namespace Yoast\WP\SEO\Dashboard\Domain\Search_Console;
 use Exception;
 
 /**
- * Exception for when a search console request returns with an unexpected response.
+ * Exception for when a Search Console request returns with an unexpected response.
  */
 class Unexpected_Response_Exception extends Exception {
 

--- a/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
+++ b/src/dashboard/infrastructure/search-console/site-kit-search-console-adapter.php
@@ -7,8 +7,10 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit\Plugin;
+use Google\Site_Kit_Dependencies\Google\Service\SearchConsole\ApiDataRow;
 use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Container;
 use Yoast\WP\SEO\Dashboard\Domain\Search_Console\Failed_Request_Exception;
+use Yoast\WP\SEO\Dashboard\Domain\Search_Console\Unexpected_Response_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Search_Rankings\Search_Ranking_Data;
 
 /**
@@ -43,7 +45,8 @@ class Site_Kit_Search_Console_Adapter {
 	 *
 	 * @return Data_Container The Site Kit API response.
 	 *
-	 * @throws Failed_Request_Exception When the request responds with an error from Site Kit.
+	 * @throws Failed_Request_Exception      When the request responds with an error from Site Kit.
+	 * @throws Unexpected_Response_Exception When the request responds with an unexpected format.
 	 */
 	public function get_data( Search_Console_Parameters $parameters ): Data_Container {
 		$api_parameters = [
@@ -63,8 +66,31 @@ class Site_Kit_Search_Console_Adapter {
 			throw new Failed_Request_Exception( \wp_kses_post( $response->get_error_message() ), (int) $error_status_code );
 		}
 
+		if ( ! \is_array( $response ) ) {
+			throw new Unexpected_Response_Exception();
+		}
+
+		return $this->parse_response( $response );
+	}
+
+	/**
+	 * Parses a response for a Site Kit API request for Search Analytics.
+	 *
+	 * @param ApiDataRow[] $response The response to parse.
+	 *
+	 * @return Data_Container The parsed Site Kit API response.
+	 *
+	 * @throws Unexpected_Response_Exception When the request responds with an unexpected format.
+	 */
+	protected function parse_response( array $response ): Data_Container {
 		$search_ranking_data_container = new Data_Container();
+
 		foreach ( $response as $ranking ) {
+
+			if ( ! \is_a( $ranking, ApiDataRow::class ) ) {
+				throw new Unexpected_Response_Exception();
+			}
+
 			/**
 			 * Filter: 'wpseo_transform_dashboard_subject_for_testing' - Allows overriding subjects like URLs for the dashboard, to facilitate testing in local environments.
 			 *
@@ -72,9 +98,9 @@ class Site_Kit_Search_Console_Adapter {
 			 *
 			 * @param string $url The subject to be transformed.
 			 */
-			$subject = \apply_filters( 'wpseo_transform_dashboard_subject_for_testing', $ranking->keys[0] );
+			$subject = \apply_filters( 'wpseo_transform_dashboard_subject_for_testing', $ranking->getKeys()[0] );
 
-			$search_ranking_data_container->add_data( new Search_Ranking_Data( $ranking->clicks, $ranking->ctr, $ranking->impressions, $ranking->position, $subject ) );
+			$search_ranking_data_container->add_data( new Search_Ranking_Data( $ranking->getClicks(), $ranking->getCtr(), $ranking->getImpressions(), $ranking->getPosition(), $subject ) );
 		}
 
 		return $search_ranking_data_container;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors endpoint to use Google libraries for parsing the responses from Google APIs.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

For the new exceptions:
* In **src\dashboard\infrastructure\search-console\site-kit-search-console-adapter.php**, change the `$response = self::$search_console_module->get_data( 'searchanalytics', $api_parameters );`  line to `$response = 'foo';` 
* Do a GET request to `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=page` or `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=query`
* Confirm that you get a 400 response with the `"error": "The response from Google Site Kit did not have an expected format."` body
* In **src\dashboard\infrastructure\analytics-4\site-kit-analytics-4-adapter.php** change the `$response       = self::$analytics_4_module->get_data( 'report', $api_parameters );` line to `$response       = 'bar';`
* Do a GET request to `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=οrganicSessionsChange` or `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=οrganicSessionsDaily`
* Confirm that you get a 400 response with the `"error": "The response from Google Site Kit did not have an expected format."` body

Impact check:
* Do a GET request to the following endpoints and confirm that you get the exact same responses without this PR/RC:
  * `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=page`
  * `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=query`
  * `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=οrganicSessionsDaily`
  * `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=οrganicSessionsChange`
 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
