### PR TITLE
Dashboard: add tests for the Search Ranking Compare widget

### DIFF
--- a/packages/js/src/dashboard/components/trend.js
+++ b/packages/js/src/dashboard/components/trend.js
@@ -28,8 +28,10 @@ export const Trend = ( { value, formattedValue } ) => {
 					! isPositive && "yst-rotate-180"
 				) }
 			/>
-			{ isPositive && "+" }
-			{ formattedValue }
+			{
+				// Add as a single string to avoid unnecessary space (easier for testing).
+				[ isPositive ? "+" : "", formattedValue ].join( "" )
+			}
 		</div>
 	);
 };

--- a/packages/js/src/dashboard/widgets/search-ranking-compare/search-ranking-compare-widget-content.js
+++ b/packages/js/src/dashboard/widgets/search-ranking-compare/search-ranking-compare-widget-content.js
@@ -100,36 +100,34 @@ export const SearchRankingCompareWidgetContent = ( { dataProvider, remoteDataPro
 		return <NoDataParagraph />;
 	}
 
-	if ( data ) {
-		return <SearchRankingCompareLayout>
-			<SearchRankingCompareMetric
-				className="@lg:yst-pe-4 @lg:yst-pb-4"
-				metricName={ META.impressions.name }
-				data={ data.impressions }
-				tooltipLocalizedContent={ META.impressions.tooltip }
-				dataSources={ META.impressions.dataSources }
-			/>
-			<SearchRankingCompareMetric
-				className="@lg:yst-ps-4 @lg:yst-pb-4"
-				metricName={ META.clicks.name }
-				data={ data.clicks }
-				tooltipLocalizedContent={ META.clicks.tooltip }
-				dataSources={ META.clicks.dataSources }
-			/>
-			<SearchRankingCompareMetric
-				className="@lg:yst-pe-4 @lg:yst-pt-4"
-				metricName={ META.ctr.name }
-				data={ data.ctr }
-				tooltipLocalizedContent={ META.ctr.tooltip }
-				dataSources={ META.ctr.dataSources }
-			/>
-			<SearchRankingCompareMetric
-				className="@lg:yst-ps-4 @lg:yst-pt-4"
-				metricName={ META.position.name }
-				data={ data.position }
-				tooltipLocalizedContent={ META.position.tooltip }
-				dataSources={ META.position.dataSources }
-			/>
-		</SearchRankingCompareLayout>;
-	}
+	return <SearchRankingCompareLayout>
+		<SearchRankingCompareMetric
+			className="@lg:yst-pe-4 @lg:yst-pb-4"
+			metricName={ META.impressions.name }
+			data={ data.impressions }
+			tooltipLocalizedContent={ META.impressions.tooltip }
+			dataSources={ META.impressions.dataSources }
+		/>
+		<SearchRankingCompareMetric
+			className="@lg:yst-ps-4 @lg:yst-pb-4"
+			metricName={ META.clicks.name }
+			data={ data.clicks }
+			tooltipLocalizedContent={ META.clicks.tooltip }
+			dataSources={ META.clicks.dataSources }
+		/>
+		<SearchRankingCompareMetric
+			className="@lg:yst-pe-4 @lg:yst-pt-4"
+			metricName={ META.ctr.name }
+			data={ data.ctr }
+			tooltipLocalizedContent={ META.ctr.tooltip }
+			dataSources={ META.ctr.dataSources }
+		/>
+		<SearchRankingCompareMetric
+			className="@lg:yst-ps-4 @lg:yst-pt-4"
+			metricName={ META.position.name }
+			data={ data.position }
+			tooltipLocalizedContent={ META.position.tooltip }
+			dataSources={ META.position.dataSources }
+		/>
+	</SearchRankingCompareLayout>;
 };

