### PR TITLE
Composer: normalize the file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,6 @@
 {
 	"name": "yoast/wordpress-seo",
 	"description": "Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.",
-	"repositories":[
-        {
-            "type":"composer",
-            "url":"https://wpackagist.org",
-            "only": [
-                "wpackagist-plugin/*"
-            ]
-        }
-    ],
 	"license": "GPL-2.0-or-later",
 	"type": "wordpress-plugin",
 	"keywords": [
@@ -45,9 +36,9 @@
 		"psr/log": "^1.0",
 		"symfony/config": "^3.4",
 		"symfony/dependency-injection": "^3.4",
+		"wpackagist-plugin/google-site-kit": "dev-trunk",
 		"yoast/wp-test-utils": "^1.2",
-		"yoast/yoastcs": "^3.1.0",
-		"wpackagist-plugin/google-site-kit": "dev-trunk"
+		"yoast/yoastcs": "^3.1.0"
 	},
 	"suggest": {
 		"ext-bcmath": "For more accurate calculations",
@@ -55,6 +46,15 @@
 		"ext-libxml": "Improves image sitemap",
 		"ext-mbstring": "For cyrillic support"
 	},
+	"repositories": [
+		{
+			"type": "composer",
+			"url": "https://wpackagist.org",
+			"only": [
+				"wpackagist-plugin/*"
+			]
+		}
+	],
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"autoload": {
@@ -74,13 +74,6 @@
 			"config/"
 		]
 	},
-    "extra": {
-        "installer-paths": {
-            "vendor/{$name}": [
-                "wpackagist-plugin/google-site-kit"
-            ]
-        }
-    },
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true,
@@ -89,6 +82,13 @@
 		},
 		"platform": {
 			"php": "7.2.5"
+		}
+	},
+	"extra": {
+		"installer-paths": {
+			"vendor/{$name}": [
+				"wpackagist-plugin/google-site-kit"
+			]
 		}
 	},
 	"scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "957a81cfc64a13b39a64a092f542b631",
+    "content-hash": "0317f6927465fca00dfe057be5b81032",
     "packages": [
         {
             "name": "composer/installers",
@@ -4878,7 +4878,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-filter": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.5"
     },


### PR DESCRIPTION
## Context

* Tidy up `composer.json` file

## Summary

This PR can be summarized in the following changelog entry:

* Tidy up `composer.json` file

## Relevant technical choices:


Well, mostly (scripts are not alphabetized, but still grouped by task).

Note: this is done as a one-time only action. The normalize script will **_not_** be run in CI to enforce normalization.

Style has been standardized to `--indent-style=tab --indent-size=1`.

Ref: https://github.com/ergebnis/composer-normalize


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_