### PR TITLE
Add error boundary on Widget level

### DIFF
--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -59,9 +59,6 @@ export { Dashboard } from "./components/dashboard";
  * @property {string} errorSupport The support link when errors occur.
  * @property {string} siteKitLearnMore The Site Kit learn more link.
  * @property {string} siteKitConsentLearnMore The Site Kit consent learn more link.
- * @property {string} topPagesInfoLearnMore The top pages learn more link.
- * @property {string} topQueriesInfoLearnMore The top queries learn more link.
- * @property {string} organicSessionsInfoLearnMore The organic sessions learn more link.
  */
 
 /**

--- a/packages/js/src/dashboard/services/use-remote-data.js
+++ b/packages/js/src/dashboard/services/use-remote-data.js
@@ -28,7 +28,7 @@ const slice = createSlice( {
 /**
  * @param {function(RequestInit): any} doFetch The fetch function.
  * @param {function(any): any} prepareData Process data.
- * @returns {{data: any, error: Error, isPending: boolean}} The data state.
+ * @returns {{data?: any, error?: Error, isPending: boolean}} The data state.
  */
 export const useRemoteData = ( doFetch, prepareData = identity ) => {
 	const [ state, dispatch ] = useReducer( slice.reducer, {}, slice.getInitialState );

--- a/packages/js/src/dashboard/widgets/organic-sessions-widget.js
+++ b/packages/js/src/dashboard/widgets/organic-sessions-widget.js
@@ -9,13 +9,13 @@ import { Widget } from "./widget";
 /**
  * @type {import("../services/data-provider")} DataProvider
  * @type {import("../services/remote-data-provider")} RemoteDataProvider
- * @type {import("../services/comparison-metrics-data-formatter")} DataFormatter
+ * @type {import("../services/data-formatter-interface")} DataFormatterInterface
  */
 
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @returns {JSX.Element} The element.
  */
 export const OrganicSessionsWidget = ( { dataProvider, remoteDataProvider, dataFormatter } ) => {

--- a/packages/js/src/dashboard/widgets/organic-sessions-widget.js
+++ b/packages/js/src/dashboard/widgets/organic-sessions-widget.js
@@ -18,41 +18,27 @@ import { Widget } from "./widget";
  * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @returns {JSX.Element} The element.
  */
-export const OrganicSessionsWidget = ( { dataProvider, remoteDataProvider, dataFormatter } ) => {
+const OrganicSessionsContent = ( { dataProvider, remoteDataProvider, dataFormatter } ) => {
 	const supportLink = dataProvider.getLink( "errorSupport" );
 	const daily = useOrganicSessionsDaily( dataProvider, remoteDataProvider, dataFormatter );
 	const compare = useOrganicSessionsCompare( dataProvider, remoteDataProvider, dataFormatter );
-	const widgetProps = {
-		className: "yst-paper__content yst-col-span-4",
-		title: __( "Organic sessions", "wordpress-seo" ),
-		tooltip: __( "The number of organic sessions that began on your website.", "wordpress-seo" ),
-		dataSources: [
-			{
-				source: "Site Kit by Google",
-			},
-		],
-	};
 
 	// Collapse the errors if they are the same.
 	if ( compare.error && daily.error && isEqual( compare.error, daily.error ) ) {
 		return (
-			<Widget { ...widgetProps }>
-				<ErrorAlert className="yst-mt-4" error={ compare.error } supportLink={ supportLink } />
-			</Widget>
+			<ErrorAlert className="yst-mt-4" error={ compare.error } supportLink={ supportLink } />
 		);
 	}
 
 	// Don't show the comparison when there is no data.
 	if ( daily.data?.labels.length === 0 ) {
 		return (
-			<Widget { ...widgetProps }>
-				<NoDataParagraph />
-			</Widget>
+			<NoDataParagraph />
 		);
 	}
 
 	return (
-		<Widget { ...widgetProps }>
+		<>
 			<div className="yst-flex yst-justify-between yst-mt-4">
 				<OrganicSessionsCompare data={ compare.data } error={ compare.error } isPending={ compare.isPending } supportLink={ supportLink } />
 			</div>
@@ -62,6 +48,28 @@ export const OrganicSessionsWidget = ( { dataProvider, remoteDataProvider, dataF
 				isPending={ daily.isPending }
 				supportLink={ supportLink }
 			/>
-		</Widget>
+		</>
 	);
 };
+
+/**
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
+ * @returns {JSX.Element} The element.
+ */
+export const OrganicSessionsWidget = ( { dataProvider, remoteDataProvider, dataFormatter } ) => (
+	<Widget
+		className="yst-paper__content yst-col-span-4"
+		title={ __( "Organic sessions", "wordpress-seo" ) }
+		tooltip={ __( "The number of organic sessions that began on your website.", "wordpress-seo" ) }
+		dataSources={ [
+			{
+				source: "Site Kit by Google",
+			},
+		] }
+		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
+	>
+		<OrganicSessionsContent dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } dataFormatter={ dataFormatter } />
+	</Widget>
+);

--- a/packages/js/src/dashboard/widgets/organic-sessions/compare.js
+++ b/packages/js/src/dashboard/widgets/organic-sessions/compare.js
@@ -7,9 +7,9 @@ import { useRemoteData } from "../../services/use-remote-data";
 import { getDifference } from "../../transformers/difference";
 
 /**
- * @type {import("../services/data-provider")} DataProvider
- * @type {import("../services/remote-data-provider")} RemoteDataProvider
- * @type {import("../services/data-formatter")} DataFormatter
+ * @type {import("../../services/data-provider")} DataProvider
+ * @type {import("../../services/remote-data-provider")} RemoteDataProvider
+ * @type {import("../../services/data-formatter-interface")} DataFormatterInterface
  */
 
 /**
@@ -28,7 +28,7 @@ import { getDifference } from "../../transformers/difference";
  */
 
 /**
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @returns {function(?RawOrganicSessionsCompareData[]): OrganicSessionsCompareData} Function to format the organic sessions compare data.
  */
 // eslint-disable-next-line complexity
@@ -47,7 +47,7 @@ const createOrganicSessionsCompareFormatter = ( dataFormatter ) => ( [ data ] ) 
  *
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  *
  * @returns {{data: OrganicSessionsCompareData?, error: Error, isPending: boolean}} The remote data info.
  */

--- a/packages/js/src/dashboard/widgets/organic-sessions/daily.js
+++ b/packages/js/src/dashboard/widgets/organic-sessions/daily.js
@@ -7,9 +7,9 @@ import { ErrorAlert } from "../../components/error-alert";
 import { useRemoteData } from "../../services/use-remote-data";
 
 /**
- * @type {import("../services/data-provider")} DataProvider
- * @type {import("../services/remote-data-provider")} RemoteDataProvider
- * @type {import("../services/data-formatter")} DataFormatter
+ * @type {import("../../services/data-provider")} DataProvider
+ * @type {import("../../services/remote-data-provider")} RemoteDataProvider
+ * @type {import("../../services/data-formatter-interface")} DataFormatterInterface
  */
 
 /**
@@ -148,7 +148,7 @@ const transformOrganicSessionsDataToChartData = ( organicSessions ) => ( {
 } );
 
 /**
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @returns {function(?OrganicSessionsDailyData[]): OrganicSessionsDailyData[]} Function to format the organic sessions daily data.
  */
 const createOrganicSessionsDailyFormatter = ( dataFormatter ) => ( data = [] ) => data.map( ( item ) => ( {
@@ -196,7 +196,7 @@ const OrganicSessionsChart = ( { data } ) => (
  *
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  *
  * @returns {{data: ChartData?, error: Error, isPending: boolean}} The remote data info.
  */

--- a/packages/js/src/dashboard/widgets/score-widget.js
+++ b/packages/js/src/dashboard/widgets/score-widget.js
@@ -29,6 +29,7 @@ export const ScoreWidget = ( { analysisType, dataProvider, remoteDataProvider } 
 		<Widget
 			className="yst-paper__content yst-@container 2xl:yst-col-span-2 yst-col-span-4"
 			title={ analysisType === "readability" ? __( "Readability scores", "wordpress-seo" ) : __( "SEO scores", "wordpress-seo" ) }
+			errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 		>
 			<Scores
 				analysisType={ analysisType }

--- a/packages/js/src/dashboard/widgets/search-ranking-compare-widget.js
+++ b/packages/js/src/dashboard/widgets/search-ranking-compare-widget.js
@@ -134,6 +134,7 @@ export const SearchRankingCompareWidget = ( { dataProvider, remoteDataProvider, 
 	return <Widget
 		className="yst-paper__content yst-col-span-4"
 		title={ ( ! isPending && ( error || data === null ) ) && __( "Impressions, Clicks, Site CTR, Average position", "wordpress-seo" ) }
+		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 	>
 		<SearchRankingCompareWidgetContent
 			data={ data }

--- a/packages/js/src/dashboard/widgets/search-ranking-compare-widget.js
+++ b/packages/js/src/dashboard/widgets/search-ranking-compare-widget.js
@@ -1,7 +1,8 @@
 import { useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
+import { useToggleState } from "@yoast/ui-library";
 import { SearchRankingCompareWidgetContent } from "./search-ranking-compare/search-ranking-compare-widget-content";
-import { Widget } from "./widget";
+import { Widget, WidgetErrorBoundary } from "./widget";
 
 /**
  * @typedef { "current"|"previous" } TimeFrame The time frame for the raw metric data.
@@ -67,17 +68,23 @@ export const SearchRankingCompareWidget = ( { dataProvider, remoteDataProvider, 
 	// However, we want to have all the fetching logic inside the content for the error boundary.
 	// We could just render the with title state here, but that seems more complex than this approach.
 	const [ showTitle, setShowTitle ] = useState( false );
+	// Need this for the error boundary, to still show the widget title on an unexpected error.
+	const [ hasUnexpectedError, , , setHasUnexpectedErrorTrue ] = useToggleState( false );
 
 	return <Widget
 		className="yst-paper__content yst-col-span-4"
-		title={ showTitle && __( "Impressions, Clicks, Site CTR, Average position", "wordpress-seo" ) }
-		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
+		title={ ( showTitle || hasUnexpectedError ) && __( "Impressions, Clicks, Site CTR, Average position", "wordpress-seo" ) }
 	>
-		<SearchRankingCompareWidgetContent
-			dataProvider={ dataProvider }
-			remoteDataProvider={ remoteDataProvider }
-			dataFormatter={ dataFormatter }
-			setShowTitle={ setShowTitle }
-		/>
+		<WidgetErrorBoundary
+			supportLink={ dataProvider.getLink( "errorSupport" ) }
+			onError={ setHasUnexpectedErrorTrue }
+		>
+			<SearchRankingCompareWidgetContent
+				dataProvider={ dataProvider }
+				remoteDataProvider={ remoteDataProvider }
+				dataFormatter={ dataFormatter }
+				setShowTitle={ setShowTitle }
+			/>
+		</WidgetErrorBoundary>
 	</Widget>;
 };

--- a/packages/js/src/dashboard/widgets/search-ranking-compare/search-ranking-compare-widget-content.js
+++ b/packages/js/src/dashboard/widgets/search-ranking-compare/search-ranking-compare-widget-content.js
@@ -1,10 +1,12 @@
-import { SkeletonLoader } from "@yoast/ui-library";
-import { SearchRankingCompareMetric } from "./search-ranking-compare-metric";
-import { SearchRankingCompareMetricDivider } from "./search-ranking-compare-metric-divider";
+import { useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
+import { SkeletonLoader } from "@yoast/ui-library";
+import { ErrorAlert } from "../../components/error-alert";
 import { NoDataParagraph } from "../../components/no-data-paragraph";
 import { WidgetTooltip, WidgetDataSources } from "../widget";
-import { ErrorAlert } from "../../components/error-alert";
+import { SearchRankingCompareMetric } from "./search-ranking-compare-metric";
+import { SearchRankingCompareMetricDivider } from "./search-ranking-compare-metric-divider";
+import { useSearchRankingCompare } from "./use-search-ranking-compare";
 
 /**
  * Represents the skeleton loader for an organic sessions compare metric component.
@@ -31,7 +33,7 @@ const SearchRankingCompareMetricSkeletonLoader = ( { tooltipLocalizedContent, da
  */
 const SearchRankingCompareSkeletonLoader = () => {
 	return (
-		<div className="yst-flex yst-flex-col yst-justify-center yst-items-center @6xl:yst-flex-row @6xl:yst-justify-evenly rtl:yst-flex-row-reverse ">
+		<div className="yst-flex yst-flex-col yst-justify-center yst-items-center @6xl:yst-flex-row @6xl:yst-justify-evenly rtl:yst-flex-row-reverse">
 			<SearchRankingCompareMetricSkeletonLoader
 				tooltipLocalizedContent={ __( "The number of times your website appeared in Google search results over the last 28 days.", "wordpress-seo" ) }
 				dataSources={ [ { source: __( "Site Kit by Google", "wordpress-seo" ) }  ] }
@@ -60,14 +62,22 @@ const SearchRankingCompareSkeletonLoader = () => {
 
 /**
  * The content of the search ranking compare widget.
+ *
  * @param {import("./search-ranking-compare-widget").SearchRankingCompareData} data the data to render.
- * @param {Error} error the error object (if an error occurred).
- * @param {boolean} isPending whether the data is still pending.
  * @param {import("../services/data-provider").DataProvider} dataProvider the data provider.
+ * @param {import("../services/remote-data-provider").RemoteDataProvider} remoteDataProvider the remote data provider.
+ * @param {function} setShowTitle The function to update the title visibility.
  *
  * @returns {JSX.Element}
  */
-export const SearchRankingCompareWidgetContent = ( { data, error, isPending, dataProvider } ) => {
+export const SearchRankingCompareWidgetContent = ( { dataProvider, remoteDataProvider, dataFormatter, setShowTitle } ) => {
+	const { data, error, isPending } = useSearchRankingCompare( { dataProvider, remoteDataProvider, dataFormatter } );
+
+	useEffect( () => {
+		// Only show the title when the data is not pending and there is an error or no data.
+		setShowTitle( ! isPending && ( error || data === null ) );
+	}, [ data, error, isPending, setShowTitle ] );
+
 	if ( isPending ) {
 		return <SearchRankingCompareSkeletonLoader />;
 	}
@@ -81,7 +91,9 @@ export const SearchRankingCompareWidgetContent = ( { data, error, isPending, dat
 	}
 
 	if ( data ) {
-		return <div className="yst-flex yst-flex-col yst-justify-center yst-items-center @7xl:yst-flex-row @7xl:yst-justify-evenly rtl:yst-flex-row-reverse ">
+		return <div
+			className="yst-flex yst-flex-col yst-justify-center yst-items-center @7xl:yst-flex-row @7xl:yst-justify-evenly rtl:yst-flex-row-reverse "
+		>
 			<SearchRankingCompareMetric
 				metricName="Impressions"
 				data={ data.impressions }

--- a/packages/js/src/dashboard/widgets/search-ranking-compare/use-search-ranking-compare.js
+++ b/packages/js/src/dashboard/widgets/search-ranking-compare/use-search-ranking-compare.js
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from "@wordpress/element";
+import { useRemoteData } from "../../services/use-remote-data";
+import { getDifference } from "../../transformers/difference";
+
+/**
+ * @param {TimeBasedData[]} rawData The raw data coming from the API call.
+ * @returns {?SearchRankingCompareData} The transformed data.
+ */
+const transformData = ( rawData ) => {
+	if ( rawData.length === 0 ) {
+		return null;
+	}
+
+	const data = {
+		impressions: {
+			value: rawData[ 0 ].current.total_impressions,
+			delta: getDifference( rawData[ 0 ].current.total_impressions, rawData[ 0 ].previous.total_impressions ),
+		},
+		clicks: {
+			value: rawData[ 0 ].current.total_clicks,
+			delta: getDifference( rawData[ 0 ].current.total_clicks, rawData[ 0 ].previous.total_clicks ),
+		},
+		ctr: null,
+		position: null,
+	};
+
+	if ( rawData[ 0 ].current.average_ctr ) {
+		data.ctr = {
+			value: rawData[ 0 ].current.average_ctr,
+			delta: getDifference( rawData[ 0 ].current.average_ctr, rawData[ 0 ].previous.average_ctr ),
+		};
+	}
+
+	if ( rawData[ 0 ].current.average_position ) {
+		data.position = {
+			value: rawData[ 0 ].current.average_position,
+			delta: getDifference( rawData[ 0 ].current.average_position, rawData[ 0 ].previous.average_position ),
+		};
+	}
+	return data;
+};
+
+/**
+ * @param {import("../services/comparison-metrics-data-formatter")} dataFormatter The data formatter.
+ * @returns {function(?SearchRankingCompareData): ?FormattedSearchRankingCompareData} Function to format the widget data.
+ */
+const createDataFormatter = ( dataFormatter ) => ( data ) => {
+	if ( data === null ) {
+		return null;
+	}
+	return {
+		impressions: dataFormatter.format( data.impressions, "impressions" ),
+		clicks: dataFormatter.format( data.clicks, "clicks" ),
+		ctr: dataFormatter.format( data.ctr, "ctr" ),
+		position: dataFormatter.format( data.position, "position" ),
+	};
+};
+
+/**
+ * @param {import("../services/data-provider")} dataProvider The data provider.
+ * @param {import("../services/remote-data-provider")} remoteDataProvider The remote data provider.
+ * @param {import("../services/comparison-metrics-data-formatter")} dataFormatter The data formatter.
+ * @returns {{data?: FormattedSearchRankingCompareData, error?: Error, isPending: boolean}} The remote data info.
+ */
+export const useSearchRankingCompare = ( { dataProvider, remoteDataProvider, dataFormatter } ) => {
+	/**
+	 * @param {RequestInit} options The options.
+	 * @returns {Promise<TimeBasedData[]|Error>} The promise of TimeBasedData[] or an Error.
+	 */
+	const getData = useCallback( ( options ) => {
+		return remoteDataProvider.fetchJson(
+			dataProvider.getEndpoint( "timeBasedSeoMetrics" ),
+			{ options: { widget: "searchRankingCompare" } },
+			options );
+	}, [ dataProvider ] );
+
+	/**
+	 * @type {function(?TimeBasedData[]): FormattedSearchRankingCompareData} Function to format the widget data.
+	 * */
+	const formatData = useMemo( () => ( rawData ) => createDataFormatter( dataFormatter )( transformData( rawData ) ), [ dataFormatter ] );
+
+	return useRemoteData( getData, formatData );
+};

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -237,6 +237,7 @@ export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatte
 			"wordpress-seo"
 		) }
 		dataSources={ dataSources }
+		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 	>
 		<TopPagesWidgetContent
 			data={ data }

--- a/packages/js/src/dashboard/widgets/top-pages-widget.js
+++ b/packages/js/src/dashboard/widgets/top-pages-widget.js
@@ -10,6 +10,9 @@ import { Widget } from "./widget";
 
 /**
  * @type {import("../index").TopPageData} TopPageData
+ * @type {import("../services/data-provider")} DataProvider
+ * @type {import("../services/remote-data-provider")} RemoteDataProvider
+ * @type {import("../services/data-formatter-interface")} DataFormatterInterface
  */
 
 /**
@@ -152,17 +155,43 @@ export const createTopPageFormatter = ( dataFormatter ) => ( data = [] ) => data
 } ) );
 
 /**
- * The content of the top pages widget.
- *
- * @param {TopPageData[]} data The data.
- * @param {boolean} isPending Whether the data is pending.
- * @param {number} limit The limit.
- * @param {Error} error The error.
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
+ * @param {number} [limit=5] The limit.
+ * @returns {{data?: TopPageData[], error?: Error, isPending: boolean}} The remote data info.
+ */
+const useTopPages = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => {
+	/**
+	 * @param {RequestInit} options The options.
+	 * @returns {Promise<TopPageData[]|Error>} The promise of TopPageData or an Error.
+	 */
+	const getTopPages = useCallback( ( options ) => {
+		return remoteDataProvider.fetchJson(
+			dataProvider.getEndpoint( "timeBasedSeoMetrics" ),
+			{ limit: limit.toString( 10 ), options: { widget: "page" } },
+			options );
+	}, [ dataProvider, limit ] );
+
+	/**
+	 * @type {function(?TopPageData[]): TopPageData[]} Function to format the top pages data.
+	 */
+	const formatTopPages = useMemo( () => createTopPageFormatter( dataFormatter ), [ dataFormatter ] );
+
+	return useRemoteData( getTopPages, formatTopPages );
+};
+
+/**
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
+ * @param {number} [limit=5] The limit.
  * @param {import("../services/data-provider")} dataProvider The data provider.
- *
  * @returns {JSX.Element} The element.
  */
-const TopPagesWidgetContent = ( { data, isPending, limit, error, dataProvider } ) => {
+const TopPagesWidgetContent = ( { dataProvider, remoteDataProvider, dataFormatter, limit } ) => {
+	const { data, isPending, error } = useTopPages( { dataProvider, remoteDataProvider, dataFormatter, limit } );
+
 	if ( isPending ) {
 		return (
 			<TopPagesTable>
@@ -189,62 +218,45 @@ const TopPagesWidgetContent = ( { data, isPending, limit, error, dataProvider } 
 };
 
 /**
- * @param {import("../services/data-provider")} dataProvider The data provider.
- * @param {import("../services/remote-data-provider")} remoteDataProvider The remote data provider.
- * @param {import("../services/data-formatter-interface")} dataFormatter The data formatter.
+ * Wraps the top pages into a widget.
+ * This contains minimal logic, in order to keep the error boundary more likely to catch errors.
+ *
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @param {number} [limit=5] The limit.
+ *
  * @returns {JSX.Element} The element.
  */
-export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => {
-	/**
-	 * @param {RequestInit} options The options.
-	 * @returns {Promise<TopPageData[]|Error>} The promise of TopPageData or an Error.
-	 */
-	const getTopPages = useCallback( ( options ) => {
-		return remoteDataProvider.fetchJson(
-			dataProvider.getEndpoint( "timeBasedSeoMetrics" ),
-			{ limit: limit.toString( 10 ), options: { widget: "page" } },
-			options );
-	}, [ dataProvider, limit ] );
-
-	/**
-	 * @type {function(?TopPageData[]): TopPageData[]} Function to format the top pages data.
-	 */
-	const formatTopPages = useMemo( () => createTopPageFormatter( dataFormatter ), [ dataFormatter ] );
-
-	const { data, error, isPending } = useRemoteData( getTopPages, formatTopPages );
-
-	const dataSources = [
-		{
-			source: "Site Kit by Google",
-			feature: __( "Clicks, Impressions, CTR, Position", "wordpress-seo" ),
-		},
-		{
-			source: "Yoast SEO",
-			feature: sprintf(
-				/* translators: 1: Yoast SEO. */
-				__( "%1$s score", "wordpress-seo" ),
-				"Yoast SEO"
-			),
-		},
-	];
-
-	return <Widget
+export const TopPagesWidget = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => (
+	<Widget
 		className="yst-paper__content yst-col-span-4"
 		title={ __( "Top 5 most popular content", "wordpress-seo" ) }
 		tooltip={ __(
 			"The top 5 URLs on your website with the highest number of clicks over the last 28 days.",
 			"wordpress-seo"
 		) }
-		dataSources={ dataSources }
+		dataSources={ [
+			{
+				source: "Site Kit by Google",
+				feature: __( "Clicks, Impressions, CTR, Position", "wordpress-seo" ),
+			},
+			{
+				source: "Yoast SEO",
+				feature: sprintf(
+					/* translators: 1: Yoast SEO. */
+					__( "%1$s score", "wordpress-seo" ),
+					"Yoast SEO"
+				),
+			},
+		] }
 		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 	>
 		<TopPagesWidgetContent
-			data={ data }
-			isPending={ isPending }
-			limit={ limit }
-			error={ error }
 			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
+			limit={ limit }
 		/>
-	</Widget>;
-};
+	</Widget>
+);

--- a/packages/js/src/dashboard/widgets/top-queries-widget.js
+++ b/packages/js/src/dashboard/widgets/top-queries-widget.js
@@ -147,6 +147,7 @@ export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormat
 			"wordpress-seo"
 		) }
 		dataSources={ dataSources }
+		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 	>
 		<TopQueriesWidgetContent
 			data={ data }

--- a/packages/js/src/dashboard/widgets/top-queries-widget.js
+++ b/packages/js/src/dashboard/widgets/top-queries-widget.js
@@ -1,17 +1,17 @@
 import { useCallback, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { SkeletonLoader } from "@yoast/ui-library";
+import { ErrorAlert } from "../components/error-alert";
 import { NoDataParagraph } from "../components/no-data-paragraph";
 import { WidgetTable } from "../components/widget-table";
 import { useRemoteData } from "../services/use-remote-data";
 import { Widget } from "./widget";
-import { ErrorAlert } from "../components/error-alert";
 
 /**
  * @type {import("../index").TopQueryData} TopQueryData
  * @type {import("../services/data-provider")} DataProvider
  * @type {import("../services/remote-data-provider")} RemoteDataProvider
- * @type {import("../services/plain-metrics-data-formatter")} DataFormatter
+ * @type {import("../services/data-formatter-interface")} DataFormatterInterface
  */
 
 /**
@@ -61,40 +61,8 @@ const TopQueriesTable = ( { data, children } ) => {
 	</WidgetTable>;
 };
 
-
 /**
- * The content for TopQueriesWidget.
- *
- * @param {TopQueryData[]} [data] The data.
- * @param {boolean} [isPending] Whether the data is pending.
- * @param {Error} [error] The error.
- * @param {number} [limit=5] The limit.
- * @param {string} [supportLink] The support link.
- *
- * @returns {JSX.Element} The element.
- */
-export const TopQueriesWidgetContent = ( { data, isPending, error, limit = 5, supportLink } ) => {
-	if ( isPending ) {
-		return (
-			<TopQueriesTable>
-				{ Array.from( { length: limit }, ( _, index ) => (
-					<TopQueriesSkeletonLoaderRow key={ `top-queries-table--row__${ index }` } index={ index } />
-				) ) }
-			</TopQueriesTable>
-		);
-	}
-	if ( error ) {
-		return <ErrorAlert error={ error } supportLink={ supportLink } className="yst-mt-4" />;
-	}
-	if ( data.length === 0 ) {
-		return <NoDataParagraph />;
-	}
-
-	return <TopQueriesTable data={ data } />;
-};
-
-/**
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @returns {function(?TopQueryData[]): TopQueryData[]} Function to format the top queries data.
  */
 export const createTopQueriesFormatter = ( dataFormatter ) => ( data = [] ) => data.map( ( item ) => ( {
@@ -108,11 +76,11 @@ export const createTopQueriesFormatter = ( dataFormatter ) => ( data = [] ) => d
 /**
  * @param {DataProvider} dataProvider The data provider.
  * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
- * @param {DataFormatter} dataFormatter The data formatter.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
  * @param {number} [limit=5] The limit.
- * @returns {JSX.Element} The element.
+ * @returns {{data?: TopPageData[], error?: Error, isPending: boolean}} The remote data info.
  */
-export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => {
+const useTopQueries = ( { dataProvider, remoteDataProvider, dataFormatter, limit } ) => {
 	/**
 	 * @param {RequestInit} options The options.
 	 * @returns {Promise<TopPageData[]|Error>} The promise of TopPageData or an Error.
@@ -124,37 +92,75 @@ export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormat
 			options );
 	}, [ dataProvider, limit ] );
 
-	const supportLink = dataProvider.getLink( "errorSupport" );
-
 	/**
 	 * @type {function(?TopQueryData[]): TopQueryData[]} Function to format the top queries data.
 	 */
 	const formatTopQueries = useMemo( () => createTopQueriesFormatter( dataFormatter ), [ dataFormatter ] );
 
-	const { data, error, isPending } = useRemoteData( getTopQueries, formatTopQueries );
+	return useRemoteData( getTopQueries, formatTopQueries );
+};
 
-	const dataSources = [
-		{
-			source: "Site Kit by Google",
-		},
-	];
+/**
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
+ * @param {number} [limit=5] The limit.
+ * @param {string} [supportLink] The support link.
+ * @returns {JSX.Element} The element.
+ */
+export const TopQueriesWidgetContent = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => {
+	const { data, error, isPending } = useTopQueries( { dataProvider, remoteDataProvider, dataFormatter, limit } );
 
-	return <Widget
+	if ( isPending ) {
+		return (
+			<TopQueriesTable>
+				{ Array.from( { length: limit }, ( _, index ) => (
+					<TopQueriesSkeletonLoaderRow key={ `top-queries-table--row__${ index }` } index={ index } />
+				) ) }
+			</TopQueriesTable>
+		);
+	}
+	if ( error ) {
+		return <ErrorAlert error={ error } supportLink={ dataProvider.getLink( "errorSupport" ) } className="yst-mt-4" />;
+	}
+	if ( data.length === 0 ) {
+		return <NoDataParagraph />;
+	}
+
+	return <TopQueriesTable data={ data } />;
+};
+
+/**
+ * Wraps the top queries into a widget.
+ * This contains minimal logic, in order to keep the error boundary more likely to catch errors.
+ *
+ * @param {DataProvider} dataProvider The data provider.
+ * @param {RemoteDataProvider} remoteDataProvider The remote data provider.
+ * @param {DataFormatterInterface} dataFormatter The data formatter.
+ * @param {number} [limit=5] The limit.
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const TopQueriesWidget = ( { dataProvider, remoteDataProvider, dataFormatter, limit = 5 } ) => (
+	<Widget
 		className="yst-paper__content yst-col-span-4"
 		title={ __( "Top 5 search queries", "wordpress-seo" ) }
 		tooltip={ __(
 			"The top 5 search queries on your website with the highest number of clicks over the last 28 days.",
 			"wordpress-seo"
 		) }
-		dataSources={ dataSources }
+		dataSources={ [
+			{
+				source: "Site Kit by Google",
+			},
+		] }
 		errorSupportLink={ dataProvider.getLink( "errorSupport" ) }
 	>
 		<TopQueriesWidgetContent
-			data={ data }
-			isPending={ isPending }
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
 			limit={ limit }
-			error={ error }
-			supportLink={ supportLink }
 		/>
-	</Widget>;
-};
+	</Widget>
+);

--- a/packages/js/src/dashboard/widgets/widget.js
+++ b/packages/js/src/dashboard/widgets/widget.js
@@ -55,15 +55,16 @@ WidgetDataSources.displayName = "Widget.DataSources";
  * @param {string} [className] The class name.
  * @param {string} supportLink The support link.
  * @param {ReactNode} children The content to wrap with an error boundary.
+ * @param {Object} [props] Any other props for the ErrorBoundary.
  * @returns {JSX.Element}
  */
-export const WidgetErrorBoundary = ( { className = "yst-mt-4", supportLink, children } ) => {
+export const WidgetErrorBoundary = ( { className = "yst-mt-4", supportLink, children, ...props } ) => {
 	const ErrorBoundaryFallback = useCallback( ( { error } ) => (
 		<ErrorAlert error={ error } className={ className } supportLink={ supportLink } />
 	), [ className, supportLink ] );
 
 	return (
-		<ErrorBoundary FallbackComponent={ ErrorBoundaryFallback }>{ children }</ErrorBoundary>
+		<ErrorBoundary { ...props } FallbackComponent={ ErrorBoundaryFallback }>{ children }</ErrorBoundary>
 	);
 };
 WidgetErrorBoundary.displayName = "Widget.ErrorBoundary";

--- a/packages/js/src/dashboard/widgets/widget.js
+++ b/packages/js/src/dashboard/widgets/widget.js
@@ -1,5 +1,7 @@
-import { Paper, Title } from "@yoast/ui-library";
+import { useCallback } from "@wordpress/element";
+import { ErrorBoundary, Paper, Title } from "@yoast/ui-library";
 import classNames from "classnames";
+import { ErrorAlert } from "../components/error-alert";
 import { InfoTooltip } from "../components/info-tooltip";
 import { __ } from "@wordpress/i18n";
 
@@ -51,14 +53,32 @@ WidgetDataSources.displayName = "Widget.DataSources";
 
 /**
  * @param {string} [className] The class name.
+ * @param {string} supportLink The support link.
+ * @param {ReactNode} children The content to wrap with an error boundary.
+ * @returns {JSX.Element}
+ */
+export const WidgetErrorBoundary = ( { className = "yst-mt-4", supportLink, children } ) => {
+	const ErrorBoundaryFallback = useCallback( ( { error } ) => (
+		<ErrorAlert error={ error } className={ className } supportLink={ supportLink } />
+	), [ className, supportLink ] );
+
+	return (
+		<ErrorBoundary FallbackComponent={ ErrorBoundaryFallback }>{ children }</ErrorBoundary>
+	);
+};
+WidgetErrorBoundary.displayName = "Widget.ErrorBoundary";
+
+/**
+ * @param {string} [className] The class name.
  * @param {string} [title] The title in an H2.
  * @param {ReactNode} [tooltip] The widget description in a tooltip of an info button.
  * @param {Object[]} [dataSources] The sources of the data in the widget.
+ * @param {string} [errorSupportLink] The support link, to show in the error fallback. If not provided, no error boundary is used.
  * @param {ReactNode} children The content.
  * @returns {JSX.Element} The widget.
  */
 // eslint-disable-next-line complexity
-export const Widget = ( { className = "yst-paper__content", title, tooltip, dataSources, children } ) => (
+export const Widget = ( { className = "yst-paper__content", title, tooltip, dataSources, children, errorSupportLink } ) => (
 	<Paper className={ classNames( "yst-shadow-md", className ) }>
 		{ ( title || tooltip ) && <div className="yst-flex yst-justify-between">
 			{ title && <WidgetTitle>{ title }</WidgetTitle> }
@@ -68,6 +88,9 @@ export const Widget = ( { className = "yst-paper__content", title, tooltip, data
 				</WidgetTooltip>
 			}
 		</div> }
-		{ children }
+		{ errorSupportLink
+			? <WidgetErrorBoundary supportLink={ errorSupportLink }>{ children }</WidgetErrorBoundary>
+			: children
+		}
 	</Paper>
 );

--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -78,9 +78,6 @@ domReady( () => {
 		errorSupport: select( STORE_NAME ).selectAdminLink( "?page=wpseo_page_support" ),
 		siteKitLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-site-kit-learn-more" ),
 		siteKitConsentLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-site-kit-consent-learn-more" ),
-		topPagesInfoLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-top-content-learn-more" ),
-		topQueriesInfoLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-top-queries-learn-more" ),
-		organicSessionsInfoLearnMore: select( STORE_NAME ).selectLink( "https://yoa.st/dashboard-organic-sessions-learn-more" ),
 	};
 
 	const siteKitConfiguration = get( window, "wpseoScriptData.dashboard.siteKitConfiguration", {

--- a/packages/js/tests/dashboard/__mocks__/data-provider.js
+++ b/packages/js/tests/dashboard/__mocks__/data-provider.js
@@ -62,7 +62,6 @@ export class MockDataProvider extends DataProvider {
 				dashboardLearnMore: "https://example.com/dashboard-learn-more",
 				errorSupport: "https://example.com/error-support",
 				siteKitLearnMore: "https://example.com/google-site-kit-learn-more",
-				organicSessionsInfoLearnMore: "https://example.com/organic-sessions-learn-more",
 			},
 			siteKitConfiguration: {
 				installUrl: "https://example.com/install",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* If there is an unexpected error, it would be nice if just that widget is taken out by it. Leaving the rest behaving. This change attempts to get closer to that possibility. It depends on the error still.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds global error catching on a per widget basis.

## Relevant technical choices:

Fixes Data formatter types since the split of interface in https://github.com/Yoast/wordpress-seo/pull/22075
  * It makes sense to me to use the interface as the type, since we just want a `format` method -- how or which particular formatter instance provides that, is not important to the widget

I had some trouble figuring out how to go about the error boundary.
If not in the widget. What decides how it should look like? We would need a generic "widget" look?
So that is why I went for inside the widget instead. Using the same layout as the widget.
However, this means that in order to catch any potential errors, the logic in the Widgets code should be moved a layer deeper.

Tiny scope creep: removing now un-used links that were in the tooltips before.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Regression: do the widgets still behave as before? Simple check if they are there should suffice

Devs only: introduce some errors.
* In any of the `Content` components, add a `throw new Error( "foo" );` line.
* ~Alternatively, add the same to the `fetchJson` in `remote-data-provider.js` for single crash all deal.~ Actually, that is caught already by the request handling, so I suppose you just have to add individual errors.
* Build, refresh and see it caught by the generic message.
* Verify the title of the `Impressions, Clicks, Site CTR, Average position` widget is there on error, but not without error

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/477
