### PR TITLE
Unblock bottom navigation on the bulk editor & redirects

### DIFF
--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -213,10 +213,9 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$order_by         = isset( $_GET['orderby'] ) && is_string( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
 		$order            = isset( $_GET['order'] ) && is_string( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
 		$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
-		$nav_class		= ( 'bottom' === $which ) ? 'bulk-navigation' : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended;
 		?>
-		<div class="tablenav  <?php echo esc_attr( $which ); ?> <?php echo esc_attr( $nav_class ); ?>">
+		<div class="tablenav  <?php echo esc_attr( $which ); ?>">
 
 			<?php if ( $which === 'top' ) { ?>
 			<form id="posts-filter" action="" method="get">

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -213,9 +213,10 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$order_by         = isset( $_GET['orderby'] ) && is_string( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
 		$order            = isset( $_GET['order'] ) && is_string( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : '';
 		$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
+		$nav_class		= ( 'bottom' === $which ) ? 'bulk-navigation' : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended;
 		?>
-		<div class="tablenav <?php echo esc_attr( $which ); ?>">
+		<div class="tablenav  <?php echo esc_attr( $which ); ?> <?php echo esc_attr( $nav_class ); ?>">
 
 			<?php if ( $which === 'top' ) { ?>
 			<form id="posts-filter" action="" method="get">

--- a/admin/class-bulk-editor-list-table.php
+++ b/admin/class-bulk-editor-list-table.php
@@ -215,7 +215,7 @@ class WPSEO_Bulk_List_Table extends WP_List_Table {
 		$post_type_filter = isset( $_GET['post_type_filter'] ) && is_string( $_GET['post_type_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type_filter'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended;
 		?>
-		<div class="tablenav  <?php echo esc_attr( $which ); ?>">
+		<div class="tablenav <?php echo esc_attr( $which ); ?>">
 
 			<?php if ( $which === 'top' ) { ?>
 			<form id="posts-filter" action="" method="get">

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -934,4 +934,10 @@ body.folded .wpseo-admin-submit-fixed {
 	line-height: normal;
 	text-wrap: nowrap;
 }
+
+@media (min-width: 768px) {
+	.bulk-navigation {
+		margin-bottom: 40px;
+	}
+}
 /*# sourceMappingURL=admin-global.css.map */

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -936,7 +936,7 @@ body.folded .wpseo-admin-submit-fixed {
 }
 
 @media (min-width: 768px) {
-	.bulk-navigation {
+	.wpseo_table_page .tablenav.bottom {
 		margin-bottom: 40px;
 	}
 }


### PR DESCRIPTION
#214

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Unblock bottom navigation on the bulk editor & redirects.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the help beacon would be displayed over table pagination on Yoast admin pages.

## Relevant technical choices:

* css rules added to apply required changes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open **Yoast SEO ** > **Tools** > **Bulk Editor**
* Add more content if required to view navigation
* Reduce screen height if required to allow scroll
* Scroll to bottom and make sure that **Need Help?** badge doesn't overlap with the navigation.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Should not impact other places.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#214](https://github.com/Yoast/ux/issues/214)
