### PR TITLE
Fix feature flag

### DIFF
--- a/packages/js/src/general/initialize.js
+++ b/packages/js/src/general/initialize.js
@@ -88,6 +88,7 @@ domReady( () => {
 		isAnalyticsConnected: false,
 		isFeatureEnabled: false,
 		isSetupWidgetDismissed: false,
+		isVersionSupported: false,
 		capabilities: {
 			installPlugins: false,
 			viewSearchConsoleData: false,

--- a/src/dashboard/application/configuration/dashboard-configuration.php
+++ b/src/dashboard/application/configuration/dashboard-configuration.php
@@ -116,7 +116,7 @@ class Dashboard_Configuration {
 	 * @return array<string, array<string>>
 	 */
 	public function get_configuration(): array {
-		return [
+		$configuration = [
 			'contentTypes'            => $this->content_types_repository->get_content_types(),
 			'indexablesEnabled'       => $this->indexable_helper->should_index_indexables(),
 			'displayName'             => $this->user_helper->get_current_user_display_name(),
@@ -128,8 +128,11 @@ class Dashboard_Configuration {
 			)->to_array(),
 			'endpoints'               => $this->endpoints_repository->get_all_endpoints()->to_array(),
 			'nonce'                   => $this->nonce_repository->get_rest_nonce(),
-			'siteKitConfiguration'    => $this->site_kit_integration_data->to_array(),
 			'setupStepsTracking'      => $this->setup_steps_tracking->to_array(),
 		];
+		if ( ! empty( $this->site_kit_integration_data->to_array() ) ) {
+			$configuration ['siteKitConfiguration'] = $this->site_kit_integration_data->to_array();
+		}
+		return $configuration;
 	}
 }

--- a/src/dashboard/application/configuration/dashboard-configuration.php
+++ b/src/dashboard/application/configuration/dashboard-configuration.php
@@ -6,7 +6,7 @@ namespace Yoast\WP\SEO\Dashboard\Application\Configuration;
 
 use Yoast\WP\SEO\Dashboard\Application\Content_Types\Content_Types_Repository;
 use Yoast\WP\SEO\Dashboard\Application\Endpoints\Endpoints_Repository;
-use Yoast\WP\SEO\Dashboard\Application\tracking\Setup_Steps_Tracking;
+use Yoast\WP\SEO\Dashboard\Application\Tracking\Setup_Steps_Tracking;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Nonces\Nonce_Repository;
 use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
@@ -130,8 +130,11 @@ class Dashboard_Configuration {
 			'nonce'                   => $this->nonce_repository->get_rest_nonce(),
 			'setupStepsTracking'      => $this->setup_steps_tracking->to_array(),
 		];
-		if ( ! empty( $this->site_kit_integration_data->to_array() ) ) {
-			$configuration ['siteKitConfiguration'] = $this->site_kit_integration_data->to_array();
+
+		$site_kit_integration_data = $this->site_kit_integration_data->to_array();
+
+		if ( ! empty( $site_kit_integration_data ) ) {
+			$configuration ['siteKitConfiguration'] = $site_kit_integration_data;
 		}
 		return $configuration;
 	}

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -177,7 +177,6 @@ class Site_Kit {
 			'setupUrl'                 => $site_kit_setup_url,
 			'updateUrl'                => $site_kit_update_url,
 			'isAnalyticsConnected'     => $this->is_ga_connected(),
-			'isFeatureEnabled'         => ( new Google_Site_Kit_Feature_Conditional() )->is_met(),
 			'isSetupWidgetDismissed'   => $this->permanently_dismissed_site_kit_configuration_repository->is_site_kit_configuration_dismissed(),
 			'capabilities'             => [
 				'installPlugins'        => \current_user_can( 'install_plugins' ),

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -177,7 +177,7 @@ class Site_Kit {
 			'setupUrl'                 => $site_kit_setup_url,
 			'updateUrl'                => $site_kit_update_url,
 			'isAnalyticsConnected'     => $this->is_ga_connected(),
-			'isFeatureEnabled' => true,
+			'isFeatureEnabled'         => true,
 			'isSetupWidgetDismissed'   => $this->permanently_dismissed_site_kit_configuration_repository->is_site_kit_configuration_dismissed(),
 			'capabilities'             => [
 				'installPlugins'        => \current_user_can( 'install_plugins' ),

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -144,6 +144,10 @@ class Site_Kit {
 	 * @return array<string, bool> Returns the name and if the feature is enabled.
 	 */
 	public function to_array(): array {
+		if ( ! ( new Google_Site_Kit_Feature_Conditional() )->is_met() ) {
+			return [];
+		}
+
 		$site_kit_activate_url = \html_entity_decode(
 			\wp_nonce_url(
 				\self_admin_url( 'plugins.php?action=activate&plugin=' . self::SITE_KIT_FILE ),

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -177,6 +177,7 @@ class Site_Kit {
 			'setupUrl'                 => $site_kit_setup_url,
 			'updateUrl'                => $site_kit_update_url,
 			'isAnalyticsConnected'     => $this->is_ga_connected(),
+			'isFeatureEnabled' => true,
 			'isSetupWidgetDismissed'   => $this->permanently_dismissed_site_kit_configuration_repository->is_site_kit_configuration_dismissed(),
 			'capabilities'             => [
 				'installPlugins'        => \current_user_can( 'install_plugins' ),

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_No_Conditional_Met_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_No_Conditional_Met_Test.php
@@ -1,0 +1,77 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Integrations;
+
+use Generator;
+
+/**
+ * Test class for the is_onboarded method.
+ *
+ * @group  site-kit
+ *
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::to_array
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::to_legacy_array
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::can_read_data
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_enabled
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_ga_connected
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_connected
+ * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_setup_completed
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Site_Kit_To_Array_No_Conditional_Met_Test extends Abstract_Site_Kit_Test {
+
+	/**
+	 * Tests if to_array returns an empty array when the conditional is not met.
+	 *
+	 * @dataProvider generate_site_kit_to_array_provider
+	 *
+	 * @param bool               $is_site_kit_installed   If the Site Kit plugin is installed.
+	 * @param bool               $is_site_kit_activated   If the Site Kit plugin is activated.
+	 * @param bool               $is_consent_granted      If consent is granted to our integration.
+	 * @param bool               $is_ga_connected         If the Google analytics setup is completed.
+	 * @param bool               $is_config_dismissed     If the configuration widget is dismissed.
+	 * @param string             $access_role_needed      The needed role for using the widgets.
+	 * @param string             $access_role_user        The role the user has.
+	 * @param int                $search_console_owner_id The id of the user that owns the SC connection.
+	 * @param int                $ga_owner_id             The id of the user that owns the GA connection.
+	 * @param array<bool|string> $expected                The expected value.
+	 *
+	 * @return void
+	 */
+	public function test_to_array(
+		bool $is_site_kit_installed,
+		bool $is_site_kit_activated,
+		bool $is_consent_granted,
+		bool $is_ga_connected,
+		bool $is_config_dismissed,
+		string $access_role_needed,
+		string $access_role_user,
+		int $search_console_owner_id,
+		int $ga_owner_id,
+		array $expected
+	) {
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+
+	/**
+	 * Provides data testing for the to array.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function generate_site_kit_to_array_provider() {
+		yield 'Everything setup' => [
+			'is_site_kit_installed'   => true,
+			'is_site_kit_activated'   => true,
+			'is_consent_granted'      => false,
+			'is_ga_connected'         => false,
+			'is_config_dismissed'     => false,
+			'access_role_needed'      => 'admin',
+			'access_role_user'        => 'admin',
+			'search_console_owner_id' => 1,
+			'ga_owner_id'             => 1,
+			'expected'                => [],
+		];
+	}
+}

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
@@ -153,7 +153,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -185,7 +185,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => false,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -217,7 +217,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -249,7 +249,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -281,7 +281,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -313,7 +313,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled' => true,
+				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
@@ -153,6 +153,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -184,6 +185,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => false,
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -215,6 +217,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -246,7 +249,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -278,6 +281,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -309,6 +313,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
+				'isFeatureEnabled' => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
@@ -19,7 +19,7 @@ use WP_User;
  * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_connected
  * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_setup_completed
  *
- * @phpcs  :disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 
@@ -53,6 +53,11 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 		int $ga_owner_id,
 		array $expected
 	) {
+
+		if ( ! \defined( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE' ) ) {
+			\define( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE', true );
+		}
+
 		Functions\expect( 'file_exists' )
 			->andReturn( $is_site_kit_installed );
 		Functions\expect( 'is_plugin_active' )
@@ -148,7 +153,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled'         => false,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -180,7 +184,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => false,
-				'isFeatureEnabled'         => false,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -212,7 +215,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled'         => false,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -244,7 +246,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled'         => false,
 
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
@@ -277,7 +278,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled'         => false,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,
@@ -309,7 +309,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'updateUrl'                => 'plugins.php?action=activate&plugin=google-site-kit/google-site-kit.php',
 				'isAnalyticsConnected'     => true,
-				'isFeatureEnabled'         => false,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
 					'installPlugins'        => true,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure no Site Kit-related logic is run when the feature flag is false.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Avoids running Site Kit-related logic by checking the feature flag conditional as soon as possible.

## Relevant technical choices:

* I left the `isFeatureEnabled` attribute in the Site Kit configuration to keep frontend code untouched.
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the feature flag and smoke-test our Site Kit widgets in the dashboard
* Edit `src/dashboard/infrastructure/integrations/site-kit.php` by changing lines 131-132 from:
  ```
  $shared_roles       = ( isset( $dashboard_sharing[ $key ]['sharedRoles'] ) ) ? $dashboard_sharing[ $key ]['sharedRoles'] : [];
  $has_viewing_rights = ( \is_array( $shared_roles ) ) ? \array_intersect( $current_user->roles, $shared_roles ) : false;
  ```

  to:
  ```
   $shared_roles       = isset( $dashboard_sharing[ $key ] ) ? $dashboard_sharing[ $key ]['sharedRoles'] : [];
   $has_viewing_rights = \array_intersect( $current_user->roles, $shared_roles );
  ```
  (this basically reverts our [hotfix](https://github.com/Yoast/wordpress-seo/pull/22160))
* Follow the steps [here](https://github.com/Yoast/wordpress-seo/issues/22154) to trigger the fatal error
  * Verify the fatal error is not triggered anymore

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#506](https://github.com/Yoast/reserved-tasks/issues/506)
