### PR TITLE
Docs: remove redundant property names in `@var` tags

### DIFF
--- a/src/dashboard/application/configuration/dashboard-configuration.php
+++ b/src/dashboard/application/configuration/dashboard-configuration.php
@@ -22,21 +22,21 @@ class Dashboard_Configuration {
 	/**
 	 * The content types repository.
 	 *
-	 * @var Content_Types_Repository $content_types_repository
+	 * @var Content_Types_Repository
 	 */
 	private $content_types_repository;
 
 	/**
 	 * The indexable helper.
 	 *
-	 * @var Indexable_Helper $indexable_helper
+	 * @var Indexable_Helper
 	 */
 	private $indexable_helper;
 
 	/**
 	 * The user helper.
 	 *
-	 * @var User_Helper $user_helper
+	 * @var User_Helper
 	 */
 	private $user_helper;
 

--- a/src/dashboard/domain/endpoint/endpoint-list.php
+++ b/src/dashboard/domain/endpoint/endpoint-list.php
@@ -10,7 +10,7 @@ class Endpoint_List {
 	/**
 	 * Holds the endpoints.
 	 *
-	 * @var array<Endpoint_Interface> $endpoints
+	 * @var array<Endpoint_Interface>
 	 */
 	private $endpoints = [];
 

--- a/src/dashboard/infrastructure/score-results/readability-score-results/cached-readability-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/readability-score-results/cached-readability-score-results-collector.php
@@ -19,7 +19,7 @@ class Cached_Readability_Score_Results_Collector implements Score_Results_Collec
 	/**
 	 * The actual collector implementation.
 	 *
-	 * @var Readability_Score_Results_Collector $readability_score_results_collector
+	 * @var Readability_Score_Results_Collector
 	 */
 	private $readability_score_results_collector;
 

--- a/src/dashboard/infrastructure/score-results/seo-score-results/cached-seo-score-results-collector.php
+++ b/src/dashboard/infrastructure/score-results/seo-score-results/cached-seo-score-results-collector.php
@@ -19,7 +19,7 @@ class Cached_SEO_Score_Results_Collector implements Score_Results_Collector_Inte
 	/**
 	 * The actual collector implementation.
 	 *
-	 * @var SEO_Score_Results_Collector $seo_score_results_collector
+	 * @var SEO_Score_Results_Collector
 	 */
 	private $seo_score_results_collector;
 

--- a/src/editors/application/integrations/integration-information-repository.php
+++ b/src/editors/application/integrations/integration-information-repository.php
@@ -15,7 +15,7 @@ class Integration_Information_Repository {
 	/**
 	 * All plugin integrations.
 	 *
-	 * @var Integration_Data_Provider_Interface[] $plugin_integrations
+	 * @var Integration_Data_Provider_Interface[]
 	 */
 	private $plugin_integrations;
 

--- a/src/editors/application/seo/post-seo-information-repository.php
+++ b/src/editors/application/seo/post-seo-information-repository.php
@@ -15,14 +15,14 @@ class Post_Seo_Information_Repository {
 	/**
 	 * The post.
 	 *
-	 * @var WP_Post $post
+	 * @var WP_Post
 	 */
 	private $post;
 
 	/**
 	 * The data providers.
 	 *
-	 * @var Abstract_Post_Seo_Data_Provider $seo_data_providers
+	 * @var Abstract_Post_Seo_Data_Provider
 	 */
 	private $seo_data_providers;
 

--- a/src/editors/application/seo/term-seo-information-repository.php
+++ b/src/editors/application/seo/term-seo-information-repository.php
@@ -15,14 +15,14 @@ class Term_Seo_Information_Repository {
 	/**
 	 * The term.
 	 *
-	 * @var WP_Term $term
+	 * @var WP_Term
 	 */
 	private $term;
 
 	/**
 	 * The data providers.
 	 *
-	 * @var Abstract_Term_Seo_Data_Provider $seo_data_providers
+	 * @var Abstract_Term_Seo_Data_Provider
 	 */
 	private $seo_data_providers;
 

--- a/src/editors/application/site/website-information-repository.php
+++ b/src/editors/application/site/website-information-repository.php
@@ -16,14 +16,14 @@ class Website_Information_Repository {
 	/**
 	 * The post site information wrapper.
 	 *
-	 * @var Post_Site_Information $post_site_information
+	 * @var Post_Site_Information
 	 */
 	private $post_site_information;
 
 	/**
 	 * The term site information wrapper.
 	 *
-	 * @var Term_Site_Information $term_site_information
+	 * @var Term_Site_Information
 	 */
 	private $term_site_information;
 

--- a/src/editors/domain/seo/description.php
+++ b/src/editors/domain/seo/description.php
@@ -10,14 +10,14 @@ class Description implements Seo_Plugin_Data_Interface {
 	/**
 	 * The formatted description date.
 	 *
-	 * @var string $description_date
+	 * @var string
 	 */
 	private $description_date;
 
 	/**
 	 * The description template.
 	 *
-	 * @var string $description_template
+	 * @var string
 	 */
 	private $description_template;
 

--- a/src/editors/domain/seo/keyphrase.php
+++ b/src/editors/domain/seo/keyphrase.php
@@ -10,14 +10,14 @@ class Keyphrase implements Seo_Plugin_Data_Interface {
 	/**
 	 * The keyphrase and the associated posts that use it.
 	 *
-	 * @var array<string> $keyword_usage_count
+	 * @var array<string>
 	 */
 	private $keyphrase_usage_count;
 
 	/**
 	 * The post types for the given post IDs.
 	 *
-	 * @var array<string> $keyword_usage_per_type
+	 * @var array<string>
 	 */
 	private $keyphrase_usage_per_type;
 

--- a/src/editors/domain/seo/social.php
+++ b/src/editors/domain/seo/social.php
@@ -10,28 +10,28 @@ class Social implements Seo_Plugin_Data_Interface {
 	/**
 	 * The Social title template.
 	 *
-	 * @var string $social_title_template
+	 * @var string
 	 */
 	private $social_title_template;
 
 	/**
 	 * The Social description template.
 	 *
-	 * @var string $social_description_template
+	 * @var string
 	 */
 	private $social_description_template;
 
 	/**
 	 * The Social image template.
 	 *
-	 * @var string $social_image_template
+	 * @var string
 	 */
 	private $social_image_template;
 
 	/**
 	 * The first content image for the social preview.
 	 *
-	 * @var string $social_first_content_image
+	 * @var string
 	 */
 	private $social_first_content_image;
 

--- a/src/editors/domain/seo/title.php
+++ b/src/editors/domain/seo/title.php
@@ -10,14 +10,14 @@ class Title implements Seo_Plugin_Data_Interface {
 	/**
 	 * The title template.
 	 *
-	 * @var string $title_template
+	 * @var string
 	 */
 	private $title_template;
 
 	/**
 	 * The title template without the fallback.
 	 *
-	 * @var string $title_template_no_fallback
+	 * @var string
 	 */
 	private $title_template_no_fallback;
 

--- a/src/editors/framework/integrations/multilingual.php
+++ b/src/editors/framework/integrations/multilingual.php
@@ -15,21 +15,21 @@ class Multilingual implements Integration_Data_Provider_Interface {
 	/**
 	 * The WPML conditional.
 	 *
-	 * @var WPML_Conditional $wpml_conditional
+	 * @var WPML_Conditional
 	 */
 	private $wpml_conditional;
 
 	/**
 	 * The Polylang conditional.
 	 *
-	 * @var Polylang_Conditional $polylang_conditional
+	 * @var Polylang_Conditional
 	 */
 	private $polylang_conditional;
 
 	/**
 	 * The TranslatePress conditional.
 	 *
-	 * @var TranslatePress_Conditional $translate_press_conditional
+	 * @var TranslatePress_Conditional
 	 */
 	private $translate_press_conditional;
 

--- a/src/editors/framework/integrations/woocommerce.php
+++ b/src/editors/framework/integrations/woocommerce.php
@@ -13,7 +13,7 @@ class WooCommerce implements Integration_Data_Provider_Interface {
 	/**
 	 * The WooCommerce conditional.
 	 *
-	 * @var WooCommerce_Conditional $woocommerce_conditional
+	 * @var WooCommerce_Conditional
 	 */
 	private $woocommerce_conditional;
 

--- a/src/editors/framework/seo/posts/description-data-provider.php
+++ b/src/editors/framework/seo/posts/description-data-provider.php
@@ -17,14 +17,14 @@ class Description_Data_Provider extends Abstract_Post_Seo_Data_Provider implemen
 	/**
 	 * The date helper.
 	 *
-	 * @var Date_Helper $date_helper
+	 * @var Date_Helper
 	 */
 	private $date_helper;
 
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper $options_helper
+	 * @var Options_Helper
 	 */
 	private $options_helper;
 

--- a/src/editors/framework/seo/posts/keyphrase-data-provider.php
+++ b/src/editors/framework/seo/posts/keyphrase-data-provider.php
@@ -17,7 +17,7 @@ class Keyphrase_Data_Provider extends Abstract_Post_Seo_Data_Provider implements
 	/**
 	 *  The meta helper.
 	 *
-	 * @var Meta_Helper $meta_helper
+	 * @var Meta_Helper
 	 */
 	private $meta_helper;
 

--- a/src/editors/framework/seo/posts/social-data-provider.php
+++ b/src/editors/framework/seo/posts/social-data-provider.php
@@ -31,7 +31,7 @@ class Social_Data_Provider extends Abstract_Post_Seo_Data_Provider implements So
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper $options_helper
+	 * @var Options_Helper
 	 */
 	private $options_helper;
 

--- a/src/editors/framework/seo/posts/title-data-provider.php
+++ b/src/editors/framework/seo/posts/title-data-provider.php
@@ -16,7 +16,7 @@ class Title_Data_Provider extends Abstract_Post_Seo_Data_Provider implements Tit
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper $options_helper
+	 * @var Options_Helper
 	 */
 	private $options_helper;
 

--- a/src/editors/framework/site/base-site-information.php
+++ b/src/editors/framework/site/base-site-information.php
@@ -18,42 +18,42 @@ abstract class Base_Site_Information {
 	/**
 	 * The short link helper.
 	 *
-	 * @var Short_Link_Helper $shortlink_helper
+	 * @var Short_Link_Helper
 	 */
 	protected $short_link_helper;
 
 	/**
 	 * The wistia embed permission repository.
 	 *
-	 * @var Wistia_Embed_Permission_Repository $wistia_embed_permission_repository
+	 * @var Wistia_Embed_Permission_Repository
 	 */
 	protected $wistia_embed_permission_repository;
 
 	/**
 	 * The meta surface.
 	 *
-	 * @var Meta_Surface $meta
+	 * @var Meta_Surface
 	 */
 	protected $meta;
 
 	/**
 	 * The product helper.
 	 *
-	 * @var Product_Helper $product_helper
+	 * @var Product_Helper
 	 */
 	protected $product_helper;
 
 	/**
 	 * The options helper.
 	 *
-	 * @var Options_Helper $options_helper
+	 * @var Options_Helper
 	 */
 	protected $options_helper;
 
 	/**
 	 * The promotion manager.
 	 *
-	 * @var Promotion_Manager $promotion_manager
+	 * @var Promotion_Manager
 	 */
 	protected $promotion_manager;
 

--- a/src/editors/framework/site/post-site-information.php
+++ b/src/editors/framework/site/post-site-information.php
@@ -18,14 +18,14 @@ class Post_Site_Information extends Base_Site_Information {
 	/**
 	 * The permalink.
 	 *
-	 * @var string $permalink
+	 * @var string
 	 */
 	private $permalink;
 
 	/**
 	 * The alert dismissal action.
 	 *
-	 * @var Alert_Dismissal_Action $alert_dismissal_action
+	 * @var Alert_Dismissal_Action
 	 */
 	private $alert_dismissal_action;
 

--- a/src/general/user-interface/general-page-integration.php
+++ b/src/general/user-interface/general-page-integration.php
@@ -69,14 +69,14 @@ class General_Page_Integration implements Integration_Interface {
 	/**
 	 * The promotion manager.
 	 *
-	 * @var Promotion_Manager $promotion_manager
+	 * @var Promotion_Manager
 	 */
 	private $promotion_manager;
 
 	/**
 	 * The alert dismissal action.
 	 *
-	 * @var Alert_Dismissal_Action $alert_dismissal_action
+	 * @var Alert_Dismissal_Action
 	 */
 	private $alert_dismissal_action;
 

--- a/src/user-meta/application/additional-contactmethods-collector.php
+++ b/src/user-meta/application/additional-contactmethods-collector.php
@@ -14,7 +14,7 @@ class Additional_Contactmethods_Collector {
 	/**
 	 * All additional contactmethods.
 	 *
-	 * @var array<Additional_Contactmethod_Interface> $additional_contactmethods
+	 * @var array<Additional_Contactmethod_Interface>
 	 */
 	private $additional_contactmethods;
 

--- a/src/user-meta/application/cleanup-service.php
+++ b/src/user-meta/application/cleanup-service.php
@@ -12,21 +12,21 @@ class Cleanup_Service {
 	/**
 	 * The additional contactmethods collector.
 	 *
-	 * @var Additional_Contactmethods_Collector $additional_contactmethods_collector The additional contactmethods collector.
+	 * @var Additional_Contactmethods_Collector
 	 */
 	private $additional_contactmethods_collector;
 
 	/**
 	 * The custom meta collector.
 	 *
-	 * @var Custom_Meta_Collector $custom_meta_collector The custom meta collector.
+	 * @var Custom_Meta_Collector
 	 */
 	private $custom_meta_collector;
 
 	/**
 	 * The cleanup repository.
 	 *
-	 * @var Cleanup_Repository $custom_meta_collector The custom meta repository.
+	 * @var Cleanup_Repository
 	 */
 	private $cleanup_repository;
 

--- a/src/user-meta/application/custom-meta-collector.php
+++ b/src/user-meta/application/custom-meta-collector.php
@@ -14,7 +14,7 @@ class Custom_Meta_Collector {
 	/**
 	 * All custom meta.
 	 *
-	 * @var array<Custom_Meta_Interface> $custom_meta
+	 * @var array<Custom_Meta_Interface>
 	 */
 	private $custom_meta;
 

--- a/src/user-meta/user-interface/additional-contactmethods-integration.php
+++ b/src/user-meta/user-interface/additional-contactmethods-integration.php
@@ -16,7 +16,7 @@ class Additional_Contactmethods_Integration implements Integration_Interface {
 	/**
 	 * The additional contactmethods collector.
 	 *
-	 * @var Additional_Contactmethods_Collector $additional_contactmethods_collector The additional contactmethods collector.
+	 * @var Additional_Contactmethods_Collector
 	 */
 	private $additional_contactmethods_collector;
 

--- a/src/user-meta/user-interface/cleanup-integration.php
+++ b/src/user-meta/user-interface/cleanup-integration.php
@@ -16,7 +16,7 @@ class Cleanup_Integration implements Integration_Interface {
 	/**
 	 * The cleanup service.
 	 *
-	 * @var Cleanup_Service $cleanup_service The cleanup service.
+	 * @var Cleanup_Service
 	 */
 	private $cleanup_service;
 

--- a/src/user-meta/user-interface/custom-meta-integration.php
+++ b/src/user-meta/user-interface/custom-meta-integration.php
@@ -16,7 +16,7 @@ class Custom_Meta_Integration implements Integration_Interface {
 	/**
 	 * The custom meta collector.
 	 *
-	 * @var Custom_Meta_Collector $custom_meta_collector The custom meta collector.
+	 * @var Custom_Meta_Collector
 	 */
 	private $custom_meta_collector;
 

--- a/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/Unit/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -72,7 +72,7 @@ final class Post_Site_Information_Test extends TestCase {
 	/**
 	 * The options helper.
 	 *
-	 * @var Mockery\MockInterface|Options_Helper $options_helper
+	 * @var Mockery\MockInterface|Options_Helper
 	 */
 	private $options_helper;
 

--- a/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
+++ b/tests/WP/Editors/Framework/Site/Post_Site_Information_Test.php
@@ -68,7 +68,7 @@ final class Post_Site_Information_Test extends TestCase {
 	/**
 	 * The options helper.
 	 *
-	 * @var Mockery\MockInterface|Options_Helper $options_helper
+	 * @var Mockery\MockInterface|Options_Helper
 	 */
 	private $options_helper;
 


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

The "variable" name is only needed with a `@var` tag when using inline docblocks for inline variables. Not when using the `@var` tag for declared properties.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_