### PR TITLE
Reverts code that did not solve a highlighting issue with NBSP characters

### DIFF
--- a/packages/js/src/decorator/helpers/positionBasedAnnotationHelper.js
+++ b/packages/js/src/decorator/helpers/positionBasedAnnotationHelper.js
@@ -14,7 +14,7 @@ const htmlTagsRegex = /(<([a-z]|\/)[^<>]+>)/ig;
  * Regex to detect HTML entities.
  * @type {RegExp}
  */
-const { entitiesWithoutGTSRegex } = helpers.htmlEntities;
+const { htmlEntitiesRegex } = helpers.htmlEntities;
 
 /**
  * Adjusts the block start and end offset for a given Mark from the first section of a Yoast sub-block.
@@ -113,68 +113,13 @@ const adjustOffsetsForHtmlTags = ( slicedBlockHtmlToStartOffset, slicedBlockHtml
 /**
  * Adjusts the block start and end offsets of a given Mark when the block HTML contains HTML entities.
  *
- * @param {string} html The block HTML.
- * @param {number} offset The block start or end offset of the Mark to adjust.
- * @param {string} richText The rich text of the block.
- * @returns {number} The adjusted offset.
- */
-const adjustOffsetsForHtmlEntities = ( html, offset, richText ) => {
-	const matchedHtmlEntities = [ ...html.matchAll( entitiesWithoutGTSRegex ) ];
-	forEachRight( matchedHtmlEntities, ( matchedEntity ) => {
-		/*
-		 * If the matchedEntity is `&amp;`, matchedEntityWithoutAmp (the second element in the array) is `amp;`.
-		 * To get the length of the HTML entity to be 1, we subtract the offset by the length of the matched entity minus the ampersand.
-		 */
-		const [ , matchedEntityWithoutAmp ] = matchedEntity;
-		offset -= matchedEntityWithoutAmp.length;
-	} );
-
-	// Special case for `&nbsp;` and `&gt;` entities.
-	/*
-	 Non-breaking space sometimes is represented as its unicode character `\u00a0` in the block's HTML.
-	 In this case, we need to adjust the offset by the length of the HTML entity.
-	 */
-	const nbspEntity = [ "&nbsp;", /\u00a0/ig ];
-	const matchedNbsp = html.match( nbspEntity[ 1 ] );
-	forEachRight( matchedNbsp, () => {
-		offset -= nbspEntity[ 0 ].length - 1;
-	} );
-	/*
-	 When adjusting the offset for `&gt;` entity, we need to consider only the entity that is found only in the rich text, and not in the HTML.
-	 This way, we minimize the risk of adjusting the offset incorrectly for the `&gt;` entity inside an HTML tag, e.g. `<strong>` or `<a>`.
-	 */
-	const gtsEntity = [ "&gt;", /\u003e/ig ];
-	const matchedGts = richText.slice( 0, offset ).match( gtsEntity[ 1 ] );
-	forEachRight( matchedGts, () => {
-		offset -= gtsEntity[ 0 ].length - 1;
-	} );
-	return offset;
-};
-
-/**
- * Adjusts the block start and end offsets of a given Mark when the block HTML contains HTML tags or entities.
- *
- * @param {number}	blockStartOffset	The block start offset of the Mark to adjust.
- * @param {number}	blockEndOffset		The block end offset of the Mark to adjust.
- * @param {string}	blockHtml			The HTML of the block.
- * @param {string}	richText			The rich text of the block.
+ * @param {string}	slicedBlockHtmlToStartOffset	The block HTML from the 0 index to the index of the block start offset.
+ * @param {string}	slicedBlockHtmlToEndOffset		The block HTML from the 0 index to the index of the block end offset.
+ * @param {number}	blockStartOffset				The block start offset of the Mark to adjust.
+ * @param {number}	blockEndOffset					The block end offset of the Mark to adjust.
  * @returns {{blockStartOffset: number, blockEndOffset: number}} The adjusted start offset and end offset of the Mark.
  */
