### PR TITLE
Improve translatability of keyphrase length assessment feedback strings

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -32,7 +32,7 @@
     "pretest": "grunt get-premium-configuration",
     "export:inclusive-language": "jest exportInclusiveLanguage",
     "test": "jest",
-    "lint": "eslint . --max-warnings 20"
+    "lint": "eslint . --max-warnings 19"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/yoastseo/src/languageProcessing/helpers/match/processExactMatchRequest.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/match/processExactMatchRequest.js
@@ -5,7 +5,7 @@ import isDoubleQuoted from "./isDoubleQuoted";
  *
  * @param {string}  keyphrase       The keyphrase to check. This must be the keyphrase accessed directly from the Paper.
  *
- * @returns {Object} Whether the exact match functionality is requested and the keyword stripped from double quotes.
+ * @returns {{exactMatchRequested: boolean, keyphrase: string}} Whether the exact match functionality is requested and the keyword stripped from double quotes.
  */
 export default function processExactMatchRequest( keyphrase ) {
 	const exactMatchRequest = { exactMatchRequested: false, keyphrase: keyphrase };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Currently, the keyphrase length assessment feedback strings that contain the words 'word(s)' or 'character(s)' are not created in a way that makes it easy/possible to translate them correctly in all languages. See https://github.com/Yoast/wordpress-seo/issues/20478 for more detail.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the translatability of feedback strings for the keyphrase length assessment.
* [shopify-seo] Improves the translatability of feedback strings for the keyphrase length assessment.
* [yoastseo] Improves the translatability of feedback strings for the keyphrase length assessment.

## Relevant technical choices:

* I lowered the number of maximum eslint warnings from 20 to 19 since I fixed one warnings inside `packages/yoastseo/src/scoring/assessments/readability/KeyphraseLengthAssessment.js`

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### WordPress

#### Post in English (a language with function word support)
* Create a new post
* Confirm that the keyphrase length assessment returns a red traffic light and the following feedback: `
Keyphrase length: No focus keyphrase was set for this page. Set a focus keyphrase in order to calculate your SEO score.`
* Add the keyphrase 'cat'
* Confirm that the keyphrase length assessment returns a green traffic light with the following feedback: `Keyphrase length: Good job!`
* Change the keyphrase to: `cat food for indoor cats`
* Confirm that the keyphrase length assessment feedback stays the same
* Change the keyphrase to: `cat food for sterilized indoor cats`
* Confirm that the keyphrase length assessment feedback returns an orange traffic light and the following feedback: `Keyphrase length: The keyphrase contains 5 content words. That's more than the recommended maximum of 4 content words. Make it shorter!`
* Change the keyphrase to: `grain-free cat food for sterilized indoor cats with kidney problems`
* Confirm that the keyphrase length assessment feedback returns a red traffic light and the following feedback: `Keyphrase length: The keyphrase contains 9 content words. That's way more than the recommended maximum of 4 content words. Make it shorter!`

#### Post in Catalan (a language without function word support)
* Change your site language to Catalan 
* Open/create a post and set the keyphrase to `gat`
* Confirm that the keyphrase length assessment returns a green traffic light with the following feedback: `Keyphrase length: Good job!`
* Change the keyphrase to: `menjar per a gats d'interior`
* Confirm that the  keyphrase length assessment feedback remains the same
* Change the keyphrase to: `menjar per a gats per a gats d'interior esterilitzats`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 9 words. That's more than the recommended maximum of 6 words. Make it shorter!`
* Change the keyphrase to: `menjar per a gats per a gats d'interior esterilitzats amb problemes renals`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 12 words. That's way more than the recommended maximum of 6 words. Make it shorter!`

#### Post in Japanese (a language that counts keyphrase length in characters)

**Note for acceptance tester**: It is possible that the strings get translated to Japanese during the RC period. In that case, the Japanese feedback strings will appear instead of English ones.

* Change your site language to Japanese 
* Open/create a post and set the keyphrase to `猫`
* Confirm that the keyphrase length assessment (`キーフレーズの長さ`) returns a green traffic light with the following feedback: `キーフレーズの長さ: いいですね !`
* Change the keyphrase to: `室内猫用のキャットフード`
* Confirm that the  keyphrase length assessment feedback remains the same
* Change the keyphrase to: `室内猫用サーモンキャットフード`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 15 character. That's more than the recommended maximum of 12 character. Make it shorter!`
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     * When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.
* Change the keyphrase to: `消毒済みの室内飼い猫用のキャットフード`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 19 character. That's way more than the recommended maximum of 12 character. Make it shorter!`
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     * When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.

#### Product page in English
* Create a new product
* Set the keyphrase to `cat`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 1 content word. That's way less than the recommended minimum of 4 content words. Make it longer!`
* Change the keyphrase to: `dry cat food`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 3 content words. That's less than the recommended minimum of 4 content words. Make it longer!`
* Change the keyphrase to: `cat food for indoor cats`
* Confirm that the keyphrase length assessment feedback returns a green traffic light and the following feedback: `Keyphrase length: Good job!`
* Change the keyphrase to: `grain-free cat food for sterilized indoor cats`
* Confirm that the keyphrase length assessment feedback returns an orange traffic light and the following feedback: `Keyphrase length: The keyphrase contains 7 content words. That's more than the recommended maximum of 6 content words. Make it shorter!`
* Change the keyphrase to: `grain-free cat food for sterilized indoor cats with kidney problems`
* Confirm that the keyphrase length assessment feedback returns a red traffic light and the following feedback: `Keyphrase length: The keyphrase contains 9 content words. That's way more than the recommended maximum of 6 content words. Make it shorter!`

#### Product page in Catalan
* Change your site language to Catalan 
* Open/create a product page and set the keyphrase to `gat`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 1 word. That's way less than the recommended minimum of 4 words. Make it longer!`
* Change the keyphrase to: `aliments sense cereals`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 3 words. That's less than the recommended minimum of 4 words. Make it longer!`
* Change the keyphrase to: `menjar per a gats d'interior`
* Confirm that the keyphrase length assessment returns a green traffic light with the following feedback: `Longitud de la frase clau: bona feina!`
* Change the keyphrase to: `menjar per a gats per a gats d'interior esterilitzats`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 9 words. That's more than the recommended maximum of 6 words. Make it shorter!`
* Change the keyphrase to: `menjar per a gats per a gats d'interior esterilitzats amb problemes renals`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 12 words. That's way more than the recommended maximum of 6 words. Make it shorter!`

#### Product page in Japanese

**Note for acceptance tester**: It is possible that the strings get translated to Japanese during the RC period. In that case, the Japanese feedback strings will appear instead of English ones.

* Change your site language to Japanese 
* Open/create a post and set the keyphrase to `猫`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 1 character. That's way less than the recommended minimum of 8 character. Make it shorter!`
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     *  When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.
* Change the keyphrase to: `健康的な猫の餌`  
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 7 character. That's less than the recommended minimum of 8 character. Make it longer!   
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     *  When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.
* Change the keyphrase to: `室内猫用のキャットフード`
* Confirm that the keyphrase length assessment (`キーフレーズの長さ`) returns a green traffic light with the following feedback: `キーフレーズの長さ: いいですね !`
* Change the keyphrase to: `室内猫用サーモンキャットフード`
* Confirm that the keyphrase length assessment returns an orange traffic light with the following feedback: `Keyphrase length: The keyphrase contains 15 character. That's more than the recommended maximum of 12 character. Make it shorter!`
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     * When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.
* Change the keyphrase to: `消毒済みの室内飼い猫用のキャットフード`
* Confirm that the keyphrase length assessment returns a red traffic light with the following feedback: `Keyphrase length: The keyphrase contains 19 character. That's way more than the recommended maximum of 12 character. Make it shorter!`
     * The untranslated string is grammatically incorrect because Japanese doesn't have plural number. Translating this string should result in a grammatically correct translation in Japanese.
     * When you switch the **user** language to English, with the site language remaining Japanese, the string should change to say `characters` instead of `character`.
     
### Shopify
* Create a product
* Follow the test instructions from the following scenarios for WordPress:
     * Product page in English
     * Product page in Catalan
     * Product page in Japanese
* A smoke test is fine, there is no reason to suspect that the changes would work differently in Shopify

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No impact other than what's covered in the test instructions.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/487
