### PR TITLE
Tests: fix variety of broken covers tags

### DIFF
--- a/tests/Unit/Builders/Indexable_Builder/Build_For_System_Page_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Build_For_System_Page_Test.php
@@ -32,7 +32,6 @@ final class Build_For_System_Page_Test extends Abstract_Indexable_Builder_TestCa
 	 * @covers ::build_for_system_page
 	 * @covers ::ensure_indexable
 	 * @covers ::build
-	 * @covers ::save_indexable
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/Builders/Indexable_Builder/Build_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Build_Test.php
@@ -144,7 +144,6 @@ final class Build_Test extends Abstract_Indexable_Builder_TestCase {
 	 *
 	 * @covers ::build
 	 * @covers ::deep_copy_indexable
-	 * @covers ::save_indexable
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/Builders/Indexable_Builder/Maybe_Build_Author_Indexable_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Maybe_Build_Author_Indexable_Test.php
@@ -49,7 +49,6 @@ final class Maybe_Build_Author_Indexable_Test extends Abstract_Indexable_Builder
 	 * @covers ::maybe_build_author_indexable
 	 * @covers ::build
 	 * @covers ::ensure_indexable
-	 * @covers ::save_indexable
 	 *
 	 * @return void
 	 */
@@ -90,7 +89,6 @@ final class Maybe_Build_Author_Indexable_Test extends Abstract_Indexable_Builder
 	 * @covers ::maybe_build_author_indexable
 	 * @covers ::build
 	 * @covers ::ensure_indexable
-	 * @covers ::save_indexable
 	 * @covers ::deep_copy_indexable
 	 *
 	 * @return void

--- a/tests/Unit/Builders/Indexable_Builder/Save_Indexable_Test.php
+++ b/tests/Unit/Builders/Indexable_Builder/Save_Indexable_Test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Builders\Indexable_Builder_Double;
  * @group indexables
  * @group builders
  *
- * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Builder
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Indexable_Helper
  */
 final class Save_Indexable_Test extends Abstract_Indexable_Builder_TestCase {
 

--- a/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
@@ -18,7 +18,6 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\SEO_Links_Mock;
  * @group builders
  *
  * @coversDefaultClass \Yoast\WP\SEO\Builders\Indexable_Link_Builder
- * @covers \Yoast\WP\SEO\Builders\Indexable_Link_Builder
  */
 final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 
@@ -232,7 +231,6 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 * @covers ::__construct
 	 * @covers ::set_dependencies
 	 * @covers ::build
-	 * @covers ::gather_images
 	 *
 	 * @return void
 	 */
@@ -388,7 +386,6 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 	 * Tests the build method when ignoring content scan.
 	 *
 	 * @covers ::build
-	 * @covers ::gather_images
 	 * @dataProvider provide_no_content_scan
 	 *
 	 * @param string $input_content The input content.

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Set_Site_Kit_Permanent_Dismissal_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Set_Site_Kit_Permanent_Dismissal_Test.php
@@ -21,7 +21,6 @@ final class Set_Site_Kit_Permanent_Dismissal_Test extends Abstract_Site_Kit_Conf
 	 * Tests the set_introduction_seen route's happy path.
 	 *
 	 * @dataProvider set_site_kit_configuration_permanent_dismissal_data
-	 * @covers ::set_introduction_seen
 	 *
 	 * @param bool $is_dismissed    The value to set.
 	 * @param int  $expected_status The expected status code.

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Set_Site_Kit_Permanent_Dismissal_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Set_Site_Kit_Permanent_Dismissal_Test.php
@@ -11,7 +11,7 @@ use WP_REST_Response;
  *
  * @group site_kit_configuration_permanent_dismissal_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Permanent_Dismissal_Route::set_site_kit_configuration_permanent_dismissal
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route::set_site_kit_configuration_permanent_dismissal
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Check_Capabilities_Test.php
@@ -7,7 +7,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
  *
  * @group site_kit_configuration_permanent_dismissal_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Permanent_Dismissal_Route::check_capabilities
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route::check_capabilities
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Constructor_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Constructor_Test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Si
  *
  * @group site_kit_configuration_permanent_dismissal_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Permanent_Dismissal_Route::__construct
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route::__construct
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
@@ -18,8 +18,6 @@ final class Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Te
 	/**
 	 * Tests the get_conditionals function.
 	 *
-	 * @covers ::get_conditionals
-	 *
 	 * @return void
 	 */
 	public function test_get_conditionals() {

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_D
  *
  * @group site_kit_configuration_permanent_dismissal_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Permanent_Dismissal_Route::get_conditionals
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route::get_conditionals
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Register_Routes_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Register_Routes_Test.php
@@ -9,7 +9,7 @@ use Brain\Monkey\Functions;
  *
  * @group site_kit_configuration_permanent_dismissal_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Permanent_Dismissal_Route::register_routes
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route::register_routes
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Get_Conditionals_Test.php
@@ -18,8 +18,6 @@ final class Site_Kit_Consent_Management_Route_Get_Conditionals_Test extends Abst
 	/**
 	 * Tests the get_conditionals function.
 	 *
-	 * @covers ::get_conditionals
-	 *
 	 * @return void
 	 */
 	public function test_get_conditionals() {

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Register_Routes_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Register_Routes_Test.php
@@ -9,7 +9,7 @@ use Brain\Monkey\Functions;
  *
  * @group site_kit_consent_management_route
  *
- * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Consent_Management::register_routes
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Consent_Management_Route::register_routes
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Conditionals_Test.php
@@ -19,8 +19,6 @@ final class Time_Based_SEO_Metrics_Route_Get_Conditionals_Test extends Abstract_
 	/**
 	 * Tests the get_conditionals function.
 	 *
-	 * @covers ::get_conditionals
-	 *
 	 * @return void
 	 */
 	public function test_get_conditionals() {

--- a/tests/Unit/Editors/Domain/Analysis_Features/Analysis_Features_List_Test.php
+++ b/tests/Unit/Editors/Domain/Analysis_Features/Analysis_Features_List_Test.php
@@ -46,7 +46,7 @@ final class Analysis_Features_List_Test extends TestCase {
 	 * Tests the to array.
 	 *
 	 * @covers ::add_feature
-	 * @covers ::parse_to_array
+	 * @covers ::to_array
 	 *
 	 * @return void
 	 */

--- a/tests/Unit/Images/Application/Image_Content_Extractor_Test.php
+++ b/tests/Unit/Images/Application/Image_Content_Extractor_Test.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @group images
  *
  * @coversDefaultClass \Yoast\WP\SEO\Images\Application\Image_Content_Extractor
- * @covers \Yoast\WP\SEO\Images\Application\Image_Content_Extractor
  */
 final class Image_Content_Extractor_Test extends TestCase {
 
@@ -65,7 +64,6 @@ final class Image_Content_Extractor_Test extends TestCase {
 	/**
 	 * Tests the build function.
 	 *
-	 * @covers ::__construct
 	 * @covers ::gather_images
 	 * @covers ::gather_images_wp
 	 * @covers ::gather_images_domdocument

--- a/tests/Unit/User_Meta/Infrastructure/Cleanup_Repository_Test.php
+++ b/tests/Unit/User_Meta/Infrastructure/Cleanup_Repository_Test.php
@@ -34,14 +34,13 @@ final class Cleanup_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests cleanup_selected_empty_usermeta.
+	 * Tests delete_empty_usermeta_query.
 	 *
-	 * @covers ::cleanup_selected_empty_usermeta
-	 * @covers ::get_meta_to_check
+	 * @covers ::delete_empty_usermeta_query
 	 *
 	 * @return void
 	 */
-	public function test_cleanup_selected_empty_usermeta() {
+	public function test_delete_empty_usermeta_query() {
 		$wpdb           = Mockery::mock( wpdb::class );
 		$wpdb->usermeta = 'wp_usermeta';
 

--- a/tests/WP/Formatter/Post_Metabox_Formatter_Test.php
+++ b/tests/WP/Formatter/Post_Metabox_Formatter_Test.php
@@ -8,6 +8,8 @@ use Yoast\WP\SEO\Tests\WP\TestCase;
 
 /**
  * Unit Test Class.
+ *
+ * @covers WPSEO_Post_Metabox_Formatter
  */
 final class Post_Metabox_Formatter_Test extends TestCase {
 
@@ -32,12 +34,6 @@ final class Post_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Test with a post being set but with no options being set.
 	 *
-	 * @covers WPSEO_Post_Metabox_Formatter::get_values
-	 * @covers WPSEO_Post_Metabox_Formatter::get_focus_keyword_usage
-	 * @covers WPSEO_Post_Metabox_Formatter::get_title_template
-	 * @covers WPSEO_Post_Metabox_Formatter::get_metadesc_template
-	 * @covers WPSEO_Post_Metabox_Formatter::get_template
-	 *
 	 * @return void
 	 */
 	public function test_post_with_empty_options() {
@@ -55,8 +51,6 @@ final class Post_Metabox_Formatter_Test extends TestCase {
 
 	/**
 	 * Testing with a post and needed options being set.
-	 *
-	 * @covers WPSEO_Post_Metabox_Formatter::get_metadesc_date
 	 *
 	 * @return void
 	 */

--- a/tests/WP/Formatter/Term_Metabox_Formatter_Test.php
+++ b/tests/WP/Formatter/Term_Metabox_Formatter_Test.php
@@ -8,6 +8,8 @@ use Yoast\WP\SEO\Tests\WP\TestCase;
 
 /**
  * Unit Test Class.
+ *
+ * @covers WPSEO_Term_Metabox_Formatter
  */
 final class Term_Metabox_Formatter_Test extends TestCase {
 
@@ -40,9 +42,6 @@ final class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Test the formatter without a term, taxonomy and options.
 	 *
-	 * @covers WPSEO_Term_Metabox_Formatter::__construct
-	 * @covers WPSEO_Term_Metabox_Formatter::get_values
-	 *
 	 * @return void
 	 */
 	public function test_no_taxonomy_no_term_and_no_options() {
@@ -56,15 +55,6 @@ final class Term_Metabox_Formatter_Test extends TestCase {
 
 	/**
 	 * Test the formatter when there is a taxonomy and term object and without any options.
-	 *
-	 * @covers WPSEO_Term_Metabox_Formatter::get_values
-	 * @covers WPSEO_Term_Metabox_Formatter::search_url
-	 * @covers WPSEO_Term_Metabox_Formatter::edit_url
-	 * @covers WPSEO_Term_Metabox_Formatter::base_url_for_js
-	 * @covers WPSEO_Term_Metabox_Formatter::get_focus_keyword_usage
-	 * @covers WPSEO_Term_Metabox_Formatter::get_title_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_metadesc_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_template
 	 *
 	 * @return void
 	 */
@@ -84,10 +74,6 @@ final class Term_Metabox_Formatter_Test extends TestCase {
 	/**
 	 * Test the formatter when there is a taxonomy and term object and without any options.
 	 *
-	 * @covers WPSEO_Term_Metabox_Formatter::get_title_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_metadesc_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_template
-	 *
 	 * @return void
 	 */
 	public function test_with_taxonomy_term_and_options() {
@@ -103,10 +89,6 @@ final class Term_Metabox_Formatter_Test extends TestCase {
 
 	/**
 	 * Test the formatter when there is a taxonomy and term object and without any options.
-	 *
-	 * @covers WPSEO_Term_Metabox_Formatter::get_title_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_metadesc_template
-	 * @covers WPSEO_Term_Metabox_Formatter::get_template
 	 *
 	 * @return void
 	 */

--- a/tests/WP/Images/Application/Image_Content_Extractor_Test.php
+++ b/tests/WP/Images/Application/Image_Content_Extractor_Test.php
@@ -11,7 +11,6 @@ use Yoast\WP\SEO\Tests\WP\TestCase;
  * @group images
  *
  * @coversDefaultClass \Yoast\WP\SEO\Images\Application\Image_Content_Extractor
- * @covers \Yoast\WP\SEO\Images\Application\Image_Content_Extractor
  */
 final class Image_Content_Extractor_Test extends TestCase {
 
@@ -65,7 +64,6 @@ final class Image_Content_Extractor_Test extends TestCase {
 	 *
 	 * @dataProvider gather_images_wp_provider
 	 *
-	 * @covers ::__construct
 	 * @covers ::gather_images
 	 * @covers ::gather_images_wp
 	 *


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

### Tests: fix/remove invalid `@covers` tags

### Tests: remove invalid `@covers` tags 

Referenced method doesn't exist.

Also test classes should not have both `@coversDefaultClass` + `@covers ::method` AND a `@covers ClassName` at class level.

### Tests: replace invalid `@covers` tag

### Tests: fix invalid `@covers` tags

### Tests: remove invalid `@covers` tags 

Having a method level `@covers ::method` tag only works if there is also a class level `@coversDefaultClass`.

As these tests have class level `@covers` tags, Let's remove the invalid ones (which now try to point to global function which don't exist).

### Tests: fix some incorrect `@covers` tags

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_