### PR TITLE
Docs: fix up inline `@var` docblocks

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -896,7 +896,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		/**
 		 * The website information repository.
 		 *
-		 * @var $repo Website_Information_Repository
+		 * @var Website_Information_Repository $repo
 		 */
 		$repo             = YoastSEO()->classes->get( Website_Information_Repository::class );
 		$site_information = $repo->get_post_site_information();

--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -191,7 +191,7 @@ class WPSEO_Taxonomy {
 			/**
 			 * The website information repository.
 			 *
-			 * @var $repo Website_Information_Repository
+			 * @var Website_Information_Repository $repo
 			 */
 			$repo             = YoastSEO()->classes->get( Website_Information_Repository::class );
 			$term_information = $repo->get_term_site_information();

--- a/admin/views/tabs/dashboard/dashboard.php
+++ b/admin/views/tabs/dashboard/dashboard.php
@@ -10,7 +10,7 @@
  *
  * @noinspection PhpUnusedLocalVariableInspection
  *
- * @var array
+ * @var array $notifications_data
  */
 $notifications_data = Yoast_Notifications::get_template_variables();
 

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -964,7 +964,7 @@ class WPSEO_Meta {
 		/**
 		 * The indexable repository.
 		 *
-		 * @var Indexable_Repository
+		 * @var Indexable_Repository $repository
 		 */
 		$repository = YoastSEO()->classes->get( Indexable_Repository::class );
 
@@ -1012,7 +1012,7 @@ class WPSEO_Meta {
 		/**
 		 * The indexable repository.
 		 *
-		 * @var Indexable_Repository
+		 * @var Indexable_Repository $repository
 		 */
 		$repository = YoastSEO()->classes->get( Indexable_Repository::class );
 

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -1092,7 +1092,7 @@ class WPSEO_Utils {
 		/**
 		 * The feature flag integration.
 		 *
-		 * @var Feature_Flag_Integration $feature_flag_integration;
+		 * @var Feature_Flag_Integration $feature_flag_integration
 		 */
 		$feature_flag_integration = YoastSEO()->classes->get( Feature_Flag_Integration::class );
 		return $feature_flag_integration->get_enabled_features();

--- a/lib/orm.php
+++ b/lib/orm.php
@@ -267,7 +267,7 @@ class ORM implements ArrayAccess {
 		/**
 		 * The global WordPress database variable.
 		 *
-		 * @var wpdb
+		 * @var wpdb $wpdb
 		 */
 		global $wpdb;
 

--- a/src/initializers/migration-runner.php
+++ b/src/initializers/migration-runner.php
@@ -155,7 +155,7 @@ class Migration_Runner implements Initializer_Interface {
 		/**
 		 * The migration to run.
 		 *
-		 * @var Migration
+		 * @var Migration $migration
 		 */
 		$migration = new $migration_class( $this->adapter );
 		try {

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -429,7 +429,7 @@ class Elementor implements Integration_Interface {
 		/**
 		 * The website information repository.
 		 *
-		 * @var $repo Website_Information_Repository
+		 * @var Website_Information_Repository $repo
 		 */
 		$repo             = \YoastSEO()->classes->get( Website_Information_Repository::class );
 		$site_information = $repo->get_post_site_information();

--- a/src/integrations/watchers/indexable-post-watcher.php
+++ b/src/integrations/watchers/indexable-post-watcher.php
@@ -300,7 +300,7 @@ class Indexable_Post_Watcher implements Integration_Interface {
 		/**
 		 * The related indexables.
 		 *
-		 * @var Indexable[] $related_indexables .
+		 * @var Indexable[] $related_indexables
 		 */
 		$related_indexables   = [];
 		$related_indexables[] = $this->repository->find_by_id_and_type( $post->post_author, 'user', false );

--- a/src/surfaces/values/meta.php
+++ b/src/surfaces/values/meta.php
@@ -193,7 +193,7 @@ class Meta {
 			/**
 			 * The indexable presenter.
 			 *
-			 * @var Abstract_Indexable_Presenter
+			 * @var Abstract_Indexable_Presenter $presenter
 			 */
 			$presenter               = new $presenter_class();
 			$presenter->presentation = $presentation;

--- a/tests/Unit/Repositories/Indexable_Repository_Test.php
+++ b/tests/Unit/Repositories/Indexable_Repository_Test.php
@@ -500,7 +500,7 @@ final class Indexable_Repository_Test extends TestCase {
 		/**
 		 * Mock indexable.
 		 *
-		 * @var Mockery\MockInterface|Indexable
+		 * @var Mockery\MockInterface|Indexable $indexable
 		 */
 		$indexable              = Mockery::mock( Indexable_Mock::class );
 		$indexable->permalink   = null;


### PR DESCRIPTION
## Context

* Improve code documentation

## Summary

This PR can be summarized in the following changelog entry:

* Improve code documentation

## Relevant technical choices:

These should always contain a `@var` tag following the following format: `@var Type $name`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_