### PR TITLE
fix the remounting of widgets on dashboard rerender

### DIFF
--- a/packages/dashboard-frontend/src/components/dashboard.js
+++ b/packages/dashboard-frontend/src/components/dashboard.js
@@ -1,18 +1,8 @@
 import { values } from "lodash";
 
 /**
- * @type {import("../index").WidgetType} WidgetType
- * @type {import("../index").WidgetInstance} WidgetInstance
  * @type {import("../services/widget-factory").WidgetFactory} WidgetFactory
  */
-
-/**
- * @param {WidgetType} type The widget type.
- * @returns {WidgetInstance} The widget instance.
- */
-const prepareWidgetInstance = ( type ) => {
-	return { id: `widget--${ type }__${ Date.now() }`, type };
-};
 
 /**
  * @param {WidgetFactory} widgetFactory The widget factory.
@@ -21,6 +11,6 @@ const prepareWidgetInstance = ( type ) => {
  */
 export const Dashboard = ( { widgetFactory } ) => (
 	<>
-		{ values( widgetFactory.types ).map( ( widget ) => widgetFactory.createWidget( prepareWidgetInstance( widget ) ) ) }
+		{ values( widgetFactory.types ).map( ( widgetType ) => widgetFactory.createWidget( widgetType ) ) }
 	</>
 );

--- a/packages/dashboard-frontend/src/index.js
+++ b/packages/dashboard-frontend/src/index.js
@@ -90,13 +90,6 @@
  *           "organicSessions"} WidgetType The widget type.
  */
 
-/**
- * @typedef {Object} WidgetInstance The widget instance. Should hold what the UI needs to render the widget.
- * @property {string} id The unique identifier.
- * @property {WidgetType} type The widget type.
- */
-
-
 export { TopPagesWidget } from "./widgets/top-pages-widget";
 export { TopQueriesWidget } from "./widgets/top-queries-widget";
 export { SearchRankingCompareWidget } from "./widgets/search-ranking-compare-widget";

