### PR TITLE
Add missing disability phrases and improve feedback for "lame" and "dumb down"

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack-bundle-analyzer": "^4.9.1"
   },
   "yoast": {
-    "pluginVersion": "25.0-RC1"
+    "pluginVersion": "25.0"
   },
   "version": "0.0.0"
 }

--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessmentsSpec.js
@@ -443,6 +443,19 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
+	it( "should return the appropriate score and feedback string for: 'birth defect'", () => {
+		const testData = [
+			{
+				identifier: "birthDefect",
+				text: "The birth defect can't be fully treated",
+				expectedFeedback: "Be careful when using <i>birth defect</i> to describe someone's specific condition. " +
+					"Consider using an alternative, such as <i>congenital disability, born with a disability, disability since birth</i>, unless referring to how you characterize your own condition. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
+			},
+		];
+		testInclusiveLanguageAssessments( testData );
+	} );
 	it( "should return the appropriate score and feedback string for: 'crippled' and 'cripple'", () => {
 		const testData = [
 			{
@@ -549,9 +562,9 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			{
 				identifier: "lame",
 				text: "Such a lame excuse!",
-				expectedFeedback: "Avoid using <i>lame</i> as it is potentially harmful. Consider using an alternative, such as <i>boring, lousy, " +
-					"unimpressive, sad, corny</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
-				expectedScore: 3,
+				expectedFeedback: "Be careful when using <i>lame</i> as it is potentially harmful. Unless you are using it as a noun to refer to an object (such as the kitchen tool), consider using an alternative. For example, <i>boring, lousy, " +
+					"unimpressive, sad, corny</i>. If referring to someone's disability, use an alternative such as <i>person with a disability, person who has difficulty with walking</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 6,
 			},
 			{
 				identifier: "lamer",
@@ -573,6 +586,45 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 
 		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should return the appropriate score and feedback string for: 'spaz' and its other forms", () => {
+		const testData = [
+			{
+				identifier: "spaz",
+				text: "another spaz",
+				expectedFeedback: "Avoid using <i>spaz</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>incompetent person, erratic person, inept person, hyperactive person, agitated person, amateur, unqualified person, ignorant person</i> when referring to a person, or <i>lose control, flip out, " +
+					"throw a tantrum, behave erratically, go on the fritz, twitch, move clumsily, move awkwardly</i> when referring to an action. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "spazzes",
+				text: "as long as no one spazzes",
+				expectedFeedback: "Avoid using <i>spazzes</i> as it is potentially harmful. Consider using an alternative, " +
+			"such as <i>incompetent people, erratic people, inept people, hyperactive people, agitated people, amateurs, unqualified people, ignorant people</i> when referring to a person, or " +
+			"<i>loses control, flips out, throws a tantrum, behaves erratically, goes on the fritz, twitches, moves clumsily, moves awkwardly</i> when referring to an action. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "spazzing",
+				text: "no one expects spazzing on stage",
+				expectedFeedback: "Avoid using <i>spazzing</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>losing control, flipping out, throwing a tantrum, behaving erratically, going on the fritz, twitching, moving clumsily, moving awkwardly</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+		];
+
+		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should not show feedback for 'spaz' when 'spaz out' is being used instead", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "spaz" ) );
+
+		const testSentence = "He apologized for spazzing out.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
 	} );
 	it( "should return the appropriate score and feedback string for: 'commit suicide' and its other forms", () => {
 		const testData = [
@@ -703,6 +755,50 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 				expectedScore: 3,
 			},
 		];
+		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should not target 'dumb' if followed by 'down'.", () => {
+		const assessment = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "dumb" ) );
+
+		const testSentence = "They're not used to dumbing down their articles.";
+		const mockPaper = new Paper( testSentence );
+		const mockResearcher = Factory.buildMockResearcher( [ testSentence ] );
+
+		expect( assessment.isApplicable( mockPaper, mockResearcher ) ).toBe( false );
+	} );
+	it( "should return the appropriate score and feedback string for both 'dumb it down' and 'dumb down' and their other forms", () => {
+		const testData = [
+			{
+				identifier: "dumbItDown",
+				text: "It's boring to have to dumb it down all the time.",
+				expectedFeedback: "Avoid using <i>dumb it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplify it</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbedItDown",
+				text: "They dumbed it down unnecessarily.",
+				expectedFeedback: "Avoid using <i>dumbed it down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplified it</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// Different forms of "dumb down" (with different alternative forms) were added under one identifier
+			{
+				identifier: "dumbedDown",
+				text: "The summary was dumbed down out of consideration.",
+				expectedFeedback: "Avoid using <i>dumbed down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplified</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "dumbingDown",
+				text: "It's a pity to be dumbing down so much of the content.",
+				expectedFeedback: "Avoid using <i>dumbing down</i> as it is potentially harmful. Consider using an alternative, such as <i>oversimplifying</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+		];
+
 		testInclusiveLanguageAssessments( testData );
 	} );
 	it( "should return the appropriate score and feedback string for: 'dumb' and its other forms", () => {
@@ -894,7 +990,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should return the appropriate score and feedback string for: the non-negated phrase of 'crazy about'", () => {
+	it( "should return the appropriate score and feedback string for: the non-negated phrase of 'crazy about', 'nuts about' and 'bananas about'", () => {
 		const testData = [
 			// The non-negated phrase for 'crazy about' without an intensifier.
 			{
@@ -905,11 +1001,20 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
-			// The non-negated phrase for 'crazy about' with an intensifier.
+			// The non-negated phrase for 'nuts about' with an intensifier.
 			{
-				identifier: "to be crazy about",
-				text: "I am so crazy about this album.",
-				expectedFeedback: "Avoid using <i>to be crazy about</i> as it is potentially harmful. " +
+				identifier: "to be nuts about",
+				text: "I am so nuts about this album.",
+				expectedFeedback: "Avoid using <i>to be nuts about</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>to love, to be obsessed with, to be infatuated with</i>. " +
+					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// The non-negated phrase for 'bananas about' with an intensifier.
+			{
+				identifier: "to be bananas about",
+				text: "I am so bananas about this album.",
+				expectedFeedback: "Avoid using <i>to be bananas about</i> as it is potentially harmful. " +
 					"Consider using an alternative, such as <i>to love, to be obsessed with, to be infatuated with</i>. " +
 					"<a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
@@ -917,7 +1022,7 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		];
 		testInclusiveLanguageAssessments( testData );
 	} );
-	it( "should not show the feedback for the non-negated form of 'crazy about' when the negated form is used.", () => {
+	it( "should not show the feedback for the non-negated form of 'crazy about' and 'nuts about' when the negated form is used.", () => {
 		const mockPaper = new Paper( "I am not so crazy about this album." );
 		const mockResearcher = Factory.buildMockResearcher( [ "I am not so crazy about this album." ] );
 		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "to be crazy about" ) );
@@ -970,13 +1075,29 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
 		expect( isApplicable ).toBeFalsy();
 	} );
-	it( "should return the appropriate score and feedback string for: 'to go crazy' and its other forms", () => {
+	it( "should not show the feedback for standalone insane when it's used as part of a more specific phrase.", () => {
+		const mockPaper = new Paper( "One can go insane over this." );
+		const mockResearcher = Factory.buildMockResearcher( [ "One can go insane over this.." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "insane" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		expect( isApplicable ).toBeFalsy();
+	} );
+	it( "should return the appropriate score and feedback string for: 'to go crazy' , 'to go insane', 'to go mad', 'to go nuts', 'to go bananas' and its other forms", () => {
 		const testData = [
 			// Form: going crazy.
 			{
 				identifier: "to go crazy",
 				text: "It's going crazy out here.",
 				expectedFeedback: "Avoid using <i>to go crazy</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
+					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// Form: going nuts.
+			{
+				identifier: "to go nuts",
+				text: "They are going nuts out here.",
+				expectedFeedback: "Avoid using <i>to go nuts</i> as it is potentially harmful. " +
 					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
@@ -990,11 +1111,29 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
+			// Form: go insane.
+			{
+				identifier: "to go insane",
+				text: "They go insane in there.",
+				expectedFeedback: "Avoid using <i>to go insane</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
+					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
 			// Form: goes crazy.
 			{
 				identifier: "to go crazy",
 				text: "He goes crazy out here.",
 				expectedFeedback: "Avoid using <i>to go crazy</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
+					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// Form: goes bananas
+			{
+				identifier: "to go bananas",
+				text: "He goes bananas over this movie.",
+				expectedFeedback: "Avoid using <i>to go bananas</i> as it is potentially harmful. " +
 					"Consider using an alternative, such as <i>to go wild, to go out of control, to go up the wall, " +
 					"to be aggravated, to get confused</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
@@ -1021,6 +1160,46 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 
 		testInclusiveLanguageAssessments( testData );
 	} );
+	it( "should show the feedback for 'nuts' and 'bananas' when they are not part of a more specific phrase and they are preceded by is/she's/he's with optional intensifier", () => {
+		const testData = [
+			{
+				identifier: "nuts",
+				text: "It is absolutely nuts out here.",
+				expectedFeedback: "Avoid using <i>nuts</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, confused, mistaken, obsessed</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			{
+				identifier: "bananas",
+				text: "She's bananas everywhere.",
+				expectedFeedback: "Avoid using <i>bananas</i> as it is potentially harmful. " +
+					"Consider using an alternative, such as <i>wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, confused, mistaken, obsessed</i>. <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+		];
+		testInclusiveLanguageAssessments( testData );
+	} );
+	it( "should not show the feedback for 'nuts' when they are part of a more specific phrase.", () => {
+		const mockPaper = new Paper( "She's so nuts about this album." );
+		const mockResearcher = Factory.buildMockResearcher( [ "She's so nuts about this album." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "nuts" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		expect( isApplicable ).toBeFalsy();
+	} );
+	it( "should not show the feedback for 'bananas' when they are part of a more specific phrase: 'bananas about'.", () => {
+		const mockPaper = new Paper( "He's bananas about this album." );
+		const mockResearcher = Factory.buildMockResearcher( [ "He's bananas about this album." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "bananas" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		expect( isApplicable ).toBeFalsy();
+	} );
+	it( "should not show feedback for 'nuts' when it's preceded by 'to be' that is not is/he's/she's but not followed by 'about'.", () => {
+		const mockPaper = new Paper( "They are nuts." );
+		const mockResearcher = Factory.buildMockResearcher( [ "They are nuts." ] );
+		const assessor = new InclusiveLanguageAssessment( assessments.find( obj => obj.identifier === "nuts" ) );
+		const isApplicable = assessor.isApplicable( mockPaper, mockResearcher );
+		expect( isApplicable ).toBeFalsy();
+	} );
 	it( "should target the phrase 'crazy in love' and retrieve correct feedback.", () => {
 		const mockPaper = new Paper( "They seem crazy in love." );
 		const mockResearcher = Factory.buildMockResearcher( [ "They seem crazy in love." ] );
@@ -1041,12 +1220,22 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 			marked: "<yoastmark class='yoast-text-mark'>They seem crazy in love.</yoastmark>",
 		} ) ] );
 	} );
-	it( "should return the appropriate score and feedback string for: 'to drive crazy' and its other forms", () => {
+	it( "should return the appropriate score and feedback string for: 'to drive crazy', 'to drive insane', 'to drive mad', 'to drive nuts', 'to drive bananas' and their other forms", () => {
 		const testData = [
-			// Form: driving (someone) crazy.
+			// For: driving (someone) insane
+			{
+				identifier: "to drive insane",
+				text: "This math problem has been driving me insane.",
+				expectedFeedback: "Avoid using <i>to drive insane</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// For: driving (someone) crazy
 			{
 				identifier: "to drive crazy",
-				text: "This math problem is driving me crazy.",
+				text: "This math problem has been driving me crazy.",
 				expectedFeedback: "Avoid using <i>to drive crazy</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
 					"to make one's blood boil, to exasperate, to get into one's head</i>." +
@@ -1063,11 +1252,31 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
+			// Form: drive (someone) mad
+			{
+				identifier: "to drive mad",
+				text: "They drive everyone mad.",
+				expectedFeedback: "Avoid using <i>to drive mad</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
 			// Form: drove (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "They drove him crazy.",
 				expectedFeedback: "Avoid using <i>to drive crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// Form: drove (someone) bananas.
+			{
+				identifier: "to drive bananas",
+				text: "They drove him bananas.",
+				expectedFeedback: "Avoid using <i>to drive bananas</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
 					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
@@ -1083,11 +1292,31 @@ describe( "a test for targeting non-inclusive phrases in disability assessments"
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
 				expectedScore: 3,
 			},
+			// Form: drives (someone) nuts.
+			{
+				identifier: "to drive nuts",
+				text: "She drives somebody nuts.",
+				expectedFeedback: "Avoid using <i>to drive nuts</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
 			// Form: driven (someone) crazy.
 			{
 				identifier: "to drive crazy",
 				text: "He has driven them crazy.",
 				expectedFeedback: "Avoid using <i>to drive crazy</i> as it is potentially harmful. Consider using an alternative, " +
+					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+					"to make one's blood boil, to exasperate, to get into one's head</i>." +
+					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",
+				expectedScore: 3,
+			},
+			// Form: driven (someone) insane.
+			{
+				identifier: "to drive insane",
+				text: "He has driven them insane.",
+				expectedFeedback: "Avoid using <i>to drive insane</i> as it is potentially harmful. Consider using an alternative, " +
 					"such as <i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
 					"to make one's blood boil, to exasperate, to get into one's head</i>." +
 					" <a href='https://yoa.st/inclusive-language-disability' target='_blank'>Learn more.</a>",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityAssessments.js
@@ -22,6 +22,7 @@ import {
 	shouldNotFollowStandaloneCrazyWhenPrecededByToBe,
 	shouldNotPrecedeStandaloneCrazy,
 	shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
+	shouldPrecedeNutsBananasWithIntensifier,
 } from "./disabilityRulesData";
 import { sprintf } from "@wordpress/i18n";
 import {
@@ -170,6 +171,21 @@ const disabilityAssessments = [
 			"unbelievable, amazing, incomprehensible, nonsensical, outrageous, ridiculous</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: redHarmful,
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isNotPrecededByException( words, shouldNotPrecedeStandaloneCrazy ) )
+				.filter( isNotFollowedAndPrecededByException( words, nonInclusivePhrase,
+					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
+					shouldNotFollowStandaloneCrazyWhenPrecededByToBe ) );
+		},
+		ruleDescription: "Not targeted with this feedback when part of a more specific phrase that we target ('to drive insane', 'to go insane').",
+	},
+	{
+		identifier: "insanely",
+		nonInclusivePhrases: [ "insanely" ],
+		inclusiveAlternatives: "<i>extremely, amazingly, wildly, ferociously, ridiculously, unbelievably</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
 	},
 	{
 		identifier: "imbecile",
@@ -228,11 +244,20 @@ const disabilityAssessments = [
 			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
 	},
 	{
+		identifier: "birthDefect",
+		nonInclusivePhrases: [ "birth defect" ],
+		inclusiveAlternatives: "<i>congenital disability, born with a disability, disability since birth</i>",
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> to describe someone's specific condition. " +
+			"Consider using an alternative, such as %2$s, unless referring to how you characterize your own condition.",
+	},
+	{
 		identifier: "lame",
 		nonInclusivePhrases: [ "lame" ],
-		inclusiveAlternatives: "<i>boring, lousy, unimpressive, sad, corny</i>",
-		score: SCORES.NON_INCLUSIVE,
-		feedbackFormat: redHarmful,
+		inclusiveAlternatives: [ "<i>boring, lousy, unimpressive, sad, corny</i>", "<i>person with a disability, person who has difficulty with walking</i>" ],
+		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
+		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. " +
+			"Unless you are using it as a noun to refer to an object (such as the kitchen tool), consider using an alternative. For example, %2$s. If referring to someone's disability, use an alternative such as %3$s.",
 	},
 	{
 		identifier: "lamer",
@@ -333,6 +358,48 @@ const disabilityAssessments = [
 		feedbackFormat: redHarmful,
 	},
 	{
+		identifier: "dumbDown",
+		nonInclusivePhrases: [ "dumb down" ],
+		inclusiveAlternatives: "<i>oversimplify</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbingDown",
+		nonInclusivePhrases: [ "dumbing down" ],
+		inclusiveAlternatives: "<i>oversimplifying</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbedDown",
+		nonInclusivePhrases: [ "dumbed down" ],
+		inclusiveAlternatives: "<i>oversimplified</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbItDown",
+		nonInclusivePhrases: [ "dumb it down" ],
+		inclusiveAlternatives: "<i>oversimplify it</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbingItDown",
+		nonInclusivePhrases: [ "dumbing it down" ],
+		inclusiveAlternatives: "<i>oversimplifying it</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "dumbedItDown",
+		nonInclusivePhrases: [ "dumbed it down" ],
+		inclusiveAlternatives: "<i>oversimplified it</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
 		identifier: "dumb",
 		nonInclusivePhrases: [ "dumb", "dumber", "dumbest" ],
 		inclusiveAlternatives: [ "<i>uninformed, ignorant, foolish, inconsiderate, irrational, reckless</i>" ],
@@ -340,7 +407,9 @@ const disabilityAssessments = [
 		feedbackFormat: redHarmful,
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, [ "deaf and" ] ) );
+				.filter( isNotPrecededByException( words, [ "deaf and" ] ) )
+				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "down" ] ) )
+				.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "it down" ] ) );
 		},
 		ruleDescription: notPreceded( [ "deaf and" ] ),
 	},
@@ -427,6 +496,32 @@ const disabilityAssessments = [
 		ruleDescription: "Targeted when preceded by a form of 'to be' or 'to get' and an optional intensifier.",
 	},
 	{
+		identifier: "to be nuts about",
+		nonInclusivePhrases: [ "nuts about" ],
+		inclusiveAlternatives: "<i>to love, to be obsessed with, to be infatuated with</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to be nuts about</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to be" and an optional intensifier (e.g. "am so nuts about")
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to be' or 'to get' and an optional intensifier.",
+	},
+	{
+		identifier: "to be bananas about",
+		nonInclusivePhrases: [ "bananas about" ],
+		inclusiveAlternatives: "<i>to love, to be obsessed with, to be infatuated with</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to be bananas about</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to be" and an optional intensifier (e.g. "am so bananas about")
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToBeWithOptionalIntensifier ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to be' or 'to get' and an optional intensifier.",
+	},
+	{
 		identifier: "crazy in love",
 		nonInclusivePhrases: [ "crazy in love" ],
 		inclusiveAlternatives: "<i>wildly in love, head over heels, infatuated</i>",
@@ -448,6 +543,62 @@ const disabilityAssessments = [
 		ruleDescription: isPreceded( formsOfToGo ),
 	},
 	{
+		identifier: "to go insane",
+		nonInclusivePhrases: [ "insane" ],
+		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to be aggravated," +
+			" to get confused</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to go insane</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to go" (e.g. 'going insane').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToGo ) );
+		},
+		ruleDescription: isPreceded( formsOfToGo ),
+	},
+	{
+		identifier: "to go mad",
+		nonInclusivePhrases: [ "mad" ],
+		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to be aggravated," +
+			" to get confused</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to go mad</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to go" (e.g. 'going mad').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToGo ) );
+		},
+		ruleDescription: isPreceded( formsOfToGo ),
+	},
+	{
+		identifier: "to go nuts",
+		nonInclusivePhrases: [ "nuts" ],
+		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to be aggravated," +
+			" to get confused</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to go nuts</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to go" (e.g. 'going nuts').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToGo ) );
+		},
+		ruleDescription: isPreceded( formsOfToGo ),
+	},
+	{
+		identifier: "to go bananas",
+		nonInclusivePhrases: [ "bananas" ],
+		inclusiveAlternatives: "<i>to go wild, to go out of control, to go up the wall, to be aggravated," +
+			" to get confused</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to go bananas</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of "to go" (e.g. 'going bananas').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, formsOfToGo ) );
+		},
+		ruleDescription: isPreceded( formsOfToGo ),
+	},
+	{
 		identifier: "to drive crazy",
 		nonInclusivePhrases: [ "crazy" ],
 		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
@@ -462,23 +613,94 @@ const disabilityAssessments = [
 		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
 	},
 	{
-		identifier: "crazy",
-		nonInclusivePhrases: [ "crazy" ],
+		identifier: "to drive insane",
+		nonInclusivePhrases: [ "insane" ],
+		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+			"to make one's blood boil, to exasperate, to get into one's head</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to drive insane</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me insane', 'drove everyone insane').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
+	},
+	{
+		identifier: "to drive mad",
+		nonInclusivePhrases: [ "mad" ],
+		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+			"to make one's blood boil, to exasperate, to get into one's head</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to drive mad</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me mad', 'drove everyone mad').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
+	},
+	{
+		identifier: "to drive nuts",
+		nonInclusivePhrases: [ "nuts" ],
+		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+			"to make one's blood boil, to exasperate, to get into one's head</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to drive nuts</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me nuts', 'drove everyone nuts').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
+	},
+	{
+		identifier: "to drive bananas",
+		nonInclusivePhrases: [ "bananas" ],
+		inclusiveAlternatives: "<i>to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, " +
+			"to make one's blood boil, to exasperate, to get into one's head</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: [ "Avoid using <i>to drive bananas</i> as it is potentially harmful.", alternative ].join( " " ),
+		// Target only when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me bananas', 'drove everyone bananas').
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, combinationsOfDriveAndObjectPronoun ) );
+		},
+		ruleDescription: "Targeted when preceded by a form of 'to drive' and an object pronoun (e.g. 'driving me')",
+	},
+	{
+		identifier: "nuts",
+		nonInclusivePhrases: [ "nuts" ],
 		inclusiveAlternatives: "<i>wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, " +
 			"confused, mistaken, obsessed</i>",
 		score: SCORES.NON_INCLUSIVE,
 		feedbackFormat: redHarmful,
-		// Don't target when 'crazy' is part of a more specific phrase that we target.
+		// Only target 'nuts' and 'bananas' when preceded by is/he's/she's and an optional intensifier. Don't target when it's part of the phrase 'to be nuts/bananas about...'
 		rule: ( words, nonInclusivePhrase ) => {
 			return includesConsecutiveWords( words, nonInclusivePhrase )
-				.filter( isNotPrecededByException( words, shouldNotPrecedeStandaloneCrazy ) )
-				.filter( isNotFollowedByException( words, nonInclusivePhrase, shouldNotFollowStandaloneCrazy ) )
+				.filter( isPrecededByException( words, shouldPrecedeNutsBananasWithIntensifier ) )
 				.filter( isNotFollowedAndPrecededByException( words, nonInclusivePhrase,
 					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
 					shouldNotFollowStandaloneCrazyWhenPrecededByToBe ) );
 		},
-		ruleDescription: "Not targeted with this feedback when part of a more specific phrase that we target ('to drive crazy', " +
-			"to go crazy', 'to (not) be crazy about', 'crazy in love').",
+		ruleDescription: "Targeted when preceded by is/he's/she's and an optional intensifier and when it's not part of a more specific phrase that we target ('to go nuts', 'to drive nuts', 'to be nuts about').",
+	},
+	{
+		identifier: "bananas",
+		nonInclusivePhrases: [ "bananas" ],
+		inclusiveAlternatives: "<i>wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, " +
+			"confused, mistaken, obsessed</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+		// Only target 'nuts' and 'bananas' when preceded by is/he's/she's and an optional intensifier. Don't target when it's part of the phrase 'to be nuts/bananas about...'
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isPrecededByException( words, shouldPrecedeNutsBananasWithIntensifier ) )
+				.filter( isNotFollowedAndPrecededByException( words, nonInclusivePhrase,
+					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
+					shouldNotFollowStandaloneCrazyWhenPrecededByToBe ) );
+		},
+		ruleDescription: "Targeted when preceded by is/he's/she's and an optional intensifier and when it's not part of a more specific phrase that we target ('to go bananas', 'to drive bananas', 'to be bananas about').",
 	},
 	{
 		identifier: "crazier",
@@ -575,6 +797,85 @@ const disabilityAssessments = [
 		feedbackFormat: "Be careful when using <i>%1$s</i> as it is potentially harmful. If you are referencing the " +
 			"medical condition, use %2$s instead, unless referring to someone who explicitly wants to be referred to with this term. " +
 			"If you are not referencing the medical condition, consider other alternatives to describe the trait or behavior, such as %3$s.",
+	},
+	{
+		identifier: "spaz",
+		nonInclusivePhrases: [ "spaz", "spazz" ],
+		inclusiveAlternatives: [ "<i>incompetent person, erratic person, inept person, hyperactive person, agitated person, amateur, unqualified person, ignorant person</i>", "<i>lose control, flip out, " +
+		"throw a tantrum, behave erratically, go on the fritz, twitch, move clumsily, move awkwardly</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, such as %2$s when referring to a person, or %3$s when referring to an action.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "out" ] ) ),
+		ruleDescription: notFollowed( [ "out" ] ),
+	},
+	{
+		identifier: "spazzes",
+		nonInclusivePhrases: [ "spazzes" ],
+		inclusiveAlternatives: [ "<i>incompetent people, erratic people, inept people, hyperactive people, agitated people, amateurs, unqualified people, ignorant people</i>", "<i>loses control, flips out, throws a " +
+		"tantrum, behaves erratically, goes on the fritz, twitches, moves clumsily, moves awkwardly</i>" ],
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: "Avoid using <i>%1$s</i> as it is potentially harmful. Consider using an alternative, such as %2$s when referring to a person, or %3$s when referring to an action.",
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "out" ] ) ),
+		ruleDescription: notFollowed( [ "out" ] ),
+	},
+	{
+		identifier: "spazzing",
+		nonInclusivePhrases: [ "spazzing" ],
+		inclusiveAlternatives: "<i>losing control, flipping out, throwing a tantrum, behaving erratically, going on the fritz, twitching, moving clumsily, moving awkwardly</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+		rule: ( words, nonInclusivePhrase ) => includesConsecutiveWords( words, nonInclusivePhrase )
+			.filter( isNotFollowedByException( words, nonInclusivePhrase, [ "out" ] ) ),
+		ruleDescription: notFollowed( [ "out" ] ),
+	},
+	{
+		identifier: "spazzed",
+		nonInclusivePhrases: [ "spazzed" ],
+		inclusiveAlternatives: "<i>lost control, flipped out, threw a tantrum, behaved erratically, went on the fritz, twitched, moved clumsily, moved awkwardly</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "spazOut",
+		nonInclusivePhrases: [ "spaz out", "spazz out" ],
+		inclusiveAlternatives: "<i>flip out, throw a tantrum, lose control, move clumsily, move awkwardly</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "spazzesOut",
+		nonInclusivePhrases: [ "spazzes out" ],
+		inclusiveAlternatives: "<i>flips out, throws a tantrum, loses control, moves clumsily, moves awkwardly</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "spazzingOut",
+		nonInclusivePhrases: [ "spazzing out" ],
+		inclusiveAlternatives: "<i>flipping out, throwing a tantrum, losing control, moving clumsily, moving awkwardly</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+	},
+	{
+		identifier: "crazy",
+		nonInclusivePhrases: [ "crazy" ],
+		inclusiveAlternatives: "<i>wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, " +
+			"confused, mistaken, obsessed</i>",
+		score: SCORES.NON_INCLUSIVE,
+		feedbackFormat: redHarmful,
+		// Don't target when 'crazy' is part of a more specific phrase that we target.
+		rule: ( words, nonInclusivePhrase ) => {
+			return includesConsecutiveWords( words, nonInclusivePhrase )
+				.filter( isNotPrecededByException( words, shouldNotPrecedeStandaloneCrazy ) )
+				.filter( isNotFollowedByException( words, nonInclusivePhrase, shouldNotFollowStandaloneCrazy ) )
+				.filter( isNotFollowedAndPrecededByException( words, nonInclusivePhrase,
+					shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
+					shouldNotFollowStandaloneCrazyWhenPrecededByToBe ) );
+		},
+		ruleDescription: "Not targeted with this feedback when part of a more specific phrase that we target ('to drive crazy', " +
+			"to go crazy', 'to (not) be crazy about', 'crazy in love').",
 	},
 	{
 		identifier: "narcissistic",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityRulesData.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/disabilityRulesData.js
@@ -60,6 +60,9 @@ export const shouldNotPrecedeStandaloneCrazy = combinationsOfDriveAndObjectProno
 export const shouldNotFollowStandaloneCrazy = [ "in love" ];
 export const shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout = formsOfToBeWithOptionalIntensifier.concat( formsOfToBeNotWithOptionalIntensifier );
 export const shouldNotFollowStandaloneCrazyWhenPrecededByToBe = [ "about" ];
+const shouldPrecedeStandaloneNutsBananas = [ "is", "she's", "he's" ];
+export const shouldPrecedeNutsBananasWithIntensifier = createCombinationsFromTwoArrays( shouldPrecedeStandaloneNutsBananas, intensifiersAndAdverbs )
+	.concat( shouldPrecedeStandaloneNutsBananas );
 
 export default {
 	formsOfToBeWithOptionalIntensifier,
@@ -71,4 +74,5 @@ export default {
 	shouldNotFollowStandaloneCrazy,
 	shouldNotPrecedeStandaloneCrazyWhenFollowedByAbout,
 	shouldNotFollowStandaloneCrazyWhenPrecededByToBe,
+	shouldPrecedeNutsBananasWithIntensifier,
 };

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Content analysis, Readability, Schema
 Tested up to: 6.8
-Stable tag: 24.9
+Stable tag: 25.0
 Requires PHP: 7.4
 
 Improve your WordPress SEO: Write better content and have a fully optimized WordPress site using the Yoast SEO plugin.
@@ -278,9 +278,11 @@ Your question has most likely been answered on our help center: [yoast.com/help/
 
 Release date: 2025-04-29
 
+Yoast SEO 25.0 brings more enhancements and bugfixes. [Find more information about our software releases and updates here](https://yoa.st/releases).
+
 #### Enhancements
 
-* Fixes an issue where running the `wp yoast cleanup` CLI command would hang when it reaches the `update_indexables_author_to_reassigned` step (for very large data sets). Props to [eddiesshop](https://github.com/eddiesshop).
+* Optimizes the `wp yoast cleanup` CLI command  `update_indexables_author_to_reassigned` step, which can become very slow for very large data sets. Props to [eddiesshop](https://github.com/eddiesshop).
 * Improves the feedback texts for the _passive voice_ and _consecutive sentences_ assessments in case there is nothing to report.
 * Makes the _images_, _internal links_, and _external links_ assessments available when no content has been added.
 

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -15,7 +15,7 @@ if ( ! function_exists( 'add_filter' ) ) {
  * {@internal Nobody should be able to overrule the real version number as this can cause
  *            serious issues with the options, so no if ( ! defined() ).}}
  */
-define( 'WPSEO_VERSION', '25.0-RC1' );
+define( 'WPSEO_VERSION', '25.0' );
 
 
 if ( ! defined( 'WPSEO_PATH' ) ) {

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -8,7 +8,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: Yoast SEO
- * Version:     25.0-RC1
+ * Version:     25.0
  * Plugin URI:  https://yoa.st/1uj
  * Description: The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.
  * Author:      Team Yoast


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds more phrases regarding disability to the _inclusive language assessment_.
* Improves the feedback for "lame" in the _inclusive language assessment_.
* [yoastseo] Adds new phrases regarding disability and forms of the word _insane_ to the _inclusive language assessment_.
* [yoastseo] Improves the feedback for "lame" in the _inclusive language assessment_ by considering homonyms.
* [shopify-seo] Adds more phrases regarding disability to the _inclusive language assessment_.
* [shopify-seo] Improves the feedback for "lame" in the _inclusive language assessment_.

## Relevant technical choices:

* For the feedback for `lame` we rephrased the "unless" condition in the feedback string from `unless you are referring to an object` to `unless you are using it as a noun to refer to an object (such as the kitchen tool)`. This was done so that the feedback wouldn't be misunderstood (one can assume the word to inclusive when referring to an object, but not when referring to people).
* Adding _spazzing out_ to the forms of _spaz out_ (alongside with _spazzed out_)
* Added _erratic_ and _agitated_ as an alternative for the noun _spaz_ (see meaning of the word[ in wiktionary](https://en.wiktionary.org/wiki/spaz) and [this thread](https://www.reddit.com/r/EnglishLearning/comments/1arpgd4/what_does_spaz_mean/))
* Added _behave erratically_ as an alternative for the verb _spaz_.
* To prevent the feedback for _spaz_ from being too long after adding alternatives, i removed _unprofessional_ from the alternatives for _spaz_ . This is because it is the most distinct from the initial meaning synonym (doesn’t mean exactly _incompetent / inept / unqualified_, but rather someone behaving unprofessionally). Also, the concept _Unprofessional_ wasn't found as a common meaning of the word.
* Reordered alternatives for _spaz_ to list the most frequent or vague meanings "incompetent" "erratic", "hyperactive", "inept" before the less frequent meanings "unqualified", "ignorant".. So the suggested alternatives for spaz (the noun) changed from 
<i>incompetent person, unqualified person, unprofessional person, ignorant person, amateur, akward person, clumsy person, hyperactive person</i> to <i>incompetent person, erratic person, inept person, hyperactive person, agitated person, amateur, unqualified person, ignorant person</i>
* A similar change was done for the verb spaz, where the suggested alternatives <i>loses control, flips out, throws a tantrum, malfunctions, goes on the fritz, twitches, moves clumsily, moves awkwardly</i> were changed into the following order <i>lose control, flip out, throw a tantrum, behave erratically, go on the fritz, twitch, move clumsily, move awkwardly</i>.
* Removed _malfunction_ from the alternatives from the verb spaz, because it is most distinct from the following meaning and is usually associated with machinery or a particular part of the body, see [Oxford dictionary](https://www.oxfordlearnersdictionaries.com/definition/english/malfunction_2) for reference.
* Since the issue was created a while ago, some variables are not anymore applicable. For example, the feedback string under the variable `redHarmful` includes the part `consider an alternative`, so a new string was created instead of using `redHarmful` for those phrases.
* _lame_ gets an orange score because it is context-dependent, while _lamer_ and _lamest_ are not. See [research issue](https://github.com/Yoast/wordpress-seo/issues/21475).
* Made a separate identified for each form of _dumb it down, dumb down_ and _lame_ because they have separate alternatives. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Active Yoast SEO Free
* Activate the Inclusive language assessment in the settings
* Add a text of at least 300 words

Phrases with "dumb"
* Add the phrase "dumb" to the text
* Confirm that the assessment shows a red bullet with the following feedback:
"Avoid using dumb as it is potentially harmful. Consider using an alternative, such as uninformed, ignorant, foolish, inconsiderate, irrational, reckless. Learn more.".
* Change "dumb" to "dumb down"
* Confirm that the feedback for "dumb" does not appear anymore
* Confirm that the assessment shows a red bullet with the following feedback: "Avoid using dumb down as it is potentially harmful. Consider using an alternative, such as oversimplify. Learn more."
* Change the form of the phrase "dumb down" to "dumbed down"
* Confirm that the assessment shows a red bullet with the following feedback (replacing the previous feedback for "dumb down"): "Avoid using dumbed down as it is potentially harmful. Consider using an alternative, such as oversimplified. Learn more."
* Add the phrase "dumbing it down"
* Confirm that the assessment shows a red bullet with the following feedback: "Avoid using dumbing it down as it is potentially harmful. Consider using an alternative, such as oversimplifying it. Learn more."

Forms of the word "lame"

* Add the phrase "lame"
* Confirm that the assessment shows an orange bullet and the following feedback: "Be careful when using lame as it is potentially harmful. Unless you are using it as a noun to refer to an object (such as the kitchen tool),  considering using an alternative. For example, boring, lousy, unimpressive, sad, corny. If referring to someone's disability, use an alternative such as person with a disability, person who has difficulty with walking. Learn more.".
* Change the phrase "lame" to "lamest"
* Confirm that the assessment shows a red bullet with the following feedback (replacing the previous feedback for "lame"): "Avoid using lamest as it is potentially harmful. Consider using an alternative, such as most boring, lousiest, most unimpressive, saddest, corniest. Learn more."
* Add the phrase "lamer"
* Confirm that the assessment shows a red bullet with the following feedback: "Avoid using lamer as it is potentially harmful. Consider using an alternative, such as more boring, lousier, more unimpressive, sadder, cornier. Learn more."

Forms of the words "spaz" and "spaz out"

* Add the phrase "spaz"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _spaz_ as it is potentially harmful. Consider using an alternative, such as _incompetent person, erratic person, inept person, hyperactive person, agitated person, amateur, unqualified person, ignorant person_ when referring to a person, or _lose control, flip out, throw a tantrum, behave erratically, go on the fritz, twitch, move clumsily, move awkwardly_ when referring to an action. Learn more."
* Change the form of the word to "spazzes"
* Confirm that the assessment shows a red bullet with the following feedback: "Avoid using _spazzes_ as it is potentially harmful. Consider using an alternative, such as _incompetent people, erratic people, inept people, hyperactive people, agitated people, amateurs, unqualified people, ignorant people_ when referring to a person, or _loses control, flips out, throws a tantrum, behaves erratically, goes on the fritz, twitches, moves clumsily, moves awkwardly_ when referring to an action. Learn more."
* Add the phrase "spazzing out"
* Confirm  that the assessment shows a red bullet with the following feedback:  "Avoid using _spazzing out_ as it is potentially harmful. Consider using an alternative, such as f_lipping out, throwing a tantrum, losing control, moving clumsily, moving awkwardly._ Learn more."

The phrase "birth defect"

* Add the phrase "birth defect"
* Confirm that the inclusive language assessment shows an orange bullet with the following feedback: "Be careful when using _birth defect_ to describe someone's specific condition. Consider using an alternative, such as _congenital disability, born with a disability, disability since birth_, unless referring to how you characterize your own condition. Learn more."

Phrases "to go insane/mad/nuts/bananas" and "to drive someone insane/mad/nuts/bananas"

* Add the phrase "driving me crazy"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _to drive crazy_ as it is potentially harmful. Consider using an alternative, such as _to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, to make one's blood boil, to exasperate, to get into one's head._ Learn more."
* Make sure the feedback for standalone "crazy" does not appear.
* Add the phrase "goes bananas"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _to go bananas_ as it is potentially harmful. Consider using an alternative, such as _to go wild, to go out of control, to go up the wall, to be aggravated, to get confused._ Learn more.
* Add the phrase "went mad"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _to go mad_ as it is potentially harmful. Consider using an alternative, such as _to go wild, to go out of control, to go up the wall, to be aggravated, to get confused._ Learn more."
* Add the phrase "drove them insane"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _to drive insane_ as it is potentially harmful. Consider using an alternative, such as _to drive one to their limit, to get on one's last nerve, to make one livid, to aggravate, to make one's blood boil, to exasperate, to get into one's head._ Learn more."
* Make sure the feedback for standalone "insane" does not appear.

Phrases "nuts" and "bananas"
* Add the phrase "They are nuts."
* Confirm that the inclusive language assessment doesn't flag the phrase
* Add the phrase "She's nuts about the movie"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _to be nuts about_as it is potentially harmful. Consider using an alternative, such as _to love, to be obsessed with, to be infatuated with_. Learn more.
* Remove the phrase "She's nuts about the movie" and add the following phrase "He's absolutely nuts"
* Confirm that the inclusive language assessment shows a red bullet with the following feedback: "Avoid using _nuts_ as it is potentially harmful. Consider using an alternative, such as _wild, baffling, out of control, inexplicable, unbelievable, aggravating, shocking, intense, impulsive, chaotic, confused, mistaken, obsessed_. Learn more."

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/orgs/Yoast/projects/51/views/1?pane=issue&itemId=91090930&issue=Yoast%7Clingo-other-tasks%7C222
