### PR TITLE
fix error handling and capabilities for consent

### DIFF
--- a/packages/js/src/dashboard/widgets/top-queries-widget.js
+++ b/packages/js/src/dashboard/widgets/top-queries-widget.js
@@ -1,9 +1,10 @@
 import { useCallback, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { Alert, SkeletonLoader } from "@yoast/ui-library";
+import { SkeletonLoader } from "@yoast/ui-library";
 import { WidgetTable } from "../components/widget-table";
 import { useRemoteData } from "../services/use-remote-data";
 import { Widget } from "./widget";
+import { ErrorAlert } from "../components/error-alert";
 
 /**
  * @type {import("../index").TopQueryData} TopQueryData
@@ -63,14 +64,15 @@ const TopQueriesTable = ( { data, children } ) => {
 /**
  * The content for TopQueriesWidget.
  *
- * @param {TopQueryData[]} [data]
- * @param {boolean} [isPending]
- * @param {Error} [error]
- * @param {number} [limit=5]
+ * @param {TopQueryData[]} [data] The data.
+ * @param {boolean} [isPending] Whether the data is pending.
+ * @param {Error} [error] The error.
+ * @param {number} [limit=5] The limit.
+ * @param {string} [supportLink] The support link.
  *
  * @returns {JSX.Element} The element.
  */
-export const TopQueriesWidgetContent = ( { data, isPending, error, limit = 5 } ) => {
+export const TopQueriesWidgetContent = ( { data, isPending, error, limit = 5, supportLink } ) => {
 	if ( isPending ) {
 		return (
 			<TopQueriesTable>
@@ -82,7 +84,7 @@ export const TopQueriesWidgetContent = ( { data, isPending, error, limit = 5 } )
 	}
 	if ( error ) {
 		return (
-			<Alert variant="error" className="yst-mt-4">{ error.message }</Alert>
+			<ErrorAlert error={ error } supportLink={ supportLink } className="yst-mt-4" />
 		);
 	}
 	if ( data.length === 0 ) {
@@ -128,6 +130,7 @@ export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormat
 	}, [ dataProvider, limit ] );
 
 	const infoLink = dataProvider.getLink( "topQueriesInfoLearnMore" );
+	const supportLink = dataProvider.getLink( "errorSupport" );
 
 	/**
 	 * @type {function(?TopQueryData[]): TopQueryData[]} Function to format the top queries data.
@@ -150,6 +153,7 @@ export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormat
 			isPending={ isPending }
 			limit={ limit }
 			error={ error }
+			supportLink={ supportLink }
 		/>
 	</Widget>;
 };

--- a/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/top-pages-widget.test.js
@@ -84,7 +84,7 @@ describe( "TopPagesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopPagesWidget component with a pending state", async() => {
+	it( "should render the component with a pending state", async() => {
 		// Never resolving promise to ensure it keeps loading.
 		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {
 		} ) );
@@ -149,12 +149,32 @@ describe( "TopPagesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopPagesWidget component with an general error state", async() => {
-		// Mock the fetchJson method to throw an error.
-		const error = new Error( "Network Error" );
-		error.status = 500;
+	it.each( [
+		{
+			status: 408,
+			name: "Unauthorized",
+			message: "The request timed out. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+		{
+			status: 400,
+			name: "TimeoutError",
+			message: "The request timed out. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+		{
+			status: 403,
+			name: "Forbidden",
+			message: "You don’t have permission to access this resource. Please contact your admin for access. In case you need further help, please check our Support page.",
+		},
+		{
+			status: 500,
+			name: "Bad Request",
+			message: "Something went wrong. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+	] )( "should render the message for an error with status $status and error name $name.", async( { status, name, message } ) => {
+		const error = new Error( name );
+		error.status = status;
+		error.name = name;
 		remoteDataProvider.fetchJson.mockRejectedValue( error );
-
 		const { getByRole } = render( <TopPagesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
@@ -163,44 +183,7 @@ describe( "TopPagesWidget", () => {
 
 		await waitFor( () => {
 			expect( getByRole( "status" ) )
-				.toHaveTextContent( "Something went wrong. Try refreshing the page. If the problem persists, please check our Support page." );
-			expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "https://example.com/error-support" );
-		} );
-	} );
-
-	it( "should render the TopPagesWidget component with an time out error state", async() => {
-		// Mock the fetchJson method to throw an error.
-		const error = new Error( "TimeoutError" );
-		error.status = 408;
-		remoteDataProvider.fetchJson.mockRejectedValue( error );
-
-		const { getByRole } = render( <TopPagesWidget
-			dataProvider={ dataProvider }
-			remoteDataProvider={ remoteDataProvider }
-			dataFormatter={ dataFormatter }
-		/> );
-
-		await waitFor( () => {
-			expect( getByRole( "status" ) )
-				.toHaveTextContent( "The request timed out. Try refreshing the page. If the problem persists, please check our Support page." );
-			expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "https://example.com/error-support" );
-		} );
-	} );
-
-	it( "should render the TopPagesWidget component with an no permission error state", async() => {
-		const error = new Error( "NoPermissionError" );
-		error.status = 403;
-		remoteDataProvider.fetchJson.mockRejectedValue( error );
-
-		const { getByRole } = render( <TopPagesWidget
-			dataProvider={ dataProvider }
-			remoteDataProvider={ remoteDataProvider }
-			dataFormatter={ dataFormatter }
-		/> );
-
-		await waitFor( () => {
-			expect( getByRole( "status" ) )
-				.toHaveTextContent( "You don’t have permission to access this resource. Please contact your admin for access. In case you need further help, please check our Support page." );
+				.toHaveTextContent( message );
 			expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "https://example.com/error-support" );
 		} );
 	} );

--- a/packages/js/tests/dashboard/widgets/top-queries-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/top-queries-widget.test.js
@@ -32,7 +32,7 @@ describe( "TopQueriesWidget", () => {
 		remoteDataProvider.fetchJson.mockClear();
 	} );
 
-	it( "should render the TopQueriesWidget component", async() => {
+	it( "should render the component", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( data );
 		const { getByRole, getByText } = render( <TopQueriesWidget
 			dataProvider={ dataProvider }
@@ -57,7 +57,7 @@ describe( "TopQueriesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopQueriesWidget component without data", async() => {
+	it( "should render the component without data", async() => {
 		remoteDataProvider.fetchJson.mockResolvedValue( [] );
 		const { getByText } = render( <TopQueriesWidget
 			dataProvider={ dataProvider }
@@ -71,21 +71,46 @@ describe( "TopQueriesWidget", () => {
 		} );
 	} );
 
-	it( "should render the TopQueriesWidget component with an error", async() => {
-		const message = "An error occurred.";
-		remoteDataProvider.fetchJson.mockRejectedValue( new Error( message ) );
-		const { getByText } = render( <TopQueriesWidget
+	it.each( [
+		{
+			status: 408,
+			name: "Unauthorized",
+			message: "The request timed out. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+		{
+			status: 400,
+			name: "TimeoutError",
+			message: "The request timed out. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+		{
+			status: 403,
+			name: "Forbidden",
+			message: "You don’t have permission to access this resource. Please contact your admin for access. In case you need further help, please check our Support page.",
+		},
+		{
+			status: 500,
+			name: "Bad Request",
+			message: "Something went wrong. Try refreshing the page. If the problem persists, please check our Support page.",
+		},
+	] )( "should render the message for an error with status $status and error name $name.", async( { status, name, message } ) => {
+		const error = new Error( name );
+		error.status = status;
+		error.name = name;
+		remoteDataProvider.fetchJson.mockRejectedValue( error );
+		const { getByRole } = render( <TopQueriesWidget
 			dataProvider={ dataProvider }
 			remoteDataProvider={ remoteDataProvider }
 			dataFormatter={ dataFormatter }
 		/> );
 
 		await waitFor( () => {
-			expect( getByText( message ) ).toBeInTheDocument();
+			expect( getByRole( "status" ) )
+				.toHaveTextContent( message );
+			expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "https://example.com/error-support" );
 		} );
 	} );
 
-	it( "should render the TopQueriesWidget component with a pending state", async() => {
+	it( "should render the component with a pending state", async() => {
 		// Never resolving promise to ensure it keeps loading.
 		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {
 		} ) );

--- a/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
@@ -6,9 +6,9 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
-use WPSEO_Capability_Utils;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
 
@@ -45,14 +45,24 @@ class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
 	private $permanently_dismissed_site_kit_configuration_repository;
 
 	/**
+	 * Holds the capabilit helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
 	 * Constructs the class.
 	 *
 	 * @param Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface $permanently_dismissed_site_kit_configuration_repository The repository.
+	 * @param Capability_Helper                                                 $capability_helper                                       The capability helper.
 	 */
 	public function __construct(
-		Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface $permanently_dismissed_site_kit_configuration_repository
+		Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface $permanently_dismissed_site_kit_configuration_repository,
+		Capability_Helper $capability_helper
 	) {
 		$this->permanently_dismissed_site_kit_configuration_repository = $permanently_dismissed_site_kit_configuration_repository;
+		$this->capability_helper                                       = $capability_helper;
 	}
 
 	/**
@@ -116,6 +126,6 @@ class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function check_capabilities() {
-		return WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
 	}
 }

--- a/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
@@ -6,6 +6,7 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
+use WPSEO_Capability_Utils;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface;
 use Yoast\WP\SEO\Main;
@@ -115,6 +116,6 @@ class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function check_capabilities() {
-		return \current_user_can( 'install_plugins' );
+		return WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
 	}
 }

--- a/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
@@ -6,6 +6,7 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
+use WPSEO_Capability_Utils;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Interface;
 use Yoast\WP\SEO\Main;
@@ -115,6 +116,6 @@ class Site_Kit_Consent_Management_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function check_capabilities() {
-		return \current_user_can( 'install_plugins' );
+		return WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
 	}
 }

--- a/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
@@ -6,9 +6,9 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
-use WPSEO_Capability_Utils;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Interface;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
 
@@ -45,14 +45,24 @@ class Site_Kit_Consent_Management_Route implements Route_Interface {
 	private $site_kit_consent_repository;
 
 	/**
+	 * Holds the capabilit helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
 	 * Constructs the class.
 	 *
 	 * @param Site_Kit_Consent_Repository_Interface $site_kit_consent_repository The repository.
+	 * @param Capability_Helper                     $capability_helper           The capability helper.
 	 */
 	public function __construct(
-		Site_Kit_Consent_Repository_Interface $site_kit_consent_repository
+		Site_Kit_Consent_Repository_Interface $site_kit_consent_repository,
+		Capability_Helper $capability_helper
 	) {
 		$this->site_kit_consent_repository = $site_kit_consent_repository;
+		$this->capability_helper           = $capability_helper;
 	}
 
 	/**
@@ -116,6 +126,6 @@ class Site_Kit_Consent_Management_Route implements Route_Interface {
 	 * @return bool
 	 */
 	public function check_capabilities() {
-		return WPSEO_Capability_Utils::current_user_can( 'wpseo_manage_options' );
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Abstract_Site_Kit_Configuration_Permanent_Dismissal_Route_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Abstract_Site_Kit_Configuration_Permanent_Dismissal_Route_Test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 use Mockery;
 use WP_Error;
 use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -25,6 +26,13 @@ abstract class Abstract_Site_Kit_Configuration_Permanent_Dismissal_Route_Test ex
 	protected $instance;
 
 	/**
+	 * Holds the mock for the capability helper.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -33,9 +41,11 @@ abstract class Abstract_Site_Kit_Configuration_Permanent_Dismissal_Route_Test ex
 		parent::set_up();
 
 		Mockery::mock( WP_Error::class );
+		$this->capability_helper = Mockery::mock( Capability_Helper::class );
 
 		$this->instance = new Site_Kit_Configuration_Dismissal_Route(
-			new Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake()
+			new Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake(),
+			$this->capability_helper
 		);
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Abstract_Site_Kit_Consent_Management_Route_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Abstract_Site_Kit_Consent_Management_Route_Test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 use Mockery;
 use WP_Error;
 use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Consent_Management_Route;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Fake;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -25,6 +26,13 @@ abstract class Abstract_Site_Kit_Consent_Management_Route_Test extends TestCase 
 	protected $instance;
 
 	/**
+	 * Holds the mock for the capability helper.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -33,9 +41,11 @@ abstract class Abstract_Site_Kit_Consent_Management_Route_Test extends TestCase 
 		parent::set_up();
 
 		Mockery::mock( WP_Error::class );
+		$this->capability_helper = Mockery::mock( Capability_Helper::class );
 
 		$this->instance = new Site_Kit_Consent_Management_Route(
-			new Site_Kit_Consent_Repository_Fake()
+			new Site_Kit_Consent_Repository_Fake(),
+			$this->capability_helper
 		);
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
@@ -2,8 +2,6 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 
-use Brain\Monkey\Functions;
-
 /**
  * Abstract class for the Permanently Dismissed Site Kit Configuration Repository tests.
  *
@@ -21,9 +19,10 @@ final class Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_
 	 * @return void
 	 */
 	public function test_check_capabilities() {
-		Functions\expect( 'current_user_can' )
+		$this->capability_helper->expects( 'current_user_can' )
 			->once()
-			->with( 'wpseo_manage_options' )->andReturn( true );
+			->with( 'wpseo_manage_options' )
+			->andReturn( true );
 
 		$this->assertTrue( $this->instance->check_capabilities() );
 	}

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
@@ -23,7 +23,7 @@ final class Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_
 	public function test_check_capabilities() {
 		Functions\expect( 'current_user_can' )
 			->once()
-			->with( 'install_plugins' )->andReturn( true );
+			->with( 'wpseo_manage_options' )->andReturn( true );
 
 		$this->assertTrue( $this->instance->check_capabilities() );
 	}

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Check_Capabilities_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Check_Capabilities_Test.php
@@ -16,14 +16,14 @@ use Brain\Monkey\Functions;
 final class Site_Kit_Consent_Management_Route_Check_Capabilities_Test extends Abstract_Site_Kit_Consent_Management_Route_Test {
 
 	/**
-	 * Tests that the capability that is tested for is `administrator`.
+	 * Tests that the capability that is tested for is `wpseo_manage_options`.
 	 *
 	 * @return void
 	 */
 	public function test_check_capabilities() {
 		Functions\expect( 'current_user_can' )
 			->once()
-			->with( 'install_plugins' )->andReturn( true );
+			->with( 'wpseo_manage_options' )->andReturn( true );
 
 		$this->assertTrue( $this->instance->check_capabilities() );
 	}

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Check_Capabilities_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Check_Capabilities_Test.php
@@ -2,8 +2,6 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 
-use Brain\Monkey\Functions;
-
 /**
  * Abstract class for the Permanently Dismissed Site Kit Configuration Repository tests.
  *
@@ -21,9 +19,10 @@ final class Site_Kit_Consent_Management_Route_Check_Capabilities_Test extends Ab
 	 * @return void
 	 */
 	public function test_check_capabilities() {
-		Functions\expect( 'current_user_can' )
+		$this->capability_helper->expects( 'current_user_can' )
 			->once()
-			->with( 'wpseo_manage_options' )->andReturn( true );
+			->with( 'wpseo_manage_options' )
+			->andReturn( true );
 
 		$this->assertTrue( $this->instance->check_capabilities() );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds error messages for the site kit top queries widget and changes the capabilities for site kit widget.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create an environment with site kit feature enabled and connected.
* Create a user with the role of SEO manager.
* Log in as an SEO manager
* [ ] Go to Yoast SEO -> Integration and check you are able to disconnect site kit
* [ ] Go to the dashboard and check you are able to connect to site kit.
* Once connected check you see the the site kit widgets "top 5 most popular content" and "Top 5 search queries"
* Check those widgets have the error message:
> You don’t have permission to access this resource. Please contact your admin for access. In case you need further help, please check our [Support page](http://acceptance.test/wp-admin/admin.php?page=wpseo_page_support).
* To allow SEO manager to see the widget, go the the site kit plugin, go to the file `includes\Core\Modules\Module_With_Owner_Trait.php` and `return 1;`. on line 42;
* Log in as admin and go to site kit, click on the sharing options and see you now can add roles to view search console.
* Add the seo manager.
* Log in as SEO manager
* [ ] Check you can now see the data in the widgets and there is no error alert.
* Disconnect site kit on the integrations page.
* Go back to the dashboard and check you can see the site kit setup widget.
* Click on the 3 vertical dots menu in the site kit setup widget and click on dismiss permanently
* [ ] Refresh and check you can no longer see the site kit setup widget.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Implement use case "User with WPSEO_manage_options capability but no capability to install plugins"](https://github.com/Yoast/reserved-tasks/issues/446)