--- a/packages/dashboard-frontend/src/services/widget-factory.js
+++ b/packages/dashboard-frontend/src/services/widget-factory.js
@@ -6,7 +6,7 @@ import { TopQueriesWidget } from "../widgets/top-queries-widget";
 import { SearchRankingCompareWidget } from "../widgets/search-ranking-compare-widget";
 
 /**
- * @type {import("../index").WidgetType} WidgetType
+ * @type {import("../index").WidgetType} The widget type.
  */
 
 /**
@@ -45,17 +45,17 @@ export class WidgetFactory {
 	}
 
 	/**
-	 * @param {WidgetInstance} widget The widget to create.
+	 * @param {WidgetType} widgetType The widget type to create.
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
-	createWidget( widget ) {
-		switch ( widget.type ) {
+	createWidget( widgetType ) {
+		switch ( widgetType ) {
 			case this.types.seoScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
 					return null;
 				}
 				return <ScoreWidget
-					key={ widget.id }
+					key={ widgetType }
 					analysisType="seo"
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
@@ -65,35 +65,35 @@ export class WidgetFactory {
 					return null;
 				}
 				return <ScoreWidget
-					key={ widget.id }
+					key={ widgetType }
 					analysisType="readability"
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
 			case this.types.topPages:
 				return <TopPagesWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.plainMetricsDataFormatter }
 				/>;
 			case this.types.topQueries:
 				return <TopQueriesWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.plainMetricsDataFormatter }
 				/>;
 			case this.types.searchRankingCompare:
 				return <SearchRankingCompareWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.comparisonMetricsDataFormatter }
 				/>;
 			case this.types.organicSessions:
 				return <OrganicSessionsWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.comparisonMetricsDataFormatter }

--- a/packages/dashboard-frontend/tests/services/widget-factory.test.js
+++ b/packages/dashboard-frontend/tests/services/widget-factory.test.js
@@ -49,16 +49,15 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
-		[ "SEO scores", { id: "seo-scores-widget", type: "seoScores" }, "SEO scores" ],
-		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
-		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
-		[ "Search Ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" }, "" ],
-		[ "Organic sessions", { id: "organic-sessions-widget", type: "organicSessions" }, "Organic sessions" ],
-		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
-	] )( "should create a %s widget", async( _, widget, title ) => {
-		const element = widgetFactory.createWidget( widget );
-		expect( element?.key ).toBe( widget.id );
+		[ "SEO scores", "seoScores", "SEO scores" ],
+		[ "Readability scores", "readabilityScores", "Readability scores" ],
+		[ "Top pages", "topPages", "Top 5 most popular content" ],
+		[ "Top queries", "topQueries", "Top 5 search queries" ],
+		[ "Search Ranking compare", "searchRankingCompare", "" ],
+		[ "Organic sessions", "organicSessions", "Organic sessions" ],
+	] )( "should create a %s widget", async( _, widgetType, title ) => {
+		const element = widgetFactory.createWidget( widgetType );
+		expect( element?.key ).toBe( widgetType );
 		const { getByRole } = render( <>{ element }</> );
 
 		await waitFor( () => {
@@ -67,5 +66,10 @@ describe( "WidgetFactory", () => {
 				expect( getByRole( "heading", { name: title } ) ).toBeInTheDocument();
 			}
 		} );
+	} );
+
+	test( "should not create a widget if the type is not supported", async() => {
+		const element = widgetFactory.createWidget( "unsupportedWidgetType" );
+		expect( element ).toBeNull();
 	} );
 } );

--- a/packages/js/src/dashboard/index.js
+++ b/packages/js/src/dashboard/index.js
@@ -97,12 +97,6 @@ export { Dashboard } from "./components/dashboard";
  */
 
 /**
- * @typedef {Object} WidgetInstance The widget instance. Should hold what the UI needs to render the widget.
- * @property {string} id The unique identifier.
- * @property {WidgetType} type The widget type.
- */
-
-/**
  * @typedef {Object} SiteKitConfiguration The Site Kit configuration.
  * @property {string} installUrl The link to install Site Kit.
  * @property {string} activateUrl The link to activate Site Kit.

--- a/packages/js/src/dashboard/services/widget-factory.js
+++ b/packages/js/src/dashboard/services/widget-factory.js
@@ -8,7 +8,7 @@ import {
 	OrganicSessionsWidget } from "@yoast/dashboard-frontend";
 
 /**
- * @type {import("../index").WidgetType} WidgetType
+ * @type {import("../index").WidgetType} The widget type.
  */
 
 /**
@@ -48,10 +48,10 @@ export class WidgetFactory {
 	}
 
 	/**
-	 * @param {WidgetInstance} widget The widget to create.
+	 * @param {WidgetType} widgetType The widget type to create.
 	 * @returns {JSX.Element|null} The widget or null.
 	 */
