### PR TITLE
Prevent duplicate HTML elements in metabox

### DIFF
--- a/admin/metabox/class-metabox-section-react.php
+++ b/admin/metabox/class-metabox-section-react.php
@@ -108,7 +108,9 @@ class WPSEO_Metabox_Section_React implements WPSEO_Metabox_Section {
 			esc_attr( $this->name )
 		);
 		echo wp_kses_post( $this->content );
-		echo '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
+		if ( 'content' === $this->name ) {
+			echo '<div id="wpseo-metabox-root" class="wpseo-metabox-root"></div>';
+		}
 		echo wp_kses_post( $this->html_after );
 		echo '</div>';
 


### PR DESCRIPTION
## Context
I found that the Yoast SEO plugin inserts multiple identical HTML elements with duplicate IDs. To resolve this, I added a condition to ensure the element is added only once.

## Summary

## Test instructions

1. Navigate to the WordPress admin panel: `{siteurl}/wp-admin/`  
2. Click on the "Pages" menu: `{siteurl}/wp-admin/edit.php?post_type=page`  
3. Open the URL in any HTML validator tool or check it using the Firefox web browser.  
4. In Firefox, view the page source to see the error.  
5. With this patch, the error is not there anymore.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [x] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #22051