### PR TITLE
fix the widgets visibility on connect and tab navigation

### DIFF
--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -33,7 +33,7 @@ const prepareWidgetInstance = ( type ) => {
  * @returns {JSX.Element} The element.
  */
 export const Dashboard = ( { widgetFactory, userName, features, links, sitekitFeatureEnabled, dataProvider } ) => {
-	const getSnapshotSiteKitConfiguration = useCallback( () => dataProvider.getSnapshotSiteKitConfiguration(), [ dataProvider ] );
+	const getSnapshotSiteKitConfiguration = useCallback( () => dataProvider.getSiteKitConfiguration(), [ dataProvider ] );
 	const subscribeSiteKitConfiguration = useCallback( ( callback ) => {
 		return dataProvider.subscribe( callback );
 	}, [ dataProvider ] );

--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -1,5 +1,7 @@
-import { useCallback, useState } from "@wordpress/element";
+import { useCallback, useSyncExternalStore } from "@wordpress/element";
 import { PageTitle } from "./page-title";
+import { values } from "lodash";
+import { WidgetFactory } from "../services/widget-factory";
 
 /**
  * @type {import("../index").ContentType} ContentType
@@ -21,32 +23,27 @@ const prepareWidgetInstance = ( type ) => {
 
 /**
  * @param {WidgetFactory} widgetFactory The widget factory.
- * @param {WidgetType[]} initialWidgets The initial widgets.
  * @param {ContentType[]} contentTypes The content types.
  * @param {string} userName The user name.
  * @param {Features} features Whether features are enabled.
  * @param {Links} links The links.
  * @param {boolean} sitekitFeatureEnabled Whether the site kit feature is enabled.
+ * @param {import("../services/data-provider")} dataProvider The data provider.
  *
  * @returns {JSX.Element} The element.
  */
-export const Dashboard = ( { widgetFactory, initialWidgets = [], userName, features, links, sitekitFeatureEnabled } ) => {
-	const [ widgets, setWidgets ] = useState( () => initialWidgets.map( prepareWidgetInstance ) );
-
-
-	const addWidget = useCallback( ( type ) => {
-		setWidgets( ( currentWidgets ) => [ prepareWidgetInstance( type ), ...currentWidgets ] );
-	}, [] );
-
-	const removeWidget = useCallback( ( type ) => {
-		setWidgets( ( currentWidgets ) => currentWidgets.filter( ( widget ) => widget.type !== type ) );
-	}, [] );
+export const Dashboard = ( { widgetFactory, userName, features, links, sitekitFeatureEnabled, dataProvider } ) => {
+	const getSnapshotSiteKitConfiguration = useCallback( () => dataProvider.getSnapshotSiteKitConfiguration(), [ dataProvider ] );
+	const subscribeSiteKitConfiguration = useCallback( ( callback ) => {
+		return dataProvider.subscribe( callback );
+	}, [ dataProvider ] );
+	useSyncExternalStore( subscribeSiteKitConfiguration, getSnapshotSiteKitConfiguration );
 
 	return (
 		<>
 			<PageTitle userName={ userName } features={ features } links={ links } sitekitFeatureEnabled={ sitekitFeatureEnabled } />
 			<div className="yst-grid yst-grid-cols-4 yst-gap-6 yst-my-6">
-				{ widgets.map( ( widget ) => widgetFactory.createWidget( widget, removeWidget, addWidget ) ) }
+				{ values( WidgetFactory.types ).map( ( widget ) => widgetFactory.createWidget( prepareWidgetInstance( widget ) ) ) }
 			</div>
 		</>
 	);

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -18,6 +18,7 @@ export class DataProvider {
 	#headers;
 	#links;
 	#siteKitConfiguration;
+	#subscribers = new Set();
 
 	/**
 	 * @param {ContentType[]} contentTypes The content types.
@@ -36,6 +37,31 @@ export class DataProvider {
 		this.#headers = headers;
 		this.#links = links;
 		this.#siteKitConfiguration = siteKitConfiguration;
+	}
+
+	/**
+	 * Get the current snapshot of the site kit configuration.
+	 * @returns {SiteKitConfiguration} The current site kit configuration.
+	 */
+	getSnapshotSiteKitConfiguration() {
+		return this.#siteKitConfiguration;
+	}
+
+	/**
+     * Subscribe to changes in the site kit configuration.
+     * @param {Function} callback The callback to call when the configuration changes.
+     * @returns {Function} Unsubscribe function.
+     */
+	subscribe( callback ) {
+		this.#subscribers.add( callback );
+		return () => this.#subscribers.delete( callback );
+	}
+
+	/**
+     * Notify all subscribers of a change in the site kit configuration.
+     */
+	notifySubscribers() {
+		this.#subscribers.forEach( callback => callback() );
 	}
 
 	/**
@@ -99,6 +125,7 @@ export class DataProvider {
 			...this.#siteKitConfiguration,
 			isConnected,
 		};
+		this.notifySubscribers();
 	}
 
 	/**
@@ -110,5 +137,6 @@ export class DataProvider {
 			...this.#siteKitConfiguration,
 			isConfigurationDismissed,
 		};
+		this.notifySubscribers();
 	}
 }

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -40,14 +40,6 @@ export class DataProvider {
 	}
 
 	/**
-	 * Get the current snapshot of the site kit configuration.
-	 * @returns {SiteKitConfiguration} The current site kit configuration.
-	 */
-	getSnapshotSiteKitConfiguration() {
-		return this.#siteKitConfiguration;
-	}
-
-	/**
      * Subscribe to changes in the site kit configuration.
      * @param {Function} callback The callback to call when the configuration changes.
      * @returns {Function} Unsubscribe function.

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -28,26 +28,26 @@ export class WidgetFactory {
 	}
 
 	/**
+	 * The widget types, also determaines the order in which they are displayed.!
+	 *
 	 * @returns {Object} The widget types.
 	 */
 	static get types() {
 		return {
+			siteKitSetup: "siteKitSetup",
+			topPages: "topPages",
+			topQueries: "topQueries",
 			seoScores: "seoScores",
 			readabilityScores: "readabilityScores",
-			topPages: "topPages",
-			siteKitSetup: "siteKitSetup",
-			topQueries: "topQueries",
 		};
 	}
 
 	/**
 	 * @param {WidgetInstance} widget The widget to create.
-	 * @param {function} onRemove The remove handler.
-	 * @param {function} onAdd The add handler.
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
-	// eslint-disable-next-line no-unused-vars
-	createWidget( widget, onRemove, onAdd ) {
+	createWidget( widget ) {
+		const { isFeatureEnabled, isConnected, isConfigurationDismissed } = this.#dataProvider.getSiteKitConfiguration();
 		switch ( widget.type ) {
 			case WidgetFactory.types.seoScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
@@ -70,7 +70,7 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
 			case WidgetFactory.types.topPages:
-				if ( ! this.#dataProvider.getSiteKitConfiguration().isConnected ) {
+				if ( ! isFeatureEnabled || ! isConnected ) {
 					return null;
 				}
 				return <TopPagesWidget
@@ -80,18 +80,18 @@ export class WidgetFactory {
 					dataFormatter={ this.#dataFormatter }
 				/>;
 			case WidgetFactory.types.siteKitSetup:
-				// This check here makes sure we don't render the setup anymore if the user dismissed and then switches away from the dashboard.
-				// Then switches back to the dashboard, but does not refresh.
-				if ( this.#dataProvider.getSiteKitConfiguration().isConfigurationDismissed ) {
+				if ( ! isFeatureEnabled || isConfigurationDismissed ) {
 					return null;
 				}
 				return <SiteKitSetupWidget
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
-					removeWidget={ onRemove }
 				/>;
 			case WidgetFactory.types.topQueries:
+				if ( ! isFeatureEnabled || ! isConnected ) {
+					return null;
+				}
 				return <TopQueriesWidget
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -78,7 +78,7 @@ export class WidgetFactory {
 					dataFormatter={ this.#dataFormatter }
 				/>;
 			case WidgetFactory.types.siteKitSetup:
-				// This check here makes sure we don't render the setup anymore if the user connected and then switches away from the dashboard.
+				// This check here makes sure we don't render the setup anymore if the user dismissed and then switches away from the dashboard.
 				// Then switches back to the dashboard, but does not refresh.
 				if ( this.#dataProvider.getSiteKitConfiguration().isConfigurationDismissed ) {
 					return null;

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -44,6 +44,7 @@ export class WidgetFactory {
 	 * @param {function} onAdd The add handler.
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
+	// eslint-disable-next-line no-unused-vars
 	createWidget( widget, onRemove, onAdd ) {
 		switch ( widget.type ) {
 			case WidgetFactory.types.seoScores:
@@ -67,6 +68,9 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
 			case WidgetFactory.types.topPages:
+				if ( ! this.#dataProvider.getSiteKitConfiguration().isConnected ) {
+					return null;
+				}
 				return <TopPagesWidget
 					key={ widget.id }
 					dataProvider={ this.#dataProvider }
@@ -76,8 +80,7 @@ export class WidgetFactory {
 			case WidgetFactory.types.siteKitSetup:
 				// This check here makes sure we don't render the setup anymore if the user connected and then switches away from the dashboard.
 				// Then switches back to the dashboard, but does not refresh.
-				if ( this.#dataProvider.getSiteKitConfiguration().isConnected ||
-				this.#dataProvider.getSiteKitConfiguration().isConfigurationDismissed ) {
+				if ( this.#dataProvider.getSiteKitConfiguration().isConfigurationDismissed ) {
 					return null;
 				}
 				return <SiteKitSetupWidget
@@ -85,7 +88,6 @@ export class WidgetFactory {
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					removeWidget={ onRemove }
-					addWidget={ onAdd }
 				/>;
 			default:
 				return null;

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -6,7 +6,6 @@ import { Button, DropdownMenu, Paper, Stepper, Title, useToggleState } from "@yo
 import { noop } from "lodash";
 import { ReactComponent as YoastConnectSiteKit } from "../../../images/yoast-connect-google-site-kit.svg";
 import { SiteKitConsentModal } from "../../shared-admin/components";
-import { WidgetFactory } from "../services/widget-factory";
 
 /**
  * @type {import("../index").SiteKitConfiguration} SiteKitConfiguration
@@ -71,27 +70,21 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, handleRerend
  *
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} removeWidget The function to remove a widget.
  *
  * @returns {JSX.Element} The widget.
  */
-export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget } ) => {
+export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const handleOnRemove = useCallback( () => {
-		removeWidget( WidgetFactory.types.siteKitSetup );
 		dataProvider.setSiteKitConfigurationDismissed( true );
-	}, [ removeWidget ] );
+	}, [ dataProvider ] );
 
-	const handleRerenderWidgets = useCallback( () => {
-		removeWidget( "" );
-	}, [ removeWidget ] );
 
-	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleRerenderWidgets );
+	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleRemovePermanently = useCallback( () => {
 		dismissPermanently();
-		removeWidget( WidgetFactory.types.siteKitSetup );
-	}, [ removeWidget, dismissPermanently ] );
+	}, [ dismissPermanently ] );
 
 	const learnMoreLink = dataProvider.getLink( "siteKitLearnMore" );
 	const consentLearnMoreLink = dataProvider.getLink( "siteKitConsentLearnMore" );

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -32,10 +32,10 @@ const steps = [
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} addSiteKitWidgets The function add the site kit widgets.
+ * @param {function} handleRerenderWidgets The function to rerender the dashboard.
  * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
