### PR TITLE
458 UI feedback small fixes for site kit widgets

### DIFF
--- a/packages/js/src/dashboard/components/error-alert.js
+++ b/packages/js/src/dashboard/components/error-alert.js
@@ -1,6 +1,7 @@
 import { createInterpolateElement } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Link } from "@yoast/ui-library";
+import classNames from "classnames";
 
 /**
  * Create an interpolate element with the link.
@@ -62,7 +63,7 @@ export const ErrorAlert = ( { error, supportLink, className = "" } ) => {
 	const link = <Link variant="error" href={ supportLink }> </Link>;
 
 	return (
-		<Alert variant="error" className={ className }>
+		<Alert variant="error" className={ classNames( "yst-max-w-2xl", className ) }>
 			{ getErrorMessage( error, link ) }
 		</Alert>
 	);

--- a/packages/js/src/dashboard/components/widget-table.js
+++ b/packages/js/src/dashboard/components/widget-table.js
@@ -40,7 +40,7 @@ const ScoreBullet = ( { score, id } ) => ( <TooltipContainer className="yst-h-4 
 		</div>
 	</TooltipTrigger>
 	{ SCORE_META[ score ]?.tooltip && <TooltipWithContext position="left" id={ id }>
-		{ score === "notAnalyzed" ? __( "Content analysis hasn't started. Plean open this page in your editor, enter a focus keyphrase, and save.", "wordpress-seo" )
+		{ score === "notAnalyzed" ? __( "Content analysis hasn't started. Please open this page in your editor, enter a focus keyphrase and save.", "wordpress-seo" )
 			: SCORE_META[ score ].tooltip }
 
 	</TooltipWithContext> }

--- a/packages/js/src/dashboard/components/widget-table.js
+++ b/packages/js/src/dashboard/components/widget-table.js
@@ -39,7 +39,11 @@ const ScoreBullet = ( { score, id } ) => ( <TooltipContainer className="yst-h-4 
 			<span className="yst-sr-only">{ SCORE_META[ score ].label }</span>
 		</div>
 	</TooltipTrigger>
-	{ SCORE_META[ score ]?.tooltip && <TooltipWithContext position="left" id={ id }>{ SCORE_META[ score ].tooltip }</TooltipWithContext> }
+	{ SCORE_META[ score ]?.tooltip && <TooltipWithContext position="left" id={ id }>
+		{ score === "notAnalyzed" ? __( "Content analysis hasn't started. Open this page in your editor, add a focus keyphrase, and save.", "wordpress-seo" )
+			: SCORE_META[ score ].tooltip }
+
+	</TooltipWithContext> }
 </TooltipContainer>
 );
 

--- a/packages/js/src/dashboard/components/widget-table.js
+++ b/packages/js/src/dashboard/components/widget-table.js
@@ -40,7 +40,7 @@ const ScoreBullet = ( { score, id } ) => ( <TooltipContainer className="yst-h-4 
 		</div>
 	</TooltipTrigger>
 	{ SCORE_META[ score ]?.tooltip && <TooltipWithContext position="left" id={ id }>
-		{ score === "notAnalyzed" ? __( "Content analysis hasn't started. Open this page in your editor, add a focus keyphrase, and save.", "wordpress-seo" )
+		{ score === "notAnalyzed" ? __( "Content analysis hasn't started. Plean open this page in your editor, enter a focus keyphrase, and save.", "wordpress-seo" )
 			: SCORE_META[ score ].tooltip }
 
 	</TooltipWithContext> }

--- a/packages/js/src/dashboard/components/widget-table.js
+++ b/packages/js/src/dashboard/components/widget-table.js
@@ -17,7 +17,7 @@ import { __ } from "@wordpress/i18n";
  * @returns {JSX.Element} The element.
  */
 const DisabledScore = ( { tooltip, id } ) => (
-	<TooltipContainer>
+	<TooltipContainer className="yst-h-4">
 		<TooltipTrigger ariaDescribedby={ id }>
 			<XIcon className="yst-w-4 yst-h-4 yst-text-slate-400" />
 			<span className="yst-sr-only">{ __( "Disabled", "wordpress-seo" ) }</span>
@@ -33,7 +33,7 @@ const DisabledScore = ( { tooltip, id } ) => (
  *
  * @returns {JSX.Element} The element.
  */
-const ScoreBullet = ( { score, id } ) => ( <TooltipContainer>
+const ScoreBullet = ( { score, id } ) => ( <TooltipContainer className="yst-h-4 yst-flex yst-items-center yst-justify-center">
 	<TooltipTrigger ariaDescribedby={ id }>
 		<div className={ classNames( "yst-shrink-0 yst-w-3 yst-aspect-square yst-rounded-full", SCORE_META[ score ].color ) }>
 			<span className="yst-sr-only">{ SCORE_META[ score ].label }</span>

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -131,16 +131,16 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWi
 				screenReaderTriggerLabel={ __( "Open Site Kit widget dropdown menu", "wordpress-seo" ) }
 				className="yst-float-end"
 			/>
-			<DropdownMenu.List className="yst-mt-6 yst-w-56">
+			<DropdownMenu.List className="yst-mt-8 yst-w-56">
 				<DropdownMenu.ButtonItem
-					className="yst-text-slate-600 yst-border-b yst-border-slate-200 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4"
+					className="yst-text-slate-600 yst-border-b yst-border-slate-200 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4 yst-font-normal"
 					onClick={ handleOnRemove }
 				>
 					<XIcon className="yst-w-4 yst-text-slate-400" />
 					{ __( "Remove until next visit", "wordpress-seo" ) }
 				</DropdownMenu.ButtonItem>
 				<DropdownMenu.ButtonItem
-					className="yst-text-red-500 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4"
+					className="yst-text-red-500 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4 yst-font-normal"
 					onClick={ handleRemovePermanently }
 				>
 					<TrashIcon className="yst-w-4" />

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -191,6 +191,39 @@ export const createTopPageFormatter = ( dataFormatter ) => ( data = [] ) => data
 } ) );
 
 /**
+ * The content of the top pages widget.
+ *
+ * @param {TopPageData[]} data The data.
+ * @param {boolean} isPending Whether the data is pending.
+ * @param {number} limit The limit.
+ * @param {Error} error The error.
+ * @param {import("../services/data-provider")} dataProvider The data provider.
+ *
+ * @returns {JSX.Element} The element.
+ */
+const TopPagesWidgetContent = ( { data, isPending, limit, error, dataProvider } ) => {
+	if ( isPending ) {
+		return (
+			<TopPagesTable>
+				{ Array.from( { length: limit }, ( _, index ) => (
+					<TopPagesSkeletonLoaderRow key={ `top-pages-table--row__${ index }` } index={ index } />
+				) ) }
+			</TopPagesTable>
+		);
+	}
+
+	if ( error ) {
+		return <ErrorAlert error={ error } supportLink={ dataProvider.getLink( "errorSupport" ) } className="yst-mt-4" />;
+	}
+
+	if ( data.length === 0 ) {
+		return <p className="yst-mt-4">{ __( "No data to display: Your site hasn't received any visitors yet.", "wordpress-seo" ) }</p>;
+	}
+
+	return <TopPagesTable data={ data } isIndexablesEnabled={ dataProvider.hasFeature( "indexables" ) } isSeoAnalysisEnabled={ dataProvider.hasFeature( "seoAnalysis" ) } />;
+};
+
+/**
  * @param {import("../services/data-provider")} dataProvider The data provider.
  * @param {import("../services/remote-data-provider")} remoteDataProvider The remote data provider.
  * @param {import("../services/data-formatter")} dataFormatter The data formatter.
@@ -211,37 +244,12 @@ export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatte
 
 	const infoLink = dataProvider.getLink( "topPagesInfoLearnMore" );
 
-	const isIndexablesEnabled = dataProvider.hasFeature( "indexables" );
-	const isSeoAnalysisEnabled = dataProvider.hasFeature( "seoAnalysis" );
-
 	/**
 	 * @type {function(?TopPageData[]): TopPageData[]} Function to format the top pages data.
 	 */
 	const formatTopPages = useMemo( () => createTopPageFormatter( dataFormatter ), [ dataFormatter ] );
 
 	const { data, error, isPending } = useRemoteData( getTopPages, formatTopPages );
-
-	const renderContent = () => {
-		if ( isPending ) {
-			return (
-				<TopPagesTable>
-					{ Array.from( { length: limit }, ( _, index ) => (
-						<TopPagesSkeletonLoaderRow key={ `top-pages-table--row__${ index }` } index={ index } />
-					) ) }
-				</TopPagesTable>
-			);
-		}
-
-		if ( error ) {
-			return <ErrorAlert error={ error } supportLink={ dataProvider.getLink( "errorSupport" ) } className="yst-mt-4" />;
-		}
-
-		if ( data.length === 0 ) {
-			return <p className="yst-mt-4">{ __( "No data to display: Your site hasn't received any visitors yet.", "wordpress-seo" ) }</p>;
-		}
-
-		return <TopPagesTable data={ data } isIndexablesEnabled={ isIndexablesEnabled } isSeoAnalysisEnabled={ isSeoAnalysisEnabled } />;
-	};
 
 	return <Widget className="yst-paper__content yst-col-span-4">
 		<div className="yst-flex yst-justify-between">
@@ -250,6 +258,12 @@ export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatte
 				<Info url={ infoLink } />
 			</InfoTooltip>
 		</div>
-		{ renderContent() }
+		<TopPagesWidgetContent
+			data={ data }
+			isPending={ isPending }
+			limit={ limit }
+			error={ error }
+			dataProvider={ dataProvider }
+		/>
 	</Widget>;
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes copy and styling for the site kit widgets. 

## Relevant technical choices:

* I refactor the top 5 most popular render content to be in a separate component for readability.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set up an environment for site kit with the feature branch enabled.
* Check you have the site kit set up widget and click on the 3 vertical dots menu.
* [ ] Check there is space of 8px between the dots and the and the menu.
* [ ] Check the menu items font weight is normal ( not 500)
* Connect to site kit.
* Check you see the table content.
* Check you see the loading effect on the table.
* Check the x in the table is vertically aligned to the center of the row.
* Hover a grey score bullet on the last row and check the copy in the tooltip is as follow:
> Content analysis hasn't started. Please open this page in your editor, enter a focus keyphrase and save.
* Create an error for the "Top 5 most popular content" widget, follow the steps [here](https://github.com/Yoast/reserved-tasks/issues/425).
* [ ] Check the error width is limited to 672px of wider screens.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [UI feedback (small fixes) for Site Kit widgets](https://github.com/Yoast/reserved-tasks/issues/458)