-	createWidget( widget ) {
+	createWidget( widgetType ) {
 		const {
 			isFeatureEnabled,
 			isSetupWidgetDismissed,
@@ -66,13 +66,13 @@ export class WidgetFactory {
 		const isSearchConsoleWidgetAllowed = isSiteKitWidgetAllowed && capabilities.viewSearchConsoleData;
 		const isAnalyticsWidgetAllowed = isSiteKitWidgetAllowed && isAnalyticsConnected && capabilities.viewAnalyticsData;
 
-		switch ( widget.type ) {
+		switch ( widgetType ) {
 			case this.types.seoScores:
 				if ( ! ( this.#dataProvider.hasFeature( "indexables" ) && this.#dataProvider.hasFeature( "seoAnalysis" ) ) ) {
 					return null;
 				}
 				return <ScoreWidget
-					key={ widget.id }
+					key={ widgetType }
 					analysisType="seo"
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
@@ -82,7 +82,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <ScoreWidget
-					key={ widget.id }
+					key={ widgetType }
 					analysisType="readability"
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
@@ -92,7 +92,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <TopPagesWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.plainMetricsDataFormatter }
@@ -102,7 +102,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <SiteKitSetupWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 				/>;
@@ -111,7 +111,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <TopQueriesWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.plainMetricsDataFormatter }
@@ -121,7 +121,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <SearchRankingCompareWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.comparisonMetricsDataFormatter }
@@ -131,7 +131,7 @@ export class WidgetFactory {
 					return null;
 				}
 				return <OrganicSessionsWidget
-					key={ widget.id }
+					key={ widgetType }
 					dataProvider={ this.#dataProvider }
 					remoteDataProvider={ this.#remoteDataProvider }
 					dataFormatter={ this.#dataFormatters.comparisonMetricsDataFormatter }

--- a/packages/js/tests/dashboard/services/widget-factory.test.js
+++ b/packages/js/tests/dashboard/services/widget-factory.test.js
@@ -51,12 +51,11 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
-		[ "SEO scores", { id: "seo-scores-widget", type: "seoScores" }, "SEO scores" ],
-		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" }, "Readability scores" ],
-		[ "Unknown", { id: undefined, type: "unknown" }, undefined ],
-	] )( "should create a %s widget", async( _, widget, title ) => {
-		const element = widgetFactory.createWidget( widget );
-		expect( element?.key ).toBe( widget.id );
+		[ "SEO scores", "seoScores", "SEO scores" ],
+		[ "Readability scores", "readabilityScores", "Readability scores" ],
+	] )( "should create a %s widget", async( _, widgetType, title ) => {
+		const element = widgetFactory.createWidget( widgetType );
+		expect( element?.key ).toBe( widgetType );
 		const { getByRole } = render( <>{ element }</> );
 
 		await waitFor( () => {
@@ -68,14 +67,14 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" }, "Top 5 most popular content" ],
-		[ "Top queries", { id: "top-queries-widget", type: "topQueries" }, "Top 5 search queries" ],
-		[ "Search Ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" }, "" ],
-		[ "Organic sessions", { id: "organic-sessions-widget", type: "organicSessions" }, "Organic sessions" ],
-	] )( "should create a %s widget (that depend on Site Kit consent)", async( _, widget, title ) => {
+		[ "Top pages", "topPages", "Top 5 most popular content" ],
+		[ "Top queries", "topQueries", "Top 5 search queries" ],
+		[ "Search Ranking compare", "searchRankingCompare", "" ],
+		[ "Organic sessions", "organicSessions", "Organic sessions" ],
+	] )( "should create a %s widget (that depend on Site Kit consent)", async( _, widgetType, title ) => {
 		dataProvider.setSiteKitConsentGranted( true );
-		const element = widgetFactory.createWidget( widget );
-		expect( element?.key ).toBe( widget.id );
+		const element = widgetFactory.createWidget( widgetType );
+		expect( element?.key ).toBe( widgetType );
 		const { getByRole } = render( <>{ element }</> );
 
 		await waitFor( () => {
@@ -87,8 +86,8 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
-		[ "SEO scores", { id: "seo-scores-widget", type: "seoScores" } ],
-		[ "Readability scores", { id: "readability-scores-widget", type: "readabilityScores" } ],
+		[ "SEO scores", "seoScores" ],
+		[ "Readability scores", "readabilityScores" ],
 	] )( "should not create the %s widget if the data provider does not have the features", ( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			features: {
@@ -108,22 +107,22 @@ describe( "WidgetFactory", () => {
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatters );
 
-		expect( widgetFactory.createWidget( { id: "site-kite-setup-widget", type: "siteKitSetup" } ) ).toBeNull();
+		expect( widgetFactory.createWidget( "siteKitSetup" ) ).toBeNull();
 	} );
 
 	test.each( [
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
-		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
-		[ "Search ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" } ],
-		[ "Site Kit setup", { id: "site-kite-setup-widget", type: "siteKitSetup" } ],
-		[ "Organic Sessions", { id: "organic-sessions-widget", type: "organicSessions" } ],
-	] )( "should not create a %s widget when site kit feature is disabled", ( _, widget ) => {
+		[ "Top pages", "topPages" ],
+		[ "Top queries", "topQueries" ],
+		[ "Search ranking compare", "searchRankingCompare" ],
+		[ "Site Kit setup", "siteKitSetup" ],
+		[ "Organic Sessions", "organicSessions" ],
+	] )( "should not create a %s widget when site kit feature is disabled", ( _, widgetType ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: { isFeatureEnabled: false },
 		} );
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider, dataFormatters );
 
-		expect( widgetFactory.createWidget( widget ) ).toBeNull();
+		expect( widgetFactory.createWidget( widgetType ) ).toBeNull();
 	} );
 
 	describe( "should not create the site kit widgets and should create the site kit setup widget", () => {
@@ -142,10 +141,10 @@ describe( "WidgetFactory", () => {
 			[ "site kit plugin version is not supported", { isInstalled: true, isActive: true, isSetupCompleted: true, isConsentGranted: true, isVersionSupported: false } ],
 		] )( "when %s", async( _, siteKitConfiguration ) => {
 			const siteKitWidgets = [
-				{ id: "top-pages-widget", type: "topPages" },
-				{ id: "top-queries-widget", type: "topQueries" },
-				{ id: "search-ranking-compare-widget", type: "searchRankingCompare" },
-				{ id: "organic-sessions-widget", type: "organicSessions" },
+				"topPages",
+				"topQueries",
+				"searchRankingCompare",
+				"organicSessions",
 			];
 			dataProvider = new MockDataProvider( {
 				siteKitConfiguration: { ...siteKitConfiguration, isFeatureEnabled: true },
@@ -156,9 +155,9 @@ describe( "WidgetFactory", () => {
 				expect( widgetFactory.createWidget( widget ) ).toBeNull();
 			} );
 
-			const element = widgetFactory.createWidget( { id: "site-kit-setup-widget", type: "siteKitSetup" } );
+			const element = widgetFactory.createWidget( "siteKitSetup" );
 
-			expect( element?.key ).toBe( "site-kit-setup-widget" );
+			expect( element?.key ).toBe( "siteKitSetup" );
 			const { getByRole } = render( <>{ element }</> );
 
 			await waitFor( () => {
@@ -181,9 +180,9 @@ describe( "WidgetFactory", () => {
 	} );
 
 	test.each( [
-		[ "Top pages", { id: "top-pages-widget", type: "topPages" } ],
-		[ "Top queries", { id: "top-queries-widget", type: "topQueries" } ],
-		[ "Search ranking compare", { id: "search-ranking-compare-widget", type: "searchRankingCompare" } ],
+		[ "Top pages", "topPages" ],
+		[ "Top queries", "topQueries" ],
+		[ "Search ranking compare", "searchRankingCompare" ],
 	] )( "should not create a %s widget when a user has no view search console data permission", ( _, widget ) => {
 		dataProvider = new MockDataProvider( {
 			siteKitConfiguration: {
@@ -195,5 +194,10 @@ describe( "WidgetFactory", () => {
 		widgetFactory = new WidgetFactory( dataProvider, remoteDataProvider );
 
 		expect( widgetFactory.createWidget( widget ) ).toBeNull();
+	} );
+
+	test( "should not create a widget if the type is not supported", async() => {
+		const element = widgetFactory.createWidget( "unsupportedWidgetType" );
+		expect( element ).toBeNull();
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes the remount of widgets on the dashboard.

## Relevant technical choices:

* Remove the `widgetInstance` type since it wasn't used any more. The reason for the widget instance in the first place was to support adding the same widget more than once. Currently it is not needed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure to configured site kit but do not connect yet.
* Go to Yoast SEO -> General, check the dashboard has the scores widgets and the site kit setup widget.
* Open the network tab and dismiss until next visit the site kit setup widget.
* Check the request for the scores widget was not triggered. ( You can also see the animation is not triggered)
* Connect to site kit, the site kit widgets should appear bellow and requests would appear int he network tab. 
* Click on the "Got it" to dismiss the site kit setup widget and check the network:
* The site kit widgets should not trigger another request ( you can also see that by the widgets not rendering the loading state when dismissing the site kit set up widget.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Fix remounting of widgets on the dashboard.](https://github.com/Yoast/reserved-tasks/issues/501)
