### PR TITLE
Handle date ranges in SK responses better

### DIFF
--- a/src/dashboard/domain/traffic/comparison-traffic-data.php
+++ b/src/dashboard/domain/traffic/comparison-traffic-data.php
@@ -9,8 +9,8 @@ use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Interface;
  */
 class Comparison_Traffic_Data implements Data_Interface {
 
-	const CURRENT_KEY  = 'current';
-	const PREVIOUS_KEY = 'previous';
+	public const CURRENT_PERIOD_KEY  = 'current';
+	public const PREVIOUS_PERIOD_KEY = 'previous';
 
 	/**
 	 * The current traffic data.

--- a/src/dashboard/domain/traffic/comparison-traffic-data.php
+++ b/src/dashboard/domain/traffic/comparison-traffic-data.php
@@ -9,6 +9,9 @@ use Yoast\WP\SEO\Dashboard\Domain\Data_Provider\Data_Interface;
  */
 class Comparison_Traffic_Data implements Data_Interface {
 
+	const CURRENT_KEY  = 'current';
+	const PREVIOUS_KEY = 'previous';
+
 	/**
 	 * The current traffic data.
 	 *

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -215,12 +215,12 @@ class Site_Kit_Analytics_4_Adapter {
 				}
 			}
 
-			$date_range = $this->get_date_range( $date_range_row );
+			$period = $this->get_period( $date_range_row );
 
-			if ( $date_range === Comparison_Traffic_Data::CURRENT_KEY ) {
+			if ( $period === Comparison_Traffic_Data::CURRENT_PERIOD_KEY ) {
 				$comparison_traffic_data->set_current_traffic_data( $traffic_data );
 			}
-			elseif ( $date_range === Comparison_Traffic_Data::PREVIOUS_KEY ) {
+			elseif ( $period === Comparison_Traffic_Data::PREVIOUS_PERIOD_KEY ) {
 				$comparison_traffic_data->set_previous_traffic_data( $traffic_data );
 			}
 		}
@@ -241,13 +241,13 @@ class Site_Kit_Analytics_4_Adapter {
 	 *
 	 * @throws Invalid_Request_Exception When the request is invalid due to unexpected parameters.
 	 */
-	private function get_date_range( Row $date_range_row ): string {
+	private function get_period( Row $date_range_row ): string {
 		foreach ( $date_range_row->getDimensionValues() as $dimension_value ) {
 			if ( $dimension_value->getValue() === 'date_range_0' ) {
-				return Comparison_Traffic_Data::CURRENT_KEY;
+				return Comparison_Traffic_Data::CURRENT_PERIOD_KEY;
 			}
 			elseif ( $dimension_value->getValue() === 'date_range_1' ) {
-				return Comparison_Traffic_Data::PREVIOUS_KEY;
+				return Comparison_Traffic_Data::PREVIOUS_PERIOD_KEY;
 			}
 		}
 

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -238,6 +238,8 @@ class Site_Kit_Analytics_4_Adapter {
 	 * @param Row $date_range_row The response row.
 	 *
 	 * @return string 'current' for the current period, 'previous' for the previous period.
+	 *
+	 * @throws Invalid_Request_Exception When the request is invalid due to unexpected parameters.
 	 */
 	private function get_date_range( Row $date_range_row ): string {
 		foreach ( $date_range_row->getDimensionValues() as $dimension_value ) {
@@ -248,6 +250,8 @@ class Site_Kit_Analytics_4_Adapter {
 				return 'previous';
 			}
 		}
+
+		throw new Invalid_Request_Exception( 'Unexpected date range names' );
 	}
 
 	/**

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -231,13 +231,13 @@ class Site_Kit_Analytics_4_Adapter {
 	}
 
 	/**
-	 * Parses the response row and gets whether it's about the current period or the previous period.
+	 * Parses the response row and returns whether it's about the current period or the previous period.
 	 *
 	 * @see https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/DateRange
 	 *
 	 * @param Row $date_range_row The response row.
 	 *
-	 * @return string 'current' for the current period, 'previous' for the previous period.
+	 * @return string The key associated with the current or the previous period.
 	 *
 	 * @throws Invalid_Request_Exception When the request is invalid due to unexpected parameters.
 	 */

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -217,10 +217,10 @@ class Site_Kit_Analytics_4_Adapter {
 
 			$date_range = $this->get_date_range( $date_range_row );
 
-			if ( $date_range === 'current' ) {
+			if ( $date_range === Comparison_Traffic_Data::CURRENT_KEY ) {
 				$comparison_traffic_data->set_current_traffic_data( $traffic_data );
 			}
-			elseif ( $date_range === 'previous' ) {
+			elseif ( $date_range === Comparison_Traffic_Data::PREVIOUS_KEY ) {
 				$comparison_traffic_data->set_previous_traffic_data( $traffic_data );
 			}
 		}
@@ -244,10 +244,10 @@ class Site_Kit_Analytics_4_Adapter {
 	private function get_date_range( Row $date_range_row ): string {
 		foreach ( $date_range_row->getDimensionValues() as $dimension_value ) {
 			if ( $dimension_value->getValue() === 'date_range_0' ) {
-				return 'current';
+				return Comparison_Traffic_Data::CURRENT_KEY;
 			}
 			elseif ( $dimension_value->getValue() === 'date_range_1' ) {
-				return 'previous';
+				return Comparison_Traffic_Data::PREVIOUS_KEY;
 			}
 		}
 

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -7,8 +7,8 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Plugin;
-use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\RunReportResponse;
 use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\Row;
+use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\RunReportResponse;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Failed_Request_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Invalid_Request_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Unexpected_Response_Exception;
@@ -196,7 +196,7 @@ class Site_Kit_Analytics_4_Adapter {
 		$comparison_traffic_data = new Comparison_Traffic_Data();
 
 		// First row is the current date range's data, second row is the previous date range's data.
-		foreach ( $response->getRows() as $date_range_key => $date_range_row ) {
+		foreach ( $response->getRows() as $date_range_row ) {
 			$traffic_data = new Traffic_Data();
 
 			// Loop through all the metrics of the date range.
@@ -232,6 +232,8 @@ class Site_Kit_Analytics_4_Adapter {
 
 	/**
 	 * Parses the response row and gets whether it's about the current period or the previous period.
+	 *
+	 * @see https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/DateRange
 	 *
 	 * @param Row $date_range_row The response row.
 	 *

--- a/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
+++ b/src/dashboard/infrastructure/analytics-4/site-kit-analytics-4-adapter.php
@@ -8,6 +8,7 @@ use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Plugin;
 use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\RunReportResponse;
+use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\Row;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Failed_Request_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Invalid_Request_Exception;
 use Yoast\WP\SEO\Dashboard\Domain\Analytics_4\Unexpected_Response_Exception;
@@ -214,10 +215,12 @@ class Site_Kit_Analytics_4_Adapter {
 				}
 			}
 
-			if ( $date_range_key === 0 ) {
+			$date_range = $this->get_date_range( $date_range_row );
+
+			if ( $date_range === 'current' ) {
 				$comparison_traffic_data->set_current_traffic_data( $traffic_data );
 			}
-			elseif ( $date_range_key === 1 ) {
+			elseif ( $date_range === 'previous' ) {
 				$comparison_traffic_data->set_previous_traffic_data( $traffic_data );
 			}
 		}
@@ -225,6 +228,24 @@ class Site_Kit_Analytics_4_Adapter {
 		$data_container->add_data( $comparison_traffic_data );
 
 		return $data_container;
+	}
+
+	/**
+	 * Parses the response row and gets whether it's about the current period or the previous period.
+	 *
+	 * @param Row $date_range_row The response row.
+	 *
+	 * @return string 'current' for the current period, 'previous' for the previous period.
+	 */
+	private function get_date_range( Row $date_range_row ): string {
+		foreach ( $date_range_row->getDimensionValues() as $dimension_value ) {
+			if ( $dimension_value->getValue() === 'date_range_0' ) {
+				return 'current';
+			}
+			elseif ( $dimension_value->getValue() === 'date_range_1' ) {
+				return 'previous';
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug with the total Organic Session number that appear in the relevant widget.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* For getting the complete data about the last 28 days and the complete data of the 28 days before that, do a GET request to `/wp-json/yoast/v1/time_based_seo_metrics?options[widget]=organicSessionsCompare`
* Confirm that the response you get is like:
```
[
    {
        "current": {
            "sessions": 9
        },
        "previous": {
            "sessions": 12
        }
    }
]
```
* Go to the actual Google Analytics platform and search for organic sessions of the last 28 days compared with the organic sessions of the 28 days before that and confirm you get the same result
  * Specifically, you can do that by changing the date range at the top right corner of the `Acquisition` page in analytics and then enable **Compare** and select `Preceding period`:
![image](https://github.com/user-attachments/assets/f4a4fdda-84fc-4bdb-9149-0b226edde963)
* You can check now the sessions from the last 28 days compared with the 28 days before that:
![image](https://github.com/user-attachments/assets/50bbccc9-7bcb-456c-8edf-c222631e4656)
* Confirm that the current sessions in our REST response is the same with the number of the period of the last 28 days in Analytics. And that the previous sessions in our REST response is the same with the number of the period of the last 28 days before the last 28 days.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/508
