### PR TITLE
CS/QA: prefer exit() over die()

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -21,7 +21,7 @@ if ( ! defined( 'WPSEO_VERSION' ) ) {
 function wpseo_ajax_json_echo_die( $results ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput -- Reason: WPSEO_Utils::format_json_encode is safe.
 	echo WPSEO_Utils::format_json_encode( $results );
-	die();
+	exit();
 }
 
 /**
@@ -31,22 +31,22 @@ function wpseo_ajax_json_echo_die( $results ) {
  */
 function wpseo_set_option() {
 	if ( ! current_user_can( 'manage_options' ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	check_ajax_referer( 'wpseo-setoption' );
 
 	if ( ! isset( $_POST['option'] ) || ! is_string( $_POST['option'] ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$option = sanitize_text_field( wp_unslash( $_POST['option'] ) );
 	if ( $option !== 'page_comments' ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	update_option( $option, 0 );
-	die( '1' );
+	exit( '1' );
 }
 
 add_action( 'wp_ajax_wpseo_set_option', 'wpseo_set_option' );
@@ -63,19 +63,19 @@ add_action( 'wp_ajax_yoast_dismiss_notification', [ 'Yoast_Notification_Center',
  */
 function wpseo_set_ignore() {
 	if ( ! current_user_can( 'manage_options' ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	check_ajax_referer( 'wpseo-ignore' );
 
 	if ( ! isset( $_POST['option'] ) || ! is_string( $_POST['option'] ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$ignore_key = sanitize_text_field( wp_unslash( $_POST['option'] ) );
 	WPSEO_Options::set( 'ignore_' . $ignore_key, true );
 
-	die( '1' );
+	exit( '1' );
 }
 
 add_action( 'wp_ajax_wpseo_set_ignore', 'wpseo_set_ignore' );
@@ -113,7 +113,7 @@ function wpseo_save_what( $what ) {
 	check_ajax_referer( 'wpseo-bulk-editor' );
 
 	if ( ! isset( $_POST['new_value'], $_POST['wpseo_post_id'], $_POST['existing_value'] ) || ! is_string( $_POST['new_value'] ) || ! is_string( $_POST['existing_value'] ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$new = sanitize_text_field( wp_unslash( $_POST['new_value'] ) );
@@ -122,7 +122,7 @@ function wpseo_save_what( $what ) {
 	$original = sanitize_text_field( wp_unslash( $_POST['existing_value'] ) );
 
 	if ( $post_id === 0 ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$results = wpseo_upsert_new( $what, $post_id, $new, $original );
@@ -289,14 +289,14 @@ function ajax_get_keyword_usage_and_post_types() {
 	check_ajax_referer( 'wpseo-keyword-usage-and-post-types', 'nonce' );
 
 	if ( ! isset( $_POST['post_id'], $_POST['keyword'] ) || ! is_string( $_POST['keyword'] ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We are casting to an integer.
 	$post_id = (int) wp_unslash( $_POST['post_id'] );
 
 	if ( $post_id === 0 || ! current_user_can( 'edit_post', $post_id ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$keyword = sanitize_text_field( wp_unslash( $_POST['keyword'] ) );
@@ -400,14 +400,14 @@ function ajax_get_keyword_usage() {
 	check_ajax_referer( 'wpseo-keyword-usage', 'nonce' );
 
 	if ( ! isset( $_POST['post_id'], $_POST['keyword'] ) || ! is_string( $_POST['keyword'] ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- We are casting to an integer.
 	$post_id = (int) wp_unslash( $_POST['post_id'] );
 
 	if ( $post_id === 0 || ! current_user_can( 'edit_post', $post_id ) ) {
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	$keyword = sanitize_text_field( wp_unslash( $_POST['keyword'] ) );

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -106,18 +106,18 @@ class Yoast_Notification_Center {
 		$notification_center = self::get();
 
 		if ( ! isset( $_POST['notification'] ) || ! is_string( $_POST['notification'] ) ) {
-			die( '-1' );
+			exit( '-1' );
 		}
 
 		$notification_id = sanitize_text_field( wp_unslash( $_POST['notification'] ) );
 
 		if ( empty( $notification_id ) ) {
-			die( '-1' );
+			exit( '-1' );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Reason: We are using the variable as a nonce.
 		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_POST['nonce'] ), $notification_id ) ) {
-			die( '-1' );
+			exit( '-1' );
 		}
 
 		$notification = $notification_center->get_notification_by_id( $notification_id );
@@ -132,10 +132,10 @@ class Yoast_Notification_Center {
 		}
 
 		if ( self::maybe_dismiss_notification( $notification ) ) {
-			die( '1' );
+			exit( '1' );
 		}
 
-		die( '-1' );
+		exit( '-1' );
 	}
 
 	/**

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -28,7 +28,7 @@ if ( isset( $_POST['create_robots'] ) ) {
 			__( 'You cannot create a %s file.', 'wordpress-seo' ),
 			'robots.txt'
 		);
-		die( esc_html( $die_msg ) );
+		exit( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo_create_robots' );
@@ -49,7 +49,7 @@ if ( isset( $_POST['submitrobots'] ) ) {
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
 			'robots.txt'
 		);
-		die( esc_html( $die_msg ) );
+		exit( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo-robotstxt' );
@@ -76,7 +76,7 @@ if ( isset( $_POST['submithtaccess'] ) ) {
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
 			'.htaccess'
 		);
-		die( esc_html( $die_msg ) );
+		exit( esc_html( $die_msg ) );
 	}
 
 	check_admin_referer( 'wpseo-htaccess' );

--- a/inc/sitemaps/class-sitemaps.php
+++ b/inc/sitemaps/class-sitemaps.php
@@ -230,7 +230,7 @@ class WPSEO_Sitemaps {
 	 */
 	public function sitemap_close() {
 		remove_all_actions( 'wp_footer' );
-		die();
+		exit();
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Code consistency

## Summary

This PR can be summarized in the following changelog entry:

* Code consistency

## Relevant technical choices:

`die()` is an alias, let's use the canonical construct name instead.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_
