### PR TITLE
Improves the feedback for passive voice and consecutive sentences assessments

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ar/arabicPaper.js
@@ -127,7 +127,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -137,7 +137,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
@@ -130,7 +130,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/cs/czechPaper.js
@@ -140,8 +140,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in " +
-			"your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper.js
@@ -146,7 +146,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/el/greekPaper.js
@@ -147,7 +147,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences." +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings." +
 			" That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper.js
@@ -127,7 +127,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -137,7 +137,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaperForPerformanceTest.js
@@ -133,7 +133,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -143,7 +143,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper.js
@@ -131,7 +131,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -141,7 +141,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaperForPerformanceTest.js
@@ -133,7 +133,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -143,7 +143,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences." +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings." +
 			" That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fa/farsiPaper.js
@@ -147,7 +147,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper.js
@@ -140,7 +140,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
@@ -144,7 +144,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/he/hebrewPaper.js
@@ -144,7 +144,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>:" +
-			" There is enough variety in your sentences. That's great!",
+			" There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		// This is not applicable to this paper since the text doesn't have any image in it.

--- a/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
@@ -138,8 +138,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety " +
-			"in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/hu/hungarianPaper.js
@@ -128,7 +128,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/id/indonesianPaper.js
@@ -130,7 +130,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper.js
@@ -118,7 +118,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -128,7 +128,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/nb/norwegianPaper.js
@@ -127,7 +127,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -137,7 +137,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/nl/dutchPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/nl/dutchPaper.js
@@ -138,7 +138,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!",
+			"There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		// This is not applicable to this paper since the text doesn't have any image in it.

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper.js
@@ -129,7 +129,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaperForPerformanceTest.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaperForPerformanceTest.js
@@ -125,7 +125,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -135,7 +135,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper.js
@@ -144,7 +144,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences." +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings." +
 			" That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pt/portuguesePaper3.js
@@ -144,7 +144,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences." +
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings." +
 			" That's great!",
 	},
 	imageKeyphrase: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper.js
