### PR TITLE
Dashboard: check search console view data permissions before returning the component

### DIFF
--- a/.github/workflows/finish-coveralls.yml
+++ b/.github/workflows/finish-coveralls.yml
@@ -105,5 +105,5 @@ jobs:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
-          carryforward: "unit-php-7.2,unit-php-8.3,php-7.2-wp-6.5,php-7.2-wp-6.5-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
+          carryforward: "unit-php-7.2,unit-php-8.3,php-7.2-wp-6.6,php-7.2-wp-6.6-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
           parallel-finished: true

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -104,7 +104,7 @@ export class WidgetFactory {
 					dataFormatter={ this.#dataFormatters.plainMetricsDataFormatter }
 				/>;
 			case WidgetFactory.types.searchRankingCompare:
-				if ( ! isFeatureEnabled || ! isSiteKitConnectionCompleted ) {
+				if ( ! isFeatureEnabled || ! isSiteKitConnectionCompleted || ! capabilities.viewSearchConsoleData ) {
 					return null;
 				}
 				return <SearchRankingCompareWidget

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -124,7 +124,7 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
-		[ "searchRankingCompare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" } ],
+		[ "Search ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" } ],
 		[ "Site Kit setup", { id: "site-kite-setup-widget", type: "siteKitSetup" } ],
 		[ "Organic Sessions", { id: "organic-sessions-widget", type: "organicSessions" } ],
 	] )( "should not create a %s widget when site kit feature is disabled", ( _, widget ) => {
@@ -202,6 +202,7 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
+		[ "Search ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" } ],
 	] )( "should not create a %s widget when a user has no view search console data permission", ( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -81,8 +81,9 @@ describe( "WidgetFactory", () => {
 	test.each( [
 		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
 		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
+		[ "Search Ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" }, "" ],
 		[ "Organic sessions", { id: "organic-sessions-widget", type: "organicSessions" }, "Organic sessions" ],
-	] )( "should create a %s widget", async( _, widget, title ) => {
+	] )( "should create a %s widget (that depend on Site Kit consent)", async( _, widget, title ) => {
 		dataProvider.setSiteKitConsentGranted( true );
 		const element = widgetFactory.createWidget( widget );
 		expect( element?.key ).toBe( widget.id );
@@ -186,7 +187,9 @@ describe( "WidgetFactory", () => {
 		expect( widgetFactory.createWidget( { id: "organic-sessions-widget", type: "organicSessions" } ) ).toBeNull();
 	} );
 
-	test.each( "should not create a OrganicSessions widget when a user has no view analytics data permission", () => {
+	test.each( [
+		[ "Organic Sessions", { id: "organic-sessions-widget", type: "organicSessions" } ],
+	] )( "should not create a %s widget when a user has no view analytics data permission", ( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {
 				capabilities: {
@@ -196,7 +199,7 @@ describe( "WidgetFactory", () => {
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 
-		expect( widgetFactory.createWidget( { id: "organic-sessions-widget", type: "organicSessions" } ) ).toBeNull();
+		expect( widgetFactory.createWidget( widget ) ).toBeNull();
 	} );
 
 	test.each( [

--- a/phpunit-wp.xml.dist
+++ b/phpunit-wp.xml.dist
@@ -33,6 +33,7 @@
 			<directory>./src</directory>
 			<exclude>
 				<directory suffix=".php">./src/deprecated</directory>
+				<directory suffix=".php">./src/generated</directory>
 				<file>./inc/wpseo-functions-deprecated.php</file>
 			</exclude>
 		</whitelist>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a, behind feature flag, bug where the Search Ranking Compare widget would be shown; Despite the user not having the search console view data permissions.

## Relevant technical choices:

* Also added the check to the tests
* Added scope creep due to coveralls report negative 8.5% code coverage for just 1 JS file WITH test coverage -- I'm not sure it is fixed now, but keeping these changes:
  * Exclude `src/generated` folder for integration/WP tests. As we already did for unit tests
  * Fix `carryforward` names to match the minimum WP version
  * I did NOT commit adding a `base-path` to the JS tests (`base-path: packages/${{ matrix.package }}`) as it did not seem to be a problem. But could be added later if running into more/similar issues

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have our Site Kit feature flag enabled
* Have Site Kit plugin connected and set up with Yoast
* Have a user with the SEO manager role
* Make sure SEO manage does not have view rights for Site Kit
* Log in as that SEO manager
* Go to our dashboard
* Verify you no longer see the Search Ranking Compare widget due to missing search console viewing rights
* Log back in as admin or user with access
* Verify you see the Search Ranking Compare widget

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2200
