### PR TITLE
Allow going back and forth with the setup widget.

### DIFF
--- a/packages/js/src/dashboard/components/dashboard.js
+++ b/packages/js/src/dashboard/components/dashboard.js
@@ -38,6 +38,8 @@ export const Dashboard = ( { widgetFactory, userName, features, links, sitekitFe
 		return dataProvider.subscribe( callback );
 	}, [ dataProvider ] );
 	useSyncExternalStore( subscribeSiteKitConfiguration, getSnapshotSiteKitConfiguration );
+	const getSnapshotSiteKitSetupCompleted = useCallback( () => dataProvider.isSiteKitConnectionCompleted(), [ dataProvider ] );
+	useSyncExternalStore( subscribeSiteKitConfiguration, getSnapshotSiteKitSetupCompleted );
 
 	return (
 		<>

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -61,6 +61,9 @@ export { Dashboard } from "./components/dashboard";
  * @property {string} siteKitConsentLearnMore The Site Kit consent learn more link.
  * @property {string} topPagesInfoLearnMore The top pages learn more link.
  * @property {string} topQueriesInfoLearnMore The top queries learn more link.
+ * @property {string} installSiteKit The Site Kit installation link.
+ * @property {string} activateSiteKit The Site Kit activation link.
+ * @property {string} setupSiteKit The Site Kit setup link.
  */
 
 /**
@@ -103,10 +106,7 @@ export { Dashboard } from "./components/dashboard";
  * @property {boolean} isInstalled Whether Site Kit is installed.
  * @property {boolean} isActive Whether Site Kit is active.
  * @property {boolean} isSetupCompleted Whether Site Kit is setup.
- * @property {boolean} isConnected Whether Site Kit is connected.
- * @property {string} installUrl The URL to install Site Kit.
- * @property {string} activateUrl The URL to activate Site Kit.
- * @property {string} setupUrl The URL to setup Site Kit.
+ * @property {boolean} isConsentGranted Whether Site Kit is connected.
  * @property {boolean} isFeatureEnabled Whether the feature is enabled.
- * @property {boolean} isConfigurationDismissed Whether the configuration is dismissed.
+ * @property {boolean} isSetupWidgetDismissed Whether the configuration is dismissed.
  */

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -141,11 +141,6 @@ export class DataProvider {
 	 * @param {boolean} isConnected Whether the site kit is connected.
 	 */
 	setSiteKitConnected( isConnected ) {
-		// This creates a new object to avoid mutation and force re-rendering.
-		this.#siteKitConfiguration = {
-			...this.#siteKitConfiguration,
-			isConnected,
-		};
 		this.#stepsStatuses[ 3 ] = isConnected;
 		this.notifySubscribers();
 	}

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -20,6 +20,8 @@ export class DataProvider {
 	#siteKitConfiguration;
 	#subscribers = new Set();
 
+	#stepsStatuses;
+
 	/**
 	 * @param {ContentType[]} contentTypes The content types.
 	 * @param {string} userName The user name.
@@ -37,6 +39,12 @@ export class DataProvider {
 		this.#headers = headers;
 		this.#links = links;
 		this.#siteKitConfiguration = siteKitConfiguration;
+		this.#stepsStatuses = [
+			this.#siteKitConfiguration.isInstalled,
+			this.#siteKitConfiguration.isActive,
+			this.#siteKitConfiguration.isSetupCompleted,
+			this.#siteKitConfiguration.isConnected,
+		]
 	}
 
 	/**
@@ -70,6 +78,12 @@ export class DataProvider {
 		return this.#userName;
 	}
 
+	/**
+	 * @returns {boolean} The possible stepper statuses.
+	 */
+	getStepsStatuses() {
+		return this.#stepsStatuses;
+	}
 	/**
 	 * @param {string} feature The feature to check.
 	 * @returns {boolean} Whether the feature is enabled.
@@ -106,6 +120,14 @@ export class DataProvider {
 	 */
 	getSiteKitConfiguration() {
 		return this.#siteKitConfiguration;
+	}
+
+	/**
+	 *
+	 * @return {number} The step that is currently unfinished. Returns -1 when all steps are finished.
+	 */
+	getSiteKitCurrentConnectionStep() {
+		return this.getStepsStatuses().findIndex( status => ! status );
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -130,6 +130,10 @@ export class DataProvider {
 		return this.#stepsStatuses.findIndex( status => ! status );
 	}
 
+	isSiteKitConnectionCompleted() {
+		return this.getSiteKitCurrentConnectionStep() === -1;
+	}
+
 	/**
 	 * @param {boolean} isConnected Whether the site kit is connected.
 	 */
@@ -139,6 +143,7 @@ export class DataProvider {
 			...this.#siteKitConfiguration,
 			isConnected,
 		};
+		this.#stepsStatuses[ 3 ] = isConnected;
 		this.notifySubscribers();
 	}
 

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -130,6 +130,9 @@ export class DataProvider {
 		return this.#stepsStatuses.findIndex( status => ! status );
 	}
 
+	/**
+	 * @returns {boolean} If the Site Kit connection is completed.
+	 */
 	isSiteKitConnectionCompleted() {
 		return this.getSiteKitCurrentConnectionStep() === -1;
 	}

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -44,7 +44,7 @@ export class DataProvider {
 			this.#siteKitConfiguration.isActive,
 			this.#siteKitConfiguration.isSetupCompleted,
 			this.#siteKitConfiguration.isConnected,
-		]
+		];
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -123,11 +123,11 @@ export class DataProvider {
 	}
 
 	/**
-	 *
-	 * @return {number} The step that is currently unfinished. Returns -1 when all steps are finished.
+	 * Gets the first incomplete step.
+	 * @returns {number} The step that is currently unfinished. Returns -1 when all steps are finished.
 	 */
 	getSiteKitCurrentConnectionStep() {
-		return this.getStepsStatuses().findIndex( status => ! status );
+		return this.#stepsStatuses.findIndex( status => ! status );
 	}
 
 	/**

--- a/packages/js/src/dashboard/services/data-provider.js
+++ b/packages/js/src/dashboard/services/data-provider.js
@@ -38,12 +38,15 @@ export class DataProvider {
 		this.#endpoints = endpoints;
 		this.#headers = headers;
 		this.#links = links;
-		this.#siteKitConfiguration = siteKitConfiguration;
+		this.#siteKitConfiguration = {
+			isFeatureEnabled: siteKitConfiguration.isFeatureEnabled,
+			isSetupWidgetDismissed: siteKitConfiguration.isSetupWidgetDismissed,
+		};
 		this.#stepsStatuses = [
-			this.#siteKitConfiguration.isInstalled,
-			this.#siteKitConfiguration.isActive,
-			this.#siteKitConfiguration.isSetupCompleted,
-			this.#siteKitConfiguration.isConnected,
+			siteKitConfiguration.isInstalled,
+			siteKitConfiguration.isActive,
+			siteKitConfiguration.isSetupCompleted,
+			siteKitConfiguration.isConsentGranted,
 		];
 	}
 
@@ -138,21 +141,21 @@ export class DataProvider {
 	}
 
 	/**
-	 * @param {boolean} isConnected Whether the site kit is connected.
+	 * @param {boolean} isConsentGranted Whether the site kit consent is granted.
 	 */
-	setSiteKitConnected( isConnected ) {
-		this.#stepsStatuses[ 3 ] = isConnected;
+	setSiteKitConsentGranted( isConsentGranted ) {
+		this.#stepsStatuses[ 3 ] = isConsentGranted;
 		this.notifySubscribers();
 	}
 
 	/**
-	 * @param {boolean} isConfigurationDismissed Whether the site kit configuration is (permanently) dismissed.
+	 * @param {boolean} isSetupWidgetDismissed Whether the site kit configuration is (permanently) dismissed.
 	 */
-	setSiteKitConfigurationDismissed( isConfigurationDismissed ) {
+	setSiteKitConfigurationDismissed( isSetupWidgetDismissed ) {
 		// This creates a new object to avoid mutation and force re-rendering.
 		this.#siteKitConfiguration = {
 			...this.#siteKitConfiguration,
-			isConfigurationDismissed,
+			isSetupWidgetDismissed,
 		};
 		this.notifySubscribers();
 	}

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -47,7 +47,7 @@ export class WidgetFactory {
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
 	createWidget( widget ) {
-		const { isFeatureEnabled, isConfigurationDismissed } = this.#dataProvider.getSiteKitConfiguration();
+		const { isFeatureEnabled, isSetupWidgetDismissed } = this.#dataProvider.getSiteKitConfiguration();
 		const isSiteKitConnectionCompleted = this.#dataProvider.isSiteKitConnectionCompleted();
 		switch ( widget.type ) {
 			case WidgetFactory.types.seoScores:
@@ -81,7 +81,7 @@ export class WidgetFactory {
 					dataFormatter={ this.#dataFormatter }
 				/>;
 			case WidgetFactory.types.siteKitSetup:
-				if ( ! isFeatureEnabled || isConfigurationDismissed ) {
+				if ( ! isFeatureEnabled || isSetupWidgetDismissed ) {
 					return null;
 				}
 				return <SiteKitSetupWidget

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -48,6 +48,7 @@ export class WidgetFactory {
 	 */
 	createWidget( widget ) {
 		const { isFeatureEnabled, isConnected, isConfigurationDismissed } = this.#dataProvider.getSiteKitConfiguration();
+		const isSiteKitConnectionCompleted = this.#dataProvider.isSiteKitConnectionCompleted();
 		switch ( widget.type ) {
 			case WidgetFactory.types.seoScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
@@ -70,7 +71,7 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
 			case WidgetFactory.types.topPages:
-				if ( ! isFeatureEnabled || ! isConnected ) {
+				if ( ! isFeatureEnabled || ! isSiteKitConnectionCompleted ) {
 					return null;
 				}
 				return <TopPagesWidget
@@ -89,7 +90,7 @@ export class WidgetFactory {
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
 			case WidgetFactory.types.topQueries:
-				if ( ! isFeatureEnabled || ! isConnected ) {
+				if ( ! isFeatureEnabled || ! isSiteKitConnectionCompleted ) {
 					return null;
 				}
 				return <TopQueriesWidget

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -47,7 +47,7 @@ export class WidgetFactory {
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
 	createWidget( widget ) {
-		const { isFeatureEnabled, isConnected, isConfigurationDismissed } = this.#dataProvider.getSiteKitConfiguration();
+		const { isFeatureEnabled, isConfigurationDismissed } = this.#dataProvider.getSiteKitConfiguration();
 		const isSiteKitConnectionCompleted = this.#dataProvider.isSiteKitConnectionCompleted();
 		switch ( widget.type ) {
 			case WidgetFactory.types.seoScores:

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -87,9 +87,9 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const learnMoreLink = dataProvider.getLink( "siteKitLearnMore" );
 	const consentLearnMoreLink = dataProvider.getLink( "siteKitConsentLearnMore" );
 
-	const stepsStatuses = [ config.isInstalled, config.isActive, config.isSetupCompleted, config.isConnected ];
-	let currentStep = stepsStatuses.findIndex( status => ! status );
+	let currentStep = dataProvider.getSiteKitCurrentConnectionStep();
 	const overallCompleted = currentStep === -1;
+
 	if ( overallCompleted ) {
 		currentStep = steps.length - 1;
 	}
@@ -145,7 +145,7 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 				<Stepper.Step
 					key={ label }
 					isActive={ currentStep === index }
-					isComplete={ stepsStatuses[ index ] }
+					isComplete={ dataProvider.getStepsStatuses[ index ] }
 				>
 					{ label }
 				</Stepper.Step>

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -41,7 +41,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 			{ ...options, method: "POST" }
 		).then( ( { success } ) => {
 			if ( success ) {
-				dataProvider.setSiteKitConnected( true );
+				dataProvider.setSiteKitConsentGranted( true );
 			}
 		} ).catch( noop );
 	}, [ dataProvider, remoteDataProvider ] );
@@ -72,7 +72,6 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const handleOnRemove = useCallback( () => {
 		dataProvider.setSiteKitConfigurationDismissed( true );
 	}, [ dataProvider ] );
-	const config = dataProvider.getSiteKitConfiguration();
 
 	const { grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
@@ -93,17 +92,17 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const buttonProps = [
 		{
 			children: __( "Install Site Kit by Google", "wordpress-seo" ),
-			href: config.installUrl,
+			href: dataProvider.getLink( "installSiteKit" ),
 			as: "a",
 		},
 		{
 			children: __( "Activate Site Kit by Google", "wordpress-seo" ),
-			href: config.activateUrl,
+			href: dataProvider.getLink( "activateSiteKit" ),
 			as: "a",
 		},
 		{
 			children: __( "Set up Site Kit by Google", "wordpress-seo" ),
-			href: config.setupUrl,
+			href: dataProvider.getLink( "setupSiteKit" ),
 			as: "a",
 		},
 		{

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -31,7 +31,7 @@ const steps = [
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
+ * @returns {UseSiteKitConfiguration} The site kit helper methods.
  */
 const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 	const grantConsent = useCallback( ( options ) => {

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -145,7 +145,7 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 				<Stepper.Step
 					key={ label }
 					isActive={ currentStep === index }
-					isComplete={ dataProvider.getStepsStatuses[ index ] }
+					isComplete={ dataProvider.getStepsStatuses()[ index ] }
 				>
 					{ label }
 				</Stepper.Step>

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -88,9 +88,8 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const consentLearnMoreLink = dataProvider.getLink( "siteKitConsentLearnMore" );
 
 	let currentStep = dataProvider.getSiteKitCurrentConnectionStep();
-	const overallCompleted = currentStep === -1;
-
-	if ( overallCompleted ) {
+	const isSiteKitConnectionCompleted = dataProvider.isSiteKitConnectionCompleted();
+	if ( isSiteKitConnectionCompleted ) {
 		currentStep = steps.length - 1;
 	}
 
@@ -170,7 +169,7 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 			</li>
 		</ul>
 		<div className="yst-flex yst-gap-1 yst-mt-6 yst-items-center">
-			{ overallCompleted
+			{ isSiteKitConnectionCompleted
 				? <>
 					<Button onClick={ handleOnRemove }>
 						{ __( "Got it!", "wordpress-seo" ) }

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -1,6 +1,6 @@
 import { ArrowRightIcon, TrashIcon, XIcon } from "@heroicons/react/outline";
 import { CheckCircleIcon } from "@heroicons/react/solid";
-import { useCallback, useState } from "@wordpress/element";
+import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button, DropdownMenu, Paper, Stepper, Title, useToggleState } from "@yoast/ui-library";
 import { noop } from "lodash";
@@ -34,8 +34,6 @@ const steps = [
  * @returns {UseSiteKitConfiguration} The site kit configuration and helper methods.
  */
 const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
-	const [ config, setConfig ] = useState( () => dataProvider.getSiteKitConfiguration() );
-
 	const grantConsent = useCallback( ( options ) => {
 		remoteDataProvider.fetchJson(
 			dataProvider.getEndpoint( "siteKitConsentManagement" ),
@@ -44,10 +42,9 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 		).then( ( { success } ) => {
 			if ( success ) {
 				dataProvider.setSiteKitConnected( true );
-				setConfig( dataProvider.getSiteKitConfiguration() );
 			}
 		} ).catch( noop );
-	}, [ dataProvider, remoteDataProvider, setConfig ] );
+	}, [ dataProvider, remoteDataProvider ] );
 
 	const dismissPermanently = useCallback( ( options ) => {
 		remoteDataProvider.fetchJson(
@@ -60,7 +57,7 @@ const useSiteKitConfiguration = ( dataProvider, remoteDataProvider ) => {
 		dataProvider.setSiteKitConfigurationDismissed( true );
 	}, [ remoteDataProvider, dataProvider ] );
 
-	return { config, grantConsent, dismissPermanently };
+	return { grantConsent, dismissPermanently };
 };
 
 /**
@@ -75,9 +72,9 @@ export const SiteKitSetupWidget = ( { dataProvider, remoteDataProvider } ) => {
 	const handleOnRemove = useCallback( () => {
 		dataProvider.setSiteKitConfigurationDismissed( true );
 	}, [ dataProvider ] );
+	const config = dataProvider.getSiteKitConfiguration();
 
-
-	const { config, grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
+	const { grantConsent, dismissPermanently } = useSiteKitConfiguration( dataProvider, remoteDataProvider );
 	const [ isConsentModalOpen, , , openConsentModal, closeConsentModal ] = useToggleState( false );
 
 	const handleRemovePermanently = useCallback( () => {

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -100,7 +100,7 @@ domReady( () => {
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
-	let currentStep = dataProvider.getSiteKitCurrentConnectionStep();
+	const currentStep = dataProvider.getSiteKitCurrentConnectionStep();
 	// -1 Means finished because there are no available steps to complete.
 	if ( currentStep === -1 ) {
 		siteKitConfiguration.isConfigurationDismissed = true;

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -93,15 +93,18 @@ domReady( () => {
 		isConfigurationDismissed: false,
 	} );
 
-	if ( siteKitConfiguration.isConnected ) {
-		siteKitConfiguration.isConfigurationDismissed = true;
-	}
+
 
 
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
+	let currentStep = dataProvider.getSiteKitCurrentConnectionStep();
+	// -1 Means finished because there are no available steps to complete.
+	if ( currentStep === -1 ) {
+		siteKitConfiguration.isConfigurationDismissed = true;
+	}
 
 	const router = createHashRouter(
 		createRoutesFromElements(

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -100,9 +100,9 @@ domReady( () => {
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
-	const currentStep = dataProvider.getSiteKitCurrentConnectionStep();
+	const isSiteKitConnectionCompleted = dataProvider.isSiteKitConnectionCompleted();
 	// -1 Means finished because there are no available steps to complete.
-	if ( currentStep === -1 ) {
+	if ( isSiteKitConnectionCompleted ) {
 		siteKitConfiguration.isConfigurationDismissed = true;
 	}
 

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -93,9 +93,6 @@ domReady( () => {
 		isConfigurationDismissed: false,
 	} );
 
-
-
-
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -79,26 +79,26 @@ domReady( () => {
 		siteKitConsentLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-site-kit-consent-learn-more" ),
 		topPagesInfoLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-top-content-learn-more" ),
 		topQueriesInfoLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-top-queries-learn-more" ),
+		installSiteKit: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.installUrl", "" ),
+		activateSiteKit: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.activateUrl", "" ),
+		setupSiteKit: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.setupUrl", "" ),
 	};
 
-	const siteKitConfiguration = get( window, "wpseoScriptData.dashboard.siteKitConfiguration", {
-		isInstalled: false,
-		isActive: false,
-		isSetupCompleted: false,
-		isConnected: false,
-		installUrl: "",
-		activateUrl: "",
-		setupUrl: "",
-		isFeatureEnabled: false,
-		isConfigurationDismissed: false,
-	} );
+	const siteKitConfiguration = {
+		isInstalled: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isInstalled", false ),
+		isActive: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isActive", false ),
+		isSetupCompleted: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isSetupCompleted", false ),
+		isConsentGranted: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isConnected", false ),
+		isFeatureEnabled: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isFeatureEnabled", false ),
+		isSetupWidgetDismissed: get( window, "wpseoScriptData.dashboard.siteKitConfiguration.isConfigurationDismissed", false ),
+	};
 
 	const remoteDataProvider = new RemoteDataProvider( { headers } );
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
 	if ( dataProvider.isSiteKitConnectionCompleted() ) {
-		siteKitConfiguration.isConfigurationDismissed = true;
+		dataProvider.setSiteKitConfigurationDismissed( true );
 	}
 
 	const router = createHashRouter(

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -97,9 +97,7 @@ domReady( () => {
 	const dataProvider = new DataProvider( { contentTypes, userName, features, endpoints, headers, links, siteKitConfiguration } );
 	const dataFormatter = new DataFormatter( { locale: userLocale } );
 	const widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatter );
-	const isSiteKitConnectionCompleted = dataProvider.isSiteKitConnectionCompleted();
-	// -1 Means finished because there are no available steps to complete.
-	if ( isSiteKitConnectionCompleted ) {
+	if ( dataProvider.isSiteKitConnectionCompleted() ) {
 		siteKitConfiguration.isConfigurationDismissed = true;
 	}
 

--- a/packages/js/src/integrations-page/recommended-integrations.js
+++ b/packages/js/src/integrations-page/recommended-integrations.js
@@ -85,7 +85,7 @@ if ( isSiteKitFeatureEnabled ) {
 		isInstalled={ get( window, "wpseoIntegrationsData.site_kit_configuration.isInstalled", false ) }
 		isActive={ get( window, "wpseoIntegrationsData.site_kit_configuration.isActive", false ) }
 		isSetupCompleted={ get( window, "wpseoIntegrationsData.site_kit_configuration.isSetupCompleted", false ) }
-		initialIsConnected={ get( window, "wpseoIntegrationsData.site_kit_configuration.isConnected", false ) }
+		initialIsConsentGranted={ get( window, "wpseoIntegrationsData.site_kit_configuration.isConnected", false ) }
 		installUrl={ get( window, "wpseoIntegrationsData.site_kit_configuration.installUrl", "" ) }
 		activateUrl={ get( window, "wpseoIntegrationsData.site_kit_configuration.activateUrl", "" ) }
 		setupUrl={ get( window, "wpseoIntegrationsData.site_kit_configuration.setupUrl", "" ) }

--- a/packages/js/src/integrations-page/site-kit-integration.js
+++ b/packages/js/src/integrations-page/site-kit-integration.js
@@ -72,7 +72,7 @@ const SuccessfullyConnected = () => {
  * @param {boolean} isActive Whether the integration is active.
  * @param {boolean} isSetupCompleted Whether the integration has been set up.
  * @param {boolean} isInstalled Whether the integration is installed.
- * @param {boolean} initialIsConnected Whether the integration is connected.
+ * @param {boolean} initialIsConsentGranted Whether the integration is connected.
  * @param {string} installUrl The installation url.
  * @param {string} activateUrl The activation url.
  * @param {string} setupUrl The setup url.
@@ -84,7 +84,7 @@ export const SiteKitIntegration = ( {
 	isActive,
 	isSetupCompleted,
 	isInstalled,
-	initialIsConnected,
+	initialIsConsentGranted,
 	installUrl,
 	activateUrl,
 	setupUrl,
@@ -92,7 +92,7 @@ export const SiteKitIntegration = ( {
 } ) => {
 	const [ isModalOpen, toggleModal ] = useToggleState( false );
 	const [ isDisconnectModalOpen, toggleDisconnectModal ] = useToggleState( false );
-	const [ isConnected, setConnected ] = useState( initialIsConnected );
+	const [ isConnected, setConnected ] = useState( initialIsConsentGranted );
 	const stepsStatuses = [ isInstalled, isActive, isSetupCompleted, isConnected ];
 	let currentStep = stepsStatuses.findIndex( status => ! status );
 	const successfullyConnected = currentStep === -1;
@@ -187,7 +187,7 @@ SiteKitIntegration.propTypes = {
 	isActive: PropTypes.bool.isRequired,
 	isSetupCompleted: PropTypes.bool.isRequired,
 	isInstalled: PropTypes.bool.isRequired,
-	initialIsConnected: PropTypes.bool.isRequired,
+	initialIsConsentGranted: PropTypes.bool.isRequired,
 	installUrl: PropTypes.string.isRequired,
 	activateUrl: PropTypes.string.isRequired,
 	setupUrl: PropTypes.string.isRequired,

--- a/packages/js/tests/dashboard/__mocks__/data-provider.js
+++ b/packages/js/tests/dashboard/__mocks__/data-provider.js
@@ -61,17 +61,13 @@ export class MockDataProvider extends DataProvider {
 				dashboardLearnMore: "https://example.com/dashboard-learn-more",
 				errorSupport: "https://example.com/error-support",
 				siteKitLearnMore: "https://example.com/google-site-kit-learn-more",
+				installSiteKit: "https://example.com/install",
+				activateSiteKit: "https://example.com/activate",
+				setupSiteKit: "https://example.com/isSetup",
 			},
 			siteKitConfiguration: {
-				isInstalled: false,
-				isActive: false,
-				isSetupCompleted: false,
-				isConnected: false,
-				installUrl: "https://example.com/install",
-				activateUrl: "https://example.com/activate",
-				setupUrl: "https://example.com/isSetup",
 				isFeatureEnabled: false,
-				isConfigurationDismissed: false,
+				isSetupWidgetDismissed: false,
 			},
 		} ) );
 		this.setSiteKitConfigurationDismissed = jest.fn();

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -58,7 +58,7 @@ describe( "Scores", () => {
 				isInstalled: true,
 				isActive: true,
 				isSetupCompleted: true,
-				isConnected: true,
+				isConsentGranted: true,
 			},
 		} );
 		remoteDataProvider = new RemoteDataProvider( {} );

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -330,21 +330,21 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=nothing&_fields=id%2Cname" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 
 		// Verify the "Nothing found" message is present.
 		expect( getByRole( "listbox" ) ).toHaveTextContent( "Nothing found" );
 	} );
 
-	it( "should be possible to clear the term filter", async () => {
+	it( "should be possible to clear the term filter",async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -337,7 +337,7 @@ describe( "Scores", () => {
 		expect( getByRole( "listbox" ) ).toHaveTextContent( "Nothing found" );
 	} );
 
-	it( "should be possible to clear the term filter",async () => {
+	it( "should be possible to clear the term filter", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -53,6 +53,13 @@ describe( "Scores", () => {
 			links: {
 				errorSupport: "admin.php?page=wpseo_page_support",
 			},
+			siteKitConfiguration: {
+				isFeatureEnabled: true,
+				isInstalled: true,
+				isActive: true,
+				isSetupCompleted: true,
+				isConnected: true,
+			},
 		} );
 		remoteDataProvider = new RemoteDataProvider( {} );
 	} );

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -68,14 +68,14 @@ describe( "Scores", () => {
 		fetchJson.mockClear();
 	} );
 
-	it( "should render the component", async() => {
+	it( "should render the component", async () => {
 		const { container, getAllByRole, getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Verify the filters are present.
@@ -89,11 +89,11 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/seo_scores?contentType=post" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 
 		// Ensure the skeleton loader is removed.
@@ -111,7 +111,7 @@ describe( "Scores", () => {
 		expect( listItems[ 3 ] ).toHaveTextContent( "Not analyzed" );
 	} );
 
-	it( "should show an error with a link to the support page", async() => {
+	it( "should show an error with a link to the support page", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
@@ -121,7 +121,7 @@ describe( "Scores", () => {
 					getEndpoint: () => "https://example.com/error",
 				} }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -135,7 +135,7 @@ describe( "Scores", () => {
 		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
 	} );
 
-	it( "should show a timeout error with a link to the support page", async() => {
+	it( "should show a timeout error with a link to the support page", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
@@ -145,7 +145,7 @@ describe( "Scores", () => {
 					getEndpoint: () => "https://example.com/timeout",
 				} }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -159,14 +159,14 @@ describe( "Scores", () => {
 		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
 	} );
 
-	it( "should not show the categories filter without taxonomies", async() => {
+	it( "should not show the categories filter without taxonomies", async () => {
 		const { getByRole, queryByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -196,14 +196,14 @@ describe( "Scores", () => {
 		expect( queryByRole( "combobox", { name: "Categories" } ) ).toBeNull();
 	} );
 
-	it( "should request the (readability) scores for a specific term", async() => {
+	it( "should request the (readability) scores for a specific term", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="readability"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -235,18 +235,18 @@ describe( "Scores", () => {
 		// Verify the taxonomy is "product_cat" and the term is the ID of "merchandise" (see data JSON).
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/readability_scores?contentType=product&taxonomy=product_cat&term=18" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 	} );
 
-	it( "should filter the content types", async() => {
+	it( "should filter the content types", async () => {
 		const { getAllByRole, getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -261,14 +261,14 @@ describe( "Scores", () => {
 		expect( getAllByRole( "option" ) ).toHaveLength( 1 );
 	} );
 
-	it( "should search for terms", async() => {
+	it( "should search for terms", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="readability"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -281,18 +281,18 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=thing&_fields=id%2Cname" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 	} );
 
-	it( "should show a loading indicator when searching for terms", async() => {
+	it( "should show a loading indicator when searching for terms", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -310,14 +310,14 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 	} );
 
-	it( "should show a message when no terms are found", async() => {
+	it( "should show a message when no terms are found", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -330,21 +330,21 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=nothing&_fields=id%2Cname" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 
 		// Verify the "Nothing found" message is present.
 		expect( getByRole( "listbox" ) ).toHaveTextContent( "Nothing found" );
 	} );
 
-	it( "should be possible to clear the term filter", async() => {
+	it( "should be possible to clear the term filter", async () => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>
+			/>,
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -364,7 +364,7 @@ describe( "Scores", () => {
 		// Verify the search is empty.
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
-			expect.any( Object )
+			expect.any( Object ),
 		);
 	} );
 } );

--- a/packages/js/tests/dashboard/scores/components/scores.test.js
+++ b/packages/js/tests/dashboard/scores/components/scores.test.js
@@ -68,14 +68,14 @@ describe( "Scores", () => {
 		fetchJson.mockClear();
 	} );
 
-	it( "should render the component", async () => {
+	it( "should render the component", async() => {
 		const { container, getAllByRole, getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Verify the filters are present.
@@ -89,11 +89,11 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 2 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/seo_scores?contentType=post" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 
 		// Ensure the skeleton loader is removed.
@@ -111,7 +111,7 @@ describe( "Scores", () => {
 		expect( listItems[ 3 ] ).toHaveTextContent( "Not analyzed" );
 	} );
 
-	it( "should show an error with a link to the support page", async () => {
+	it( "should show an error with a link to the support page", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
@@ -121,7 +121,7 @@ describe( "Scores", () => {
 					getEndpoint: () => "https://example.com/error",
 				} }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -135,7 +135,7 @@ describe( "Scores", () => {
 		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
 	} );
 
-	it( "should show a timeout error with a link to the support page", async () => {
+	it( "should show a timeout error with a link to the support page", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
@@ -145,7 +145,7 @@ describe( "Scores", () => {
 					getEndpoint: () => "https://example.com/timeout",
 				} }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -159,14 +159,14 @@ describe( "Scores", () => {
 		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "admin.php?page=wpseo_page_support" );
 	} );
 
-	it( "should not show the categories filter without taxonomies", async () => {
+	it( "should not show the categories filter without taxonomies", async() => {
 		const { getByRole, queryByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -196,14 +196,14 @@ describe( "Scores", () => {
 		expect( queryByRole( "combobox", { name: "Categories" } ) ).toBeNull();
 	} );
 
-	it( "should request the (readability) scores for a specific term", async () => {
+	it( "should request the (readability) scores for a specific term", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="readability"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -235,18 +235,18 @@ describe( "Scores", () => {
 		// Verify the taxonomy is "product_cat" and the term is the ID of "merchandise" (see data JSON).
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/readability_scores?contentType=product&taxonomy=product_cat&term=18" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 	} );
 
-	it( "should filter the content types", async () => {
+	it( "should filter the content types", async() => {
 		const { getAllByRole, getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -261,14 +261,14 @@ describe( "Scores", () => {
 		expect( getAllByRole( "option" ) ).toHaveLength( 1 );
 	} );
 
-	it( "should search for terms", async () => {
+	it( "should search for terms", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="readability"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -281,18 +281,18 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=thing&_fields=id%2Cname" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 	} );
 
-	it( "should show a loading indicator when searching for terms", async () => {
+	it( "should show a loading indicator when searching for terms", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -310,14 +310,14 @@ describe( "Scores", () => {
 		await waitFor( () => expect( fetchJson ).toHaveBeenCalledTimes( 3 ) );
 	} );
 
-	it( "should show a message when no terms are found", async () => {
+	it( "should show a message when no terms are found", async() => {
 		const { getByRole } = render(
 			<Scores
 				analysisType="seo"
 				contentTypes={ contentTypes }
 				dataProvider={ dataProvider }
 				remoteDataProvider={ remoteDataProvider }
-			/>,
+			/>
 		);
 
 		// Await the fetch calls: scores and terms.
@@ -364,7 +364,7 @@ describe( "Scores", () => {
 		// Verify the search is empty.
 		expect( fetchJson ).toHaveBeenCalledWith(
 			expect.objectContaining( { href: "https://example.com/categories?search=&_fields=id%2Cname" } ),
-			expect.any( Object ),
+			expect.any( Object )
 		);
 	} );
 } );

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -20,6 +20,9 @@ describe( "WidgetFactory", () => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {
 				isFeatureEnabled: true,
+				isInstalled: true,
+				isActive: true,
+				isSetupCompleted: true,
 			},
 		} );
 		remoteDataProvider = new MockRemoteDataProvider( {} );

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -33,14 +33,14 @@ describe( "WidgetFactory", () => {
 		[ "seoScores" ],
 		[ "readabilityScores" ],
 		[ "topPages" ],
-	] )( "should have the widget type: %s", async ( type ) => {
+	] )( "should have the widget type: %s", async( type ) => {
 		expect( WidgetFactory.types[ type ] ).toBe( type );
 	} );
 
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
-	] )( "should not create a %s widget when site kit is not connected", async ( _, widget ) => {
+	] )( "should not create a %s widget when site kit is not connected", async( _, widget ) => {
 		dataProvider.setSiteKitConnected( false );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 		expect( widgetFactory.createWidget( widget ) ).toBeNull();
@@ -51,7 +51,7 @@ describe( "WidgetFactory", () => {
 		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
 		[ "Site Kit setup", { id: "site-kit-setup-widget", type: "siteKitSetup" }, "Expand your dashboard with insights from Google!" ],
 		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
-	] )( "should create a %s widget", async ( _, widget, title ) => {
+	] )( "should create a %s widget", async( _, widget, title ) => {
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
 		const { getByRole } = render( <>{ element }</> );
@@ -67,7 +67,7 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
-	] )( "should create a %s widget", async ( _, widget, title ) => {
+	] )( "should create a %s widget", async( _, widget, title ) => {
 		dataProvider.setSiteKitConnected( true );
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
@@ -81,7 +81,7 @@ describe( "WidgetFactory", () => {
 		} );
 	} );
 
-	test( "should create the site kit set up widget", async () => {
+	test( "should create the site kit set up widget", async() => {
 		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" }, jest.fn() );
 		expect( element?.key ).toBe( "site-kit-setup-widget" );
 		const { getByRole } = render( <>{ element }</> );
@@ -91,7 +91,7 @@ describe( "WidgetFactory", () => {
 		} );
 	} );
 
-	test( "should not create the site kit set up widget", async () => {
+	test( "should not create the site kit set up widget", async() => {
 		dataProvider.setSiteKitConnected( true );
 		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" } );
 		expect( element?.key ).toBe( "site-kit-setup-widget" );
@@ -132,7 +132,7 @@ describe( "WidgetFactory", () => {
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
 		[ "siteKitSetup", { id: "site-kite-setup-widget", type: "siteKitSetup" } ],
-	] )( "should not create a %s widget when site kit feature is disabled", async ( _, widget ) => {
+	] )( "should not create a %s widget when site kit feature is disabled", async( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: { isFeatureEnabled: false },
 		} );

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -33,14 +33,14 @@ describe( "WidgetFactory", () => {
 		[ "seoScores" ],
 		[ "readabilityScores" ],
 		[ "topPages" ],
-	] )( "should have the widget type: %s", async( type ) => {
+	] )( "should have the widget type: %s", async ( type ) => {
 		expect( WidgetFactory.types[ type ] ).toBe( type );
 	} );
 
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
-	] )( "should not create a %s widget when site kit is not connected", async( _, widget ) => {
+	] )( "should not create a %s widget when site kit is not connected", async ( _, widget ) => {
 		dataProvider.setSiteKitConnected( false );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 		expect( widgetFactory.createWidget( widget ) ).toBeNull();
@@ -51,7 +51,7 @@ describe( "WidgetFactory", () => {
 		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
 		[ "Site Kit setup", { id: "site-kit-setup-widget", type: "siteKitSetup" }, "Expand your dashboard with insights from Google!" ],
 		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
-	] )( "should create a %s widget", async( _, widget, title ) => {
+	] )( "should create a %s widget", async ( _, widget, title ) => {
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
 		const { getByRole } = render( <>{ element }</> );
@@ -67,7 +67,7 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
-	] )( "should create a %s widget", async( _, widget, title ) => {
+	] )( "should create a %s widget", async ( _, widget, title ) => {
 		dataProvider.setSiteKitConnected( true );
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
@@ -81,7 +81,7 @@ describe( "WidgetFactory", () => {
 		} );
 	} );
 
-	test( "should create the site kit set up widget", async() => {
+	test( "should create the site kit set up widget", async () => {
 		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" }, jest.fn() );
 		expect( element?.key ).toBe( "site-kit-setup-widget" );
 		const { getByRole } = render( <>{ element }</> );
@@ -91,7 +91,7 @@ describe( "WidgetFactory", () => {
 		} );
 	} );
 
-	test( "should not create the site kit set up widget", async() => {
+	test( "should not create the site kit set up widget", async () => {
 		dataProvider.setSiteKitConnected( true );
 		const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" } );
 		expect( element?.key ).toBe( "site-kit-setup-widget" );
@@ -132,7 +132,7 @@ describe( "WidgetFactory", () => {
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
 		[ "siteKitSetup", { id: "site-kite-setup-widget", type: "siteKitSetup" } ],
-	] )( "should not create a %s widget when site kit feature is disabled", async( _, widget ) => {
+	] )( "should not create a %s widget when site kit feature is disabled", async ( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: { isFeatureEnabled: false },
 		} );

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -62,7 +62,7 @@ describe( "WidgetFactory", () => {
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
 	] )( "should create a %s widget", async( _, widget, title ) => {
-		dataProvider.setSiteKitConnected( true );
+		dataProvider.setSiteKitConsentGranted( true );
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
 		const { getByRole } = render( <>{ element }</> );
@@ -92,9 +92,9 @@ describe( "WidgetFactory", () => {
 	} );
 
 
-	test( "should not create the Site Kit setup widget if the data provider has isConfigurationDismissed set to true", () => {
+	test( "should not create the Site Kit setup widget if the data provider has isSetupWidgetDismissed set to true", () => {
 		dataProvider = new MockDataProvider( {
-			siteKitConfiguration: { isConfigurationDismissed: true },
+			siteKitConfiguration: { isSetupWidgetDismissed: true },
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 
@@ -116,14 +116,14 @@ describe( "WidgetFactory", () => {
 
 	describe( "should not create the site kit widgets and should create the site kit setup widget", () => {
 		test.each( [
-			[ "no step is completed", { isInstalled: false, isActive: false, isSetupCompleted: false, isConnected: false } ],
-			[ "only installed", { isInstalled: true, isActive: false, isSetupCompleted: false, isConnected: false } ],
-			[ "only installed and activated", { isInstalled: true, isActive: true, isSetupCompleted: false, isConnected: false } ],
-			[ "only not connected", { isInstalled: true, isActive: true, isSetupCompleted: true, isConnected: false } ],
-			[ "only connected", { isInstalled: false, isActive: false, isSetupCompleted: false, isConnected: true } ],
-			[ "only site kit setup completed and connected", { isInstalled: false, isActive: false, isSetupCompleted: true, isConnected: true } ],
-			[ "only not activated", { isInstalled: true, isActive: false, isSetupCompleted: true, isConnected: true } ],
-			[ "only site kit setup is not completed", { isInstalled: true, isActive: true, isSetupCompleted: false, isConnected: true } ],
+			[ "no step is completed", { isInstalled: false, isActive: false, isSetupCompleted: false, isConsentGranted: false } ],
+			[ "only installed", { isInstalled: true, isActive: false, isSetupCompleted: false, isConsentGranted: false } ],
+			[ "only installed and activated", { isInstalled: true, isActive: true, isSetupCompleted: false, isConsentGranted: false } ],
+			[ "only not connected", { isInstalled: true, isActive: true, isSetupCompleted: true, isConsentGranted: false } ],
+			[ "only connected", { isInstalled: false, isActive: false, isSetupCompleted: false, isConsentGranted: true } ],
+			[ "only site kit setup completed and connected", { isInstalled: false, isActive: false, isSetupCompleted: true, isConsentGranted: true } ],
+			[ "only not activated", { isInstalled: true, isActive: false, isSetupCompleted: true, isConsentGranted: true } ],
+			[ "only site kit setup is not completed", { isInstalled: true, isActive: true, isSetupCompleted: false, isConsentGranted: true } ],
 		] )( "when %s", async( _, siteKitConfiguration ) => {
 			const siteKitWidgets = [
 				{ id: "top-pages-widget", type: "topPages" },

--- a/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/site-kit-setup-widget.test.js
@@ -185,7 +185,7 @@ describe( "SiteKitSetupWidget", () => {
 				isInstalled: true,
 				isActive: true,
 				isSetupCompleted: true,
-				isConnected: true,
+				isConsentGranted: true,
 			},
 		} );
 		render( <SiteKitSetupWidget

--- a/packages/js/tests/integrations-page/SiteKitIntegration.test.js
+++ b/packages/js/tests/integrations-page/SiteKitIntegration.test.js
@@ -34,7 +34,7 @@ describe( "SiteKitIntegration", () => {
 			isActive={ false }
 			isSetupCompleted={ false }
 			isInstalled={ false }
-			initialIsConnected={ false }
+			initialIsConsentGranted={ false }
 			{ ...urlsProps }
 		/> );
 		expect( screen.getByText( "Site Kit by Google" ) ).toBeInTheDocument();
@@ -44,12 +44,12 @@ describe( "SiteKitIntegration", () => {
 		[ "not installed, not active, not after setup, and not connected", false, false, false, false ],
 		[ "not installed, not active, after setup, and not connected", false, false, true, false ],
 		[ "not installed, not active, after setup, and connected", false, false, true, true ],
-	] )( "shows 'Install Site Kit by Google' link when not installed when %s", ( _title, isInstalled, isActive, isSetupCompleted, initialIsConnected = {} ) => {
+	] )( "shows 'Install Site Kit by Google' link when not installed when %s", ( _title, isInstalled, isActive, isSetupCompleted, initialIsConsentGranted = {} ) => {
 		render( <SiteKitIntegration
 			isActive={ isActive }
 			isSetupCompleted={ isSetupCompleted }
 			isInstalled={ isInstalled }
-			initialIsConnected={ initialIsConnected }
+			initialIsConsentGranted={ initialIsConsentGranted }
 			{ ...urlsProps }
 		/> );
 		const link = screen.getByRole( "link", { name: "Install Site Kit by Google" } );
@@ -61,12 +61,12 @@ describe( "SiteKitIntegration", () => {
 		[ "installed, not active, not after setup, and not connected", true, false, false, false ],
 		[ "installed, not active, after setup, and not connected", true, false, true, false ],
 		[ "installed, not active, after setup, and connected", true, false, true, true ],
-	] )( "shows 'Activate Site Kit by Google' button when installed but not active when %s", ( _title, isInstalled, isActive, isSetupCompleted, initialIsConnected = {} ) => {
+	] )( "shows 'Activate Site Kit by Google' button when installed but not active when %s", ( _title, isInstalled, isActive, isSetupCompleted, initialIsConsentGranted = {} ) => {
 		render( <SiteKitIntegration
 			isActive={ isActive }
 			isSetupCompleted={ isSetupCompleted }
 			isInstalled={ isInstalled }
-			initialIsConnected={ initialIsConnected }
+			initialIsConsentGranted={ initialIsConsentGranted }
 			{ ...urlsProps }
 		/> );
 		const link = screen.getByRole( "link", { name: "Activate Site Kit by Google" } );
@@ -77,7 +77,7 @@ describe( "SiteKitIntegration", () => {
 
 	it( "shows 'Set up Site Kit by Google' button when active but not set up", () => {
 		render( <SiteKitIntegration
-			isActive={ true } isSetupCompleted={ false } isInstalled={ true } initialIsConnected={ false } { ...urlsProps }
+			isActive={ true } isSetupCompleted={ false } isInstalled={ true } initialIsConsentGranted={ false } { ...urlsProps }
 		/> );
 		const link = screen.getByRole( "link", { name: "Set up Site Kit by Google" } );
 		expect( link ).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe( "SiteKitIntegration", () => {
 
 	it( "shows 'Connect Site Kit by Google' button when set up but not connected", () => {
 		render( <SiteKitIntegration
-			isActive={ true } isSetupCompleted={ true } isInstalled={ true } initialIsConnected={ false } { ...urlsProps }
+			isActive={ true } isSetupCompleted={ true } isInstalled={ true } initialIsConsentGranted={ false } { ...urlsProps }
 		/> );
 		expect( screen.getByRole( "button", { name: "Connect Site Kit by Google" } ) ).toBeInTheDocument();
 	} );
@@ -94,7 +94,7 @@ describe( "SiteKitIntegration", () => {
 	it( "shows 'Disconnect' button when connected", () => {
 		render( <SiteKitIntegration
 			isActive={ true } isSetupCompleted={ true } isInstalled={ true }
-			initialIsConnected={ true } { ...urlsProps }
+			initialIsConsentGranted={ true } { ...urlsProps }
 		/> );
 		expect( screen.getByRole( "button", { name: "Disconnect" } ) ).toBeInTheDocument();
 		expect( screen.getByText( "Successfully connected" ) ).toBeInTheDocument();
@@ -106,7 +106,7 @@ describe( "SiteKitIntegration", () => {
 			isActive={ true }
 			isSetupCompleted={ true }
 			isInstalled={ true }
-			initialIsConnected={ false }
+			initialIsConsentGranted={ false }
 			{ ...urlsProps }
 		/> );
 		const connectButton = screen.getByRole( "button", { name: "Connect Site Kit by Google" } );
@@ -142,7 +142,7 @@ describe( "SiteKitIntegration", () => {
 			isActive={ true }
 			isSetupCompleted={ true }
 			isInstalled={ true }
-			initialIsConnected={ true }
+			initialIsConsentGranted={ true }
 			{ ...urlsProps }
 		/> );
 		const disconnectButton = screen.getByRole( "button", { name: "Disconnect" } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want users to be able to see the setup widget again after reverting one of the steps.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows the Site kit setup widget to show up after completing it and then reverting one of the steps.

## Relevant technical choices:

* Did renaming of `isConnected` to `isConsentGranted` on the frontend only.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new site and make sure you can still complete the entire Sit Kit setup.
* After fully connecting Site kit disable the plugin and make sure the setup widget now shows the `activate` step.
* Active the plugin again and make sure the widget is now gone again.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Restore site kit set up widget when one of the steps has reverted](https://github.com/Yoast/reserved-tasks/issues/468)
