### PR TITLE
Revert "PHPCS: minor ruleset tweak"

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -159,21 +159,6 @@
 		</properties>
 	</rule>
 
-	<!-- Excluded in WPCS, but the exclusion does not work well with a code base using short arrays.
-		 This may lead to some duplicate notices, but rather that, than these issues not being flagged.
-		 Note: this change will be included in YoastCS 3.1.1 and this tweak can be removed after that.
-	-->
-	<rule ref="Universal.WhiteSpace.CommaSpacing.SpaceBeforeInFunctionCall">
-		<severity>5</severity>
-	</rule>
-	<rule ref="Universal.WhiteSpace.CommaSpacing.TooMuchSpaceAfterInFunctionCall">
-		<severity>5</severity>
-	</rule>
-	<rule ref="Universal.WhiteSpace.CommaSpacing.NoSpaceAfterInFunctionCall">
-		<severity>5</severity>
-	</rule>
-
-
 	<!--
 	##########################################################################
 	SELECTIVE EXCLUSIONS


### PR DESCRIPTION
## Context

* Code style consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code style consistency

## Relevant technical choices:

This reverts commit 0990078fcb998e353a4027d3415f9204b16ab966 which is no longer needed as the same fix is included in YoastCS 3.2.0 (update happened in #22122).

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