-const adjustMarkOffsets = ( blockStartOffset, blockEndOffset, blockHtml, richText ) => {
-	const slicedBlockHtmlToStartOffset = blockHtml.slice( 0, blockStartOffset );
-	const slicedBlockHtmlToEndOffset = blockHtml.slice( 0, blockEndOffset );
-
-	// Adjust the offsets when there are HTML tags found between the start of the HTML and the start/end offset of the Mark.
-	const adjustedOffsetsInCaseOfHtmlTags = adjustOffsetsForHtmlTags(
-		slicedBlockHtmlToStartOffset,
-		slicedBlockHtmlToEndOffset,
-		blockStartOffset,
-		blockEndOffset
-	);
-	blockStartOffset = adjustedOffsetsInCaseOfHtmlTags.blockStartOffset;
-	blockEndOffset = adjustedOffsetsInCaseOfHtmlTags.blockEndOffset;
-
-	// Adjust the offsets when there are HTML entities found between the start of the HTML and the start/end offset of the Mark.
+const adjustOffsetsForHtmlEntities = ( slicedBlockHtmlToStartOffset, slicedBlockHtmlToEndOffset, blockStartOffset, blockEndOffset ) => {
 	/*
 	 * In `yoastseo`, we process the HTML entities so that their length is the length of their extended version.
 	 * For example, the ampersand `&` length is the length of `&amp;` => 5.
@@ -195,8 +140,56 @@ const adjustMarkOffsets = ( blockStartOffset, blockEndOffset, blockHtml, richTex
 	 * Only subtracting the end offset by the length of the HTML entities/tags found between the 0 index of the HTML
 	 * to the start offset of the Mark will result in incorrect position information.
 	 */
-	blockStartOffset = adjustOffsetsForHtmlEntities( slicedBlockHtmlToStartOffset, blockStartOffset, richText );
-	blockEndOffset = adjustOffsetsForHtmlEntities( slicedBlockHtmlToEndOffset, blockEndOffset, richText );
+	let matchedHtmlEntities = [ ...slicedBlockHtmlToStartOffset.matchAll( htmlEntitiesRegex ) ];
+	forEachRight( matchedHtmlEntities, ( matchedEntity ) => {
+		/*
+		 * If the matchedEntity is `&amp;`, matchedEntityWithoutAmp (the second element in the array) is `amp;`.
+		 * To get the length of the HTML entity to be 1, we subtract the offset by the length of the matched entity minus the ampersand.
+		 */
+		const [ , matchedEntityWithoutAmp ] = matchedEntity;
+		blockStartOffset -= matchedEntityWithoutAmp.length;
+	} );
+
+	matchedHtmlEntities = [ ...slicedBlockHtmlToEndOffset.matchAll( htmlEntitiesRegex ) ];
+	forEachRight( matchedHtmlEntities, ( matchedEntity ) => {
+		const [ , matchedEntityWithoutAmp ] = matchedEntity;
+		blockEndOffset -= matchedEntityWithoutAmp.length;
+	} );
+
+	return { blockStartOffset, blockEndOffset };
+};
+
+/**
+ * Adjusts the block start and end offsets of a given Mark when the block HTML contains HTML tags or entities.
+ *
+ * @param {number}	blockStartOffset	The block start offset of the Mark to adjust.
+ * @param {number}	blockEndOffset		The block end offset of the Mark to adjust.
+ * @param {string}	blockHtml			The HTML of the block.
+ * @returns {{blockStartOffset: number, blockEndOffset: number}} The adjusted start offset and end offset of the Mark.
+ */
+const adjustMarkOffsets = ( blockStartOffset, blockEndOffset, blockHtml ) => {
+	const slicedBlockHtmlToStartOffset = blockHtml.slice( 0, blockStartOffset );
+	const slicedBlockHtmlToEndOffset = blockHtml.slice( 0, blockEndOffset );
+
+	// Adjust the offsets when there are HTML tags found between the start of the HTML and the start/end offset of the Mark.
+	const adjustedOffsetsInCaseOfHtmlTags = adjustOffsetsForHtmlTags(
+		slicedBlockHtmlToStartOffset,
+		slicedBlockHtmlToEndOffset,
+		blockStartOffset,
+		blockEndOffset
+	);
+	blockStartOffset = adjustedOffsetsInCaseOfHtmlTags.blockStartOffset;
+	blockEndOffset = adjustedOffsetsInCaseOfHtmlTags.blockEndOffset;
+
+	// Adjust the offsets when there are HTML entities found between the start of the HTML and the start/end offset of the Mark.
+	const adjustedOffsetsInCaseOfHtmlEntities = adjustOffsetsForHtmlEntities(
+		slicedBlockHtmlToStartOffset,
+		slicedBlockHtmlToEndOffset,
+		blockStartOffset,
+		blockEndOffset
+	);
+	blockStartOffset = adjustedOffsetsInCaseOfHtmlEntities.blockStartOffset;
+	blockEndOffset = adjustedOffsetsInCaseOfHtmlEntities.blockEndOffset;
 
 	return { blockStartOffset, blockEndOffset };
 };
@@ -243,7 +236,7 @@ export function createAnnotationsFromPositionBasedMarks( mark, blockClientId, bl
 		}
 
 		// If not, adjust the offsets further by checking for HTML tags or entities.
-		const adjustedMarkOffsets = adjustMarkOffsets( blockStartOffset, blockEndOffset, blockHtml, richText );
+		const adjustedMarkOffsets = adjustMarkOffsets( blockStartOffset, blockEndOffset, blockHtml );
 		return [
 			{
 				startOffset: adjustedMarkOffsets.blockStartOffset,

--- a/packages/js/tests/decorator/helpers/positionBasedAnnotationHelper.test.js
+++ b/packages/js/tests/decorator/helpers/positionBasedAnnotationHelper.test.js
@@ -99,6 +99,43 @@ describe( "createAnnotationsFromPositionBasedMarks", () => {
 	} );
 
 	it( "should return annotations with adjusted block start and end position when the block html is not the same as the rich text: " +
+		"The mark is for non-Yoast block, and the nbsp tags appear in several places", () => {
+		/*
+         * The block start and end offsets that are coming from the analysis is off by the length of the following tags:
+         * 1. The length of the HTML tags found in the text preceding the word we want to annotate
+         *  - From the html text below, the html tags are:
+         *  a. <a href="https://www.worldwildlife.org/species/red-panda">: 58 chars
+         *  b. </a>: 4 chars
+         *  c. &nbsp;: 10 chars before the start offset, 20 chars before the end offset
+         *
+         * The correct block start offset of the sentence is 255 - 72 = 183.
+         * The correct block end offset of the sentence is 384 - 82 = 302.
+        */
+		const mark = new Mark( {
+			position: {
+				startOffsetBlock: 255,
+				endOffsetBlock: 384,
+				clientId: "261e3892-f28c-4273-86b4-a00801c38d22",
+			},
+		} );
+		const html = "Approximately 38% of the total potential&nbsp;<a href=\"https://www.worldwildlife.org/species/red-panda\">red panda</a>&nbsp;habitat is in Nepal. We work with yak herders and other community groups to reduce human impact on the red panda’s fragile habitat. Any person found guilty of killing, buying or selling red pandas faces a fine of up to&nbsp;$1,000 and/or up to&nbsp;10 years in jail. Other community initiatives to stop the hunting and capture of red pandas for income include:d";
+		const richText = "Approximately 38% of the total potential red panda habitat is in Nepal. We work with yak herders and other community groups to reduce human impact on the red panda’s fragile habitat. Any person found guilty of killing, buying or selling red pandas faces a fine of up to $1,000 and/or up to 10 years in jail. Other community initiatives to stop the hunting and capture of red pandas for income include:d";
+
+		const actual = createAnnotationsFromPositionBasedMarks(
+			mark,
+			"261e3892-f28c-4273-86b4-a00801c38d22",
+			"",
+			html,
+			richText
+		);
+
+		expect( actual ).toEqual( [ {
+			startOffset: 183,
+			endOffset: 302,
+		} ] );
+	} );
+
+	it( "should return annotations with adjusted block start and end position when the block html is not the same as the rich text: " +
 		"The html contains html tags and html entities", () => {
 		/*
          * The block start offset that is coming from the analysis is off by the length of the following tags and entities:

--- a/packages/yoastseo/src/helpers/htmlEntities.js
+++ b/packages/yoastseo/src/helpers/htmlEntities.js
@@ -23,8 +23,6 @@ const htmlEntities = new Map( [
 
 // Regex to find all HTML entities.
 const htmlEntitiesRegex = new RegExp( "&(" + [ ...htmlEntities.keys() ].join( "|" ) + ")", "ig" );
-// Regex to find all HTML entities except for the HTML entity for the greater-than sign `gt;`.
-const entitiesWithoutGTSRegex = new RegExp( "&(amp;|lt;|quot;|apos;|ndash;|mdash;|copy;|reg;|trade;|pound;|yen;|euro;|dollar;|deg;|asymp;|ne;|nbsp;)", "ig" );
 
 // Contains special characters along with their hashed HTML entities (e.g. '#amp;' instead of '&amp;' for the ampersand character '&').
 const hashedHtmlEntities = new Map();
@@ -36,7 +34,6 @@ const hashedHtmlEntitiesRegexEnd = new RegExp( "(" + [ ...hashedHtmlEntities.key
 
 export {
 	htmlEntities,
-	entitiesWithoutGTSRegex,
 	htmlEntitiesRegex,
 	hashedHtmlEntities,
 	hashedHtmlEntitiesRegexStart,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Parts of https://github.com/Yoast/wordpress-seo/pull/21974 intended to solve an issue with the highlighting in case there were NBSP characters present. However, without Premium active, this turned out to be a regression. Therefore, in this PR, we want to revert that part of the PR. We also add one unit test to confirm the current behaviour works. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts code that did not solve a highlighting issue with NBSP characters in the Gutenberg editor.

## Relevant technical choices:

* We here revert commits to `packages/js/src/decorator/helpers/positionBasedAnnotationHelper.js` and `packages/js/tests/decorator/helpers/positionBasedAnnotationHelper.test.js`. 
* The reason that the previous PR passed acceptance is that in Premium, we use the `yoast.analysis.data` filter to replace NBSP characters (see also https://github.com/Yoast/wordpress-seo-premium/pull/4606). With only Free active, we don't do that, and the previous changes did not fix that. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* As this is a revert, the situation is basically the same as before. 
* You can do a smoke test with the text in https://github.com/Yoast/plugins-automated-testing/issues/2226 in Gutenberg only. However, replace the NBSP character in `up to 10 years in jail` to `up to&nbsp;10 years in jail`. Make sure to only have Free active.
* Confirm highlighting works.
* Confirm that with the unedited text (so without changing the text from https://github.com/Yoast/plugins-automated-testing/issues/2226), highlighting does not work initially, but it works again after you add some text anywhere in the document.
* With https://github.com/Yoast/wordpress-seo-premium/pull/4606 in place, activate Premium, and repeat the above steps. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Highlighting in the block editor, but it's a revert to the previous situation. 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2226