@@ -131,7 +131,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		// This is not applicable to this paper since the text doesn't have any image in it.

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sk/slovakPaper.js
@@ -127,7 +127,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -137,7 +137,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper.js
@@ -126,7 +126,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		// This assessment is not applicable for this paper since the text doesn't contain any image.

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper.js
@@ -118,7 +118,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,
@@ -128,7 +128,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	imageKeyphrase: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessments/readability/PassiveVoiceAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/PassiveVoiceAssessmentSpec.js
@@ -6,34 +6,32 @@ import DefaultResearcher from "../../../../src/languageProcessing/languages/_def
 import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 
 describe( "An assessment for scoring passive voice.", function() {
-	const paper = new Paper();
+	const paper = new Paper( "" );
+	const goodFeedback = "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!";
+
 	it( "returns result when the text is empty", function() {
 		const assessment = new PassiveVoiceAssessment().getResult( paper, Factory.buildMockResearcher( { total: 0, passives: [] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
-			" active voice. That's great!" );
+		expect( assessment.getText() ).toBe( goodFeedback );
 	} );
 
 	it( "scores 0 passive sentences - 0%", function() {
 		const assessment = new PassiveVoiceAssessment().getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
-			" active voice. That's great!" );
+		expect( assessment.getText() ).toBe( goodFeedback );
 	} );
 
 	it( "scores 1 passive sentence - 5%", function() {
 		const assessment = new PassiveVoiceAssessment().getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1 ] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
-			" active voice. That's great!" );
+		expect( assessment.getText() ).toBe( goodFeedback );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
 	it( "scores 2 passive sentences - 10%", function() {
 		const assessment = new PassiveVoiceAssessment().getResult( paper, Factory.buildMockResearcher( { total: 20, passives: [ 1, 2 ] } ) );
 		expect( assessment.getScore() ).toBe( 9 );
-		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough" +
-			" active voice. That's great!" );
+		expect( assessment.getText() ).toBe( goodFeedback );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 

--- a/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/readability/SentenceBeginningsAssessmentSpec.js
@@ -37,14 +37,14 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 			{ word: "couch", count: 1 } ] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
+			"There are no repetitive sentence beginnings. That's great!" );
 	} );
 
 	it( "returns a good score when there are no words in the text.", function() {
 		const assessment = new SentenceBeginningsAssessment().getResult( paper, Factory.buildMockResearcher( [] ) );
 		expect( assessment.getScore() ).toBe( 9 );
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
-			"There is enough variety in your sentences. That's great!" );
+			"There are no repetitive sentence beginnings. That's great!" );
 	} );
 
 	it( "is applicable when the researcher that has the getSentenceBeginnings research.", function() {

--- a/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -120,8 +120,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There is enough " +
-			"variety in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	wordComplexity: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper2.js
@@ -119,8 +119,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There is enough variety " +
-			"in your sentences. That's great!",
+		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. That's great!",
 	},
 	wordComplexity: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/scoring/assessors/collectionPages/fullTextTests/testTexts/en/englishPaper3.js
@@ -121,7 +121,7 @@ const expectedResults = {
 	sentenceBeginnings: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. " +
+		resultText: "<a href='https://yoa.st/shopify5' target='_blank'>Consecutive sentences</a>: There are no repetitive sentence beginnings. " +
 			"That's great!",
 	},
 	wordComplexity: {

--- a/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/scoring/assessors/productPages/fullTextTests/testTexts/en/englishPaper1.js
@@ -149,7 +149,7 @@ const expectedResults = {
 	passiveVoice: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		resultText: "<a href='https://yoa.st/shopify42' target='_blank'>Passive voice</a>: You are not using too much passive voice. That's great!",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING READABILITY.md
@@ -87,10 +87,10 @@ Below is a detailed overview of how scores for the readability assessments are c
 
 **Call to action URL**: [https://yoa.st/35g](https://yoast.com/consecutive-sentences-check-yoast-seo/#utm_source=yoast-seo&utm_medium=software&utm_term=sentence-beginnings-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-|Traffic light	|Score|	Criterion	|Feedback|
-|------------------  |------------------	|--------------------- |--------------------- |
-|Red	|3 |3 or more consecutive sentences start with the same word	|**Consecutive sentences**: the text contains X consecutive sentences starting with the same word. **Try to mix things up!**|
-|Green	|9 |Less than 3 consecutive sentences start with the same word	|**Consecutive sentences**: there is enough variety in your sentences. That's great!|
+| Traffic light | Score | Criterion                                                  | Feedback                                                                                                                    |
+|---------------|-------|------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| Red           | 3     | 3 or more consecutive sentences start with the same word   | **Consecutive sentences**: The text contains X consecutive sentences starting with the same word. **Try to mix things up!** |
+| Green         | 9     | Less than 3 consecutive sentences start with the same word | **Consecutive sentences**: There are no repetitive sentence beginnings. That's great!                                       |
 
 ### 5) Passive voice
 **What it does**: Checks whether the number of sentences containing passive voice exceeds the recommended maximum amount.
@@ -103,11 +103,11 @@ Below is a detailed overview of how scores for the readability assessments are c
 
 **Call to action URL**: [https://yoa.st/34u](https://yoast.com/the-passive-voice-what-is-it-and-how-to-avoid-it/#utm_source=yoast-seo&utm_medium=software&utm_term=passive-voice-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-|Traffic light	|Score |	Criterion|	Feedback|
-|-------|------	|----- |------- |
-|Red	|3	|> 15% of sentences              |**Passive voice**: X of the sentences contain passive voice, which is more than the recommended maximum of X. **Try to use their active counterparts**. |
-|Orange	|6	|Between 10 and 15% of sentences |**Passive voice**: X of the sentences contain passive voice, which is more than the recommended maximum of X. **Try to use their active counterparts**.|
-|Green	|9	|≤ 10% of sentences              |**Passive voice**: you're using enough active voice. That's great!|
+| Traffic light | Score | Criterion                       | Feedback                                                                                                                                                |
+|---------------|-------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Red           | 3     | > 15% of sentences              | **Passive voice**: X of the sentences contain passive voice, which is more than the recommended maximum of X. **Try to use their active counterparts**. |
+| Orange        | 6     | Between 10 and 15% of sentences | **Passive voice**: X of the sentences contain passive voice, which is more than the recommended maximum of X. **Try to use their active counterparts**. |
+| Green         | 9     | ≤ 10% of sentences              | **Passive voice**: You are not using too much passive voice. That's great!                                                                              |
 
 ### 6) Transition words
 **What it does**: Checks whether there are enough sentences containing transition words.

--- a/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/PassiveVoiceAssessment.js
@@ -4,11 +4,16 @@ import { map, merge } from "lodash";
 import formatNumber from "../../../helpers/formatNumber";
 import { inRangeEndInclusive as inRange } from "../../helpers/assessments/inRange";
 import marker from "../../../markers/addMark";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import { stripIncompleteTags as stripTags } from "../../../languageProcessing/helpers/sanitize/stripHTMLTags";
 import AssessmentResult from "../../../values/AssessmentResult";
 import Mark from "../../../values/Mark";
 import Assessment from "../assessment";
+
+/**
+ * @typedef {import("../../../languageProcessing/AbstractResearcher").default } Researcher
+ * @typedef {import("../../../values/").Paper } Paper
+ */
 
 /**
  * Represents the assessment that checks whether there are passive sentences in the text.
@@ -18,8 +23,6 @@ export default class PassiveVoiceAssessment extends Assessment {
 	 * Sets the identifier and the config.
 	 *
 	 * @param {object} config The configuration to use.
-	 *
-	 * @returns {void}
 	 */
 	constructor( config = {} ) {
 		super();
@@ -36,12 +39,12 @@ export default class PassiveVoiceAssessment extends Assessment {
 	/**
 	 * Calculates the result based on the number of sentences and passives.
 	 *
-	 * @param {object} passiveVoice     The object containing the number of sentences and passives.
+	 * @param {{total: number, passives:{length: number, total: number}}} passiveVoice Object containing the number of sentences and passives.
 	 *
-	 * @returns {{score: number, text}} resultobject with score and text.
+	 * @returns {{score: number, text: string, hasMarks: boolean}} Result object with score and text, and whether there are marks.
 	 */
 	calculatePassiveVoiceResult( passiveVoice ) {
-		let score;
+		let score = 0;
 		let percentage = 0;
 		const recommendedValue = 10;
 
@@ -74,7 +77,7 @@ export default class PassiveVoiceAssessment extends Assessment {
 				text: sprintf(
 					/* translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag. */
 					__(
-						"%1$sPassive voice%2$s: You're using enough active voice. That's great!",
+						"%1$sPassive voice%2$s: You are not using too much passive voice. That's great!",
 						"wordpress-seo"
 					),
 					this._config.urlTitle,
@@ -104,10 +107,10 @@ export default class PassiveVoiceAssessment extends Assessment {
 	/**
 	 * Marks all sentences that have the passive voice.
 	 *
-	 * @param {object} paper        The paper to use for the assessment.
-	 * @param {object} researcher   The researcher used for calling research.
+	 * @param {Paper} paper The paper to use for the assessment.
+	 * @param {Researcher} researcher The researcher used for calling research.
 	 *
-	 * @returns {object} All marked sentences.
+	 * @returns {Mark[]} All marked sentences.
 	 */
 	getMarks( paper, researcher ) {
 		const passiveVoice = researcher.getResearch( "getPassiveVoiceResult" );
@@ -124,10 +127,10 @@ export default class PassiveVoiceAssessment extends Assessment {
 	/**
 	 * Runs the passiveVoice module, based on this returns an assessment result with score and text.
 	 *
-	 * @param {object} paper        The paper to use for the assessment.
-	 * @param {object} researcher   The researcher used for calling research.
+	 * @param {Paper} paper The paper to use for the assessment.
+	 * @param {Researcher} researcher The researcher used for calling research.
 	 *
-	 * @returns {object} the Assessmentresult
+	 * @returns {AssessmentResult} The result of the assessment.
 	 */
 	getResult( paper, researcher ) {
 		const passiveVoice = researcher.getResearch( "getPassiveVoiceResult" );

--- a/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/readability/SentenceBeginningsAssessment.js
@@ -93,7 +93,7 @@ export default class SentenceBeginningsAssessment extends Assessment {
 			assessmentResult.setText( sprintf(
 				/* translators: %1$s expands to a link on yoast.com, %2$s expands to the anchor end tag */
 				__(
-					"%1$sConsecutive sentences%2$s: There is enough variety in your sentences. That's great!",
+					"%1$sConsecutive sentences%2$s: There are no repetitive sentence beginnings. That's great!",
 					"wordpress-seo"
 				),
 				this._config.urlTitle,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the 'good' feedback for the _passive voice_ and _consecutive sentences_ assessments, because after #22156 they are also shown when there is little to no text in the post.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the feedback texts for the _passive voice_ and _consecutive sentences_ assessments in case there is nothing to report.
* [shopify-seo] Improves the feedback texts for the _passive voice_ and _consecutive sentences_ assessments in case there is nothing to report.
* [yoastseo] Improves the feedback texts for the _passive voice_ and _consecutive sentences_ assessments in case there is nothing to report.

## Relevant technical choices:

* Improved the JSDoc for the _passive voice_ assessment while at it.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Posts in WordPress

* Activate Yoast SEO and Yoast SEO Premium 
* Create a new post without any content

##### Passive voice assessment
* Confirm that the passive voice assessment returns a green traffic light with the following feedback: `Passive voice: You are not using too much passive voice. That's great!` **(this is the changed behavior from this PR!)**
* Add the following sentence: "The mouse is eaten by the cat."
* Confirm that the traffic light turns red and the assessment shows the following feedback: `Passive voice: 100% of the sentences contain passive voice, which is more than the recommended maximum of 10%. Try to use their active counterparts.`
* Remove all text from the post.

##### Consecutive sentences assessment
* Confirm that the consecutive sentences assessment returns a green traffic light with the following feedback: `Consecutive sentences: There are no repetitive sentence beginnings. That's great!` **(this is the changed behavior from this PR!)**
* Add the following sentences to the text: "Cats are beautiful. Cats are adorable. Cats are the best animals."
* Confirm that the traffic light turns red and the assessment shows the following feedback: `Consecutive sentences: The text contains 3 consecutive sentences starting with the same word. Try to mix things up!`
* Remove all text from the post.

#### Shopify

* Create a product with no content
* Repeat the steps to test the passive voice assessment (the consecutive sentences assessment is not available on products).
* Create a collection with no content
* Repeat the steps to test the consecutive sentences assessment

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No further impact.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other. 
  * See the assessment documentation.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2229
