### PR TITLE
Removed unnecessary condition checks

### DIFF
--- a/admin/ajax.php
+++ b/admin/ajax.php
@@ -303,16 +303,9 @@ function ajax_get_keyword_usage_and_post_types() {
 
 	$post_ids = WPSEO_Meta::keyword_usage( $keyword, $post_id );
 
-	if ( ! empty( $post_ids ) ) {
-		$post_types = WPSEO_Meta::post_types_for_ids( $post_ids );
-	}
-	else {
-		$post_types = [];
-	}
-
 	$return_object = [
 		'keyword_usage' => $post_ids,
-		'post_types'    => $post_types,
+		'post_types'    => WPSEO_Meta::post_types_for_ids( $post_ids ),
 	];
 
 	wp_die(

--- a/inc/class-wpseo-meta.php
+++ b/inc/class-wpseo-meta.php
@@ -1008,16 +1008,15 @@ class WPSEO_Meta {
 	 * @return array The post types.
 	 */
 	public static function post_types_for_ids( $post_ids ) {
-
-		/**
-		 * The indexable repository.
-		 *
-		 * @var Indexable_Repository $repository
-		 */
-		$repository = YoastSEO()->classes->get( Indexable_Repository::class );
-
 		// Check if post ids is not empty.
 		if ( ! empty( $post_ids ) ) {
+			/**
+			 * The indexable repository.
+			 *
+			 * @var Indexable_Repository $repository
+			 */
+			$repository = YoastSEO()->classes->get( Indexable_Repository::class );
+
 			// Get the post subtypes for the posts that share the keyword.
 			$post_types = $repository->query()
 				->select( 'object_sub_type' )


### PR DESCRIPTION
## Context

I removed the `if` condition before calling `post_types_for_ids()` because it already handles the check internally.

Additionally, I moved the initialization of `$repository = YoastSEO()->classes->get( Indexable_Repository::class );` inside the `if` block to ensure it's only executed when `$post_ids` is not empty.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Optimizes the function used to fetch post IDs which share the same focus keyphrase. Props to [dilipbheda](https://github.com/dilipbheda).

## Relevant technical choices:

## Test instructions

* Edit a post and give it a keyphrase, e.g. "test"
* Edit another post and give it the same keyphrase
* Open the `SEO analysis` tab in the metabox or in the Yoast sidebar
  * Check that you get the message `Previously used keyphrase: you've used this keyphrase multiple times before. Do not use your keyphrase more than once.` 
  * Click on the `multiple times before` link 
    * Check that you get a list with the other post where you specified the same keyphrase 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/22168