-const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWidgets ) => {
+const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, handleRerenderWidgets ) => {
 	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
 
 	const grantConsent = useCallback( ( options ) => {
@@ -46,7 +46,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWi
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				addSiteKitWidgets();
+				handleRerenderWidgets();
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );
@@ -72,26 +72,26 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, addSiteKitWi
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
  * @param {function} removeWidget The function to remove a widget.
- * @param {function} addWidget The function to add a widget.
  *
  * @returns {JSX.Element} The widget.
  */
-export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget, addWidget } ) => {
-	const handleAddSiteKitWidgets = useCallback( () => {
-		[ WidgetFactory.types.topPages ].forEach( ( type ) => addWidget( type ) );
-	}, [ addWidget ] );
-
-	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleAddSiteKitWidgets );
-	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
-
+export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider, removeWidget } ) => {
 	const handleOnRemove = useCallback( () => {
 		removeWidget( WidgetFactory.types.siteKitSetup );
+		dataProvider.setSiteKitConfigurationDismissed( true );
 	}, [ removeWidget ] );
+
+	const handleRerenderWidgets = useCallback( () => {
+		removeWidget( "" );
+	}, [ removeWidget ] );
+
+	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider, handleRerenderWidgets );
+	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleRemovePermanently = useCallback( () => {
 		dismissPermanently();
-		handleOnRemove();
-	}, [ handleOnRemove, dismissPermanently ] );
+		removeWidget( WidgetFactory.types.siteKitSetup );
+	}, [ removeWidget, dismissPermanently ] );
 
 	const learnMoreLink = dataProvider.getLink( "siteKitLearnMore" );
 	const consentLearnMoreLink = dataProvider.getLink( "siteKitConsentLearnMore" );

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -31,10 +31,9 @@ const steps = [
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {function} handleRerenderWidgets The function to rerender the dashboard.
  * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
-const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, handleRerenderWidgets ) => {
+const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
 
 	const grantConsent = useCallback( ( options ) => {
@@ -45,7 +44,6 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider, handleRerend
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				handleRerenderWidgets();
 				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -28,7 +28,7 @@ import { ALERT_CENTER_NAME } from "./store/alert-center";
  * @type {import("../index").Endpoints} Endpoints
  */
 
-domReady( () => { // eslint-disable-line complexity
+domReady( () => {
 	const root = document.getElementById( "yoast-seo-general" );
 	if ( ! root ) {
 		return;
@@ -93,24 +93,15 @@ domReady( () => { // eslint-disable-line complexity
 		isConfigurationDismissed: false,
 	} );
 
+	if ( siteKitConfiguration.isConnected ) {
+		siteKitConfiguration.isConfigurationDismissed = true;
+	}
+
+
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
-
-	const initialWidgets = [];
-
-	// If site kit feature is enabled, add the site kit setup widget.
-	if ( siteKitConfiguration.isFeatureEnabled && ! siteKitConfiguration.isConfigurationDismissed && ! siteKitConfiguration.isConnected ) {
-		initialWidgets.push( WidgetFactory.types.siteKitSetup );
-	}
-
-	// If site kit feature is enabled and connected: add the top pages widget.
-	if ( siteKitConfiguration.isFeatureEnabled ) {
-		initialWidgets.push( WidgetFactory.types.topPages );
-	}
-
-	initialWidgets.push( WidgetFactory.types.seoScores, WidgetFactory.types.readabilityScores );
 
 	const router = createHashRouter(
 		createRoutesFromElements(
@@ -121,11 +112,11 @@ domReady( () => { // eslint-disable-line complexity
 						<SidebarLayout>
 							<Dashboard
 								widgetFactory={ widgetFactory }
-								initialWidgets={ initialWidgets }
 								userName={ userName }
 								features={ features }
 								links={ links }
 								sitekitFeatureEnabled={ siteKitConfiguration.isFeatureEnabled }
+								dataProvider={ dataProvider }
 							/>
 							<ConnectedPremiumUpsellList />
 						</SidebarLayout>

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -105,7 +105,7 @@ domReady( () => { // eslint-disable-line complexity
 	}
 
 	// If site kit feature is enabled and connected: add the top pages widget.
-	if ( siteKitConfiguration.isFeatureEnabled && siteKitConfiguration.isConnected ) {
+	if ( siteKitConfiguration.isFeatureEnabled ) {
 		initialWidgets.push( WidgetFactory.types.topPages );
 	}
 

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -33,7 +33,7 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "SEO scores", { id: "seo-scores-widget", type: "seoScores" }, "SEO scores" ],
 		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
+		// [ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
 		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
 	] )( "should create a %s widget", async( _, widget, title ) => {
 		const element = widgetFactory.createWidget( widget, jest.fn() );
@@ -45,6 +45,38 @@ describe( "WidgetFactory", () => {
 			if ( title ) {
 				expect( getByRole( "heading", { name: title } ) ).toBeInTheDocument();
 			}
+		} );
+	} );
+
+	test( "should create the top pages widget", async() => {
+		dataProvider.setSiteKitConnected( true );
+		const element = widgetFactory.createWidget( { id: "top-pages-widget", type: "topPages" }, jest.fn() );
+		expect( element?.key ).toBe( "top-pages-widget" );
+		const { getByRole } = render( <>{ element }</> );
+
+		await waitFor( () => {
+			expect( getByRole( "heading", { name: "Top 5 most popular content" } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	test( "should create the site kit set up widget", async() => {
+		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" }, jest.fn() );
+		expect( element?.key ).toBe( "site-kit-setup-widget" );
+		const { getByRole } = render( <>{ element }</> );
+
+		await waitFor( () => {
+			expect( getByRole( "heading", { name: "Expand your dashboard with insights from Google!" } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	test( "should not create the site kit set up widget", async() => {
+		dataProvider.setSiteKitConnected( true );
+		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" }, jest.fn() );
+		expect( element?.key ).toBe( "site-kit-setup-widget" );
+		const { getByRole } = render( <>{ element }</> );
+
+		await waitFor( () => {
+			expect( getByRole( "heading", { name: "Expand your dashboard with insights from Google!" } ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -35,12 +35,21 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
+		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
+		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
+	] )( "should not create a %s widget when site kit is not connected", async( _, widget ) => {
+		dataProvider.setSiteKitConnected( false );
+		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
+		expect( widgetFactory.createWidget( widget ) ).toBeNull();
+	} );
+
+	test.each( [
 		[ "SEO scores", { id: "seo-scores-widget", type: "seoScores" }, "SEO scores" ],
 		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
 		[ "Site Kit setup", { id: "site-kit-setup-widget", type: "siteKitSetup" }, "Expand your dashboard with insights from Google!" ],
 		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
 	] )( "should create a %s widget", async( _, widget, title ) => {
-		const element = widgetFactory.createWidget( widget, jest.fn(), jest.fn() );
+		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
 		const { getByRole } = render( <>{ element }</> );
 
@@ -57,7 +66,7 @@ describe( "WidgetFactory", () => {
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
 	] )( "should create a %s widget", async( _, widget, title ) => {
 		dataProvider.setSiteKitConnected( true );
-		const element = widgetFactory.createWidget( widget, jest.fn(), jest.fn() );
+		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
 		const { getByRole } = render( <>{ element }</> );
 
@@ -66,21 +75,6 @@ describe( "WidgetFactory", () => {
 			if ( title ) {
 				expect( getByRole( "heading", { name: title } ) ).toBeInTheDocument();
 			}
-		} );
-	} );
-
-	test.each( [
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
-		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
-	] )( "should not create a %s widget when site kit is not connected", async( _, widget, title ) => {
-		const element = widgetFactory.createWidget( widget, jest.fn(), jest.fn() );
-		expect( element?.key ).toBe( widget.id );
-		const { queryByRole } = render( <>{ element }</> );
-
-		await waitFor( () => {
-			// Verify the title is not present.
-			const heading = queryByRole( "heading", { name: title } );
-			expect( heading ).not.toBe();
 		} );
 	} );
 
@@ -96,7 +90,7 @@ describe( "WidgetFactory", () => {
 
 	test( "should not create the site kit set up widget", async() => {
 		dataProvider.setSiteKitConnected( true );
-		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" }, jest.fn() );
+		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" } );
 		expect( element?.key ).toBe( "site-kit-setup-widget" );
 		const { getByRole } = render( <>{ element }</> );
 
@@ -118,7 +112,7 @@ describe( "WidgetFactory", () => {
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 
-		expect( widgetFactory.createWidget( widget, jest.fn(), jest.fn() ) ).toBeNull();
+		expect( widgetFactory.createWidget( widget ) ).toBeNull();
 	} );
 
 
@@ -128,6 +122,19 @@ describe( "WidgetFactory", () => {
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 
-		expect( widgetFactory.createWidget( { id: "site-kite-setup-widget", type: "siteKitSetup" }, jest.fn(), jest.fn() ) ).toBeNull();
+		expect( widgetFactory.createWidget( { id: "site-kite-setup-widget", type: "siteKitSetup" } ) ).toBeNull();
+	} );
+
+	test.each( [
+		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
+		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
+		[ "siteKitSetup", { id: "site-kite-setup-widget", type: "siteKitSetup" } ],
+	] )( "should not create a %s widget when site kit feature is disabled", async( _, widget ) => {
+		dataProvider = new MockDataProvider( {
+			siteKitConfiguration: { isFeatureEnabled: false },
+		} );
+		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
+
+		expect( widgetFactory.createWidget( widget ) ).toBeNull();
 	} );
 } );

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -8,11 +8,6 @@ describe( "SiteKitSetupWidget", () => {
 	let dataProvider;
 	const remoteDataProvider = new MockRemoteDataProvider( {} );
 	const removeWidget = jest.fn();
-	const addWidget = jest.fn();
-	const props = {
-		removeWidget,
-		addWidget,
-	};
 
 	beforeEach( () => {
 		dataProvider = new MockDataProvider();
@@ -24,7 +19,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const installLink = screen.getByRole( "link", { name: /Install Site Kit by Google/i } );
 		expect( installLink ).toBeInTheDocument();
@@ -35,7 +30,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const learnMoreLink = screen.getByRole( "link", { name: /Learn more/i } );
 		expect( learnMoreLink ).toBeInTheDocument();
@@ -51,7 +46,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const activateLink = screen.getByRole( "link", { name: /Activate Site Kit by Google/i } );
 		expect( activateLink ).toBeInTheDocument();
@@ -68,7 +63,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const setupLink = screen.getByRole( "link", { name: /Set up Site Kit by Google/i } );
 		expect( setupLink ).toBeInTheDocument();
@@ -86,7 +81,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		expect( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) ).toBeInTheDocument();
 	} );
@@ -102,7 +97,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const connectButton = screen.getByRole( "button", { name: /Connect Site Kit by Google/i } );
 		fireEvent.click( connectButton );
@@ -119,7 +114,7 @@ describe( "SiteKitSetupWidget", () => {
 		} );
 		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: true } );
 		render( <SiteKitSetupWidget
-			{ ...props }
+			removeWidget={ removeWidget }
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
 		/> );
@@ -149,7 +144,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -159,7 +154,7 @@ describe( "SiteKitSetupWidget", () => {
 			expect( grantConsentButton ).toBeInTheDocument();
 		} );
 		expect( screen.queryByRole( "button", { name: /Got it!/i } ) ).not.toBeInTheDocument();
-		expect( addWidget ).toHaveBeenCalledWith( "topPages" );
+		expect( removeWidget ).not.toHaveBeenCalled();
 
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-consent-management",
@@ -180,7 +175,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -211,7 +206,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		const dismissButton = screen.getByRole( "button", { name: /Got it/i } );
 		expect( dismissButton ).toBeInTheDocument();
@@ -230,7 +225,7 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			{ ...props }
+			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
 		const removeButton = screen.getByRole( "menuitem", { name: /Remove permanently/i, type: "button" } );

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import { SiteKitSetupWidget } from "../../../src/dashboard/widgets/site-kit-setup-widget";
 import { fireEvent, render, screen, waitFor } from "../../test-utils";
 import { MockDataProvider } from "../__mocks__/data-provider";
@@ -7,19 +7,16 @@ import { MockRemoteDataProvider } from "../__mocks__/remote-data-provider";
 describe( "SiteKitSetupWidget", () => {
 	let dataProvider;
 	const remoteDataProvider = new MockRemoteDataProvider( {} );
-	const removeWidget = jest.fn();
 
 	beforeEach( () => {
 		dataProvider = new MockDataProvider();
 		remoteDataProvider.fetchJson.mockClear();
-		removeWidget.mockClear();
 	} );
 
 	it( "renders the widget with install button", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const installLink = screen.getByRole( "link", { name: /Install Site Kit by Google/i } );
 		expect( installLink ).toBeInTheDocument();
@@ -30,7 +27,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const learnMoreLink = screen.getByRole( "link", { name: /Learn more/i } );
 		expect( learnMoreLink ).toBeInTheDocument();
@@ -46,7 +42,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const activateLink = screen.getByRole( "link", { name: /Activate Site Kit by Google/i } );
 		expect( activateLink ).toBeInTheDocument();
@@ -63,7 +58,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const setupLink = screen.getByRole( "link", { name: /Set up Site Kit by Google/i } );
 		expect( setupLink ).toBeInTheDocument();
@@ -81,7 +75,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		expect( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) ).toBeInTheDocument();
 	} );
@@ -97,7 +90,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const connectButton = screen.getByRole( "button", { name: /Connect Site Kit by Google/i } );
 		fireEvent.click( connectButton );
@@ -114,16 +106,12 @@ describe( "SiteKitSetupWidget", () => {
 		} );
 		remoteDataProvider.fetchJson.mockResolvedValueOnce( { success: true } );
 		render( <SiteKitSetupWidget
-			removeWidget={ removeWidget }
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
 		fireEvent.click( screen.getByRole( "button", { name: /Grant consent/i } ) );
-		await waitFor( () => {
-			expect( screen.getByRole( "button", { name: /Got it!/i } ) ).toBeInTheDocument();
-		} );
 
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-consent-management",
@@ -144,7 +132,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -154,7 +141,6 @@ describe( "SiteKitSetupWidget", () => {
 			expect( grantConsentButton ).toBeInTheDocument();
 		} );
 		expect( screen.queryByRole( "button", { name: /Got it!/i } ) ).not.toBeInTheDocument();
-		expect( removeWidget ).not.toHaveBeenCalled();
 
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-consent-management",
@@ -175,7 +161,6 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Connect Site Kit by Google/i } ) );
 
@@ -206,12 +191,10 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		const dismissButton = screen.getByRole( "button", { name: /Got it/i } );
 		expect( dismissButton ).toBeInTheDocument();
 		fireEvent.click( dismissButton );
-		expect( removeWidget ).toHaveBeenCalledWith( "siteKitSetup" );
 	} );
 
 	it( "opens the menu and calls dismissPermanently and removeWidget when 'Remove permanently' is clicked", async() => {
@@ -225,12 +208,10 @@ describe( "SiteKitSetupWidget", () => {
 		render( <SiteKitSetupWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
-			removeWidget={ removeWidget }
 		/> );
 		fireEvent.click( screen.getByRole( "button", { name: /Open Site Kit widget dropdown menu/i } ) );
 		const removeButton = screen.getByRole( "menuitem", { name: /Remove permanently/i, type: "button" } );
 		fireEvent.click( removeButton );
-		expect( removeWidget ).toHaveBeenCalled();
 		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledWith(
 			"https://example.com/site-kit-configuration-dismissal",
 			// eslint-disable-next-line camelcase


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Once connected, the site kit widget should be dismissed by the "Got it!" button. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes unreleased bug where the site kit widget "Top 5 mot popular content" would disappear on tab navigation.  

## Relevant technical choices:

*  Since the initial list of widgets before site kit is connected doesn't include the "Top 5 most popular content" widget, I had to add that with condition in the widget factory, that solves the bug where the "Top 5 most popular content" widget would disappear on tab navigation. 
* Adding and removing the widgets from inside the site kit widget would create duplication because of the condition above. The removing or adding would change the state and in turn would re-render the dashboard component. That is why I used the remove callback with empty string to only re-render the dashboard.
* I updated the factory data for site kit setup dismissed permanently without calling the endpoint , for the "dismissed until next visit" and "Got it!" buttons, to avoid re-rendering of the setup widget on tab change ( approved by ux).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Connect to site kit and check you still see the set up widget with a button "Got it!"
* Check the widgets "Top 5 most popular content" and "Top 5 search queries" are below it.
* Navigate to other tabs in the dashboard like alert center or first time configuration and return to the dashboard.
* Check both widgets are still there.
* Click on "Got it" and check the set up widget disappears
* Navigate to other tabs in the dashboard like alert center or first time configuration and return to the dashboard.
* Check the setup widget is still not there.
* Go to integration page and disconnect the widget.
* Go back to the dashboard and check you see the set up widget again.
* Click on the the 3 vertical dots menu and dismiss until next visit.
* Go to other tabs and return to the dashboard. 
* Check you don't see the setup widget.
* Refresh and check you do see the set up widget again. 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Fix sit kit set up flow and tab navigation](https://github.com/Yoast/reserved-tasks/issues/462)
