### PR TITLE
Add site kit conditional when needed.

### DIFF
--- a/src/conditionals/third-party/site-kit-conditional.php
+++ b/src/conditionals/third-party/site-kit-conditional.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals\Third_Party;
+
+use Yoast\WP\SEO\Conditionals\Conditional;
+use Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit;
+
+/**
+ * Conditional that is only met when the SiteKit plugin is active.
+ */
+class Site_Kit_Conditional implements Conditional {
+
+	/**
+	 * Site Kit configuration
+	 *
+	 * @var Site_Kit $site_kit
+	 */
+	protected $site_kit;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Site_Kit $site_kit The Site Kit configuration object.
+	 */
+	public function __construct( Site_Kit $site_kit ) {
+		$this->site_kit = $site_kit;
+	}
+
+	/**
+	 * Checks whether the SiteKit plugin is active.
+	 *
+	 * @return bool Whether the SiteKit plugin is active.
+	 */
+	public function is_met() {
+		return $this->site_kit->is_enabled();
+	}
+}

--- a/src/dashboard/user-interface/configuration/site-kit-capabilities-integration.php
+++ b/src/dashboard/user-interface/configuration/site-kit-capabilities-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Dashboard\User_Interface\Configuration;
 
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -27,7 +28,7 @@ class Site_Kit_Capabilities_Integration implements Integration_Interface {
 	 */
 	public static function get_conditionals() {
 		// This cannot have the Admin Conditional since it also needs to run in Rest requests.
-		return [ Google_Site_Kit_Feature_Conditional::class ];
+		return [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ];
 	}
 
 	/**

--- a/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-configuration-dismissal-route.php
@@ -6,7 +6,7 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Main;
@@ -20,8 +20,6 @@ use Yoast\WP\SEO\Routes\Route_Interface;
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 *  The namespace for this route.
@@ -50,6 +48,16 @@ class Site_Kit_Configuration_Dismissal_Route implements Route_Interface {
 	 * @var Capability_Helper
 	 */
 	private $capability_helper;
+
+	/**
+	 * The needed conditionals.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		// This cannot have the Admin Conditional since it also needs to run in Rest requests.
+		return [ Google_Site_Kit_Feature_Conditional::class ];
+	}
 
 	/**
 	 * Constructs the class.

--- a/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
+++ b/src/dashboard/user-interface/configuration/site-kit-consent-management-route.php
@@ -6,7 +6,8 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Interface;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Main;
@@ -20,8 +21,6 @@ use Yoast\WP\SEO\Routes\Route_Interface;
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Site_Kit_Consent_Management_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 *  The namespace for this route.
@@ -50,6 +49,16 @@ class Site_Kit_Consent_Management_Route implements Route_Interface {
 	 * @var Capability_Helper
 	 */
 	private $capability_helper;
+
+	/**
+	 * The needed conditionals.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		// This cannot have the Admin Conditional since it also needs to run in Rest requests.
+		return [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ];
+	}
 
 	/**
 	 * Constructs the class.

--- a/src/dashboard/user-interface/time-based-seo-metrics/time-based-seo-metrics-route.php
+++ b/src/dashboard/user-interface/time-based-seo-metrics/time-based-seo-metrics-route.php
@@ -8,6 +8,7 @@ use Exception;
 use WP_REST_Request;
 use WP_REST_Response;
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Dashboard\Application\Search_Rankings\Search_Ranking_Compare_Repository;
 use Yoast\WP\SEO\Dashboard\Application\Search_Rankings\Top_Page_Repository;
 use Yoast\WP\SEO\Dashboard\Application\Search_Rankings\Top_Query_Repository;
@@ -76,7 +77,7 @@ final class Time_Based_SEO_Metrics_Route implements Route_Interface {
 	private $search_ranking_compare_repository;
 
 	/**
-	 * Holds the capabilit helper instance.
+	 * Holds the capability helper instance.
 	 *
 	 * @var Capability_Helper
 	 */
@@ -88,7 +89,7 @@ final class Time_Based_SEO_Metrics_Route implements Route_Interface {
 	 * @return array<string> The conditionals that must be met to load this.
 	 */
 	public static function get_conditionals(): array {
-		return [ Google_Site_Kit_Feature_Conditional::class ];
+		return [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ];
 	}
 
 	/**

--- a/src/dashboard/user-interface/tracking/setup-steps-tracking-route.php
+++ b/src/dashboard/user-interface/tracking/setup-steps-tracking-route.php
@@ -6,7 +6,7 @@ use Exception;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Tracking\Setup_Steps_Tracking_Repository_Interface;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Main;
@@ -20,8 +20,6 @@ use Yoast\WP\SEO\Routes\Route_Interface;
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Setup_Steps_Tracking_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 *  The namespace for this route.
@@ -50,6 +48,15 @@ class Setup_Steps_Tracking_Route implements Route_Interface {
 	 * @var Capability_Helper
 	 */
 	private $capability_helper;
+
+	/**
+	 * Returns the needed conditionals.
+	 *
+	 * @return array<string> The conditionals that must be met to load this.
+	 */
+	public static function get_conditionals(): array {
+		return [ Google_Site_Kit_Feature_Conditional::class ];
+	}
 
 	/**
 	 * Constructs the class.

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Capabilities_Integration_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Capabilities_Integration_Get_Conditionals_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Capabilities_Integration;
 
 /**
@@ -22,6 +23,6 @@ final class Site_Kit_Capabilities_Integration_Get_Conditionals_Test extends Abst
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class ], Site_Kit_Capabilities_Integration::get_conditionals() );
+		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ], Site_Kit_Capabilities_Integration::get_conditionals() );
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Test.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Configuration_Dismissal_Route;
 
 /**
@@ -21,6 +22,6 @@ final class Site_Kit_Configuration_Permanent_Dismissal_Route_Get_Conditionals_Te
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [], Site_Kit_Configuration_Dismissal_Route::get_conditionals() );
+		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class ], Site_Kit_Configuration_Dismissal_Route::get_conditionals() );
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Configuration/Site_Kit_Consent_Management_Route_Get_Conditionals_Test.php
@@ -2,6 +2,8 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Configuration;
 
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\Configuration\Site_Kit_Consent_Management_Route;
 
 /**
@@ -21,6 +23,6 @@ final class Site_Kit_Consent_Management_Route_Get_Conditionals_Test extends Abst
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [], Site_Kit_Consent_Management_Route::get_conditionals() );
+		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ], Site_Kit_Consent_Management_Route::get_conditionals() );
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Conditionals_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Time_Based_SEO_Metrics;
 
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\Time_Based_SEO_Metrics\Time_Based_SEO_Metrics_Route;
 
 /**
@@ -22,6 +23,6 @@ final class Time_Based_SEO_Metrics_Route_Get_Conditionals_Test extends Abstract_
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class ], Time_Based_SEO_Metrics_Route::get_conditionals() );
+		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class, Site_Kit_Conditional::class ], Time_Based_SEO_Metrics_Route::get_conditionals() );
 	}
 }

--- a/tests/Unit/Dashboard/User_Interface/Tracking/Setup_Steps_Tracking_Route_Get_Conditionals_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Tracking/Setup_Steps_Tracking_Route_Get_Conditionals_Test.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Tracking;
 
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\User_Interface\Tracking\Setup_Steps_Tracking_Route;
 
 /**
@@ -21,6 +22,6 @@ final class Setup_Steps_Tracking_Route_Get_Conditionals_Test extends Abstract_Se
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertEquals( [], Setup_Steps_Tracking_Route::get_conditionals() );
+		$this->assertEquals( [ Google_Site_Kit_Feature_Conditional::class ], Setup_Steps_Tracking_Route::get_conditionals() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to load routes that are not needed when Site Kit is disabled.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds some more conditionals for a set of Site Kit dependent routes.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Smoke test the Site Kit setup widget and our widgets to make sure they still work.
* Disable Site Kit
  * Make sure there are no errors and the setup still works as expected.
  * Try to perform the following REST request with any HTTP client:
    ```
    http://sitekittest.test/wp-json/yoast/v1/site_kit_manage_consent?consent=false
    ```
    * Verify you get a `rest_no_route` response
* Enable Site Kit
  * Perform the same request as above and verify you get a `success: true` response this time 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