--- a/packages/js/tests/dashboard/widgets/search-ranking-compare-widget.test.js
+++ b/packages/js/tests/dashboard/widgets/search-ranking-compare-widget.test.js
@@ -1,0 +1,162 @@
+import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import { ComparisonMetricsDataFormatter } from "../../../src/dashboard/services/comparison-metrics-data-formatter";
+import { SearchRankingCompareWidget } from "../../../src/dashboard/widgets/search-ranking-compare-widget";
+import { render, waitFor } from "../../test-utils";
+import { MockDataProvider } from "../__mocks__/data-provider";
+import { MockRemoteDataProvider } from "../__mocks__/remote-data-provider";
+
+describe( "SearchRankingCompareWidget", () => {
+	let dataProvider;
+	let remoteDataProvider;
+	let dataFormatter;
+	beforeAll( () => {
+		dataProvider = new MockDataProvider();
+		remoteDataProvider = new MockRemoteDataProvider( {} );
+		dataFormatter = new ComparisonMetricsDataFormatter();
+	} );
+	beforeEach( () => {
+		remoteDataProvider.fetchJson.mockClear();
+	} );
+
+	describe.each( [
+		[
+			"with all data points",
+			[
+				{
+					/* eslint-disable camelcase */
+					current: {
+						total_clicks: 6,
+						total_impressions: 59,
+						average_ctr: 0.10169491525423729,
+						average_position: 36.288135593220325,
+					},
+					previous: {
+						total_clicks: 9,
+						total_impressions: 51,
+						average_ctr: 0.17647058823529413,
+						average_position: 34.450980392156858,
+					},
+					/* eslint-enable camelcase */
+				},
+			],
+			[
+				[ "Impressions", "59", "+15.69%" ],
+				[ "Clicks", "6", "-33.33%" ],
+				[ "Average CTR", "10.17%", "-42.37%" ],
+				[ "Average position", "36.29", "+5.33%" ],
+			],
+		],
+		[
+			"without averages",
+			[
+				{
+					/* eslint-disable camelcase */
+					current: {
+						total_clicks: 10,
+						total_impressions: 75,
+					},
+					previous: {
+						total_clicks: 8,
+						total_impressions: 100,
+					},
+					/* eslint-enable camelcase */
+				},
+			],
+			[
+				[ "Impressions", "75", "-25.00%" ],
+				[ "Clicks", "10", "+25.00%" ],
+				[ "Average CTR", "", "" ],
+				[ "Average position", "", "" ],
+			],
+		],
+	] )( "%s", ( _, data, metricTests ) => {
+		let renderResult;
+
+		beforeAll( () => {
+			remoteDataProvider.fetchJson.mockResolvedValue( data );
+		} );
+		beforeEach( async() => {
+			renderResult = render( <SearchRankingCompareWidget
+				dataProvider={ dataProvider }
+				remoteDataProvider={ remoteDataProvider }
+				dataFormatter={ dataFormatter }
+			/> );
+			await waitFor( () => {
+				expect( remoteDataProvider.fetchJson ).toHaveBeenCalled();
+			} );
+		} );
+
+		it( "should render 4 tooltips", async() => {
+			expect( renderResult.getAllByRole( "tooltip" ) ).toHaveLength( 4 );
+
+			// Tested here because it is not unique to each tooltip.
+			expect( renderResult.getAllByText( "Data provided by:" ) ).toHaveLength( 4 );
+			expect( renderResult.getAllByText( "Site Kit by Google" ) ).toHaveLength( 4 );
+		} );
+
+		test.each( [
+			[ "Impressions", "The number of times your website appeared in the Google search results over the last 28 days." ],
+			[ "Clicks", "The number of times users clicked on your website's link in the Google search results over the last 28 days." ],
+			[ "Average CTR", "The average click-through-rate for your website in the Google search results over the last 28 days." ],
+			[ "Average position", "The average position of your website in the Google search results over the last 28 days." ],
+		] )( "should render the tooltip for: %s", async( __, tooltip ) => {
+			expect( renderResult.getByText( tooltip ) ).toBeInTheDocument();
+		} );
+
+		test.each( metricTests )( "should render metric: %s", async( name, value, trend ) => {
+			expect( renderResult.getByText( name ) ).toBeInTheDocument();
+			if ( value ) {
+				expect( renderResult.getByText( value ) ).toBeInTheDocument();
+			}
+			if ( trend ) {
+				expect( renderResult.getByText( trend ) ).toBeInTheDocument();
+			}
+		} );
+	} );
+
+	it( "should show no data message and title without data", async() => {
+		remoteDataProvider.fetchJson.mockResolvedValueOnce( [] );
+		const { getByRole, getByText } = render( <SearchRankingCompareWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
+		/> );
+		await waitFor( () => {
+			expect( getByRole( "heading", { name: "Impressions, Clicks, Site CTR, Average position" } ) ).toBeInTheDocument();
+		} );
+		expect( getByText( "No data to display: Your site hasn't received any visitors yet." ) ).toBeInTheDocument();
+	} );
+
+	it( "should show alert message and title on error", async() => {
+		const error = new Error( "Network Error" );
+		error.status = 500;
+		remoteDataProvider.fetchJson.mockRejectedValueOnce( error );
+		const { getByRole } = render( <SearchRankingCompareWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
+		/> );
+		await waitFor( () => {
+			expect( getByRole( "heading", { name: "Impressions, Clicks, Site CTR, Average position" } ) ).toBeInTheDocument();
+		} );
+		expect( getByRole( "status" ) )
+			.toHaveTextContent( "Something went wrong. Try refreshing the page. If the problem persists, please check our Support page." );
+		expect( getByRole( "link", { name: "Support page" } ) ).toHaveAttribute( "href", "https://example.com/error-support" );
+	} );
+
+	it( "should show loading state while the request is not finished", async() => {
+		remoteDataProvider.fetchJson.mockImplementation( () => new Promise( () => {
+		} ) );
+		const { getAllByText } = render( <SearchRankingCompareWidget
+			dataProvider={ dataProvider }
+			remoteDataProvider={ remoteDataProvider }
+			dataFormatter={ dataFormatter }
+		/> );
+		await waitFor( () => {
+			expect( remoteDataProvider.fetchJson ).toHaveBeenCalled();
+		} );
+		const loaders = getAllByText( "Dummy" );
+		expect( loaders ).toHaveLength( 4 );
+		expect( loaders[ 0 ].parentElement.classList ).toContain( "yst-skeleton-loader" );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tests for the Search Ranking Compare widget.

## Relevant technical choices:

* I did not test each individual component. Just the widget itself, more like an integration test
* I changed the Trend component to output the sign in the same string, as otherwise I had to account for the indent in the code
* I removed the data truthy check in the content as there is no valid way for that to not be there. If the server responds and there is no error, we have no reason for the data to be suddenly falsy
* Not sure if that describe.each is totally necessary like that, as we repeat other tests. But the setup is the same for those, and I don't mind it also testing the tooltips if there are no averages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the code
* Run the test with coverage: `yarn workspace @yoast/wordpress-seo test packages/js/tests/dashboard/widgets/search-ranking-compare-widget.test.js --coverage`
* Verify it has full coverage, including branches (check the report in the terminal output or open the HTML report inside the `packages/js/coverage` path)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Tests, so it is covered by tooling.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/485
