### PR TITLE
CS/QA: no need for `is_null()`

### DIFF
--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -591,7 +591,7 @@ class Yoast_Form {
 	 * @return void
 	 */
 	public function hidden( $variable, $id = '', $val = null ) {
-		if ( is_null( $val ) ) {
+		if ( $val === null ) {
 			$val = $this->get_field_value( $variable, '' );
 		}
 

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -330,11 +330,11 @@ class Yoast_Notification_Center {
 
 			// If notification ID exists in notifications, don't add again.
 			$present_notification = $this->get_notification_by_id( $notification_id, $user_id );
-			if ( ! is_null( $present_notification ) ) {
+			if ( $present_notification !== null ) {
 				$this->remove_notification( $present_notification, false );
 			}
 
-			if ( is_null( $present_notification ) ) {
+			if ( $present_notification === null ) {
 				$this->new[] = $notification_id;
 			}
 		}

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -52,7 +52,7 @@ class Yoast_Plugin_Conflict {
 	 */
 	public static function get_instance( $class_name = '' ) {
 
-		if ( is_null( self::$instance ) ) {
+		if ( self::$instance === null ) {
 			if ( ! is_string( $class_name ) || $class_name === '' ) {
 				$class_name = self::class;
 			}

--- a/admin/import/plugins/class-import-squirrly.php
+++ b/admin/import/plugins/class-import-squirrly.php
@@ -135,7 +135,7 @@ class WPSEO_Import_Squirrly extends WPSEO_Plugin_Importer {
 		global $wpdb;
 
 		$result = $wpdb->get_var( "SHOW TABLES LIKE '{$this->table_name}'" );
-		if ( is_wp_error( $result ) || is_null( $result ) ) {
+		if ( is_wp_error( $result ) || $result === null ) {
 			return false;
 		}
 

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -145,7 +145,7 @@ class WPSEO_Taxonomy {
 
 		if (
 			self::is_term_edit( $pagenow )
-			&& ! is_null( $tag_id )
+			&& $tag_id !== null
 		) {
 			wp_enqueue_media(); // Enqueue files needed for upload functionality.
 

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -345,7 +345,7 @@ class WPSEO_Addon_Manager {
 			// If the add-on's version is the latest, we have to do no further checks.
 			if ( version_compare( $installed_plugin['Version'], $plugin_data->new_version, '<' ) ) {
 				// If we haven't retrieved the Yoast Free requirements for the WP version yet, do nothing. The next run will probably get us that information.
-				if ( is_null( $plugin_data->requires ) ) {
+				if ( $plugin_data->requires === null ) {
 					continue;
 				}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -154,7 +154,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool True if SEO score is enabled, false otherwise.
 	 */
 	protected function get_is_seo_enabled() {
-		if ( is_null( $this->is_seo_enabled ) ) {
+		if ( $this->is_seo_enabled === null ) {
 			$this->is_seo_enabled = ( new WPSEO_Metabox_Analysis_SEO() )->is_enabled();
 		}
 
@@ -167,7 +167,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool True if readability is enabled, false otherwise.
 	 */
 	protected function get_is_readability_enabled() {
-		if ( is_null( $this->is_readability_enabled ) ) {
+		if ( $this->is_readability_enabled === null ) {
 			$this->is_readability_enabled = ( new WPSEO_Metabox_Analysis_Readability() )->is_enabled();
 		}
 
@@ -180,7 +180,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool|Indexable The indexable, false if none could be found.
 	 */
 	protected function get_current_indexable() {
-		if ( is_null( $this->current_indexable ) ) {
+		if ( $this->current_indexable === null ) {
 			$this->current_indexable = $this->indexable_repository->for_current_page();
 		}
 
@@ -227,7 +227,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				$indexable = $this->get_current_indexable();
 
 				if ( $is_seo_enabled ) {
-					$focus_keyword = ( ! is_a( $indexable, 'Yoast\WP\SEO\Models\Indexable' ) || is_null( $indexable->primary_focus_keyword ) ) ? __( 'not set', 'wordpress-seo' ) : $indexable->primary_focus_keyword;
+					$focus_keyword = ( ! is_a( $indexable, 'Yoast\WP\SEO\Models\Indexable' ) || $indexable->primary_focus_keyword === null ) ? __( 'not set', 'wordpress-seo' ) : $indexable->primary_focus_keyword;
 
 					$wp_admin_bar->add_menu(
 						[

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -28,7 +28,7 @@ class WPSEO_Custom_Fields {
 		global $wpdb;
 
 		// Use cached value if available.
-		if ( ! is_null( self::$custom_fields ) ) {
+		if ( self::$custom_fields !== null ) {
 			return self::$custom_fields;
 		}
 

--- a/inc/class-wpseo-custom-taxonomies.php
+++ b/inc/class-wpseo-custom-taxonomies.php
@@ -24,7 +24,7 @@ class WPSEO_Custom_Taxonomies {
 	 */
 	public static function get_custom_taxonomies() {
 		// Use cached value if available.
-		if ( ! is_null( self::$custom_taxonomies ) ) {
+		if ( self::$custom_taxonomies !== null ) {
 			return self::$custom_taxonomies;
 		}
 

--- a/inc/class-wpseo-replace-vars.php
+++ b/inc/class-wpseo-replace-vars.php
@@ -307,7 +307,7 @@ class WPSEO_Replace_Vars {
 				$replacement = $this->$method_name();
 			}
 			// Deal with externally defined variable names.
-			elseif ( isset( self::$external_replacements[ $var ] ) && ! is_null( self::$external_replacements[ $var ] ) ) {
+			elseif ( isset( self::$external_replacements[ $var ] ) && is_callable( self::$external_replacements[ $var ] ) ) {
 				$replacement = call_user_func( self::$external_replacements[ $var ], $var, $this->args );
 			}
 

--- a/inc/sitemaps/class-sitemaps-cache-validator.php
+++ b/inc/sitemaps/class-sitemaps-cache-validator.php
@@ -50,7 +50,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 	public static function get_storage_key( $type = null, $page = 1 ) {
 
 		// Using SITEMAP_INDEX_TYPE for sitemap index cache.
-		$type = is_null( $type ) ? WPSEO_Sitemaps::SITEMAP_INDEX_TYPE : $type;
+		$type = ( $type === null ) ? WPSEO_Sitemaps::SITEMAP_INDEX_TYPE : $type;
 
 		$global_cache_validator = self::get_validator();
 		$type_cache_validator   = self::get_validator( $type );
@@ -141,7 +141,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 		$old_validator = null;
 
 		// Get the current type validator.
-		if ( ! is_null( $type ) ) {
+		if ( $type !== null ) {
 			$old_validator = self::get_validator( $type );
 		}
 
@@ -170,7 +170,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 
 		global $wpdb;
 
-		if ( is_null( $type ) ) {
+		if ( $type === null ) {
 			// Clear all cache if no type is provided.
 			$like = sprintf( '%s%%', self::STORAGE_KEY_PREFIX );
 		}
@@ -221,7 +221,7 @@ class WPSEO_Sitemaps_Cache_Validator {
 		$key = self::get_validator_key( $type );
 
 		$current = get_option( $key, null );
-		if ( ! is_null( $current ) ) {
+		if ( $current !== null ) {
 			return $current;
 		}
 

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -518,7 +518,7 @@ class WPSEO_Sitemaps {
 			}
 		}
 
-		if ( is_null( $post_type_dates ) ) {
+		if ( $post_type_dates === null ) {
 
 			$post_type_dates = [];
 			$post_type_names = WPSEO_Post_Type::get_accessible_post_types();

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -332,7 +332,7 @@ class ORM implements ArrayAccess {
 	 */
 	public function create( $data = null ) {
 		$this->is_new = true;
-		if ( ! \is_null( $data ) ) {
+		if ( $data !== null ) {
 			$this->hydrate( $data )->force_all_dirty();
 		}
 
@@ -381,7 +381,7 @@ class ORM implements ArrayAccess {
 	 * @return bool|Model
 	 */
 	public function find_one( $id = null ) {
-		if ( ! \is_null( $id ) ) {
+		if ( $id !== null ) {
 			$this->where_id_is( $id );
 		}
 		$this->limit( 1 );
@@ -618,7 +618,7 @@ class ORM implements ArrayAccess {
 	 * @return ORM
 	 */
 	protected function add_result_column( $expr, $alias = null ) {
-		if ( ! \is_null( $alias ) ) {
+		if ( $alias !== null ) {
 			$expr .= ' AS ' . $this->quote_identifier( $alias );
 		}
 		if ( $this->using_default_result_columns ) {
@@ -645,7 +645,7 @@ class ORM implements ArrayAccess {
 			return \count( \array_filter( $this->id(), 'is_null' ) );
 		}
 		else {
-			return \is_null( $this->id() ) ? 1 : 0;
+			return ( $this->id() === null ) ? 1 : 0;
 		}
 	}
 
@@ -809,7 +809,7 @@ class ORM implements ArrayAccess {
 		$join_operator = \trim( "{$join_operator} JOIN" );
 		$table         = $this->quote_identifier( $table );
 		// Add table alias if present.
-		if ( ! \is_null( $table_alias ) ) {
+		if ( $table_alias !== null ) {
 			$table_alias = $this->quote_identifier( $table_alias );
 			$table      .= " {$table_alias}";
 		}
@@ -838,7 +838,7 @@ class ORM implements ArrayAccess {
 	 */
 	public function raw_join( $table, $constraint, $table_alias, $parameters = [] ) {
 		// Add table alias if present.
-		if ( ! \is_null( $table_alias ) ) {
+		if ( $table_alias !== null ) {
 			$table_alias = $this->quote_identifier( $table_alias );
 			$table      .= " {$table_alias}";
 		}
@@ -1107,7 +1107,7 @@ class ORM implements ArrayAccess {
 			// Add the table name in case of ambiguous columns.
 			if ( \count( $result->join_sources ) > 0 && \strpos( $key, '.' ) === false ) {
 				$table = $result->table_name;
-				if ( ! \is_null( $result->table_alias ) ) {
+				if ( $result->table_alias !== null ) {
 					$table = $result->table_alias;
 				}
 				$key = "{$table}.{$key}";
@@ -1758,7 +1758,7 @@ class ORM implements ArrayAccess {
 			$result_columns = 'DISTINCT ' . $result_columns;
 		}
 		$fragment .= "{$result_columns} FROM " . $this->quote_identifier( $this->table_name );
-		if ( ! \is_null( $this->table_alias ) ) {
+		if ( $this->table_alias !== null ) {
 			$fragment .= ' ' . $this->quote_identifier( $this->table_alias );
 		}
 
@@ -1850,7 +1850,7 @@ class ORM implements ArrayAccess {
 	 * @return string
 	 */
 	protected function build_limit() {
-		if ( ! \is_null( $this->limit ) ) {
+		if ( $this->limit !== null ) {
 			return "LIMIT {$this->limit}";
 		}
 
@@ -1863,7 +1863,7 @@ class ORM implements ArrayAccess {
 	 * @return string
 	 */
 	protected function build_offset() {
-		if ( ! \is_null( $this->offset ) ) {
+		if ( $this->offset !== null ) {
 			return 'OFFSET ' . $this->offset;
 		}
 
@@ -2033,7 +2033,7 @@ class ORM implements ArrayAccess {
 	 * @return string The primary key ID of the row.
 	 */
 	protected function get_id_column_name() {
-		if ( ! \is_null( $this->instance_id_column ) ) {
+		if ( $this->instance_id_column !== null ) {
 			return $this->instance_id_column;
 		}
 
@@ -2277,7 +2277,7 @@ class ORM implements ArrayAccess {
 					}
 
 					// Only register the value if it is not null.
-					if ( ! \is_null( $model->orm->dirty_fields[ $dirty_column ] ) ) {
+					if ( $model->orm->dirty_fields[ $dirty_column ] !== null ) {
 						$model_values[] = $model->orm->dirty_fields[ $dirty_column ];
 					}
 				}
@@ -2483,7 +2483,7 @@ class ORM implements ArrayAccess {
 	 */
 	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
-		if ( \is_null( $offset ) ) {
+		if ( $offset === null ) {
 			return;
 		}
 		$this->set( $offset, $value );

--- a/src/actions/configuration/first-time-configuration-action.php
+++ b/src/actions/configuration/first-time-configuration-action.php
@@ -299,7 +299,7 @@ class First_Time_Configuration_Action {
 	public function get_configuration_state() {
 		$configuration_option = $this->options_helper->get( 'configuration_finished_steps' );
 
-		if ( ! \is_null( $configuration_option ) ) {
+		if ( $configuration_option !== null ) {
 			return (object) [
 				'success' => true,
 				'status'  => 200,

--- a/src/actions/indexing/abstract-indexing-action.php
+++ b/src/actions/indexing/abstract-indexing-action.php
@@ -85,7 +85,7 @@ abstract class Abstract_Indexing_Action implements Indexation_Action_Interface, 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_count_query returns a prepared query.
 		$count = ( $query === '' ) ? 0 : $this->wpdb->get_var( $query );
 
-		if ( \is_null( $count ) ) {
+		if ( $count === null ) {
 			return false;
 		}
 

--- a/src/actions/wincher/wincher-account-action.php
+++ b/src/actions/wincher/wincher-account-action.php
@@ -54,7 +54,7 @@ class Wincher_Account_Action {
 			$history = $results['limits']['history_days'];
 
 			return (object) [
-				'canTrack'    => \is_null( $limit ) || $usage < $limit,
+				'canTrack'    => ( $limit === null || $usage < $limit ),
 				'limit'       => $limit,
 				'usage'       => $usage,
 				'historyDays' => $history,

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -331,7 +331,7 @@ class Wincher_Keyphrases_Action {
 			$keyphrases = [ $keyphrases ];
 		}
 
-		if ( \is_null( $limits->limit ) ) {
+		if ( $limits->limit === null ) {
 			return false;
 		}
 

--- a/src/builders/indexable-builder.php
+++ b/src/builders/indexable-builder.php
@@ -382,7 +382,7 @@ class Indexable_Builder {
 			return $this->indexable_helper->save_indexable( $indexable, $indexable_before );
 		}
 		catch ( Source_Exception $exception ) {
-			if ( ! $this->is_type_with_no_id( $indexable->object_type ) && ( ! isset( $indexable->object_id ) || \is_null( $indexable->object_id ) ) ) {
+			if ( ! $this->is_type_with_no_id( $indexable->object_type ) && ! isset( $indexable->object_id ) ) {
 				return false;
 			}
 

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -53,7 +53,7 @@ class Badge_Group_Names {
 
 		$group_version = $this::GROUP_NAMES[ $group ];
 
-		if ( \is_null( $current_version ) ) {
+		if ( $current_version === null ) {
 			$current_version = $this->version;
 		}
 

--- a/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
+++ b/src/content-type-visibility/application/content-type-visibility-watcher-actions.php
@@ -141,7 +141,7 @@ class Content_Type_Visibility_Watcher_Actions implements Integration_Interface {
 	 */
 	public function maybe_add_notification() {
 		$notification = $this->notification_center->get_notification_by_id( 'content-types-made-public' );
-		if ( \is_null( $notification ) ) {
+		if ( $notification === null ) {
 			$this->add_notification();
 		}
 	}

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -523,7 +523,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				break;
 			default:
 				$additional_type = $this->indexable->schema_page_type;
-				if ( \is_null( $additional_type ) ) {
+				if ( $additional_type === null ) {
 					$additional_type = $this->options->get( 'schema-page-type-' . $this->indexable->object_sub_type );
 				}
 
@@ -553,7 +553,7 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 */
 	public function generate_schema_article_type() {
 		$additional_type = $this->indexable->schema_article_type;
-		if ( \is_null( $additional_type ) ) {
+		if ( $additional_type === null ) {
 			$additional_type = $this->options->get( 'schema-article-type-' . $this->indexable->object_sub_type );
 		}
 

--- a/src/deprecated/frontend/breadcrumbs.php
+++ b/src/deprecated/frontend/breadcrumbs.php
@@ -106,7 +106,7 @@ class WPSEO_Breadcrumbs {
 	 * @return static The instance.
 	 */
 	public static function get_instance() {
-		if ( is_null( self::$instance ) ) {
+		if ( self::$instance === null ) {
 			self::$instance = new self();
 		}
 

--- a/src/deprecated/frontend/frontend.php
+++ b/src/deprecated/frontend/frontend.php
@@ -92,7 +92,7 @@ class WPSEO_Frontend {
 	 * @return static The instance.
 	 */
 	public static function get_instance() {
-		if ( is_null( self::$instance ) ) {
+		if ( self::$instance === null ) {
 			self::$instance = new self();
 		}
 

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -277,7 +277,7 @@ class Person extends Abstract_Schema_Piece {
 			&& $this->helpers->schema->article->is_author_supported( $this->context->indexable->object_sub_type )
 			&& $this->context->schema_article_type !== 'None'
 		) {
-			$user_id = ( ( ! \is_null( $user_data ) ) && ( isset( $user_data->ID ) ) ) ? $user_data->ID : $this->context->indexable->author_id;
+			$user_id = ( $user_data instanceof WP_User && isset( $user_data->ID ) ) ? $user_data->ID : $this->context->indexable->author_id;
 
 			return $this->context->site_user_id === $user_id;
 		}

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -480,7 +480,7 @@ class Current_Page_Helper {
 		$term     = $wp_query->get_queried_object();
 
 		$queried_terms = $wp_query->tax_query->queried_terms;
-		if ( \is_null( $term ) || empty( $queried_terms[ $term->taxonomy ]['terms'] ) ) {
+		if ( $term === null || empty( $queried_terms[ $term->taxonomy ]['terms'] ) ) {
 			return 0;
 		}
 

--- a/src/helpers/indexable-to-postmeta-helper.php
+++ b/src/helpers/indexable-to-postmeta-helper.php
@@ -165,7 +165,7 @@ class Indexable_To_Postmeta_Helper {
 	 * @return void
 	 */
 	public function noindex_map( $indexable, $post_meta_key ) {
-		if ( \is_null( $indexable->is_robots_noindex ) ) {
+		if ( $indexable->is_robots_noindex === null ) {
 			$this->meta->delete( $post_meta_key, $indexable->object_id );
 			return;
 		}
@@ -188,7 +188,7 @@ class Indexable_To_Postmeta_Helper {
 	 * @return void
 	 */
 	public function nofollow_map( $indexable, $post_meta_key ) {
-		if ( \is_null( $indexable->is_robots_nofollow ) || $indexable->is_robots_nofollow === false ) {
+		if ( $indexable->is_robots_nofollow === null || $indexable->is_robots_nofollow === false ) {
 			$this->meta->delete( $post_meta_key, $indexable->object_id );
 		}
 

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -15,7 +15,7 @@ class Article_Helper {
 	 * @return bool True if it has Article schema, false if not.
 	 */
 	public function is_article_post_type( $post_type = null ) {
-		if ( \is_null( $post_type ) ) {
+		if ( $post_type === null ) {
 			$post_type = \get_post_type();
 		}
 

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -30,7 +30,7 @@ class Url_Helper {
 			return $home_url;
 		}
 
-		if ( \is_null( $home_path ) ) { // Home at site root, always slash.
+		if ( $home_path === null ) { // Home at site root, always slash.
 			return \trailingslashit( $home_url );
 		}
 
@@ -185,7 +185,7 @@ class Url_Helper {
 
 		$base_url = \trailingslashit( $url_parts['scheme'] . '://' . $url_parts['host'] );
 
-		if ( ! \is_null( $path ) ) {
+		if ( \is_string( $path ) ) {
 			$base_url .= \ltrim( $path, '/' );
 		}
 
@@ -213,7 +213,7 @@ class Url_Helper {
 			return ( $is_image ) ? SEO_Links::TYPE_EXTERNAL_IMAGE : SEO_Links::TYPE_EXTERNAL;
 		}
 
-		if ( \is_null( $home_url ) ) {
+		if ( $home_url === null ) {
 			$home_url = \wp_parse_url( \home_url() );
 		}
 

--- a/src/helpers/wpdb-helper.php
+++ b/src/helpers/wpdb-helper.php
@@ -35,7 +35,7 @@ class Wpdb_Helper {
 	public function table_exists( $table ) {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Reason: There is no unescaped user input.
 		$table_exists = $this->wpdb->get_var( "SHOW TABLES LIKE '{$table}'" );
-		if ( \is_wp_error( $table_exists ) || \is_null( $table_exists ) ) {
+		if ( \is_wp_error( $table_exists ) || $table_exists === null ) {
 			return false;
 		}
 

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -319,7 +319,7 @@ class Front_End_Integration implements Integration_Interface {
 		}
 
 		// Check $this->next or $this->prev for existing links.
-		if ( \is_null( $this->$rel ) ) {
+		if ( $this->$rel === null ) {
 			return $link;
 		}
 
@@ -433,7 +433,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
 	public function get_presenters( $page_type, $context = null ) {
-		if ( \is_null( $context ) ) {
+		if ( $context === null ) {
 			$context = $this->context_memoizer->for_current_page();
 		}
 

--- a/src/integrations/watchers/indexable-ancestor-watcher.php
+++ b/src/integrations/watchers/indexable-ancestor-watcher.php
@@ -119,7 +119,7 @@ class Indexable_Ancestor_Watcher implements Integration_Interface {
 		}
 
 		// If the permalink was null it means it was reset instead of changed.
-		if ( $indexable->permalink === $indexable_before->permalink || \is_null( $indexable_before->permalink ) ) {
+		if ( $indexable->permalink === $indexable_before->permalink || $indexable_before->permalink === null ) {
 			return false;
 		}
 

--- a/src/presentations/indexable-term-archive-presentation.php
+++ b/src/presentations/indexable-term-archive-presentation.php
@@ -92,7 +92,7 @@ class Indexable_Term_Archive_Presentation extends Indexable_Presentation {
 	 * @return array The source.
 	 */
 	public function generate_source() {
-		if ( ! empty( $this->model->object_id ) || \is_null( \get_queried_object() ) ) {
+		if ( ! empty( $this->model->object_id ) || \get_queried_object() === null ) {
 			return \get_term( $this->model->object_id, $this->model->object_sub_type );
 		}
 

--- a/src/presenters/admin/notice-presenter.php
+++ b/src/presenters/admin/notice-presenter.php
@@ -110,13 +110,13 @@ class Notice_Presenter extends Abstract_Presenter {
 		$out .= '</div>';
 		$out .= '<div class="notice-yoast-content">';
 		$out .= '<p>' . $this->content . '</p>';
-		if ( ! \is_null( $this->button ) ) {
+		if ( $this->button !== null ) {
 			$out .= '<p>' . $this->button . '</p>';
 		}
 		$out .= '</div>';
 		$out .= '</div>';
 
-		if ( ! \is_null( $this->image_filename ) ) {
+		if ( $this->image_filename !== null ) {
 			$out .= '<img src="' . \esc_url( \plugin_dir_url( \WPSEO_FILE ) . 'images/' . $this->image_filename ) . '" alt="" height="60" width="75"/>';
 		}
 

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -277,7 +277,7 @@ class Meta_Surface {
 		if ( ! \is_a( $indexable, Indexable::class ) ) {
 			return false;
 		}
-		if ( \is_null( $page_type ) ) {
+		if ( $page_type === null ) {
 			$page_type = $this->indexable_helper->get_page_type_for_indexable( $indexable );
 		}
 
@@ -295,7 +295,7 @@ class Meta_Surface {
 	public function for_indexables( $indexables, $page_type = null ) {
 		$closure = function ( $indexable ) use ( $page_type ) {
 			$this_page_type = $page_type;
-			if ( \is_null( $this_page_type ) ) {
+			if ( $this_page_type === null ) {
 				$this_page_type = $this->indexable_helper->get_page_type_for_indexable( $indexable );
 			}
 

--- a/src/values/oauth/oauth-token.php
+++ b/src/values/oauth/oauth-token.php
@@ -84,7 +84,7 @@ class OAuth_Token {
 
 		$this->expires = $expires;
 
-		if ( \is_null( $has_expired ) ) {
+		if ( $has_expired === null ) {
 			throw new Empty_Property_Exception( 'has_expired' );
 		}
 

--- a/tests/Unit/Helpers/Short_Link_Helper_Test.php
+++ b/tests/Unit/Helpers/Short_Link_Helper_Test.php
@@ -190,7 +190,7 @@ final class Short_Link_Helper_Test extends TestCase {
 		$this->assertEquals( $query_params['software'], $expected['software'] );
 		$this->assertEquals( $query_params['platform'], $expected['platform'] );
 
-		if ( ! \is_null( $page ) ) {
+		if ( $page !== null ) {
 			$this->assertContains( 'screen', $query_param_keys );
 		}
 	}

--- a/tests/Unit/Helpers/Url_Helper_Test.php
+++ b/tests/Unit/Helpers/Url_Helper_Test.php
@@ -515,7 +515,7 @@ final class Url_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_link_type( $url, $home_url, $is_image, $link_type, $message ) {
-		if ( \is_null( $home_url ) ) {
+		if ( $home_url === null ) {
 			Monkey\Functions\expect( 'home_url' )
 				->once()
 				->andReturn( 'home_url' );

--- a/tests/WP/Doubles/Admin/Meta_Columns_Double.php
+++ b/tests/WP/Doubles/Admin/Meta_Columns_Double.php
@@ -78,7 +78,7 @@ final class Meta_Columns_Double extends WPSEO_Meta_Columns {
 	 * @return string
 	 */
 	public function get_current_post_type() {
-		if ( ! \is_null( $this->current_post_type ) ) {
+		if ( $this->current_post_type !== null ) {
 			return $this->current_post_type;
 		}
 		else {


### PR DESCRIPTION


## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

No need for a function call when a direct comparison will do. The `is_null()` function should generally only be used as a callback.

Also no need to do both an `isset()` as well as a `is_null()`. `isset()` will already return `false` if the value is `null`, so that is just a duplicate check.

Includes replacing some unsafe type checks with safer ones.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_