### PR TITLE
448 not show ai modal on admin pages

### DIFF
--- a/packages/js/src/introductions/initialize.js
+++ b/packages/js/src/introductions/initialize.js
@@ -13,7 +13,16 @@ const DATA_NAME = "wpseoIntroductions";
 
 domReady( () => {
 	const initialIntroductions = get( window, `${ DATA_NAME }.introductions`, [] );
+
 	if ( isEmpty( initialIntroductions ) ) {
+		return;
+	}
+
+	const initialComponents = {
+		// "ai-fix-assessments-upsell": Content,
+	};
+
+	if ( isEmpty( initialComponents ) ) {
 		return;
 	}
 
@@ -29,9 +38,7 @@ domReady( () => {
 	const rootContext = {
 		isRtl: Boolean( get( window, `${ DATA_NAME }.isRtl`, false ) ),
 	};
-	const initialComponents = {
-		"ai-fix-assessments-upsell": Content,
-	};
+
 
 	const root = document.createElement( "div" );
 	root.id = "wpseo-introductions";

--- a/packages/js/src/introductions/initialize.js
+++ b/packages/js/src/introductions/initialize.js
@@ -5,7 +5,7 @@ import { doAction } from "@wordpress/hooks";
 import { Root } from "@yoast/ui-library";
 import { get, isEmpty } from "lodash";
 import { LINK_PARAMS_NAME, PLUGIN_URL_NAME, WISTIA_EMBED_PERMISSION_NAME } from "../shared-admin/store";
-import { Content, Introduction, IntroductionProvider, Modal } from "./components";
+import { Introduction, IntroductionProvider, Modal } from "./components";
 import { STORE_NAME_INTRODUCTIONS } from "./constants";
 import { registerStore } from "./store";
 

--- a/packages/js/src/introductions/initialize.js
+++ b/packages/js/src/introductions/initialize.js
@@ -39,7 +39,6 @@ domReady( () => {
 		isRtl: Boolean( get( window, `${ DATA_NAME }.isRtl`, false ) ),
 	};
 
-
 	const root = document.createElement( "div" );
 	root.id = "wpseo-introductions";
 	document.body.appendChild( root );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Remove  **Optimize your SEO content with Yoast AI** modal on Yoast admin pages.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the Yoast AI Optimize modals from the Yoast admin pages.

## Relevant technical choices:

* We decided to live introduction behaviour for the feature. So initialComponents moved into beginning and if it's empty to prevent showing backdrop only early return is used.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Check that **Optimize your SEO content with Yoast AI** modal is not displayed in Admin pages.
* Deactivate Yoast Premium plugin.
* Open Yoast Test plugin  and click **Reset First time configuration progress**.
![image](https://github.com/user-attachments/assets/6480a6cd-58e1-4d51-bd95-228edf78b303)
* Open any sql editor or use `wp db query` wp-cli command and remove **_yoast_wpseo_introductions** meta_key from **wp_usermeta** table:
```DELETE FROM `wp_usermeta` WHERE `meta_key` = '_yoast_wpseo_introductions'```
* Deactivate and than again activate the free plugin.
* On plugins page click **Finish your first-time configuration** or open link directly link `/wp-admin/admin.php?page=wpseo_dashboard#/first-time-configuration`.
* Make sure that **Optimize your SEO content with Yoast AI** modal is not dispalyed.
* Repeat steps with the Yoast Premium switched on.

### Check that **Optimize your SEO content with Yoast AI** modal still works for posts.
* Deactivate Yoast Premium plugin.
* Create a post and add content.
* Add a keyword.
* Add sentence with more than 20 words.
* Make sure that **Sentence length** issue is present in Readability tab and **Optimize with AI** button is present.
* Click **Optimize with AI**.
* Make sure that  your the Modal **Optimize your SEO content with Yoast AI** is displayed.
<img width="510" alt="image" src="https://github.com/user-attachments/assets/e7d5778a-f1e0-44e5-a506-db850717cfc7" />

### Check that **Grant consent for Yoast AI** modal still works for posts.
* Activate Yoast Premium.
* Open current user profile and scroll down.
* Click **Revoke consent** if or make sure that **Grant consent* button is displayed.
* Create a post and add content.
* Add a keyword.
* Add sentence with more than 20 words.
* Make sure that **Sentence length** issue is present in Readability tab and **Optimize with AI** button is present.
* Click **Optimize with AI** 
* Make sure that **Grant consent for Yoast AI** modal is displayed.
<img width="514" alt="image" src="https://github.com/user-attachments/assets/1ae288bb-b53b-492a-9c98-1429145af61c" />


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This should impact only AI modals described in the Test cases.

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#448](https://github.com/Yoast/reserved-tasks/issues/448)
