### PR TITLE
Add two CTB button codes with difference for different upsells.

### DIFF
--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -6,6 +6,7 @@ import { __, sprintf } from "@wordpress/i18n";
 
 const STORE = "yoast-seo/editor";
 
+/* eslint-disable max-statements */
 /**
  * @returns {JSX.Element} The element.
  */
@@ -89,3 +90,4 @@ export const ModalContent = () => {
 		/>
 	);
 };
+/* eslint-enable max-statements */

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -53,6 +53,7 @@ export const ModalContent = () => {
 				"Yoast WooCommerce SEO"
 			);
 			upsellProps.upsellLink = upsellLinkWoo;
+			upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
 		} else if ( ! isWooSeoActive ) {
 			upsellProps.upsellLabel = `${sprintf(
 				/* translators: %1$s expands to Woo Premium bundle. */
@@ -63,6 +64,7 @@ export const ModalContent = () => {
 				{ `*${upsellPremiumWooLabel}` }
 			</div>;
 			upsellProps.upsellLink = upsellLinkWooPremiumBundle;
+			upsellProps.ctbId = "c7e7baa1-2020-420c-a427-89701700b607";
 		}
 	}
 

--- a/packages/js/src/shared-admin/components/ai-fix-assessments-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-fix-assessments-upsell.js
@@ -90,6 +90,8 @@ export const AiFixAssessmentsUpsell = ( {
 						href={ upsellLink }
 						target="_blank"
 						ref={ initialFocus }
+						data-action="load-nfd-ctb"
+						data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 					>
 						<LockOpenIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5" />
 						{ upsellLabel }

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -16,7 +16,7 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {string} upsellLabel The upsell label.
  * @param {string} newToText The new to text.
  * @param {string|JSX.Element} bundleNote The bundle note.
- * @param {string } ctbId The click to buy to register for this upsell instance.
+ * @param {string} ctbId The click to buy to register for this upsell instance.
  * @returns {JSX.Element} The element.
  */
 export const AiGenerateTitlesAndDescriptionsUpsell = ( {

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -16,6 +16,7 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {string} upsellLabel The upsell label.
  * @param {string} newToText The new to text.
  * @param {string|JSX.Element } bundleNote The bundle note.
+ * @param {string } ctbId The click to buy to register for this upsell instance.
  * @returns {JSX.Element} The element.
  */
 export const AiGenerateTitlesAndDescriptionsUpsell = ( {
@@ -28,6 +29,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 	upsellLabel,
 	newToText,
 	bundleNote,
+	ctbId,
 } ) => {
 	const { onClose, initialFocus } = useModalContext();
 
@@ -103,6 +105,8 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 						href={ upsellLink }
 						target="_blank"
 						ref={ initialFocus }
+						data-action="load-nfd-ctb"
+						data-ctb-id={ ctbId }
 					>
 						<LockOpenIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5" />
 						{ upsellLabel }
@@ -148,6 +152,7 @@ AiGenerateTitlesAndDescriptionsUpsell.propTypes = {
 		PropTypes.string,
 		PropTypes.element,
 	] ),
+	ctbId: PropTypes.string,
 };
 
 AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {
@@ -160,4 +165,5 @@ AiGenerateTitlesAndDescriptionsUpsell.defaultProps = {
 	newToText: "Yoast SEO Premium",
 	isProductCopy: false,
 	bundleNote: "",
+	ctbId: "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 };

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -15,7 +15,7 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {string} title The title.
  * @param {string} upsellLabel The upsell label.
  * @param {string} newToText The new to text.
- * @param {string|JSX.Element } bundleNote The bundle note.
+ * @param {string|JSX.Element} bundleNote The bundle note.
  * @param {string } ctbId The click to buy to register for this upsell instance.
  * @returns {JSX.Element} The element.
  */

--- a/packages/js/tests/shared-admin/components/__snapshots__/ai-fix-assessments-upsell.test.js.snap
+++ b/packages/js/tests/shared-admin/components/__snapshots__/ai-fix-assessments-upsell.test.js.snap
@@ -88,6 +88,8 @@ exports[`AiFixAssessmentsUpsell renders the component correctly 1`] = `
     >
       <a
         class="yst-button yst-button--upsell yst-button--extra-large yst-grow"
+        data-action="load-nfd-ctb"
+        data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
         href="https://example.com/upsell"
         target="_blank"
       >

--- a/packages/js/tests/shared-admin/components/__snapshots__/ai-generate-titles-and-descriptions-upsell.test.js.snap
+++ b/packages/js/tests/shared-admin/components/__snapshots__/ai-generate-titles-and-descriptions-upsell.test.js.snap
@@ -86,6 +86,8 @@ exports[`AiGenerateTitlesAndDescriptionsUpsell renders the component correctly f
     >
       <a
         class="yst-button yst-button--upsell yst-button--extra-large yst-grow"
+        data-action="load-nfd-ctb"
+        data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
         href="https://example.com/upsell"
         target="_blank"
       >
@@ -208,6 +210,8 @@ exports[`AiGenerateTitlesAndDescriptionsUpsell renders the component correctly f
     >
       <a
         class="yst-button yst-button--upsell yst-button--extra-large yst-grow"
+        data-action="load-nfd-ctb"
+        data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
         href="https://example.com/upsell"
         target="_blank"
       >


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds data attributes to upsell buttons.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable premium.
* Go to the post editor and click on the `use ai` button in the metabox for both `SEO title` and `Meta description`.
* In the modal make sure that the `Unlock with Yoast SEO Premium` button has the following two data attributes: 
```
data-action="load-nfd-ctb"
data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
```
* Do the same for the  ✨ button in the readability analysis.
* ~~Do the same for the initial upsell popup after first installing the plugin. (This is the same popup as the ✨ one).~~

---
* Make sure you have Woo enabled and premium and our Woo add-on disabled.
* Edit a product and click on `use ai`  Make sure the upsell button shows `Unlock with the Woo Premium bundle*` and  has the following two data attributes: 
```
data-action="load-nfd-ctb"
data-ctb-id="c7e7baa1-2020-420c-a427-89701700b607"
```
* enable only the Woo add-on make sure the button now says `Unlock with Yoast SEO Premium` and 
```
data-action="load-nfd-ctb"
data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
```

* Disable the woo add-on and enable premium make sure the button now says `Unlock with Yoast WooCommerce SEO` and 
```
data-action="load-nfd-ctb"
data-ctb-id=5b32250e-e6f0-44ae-ad74-3cefc8e427f9
```

* Enable premium and make sure the upsell is gone.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
