### PR TITLE
Inclusive language: Improve the feedback string for 'exotic' and add exceptions

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/cultureAssessmentsSpec.js
@@ -46,9 +46,11 @@ describe( "A test for Culture Assessments", () => {
 
 	it( "should not target exotic when followed by exception words.", () => {
 		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "exotic" ) );
-		[ "shorthair", "shorthairs", "longhair", "longhairs", "blooms", "species", "florals", "botanicals", "leathers",
-			"material", "timber", "composites", "atom", "molecule", "hardon", "sphere", "star", "car",
-			"sports car" ].map( ( exceptionWord ) => {
+		[ "longhair", "longhairs", "shorthair", "shorthairs",
+			"bloom", "blooms", "species", "florals", "botanical", "botanicals", "leather", "leathers", "material",
+			"materials", "timber", "timbers", "composite", "composites", "atom", "atoms", "molecule", "molecules",
+			"hadron", "hadrons", "sphere", "spheres", "star", "stars", "car", "cars", "sports car",
+			"sports cars" ].map( ( exceptionWord ) => {
 			const testSentence = `It is common to have exotic ${exceptionWord}.`;
 			const mockPaper = new Paper( testSentence );
 			const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/cultureAssessments.js
@@ -60,12 +60,14 @@ const cultureAssessments = [
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
 				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "longhair", "longhairs", "shorthair", "shorthairs",
-					"blooms", "species", "florals", "botanicals", "leathers", "material", "timber", "composites", "atom",
-					"molecule", "hardon", "sphere", "star", "car", "sports car" ] ) );
+					"bloom", "blooms", "species", "florals", "botanical", "botanicals", "leather", "leathers", "material",
+					"materials", "timber", "timbers", "composite", "composites", "atom", "atoms", "molecule", "molecules",
+					"hadron", "hadrons", "sphere", "spheres", "star", "stars", "car", "cars", "sports car", "sports cars" ] ) );
 		},
-		ruleDescription: notFollowed( [ "longhair", "longhairs", "shorthair", "shorthairs", "blooms",
-			"species", "florals", "botanicals", "leathers", "material", "timber", "composites", "atom",
-			"molecule", "hardon", "sphere", "star", "car", "sports car" ] ),
+		ruleDescription: notFollowed( [ "longhair", "longhairs", "shorthair", "shorthairs",
+			"bloom", "blooms", "species", "florals", "botanical", "botanicals", "leather", "leathers", "material",
+			"materials", "timber", "timbers", "composite", "composites", "atom", "atoms", "molecule", "molecules",
+			"hadron", "hadrons", "sphere", "spheres", "star", "stars", "car", "cars", "sports car", "sports cars" ] ),
 	},
 	{
 		identifier: "sherpa",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the inclusive language analysis feedback for the potentially non-inclusive word _exotic_, and prevents the feedback from appearing when _exotic_ is followed by words common in scientific contexts.
* [shopify-seo] Improves the inclusive language analysis feedback for the potentially non-inclusive word _exotic_, and prevents the feedback from appearing when _exotic_ is followed by words common in scientific contexts.
* [yoastseo] Improves the inclusive language analysis feedback for the potentially non-inclusive word _exotic_, and prevents the feedback from appearing when _exotic_ is followed by words common in scientific contexts.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post and add the word 'exotic' to it
* Confirm that the inclusive language analysis returns the following feedback with an orange traffic light:
     * Be careful when using _exotic_ as it is potentially harmful. Unless you are referring to animals or scientific terms, consider using an alternative, such as _unfamiliar_, _foreign_, _peculiar_, _fascinating_, _alluring_, _bizarre_, _non-native_, _introduced_. [Learn more.](https://yoa.st/inclusive-language-culture?php_version=8.1&platform=wordpress&platform_version=6.7.2&software=free&software_version=24.7-RC1&days_active=673&user_language=en_US) 
* Add the word "florals" after "exotic"
* Confirm that the feedback disappears
* Replace "florals" to "sports car"
* Confirm that the feedback for 'exotic' is still not showing

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change, see https://docs.google.com/spreadsheets/d/1YsSWmWq9hw5I24fTwy4v7wXxKF4XZdEE/edit?gid=769144014#gid=769144014

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Inclusive language: update feedback string for "exotic" and add exceptions](https://github.com/Yoast/lingo-other-tasks/issues/439)
