### PR TITLE
Use Authentication class from Site Kit to detect if it's set up

### DIFF
--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -2,6 +2,8 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Dashboard\Infrastructure\Integrations;
 
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Plugin;
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Analytics_4\Site_Kit_Analytics_4_Adapter;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface as Configuration_Repository;
@@ -69,7 +71,13 @@ class Site_Kit {
 	 * @return bool If the Google site kit setup has been completed.
 	 */
 	private function is_setup_completed() {
-		return \get_option( 'googlesitekit_has_connected_admins', false ) === '1';
+		if ( \class_exists( 'Google\Site_Kit\Plugin' ) ) {
+			$site_kit_plugin = Plugin::instance();
+			$authentication  = new Authentication( $site_kit_plugin->context() );
+			return $authentication->is_setup_completed();
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -70,7 +70,7 @@ class Site_Kit {
 	 *
 	 * @return bool If the Google site kit setup has been completed.
 	 */
-	private function is_setup_completed() {
+	private function is_setup_completed(): bool {
 		if ( \class_exists( 'Google\Site_Kit\Plugin' ) ) {
 			$site_kit_plugin = Plugin::instance();
 			$authentication  = new Authentication( $site_kit_plugin->context() );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR was originally created to fix a bug in a specific website that wasn't reproduceable anywhere else, as described in [the original task](https://github.com/Yoast/reserved-tasks/issues/471). 
* The fix of this PR not only fixed that niche bug in that website, but also makes more sense for all cases, even in websites that didn't experience that bug.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the way we detect if Site Kit has been set up, by using a more appropriate Site Kit function.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install the PR/RC in a brand new site and go through the onboarding flow of our Site Kit integration
* As soon as you complete the 3rd step (Site Kit setup), go to our dashboard and confirm that the onboarding widget reflects that indeed Site Kit is set up
* Finish the onboarding flow, refresh our dashboard and confirm that you don't see the onboarding widget anymore
* As the managing user, give viewing rights to other admins and SEO managers
* Log in as a different admin, go to our dashboard and confirm that you don't see the onboarding widget
* Log in as a SEO manager, go to our dashboard and confirm that you don't see the onboarding widget
* Deactivate Site Kit, go to our dashboard and confirm that you see our onboarding widget again without issues.
* Repeat the above tests, but this time instead of looking into our dashboard, look into the integration page and confirm that everything is expected in every stage.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/471
