### PR TITLE
Change the Site Kit dashboard feature flag to an option.

### DIFF
--- a/admin/tracking/class-tracking-settings-data.php
+++ b/admin/tracking/class-tracking-settings-data.php
@@ -233,6 +233,7 @@ class WPSEO_Tracking_Settings_Data implements WPSEO_Collection {
 		'last_known_no_unindexed',
 		'site_kit_connected',
 		'site_kit_usage_tracking',
+		'google_site_kit_feature_enabled',
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -148,6 +148,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'setup_widget_temporarily_dismissed' => 'no',
 			'setup_widget_permanently_dismissed' => 'no',
 		],
+		'google_site_kit_feature_enabled'              => false,
 	];
 
 	/**
@@ -519,6 +520,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				 *  'show_new_content_type_notification'
 				 *  'site_kit_configuration_permanently_dismissed',
 				 * 'site_kit_connected',
+				 * 'google_site_kit_feature_enabled',
 				 *  and most of the feature variables.
 				 */
 				default:
@@ -587,6 +589,7 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'search_cleanup_patterns'            => false,
 			'redirect_search_pretty_urls'        => false,
 			'algolia_integration_active'         => false,
+			'google_site_kit_feature_enabled'    => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/src/conditionals/google-site-kit-feature-conditional.php
+++ b/src/conditionals/google-site-kit-feature-conditional.php
@@ -2,17 +2,35 @@
 
 namespace Yoast\WP\SEO\Conditionals;
 
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
 /**
- * Conditional for the GOOGLE_SITE_KIT_FEATURE feature flag.
+ * Conditional for the Google Site Kit feature.
  */
-class Google_Site_Kit_Feature_Conditional extends Feature_Flag_Conditional {
+class Google_Site_Kit_Feature_Conditional implements Conditional {
 
 	/**
-	 * Returns the name of the feature flag.
+	 * The options helper.
 	 *
-	 * @return string The name of the feature flag.
+	 * @var Options_Helper
 	 */
-	protected function get_feature_flag() {
-		return 'GOOGLE_SITE_KIT_FEATURE';
+	private $options;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Options_Helper $options The options helper.
+	 */
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Returns `true` when the Site Kit feature is enabled.
+	 *
+	 * @return bool `true` when the Site Kit feature is enabled.
+	 */
+	public function is_met() {
+		return $this->options->get( 'google_site_kit_feature_enabled' ) === true;
 	}
 }

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -17,6 +17,13 @@ class Site_Kit {
 	private const SITE_KIT_FILE = 'google-site-kit/google-site-kit.php';
 
 	/**
+	 * The Site Kit feature conditional.
+	 *
+	 * @var Google_Site_Kit_Feature_Conditional
+	 */
+	protected $site_kit_feature_conditional;
+
+	/**
 	 * Variable to locally cache the setup completed value.
 	 *
 	 * @var bool $setup_completed
@@ -68,20 +75,23 @@ class Site_Kit {
 	/**
 	 * The constructor.
 	 *
-	 * @param Site_Kit_Consent_Repository_Interface $site_kit_consent_repository The Site Kit consent repository.
-	 * @param Configuration_Repository              $configuration_repository    The Site Kit permanently dismissed
-	 *                                                                           configuration repository.
-	 * @param Site_Kit_Is_Connected_Call            $site_kit_is_connected_call  The api call to check if the site is
-	 *                                                                           connected.
+	 * @param Site_Kit_Consent_Repository_Interface $site_kit_consent_repository  The Site Kit consent repository.
+	 * @param Configuration_Repository              $configuration_repository     The Site Kit permanently dismissed
+	 *                                                                            configuration repository.
+	 * @param Site_Kit_Is_Connected_Call            $site_kit_is_connected_call   The api call to check if the site is
+	 *                                                                            connected.
+	 * @param Google_Site_Kit_Feature_Conditional   $site_kit_feature_conditional The Site Kit feature conditional.
 	 */
 	public function __construct(
 		Site_Kit_Consent_Repository_Interface $site_kit_consent_repository,
 		Configuration_Repository $configuration_repository,
-		Site_Kit_Is_Connected_Call $site_kit_is_connected_call
+		Site_Kit_Is_Connected_Call $site_kit_is_connected_call,
+		Google_Site_Kit_Feature_Conditional $site_kit_feature_conditional
 	) {
 		$this->site_kit_consent_repository                             = $site_kit_consent_repository;
 		$this->permanently_dismissed_site_kit_configuration_repository = $configuration_repository;
 		$this->site_kit_is_connected_call                              = $site_kit_is_connected_call;
+		$this->site_kit_feature_conditional                            = $site_kit_feature_conditional;
 	}
 
 	/**
@@ -182,7 +192,7 @@ class Site_Kit {
 	 * @return array<string, bool> Returns the name and if the feature is enabled.
 	 */
 	public function to_array(): array {
-		if ( ! ( new Google_Site_Kit_Feature_Conditional() )->is_met() ) {
+		if ( ! $this->site_kit_feature_conditional->is_met() ) {
 			return [];
 		}
 		if ( $this->is_enabled() ) {

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Abstract_Site_Kit_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Abstract_Site_Kit_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Integrations;
 
 use Mockery;
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Interface as Configuration_Repository;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Connection\Site_Kit_Is_Connected_Call;
@@ -49,6 +50,13 @@ abstract class Abstract_Site_Kit_Test extends TestCase {
 	protected $site_kit_is_connected_call;
 
 	/**
+	 * Holds the site kit conditional.
+	 *
+	 * @var Mockery\MockInterface|Google_Site_Kit_Feature_Conditional
+	 */
+	protected $site_kit_conditional;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -61,7 +69,8 @@ abstract class Abstract_Site_Kit_Test extends TestCase {
 		$this->site_kit_consent_repository = Mockery::mock( Site_Kit_Consent_Repository::class );
 		$this->configuration_repository    = Mockery::mock( Configuration_Repository::class );
 		$this->site_kit_is_connected_call  = Mockery::mock( Site_Kit_Is_Connected_Call::class );
+		$this->site_kit_conditional        = Mockery::mock( Google_Site_Kit_Feature_Conditional::class );
 
-		$this->instance = new Site_Kit( $this->site_kit_consent_repository, $this->configuration_repository, $this->site_kit_is_connected_call );
+		$this->instance = new Site_Kit( $this->site_kit_consent_repository, $this->configuration_repository, $this->site_kit_is_connected_call, $this->site_kit_conditional );
 	}
 }

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_No_Conditional_Met_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_No_Conditional_Met_Test.php
@@ -51,6 +51,7 @@ final class Site_Kit_To_Array_No_Conditional_Met_Test extends Abstract_Site_Kit_
 		int $ga_owner_id,
 		array $expected
 	) {
+		$this->site_kit_conditional->expects( 'is_met' )->andReturn( false );
 
 		$this->assertSame( $expected, $this->instance->to_array() );
 	}

--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
@@ -24,6 +24,16 @@ use WP_User;
 final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 
 	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->site_kit_conditional->expects( 'is_met' )->andReturn( true );
+	}
+
+	/**
 	 * Tests if to_array generated correctly.
 	 *
 	 * @dataProvider generate_site_kit_to_array_provider
@@ -61,11 +71,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 		array $authenticated,
 		array $expected
 	) {
-
-		if ( ! \defined( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE' ) ) {
-			\define( 'YOAST_SEO_GOOGLE_SITE_KIT_FEATURE', true );
-		}
-
 		Functions\expect( 'file_exists' )
 			->andReturn( $is_site_kit_installed );
 		Functions\expect( 'is_plugin_active' )

--- a/tests/WP/Dashboard/Infrastructure/Integrations/Is_Site_Kit_On_Boarded_Test.php
+++ b/tests/WP/Dashboard/Infrastructure/Integrations/Is_Site_Kit_On_Boarded_Test.php
@@ -3,9 +3,11 @@
 namespace Yoast\WP\SEO\Tests\WP\Dashboard\Infrastructure\Integrations;
 
 use Generator;
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Interface;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Connection\Site_Kit_Is_Connected_Call;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Fake;
 use Yoast\WP\SEO\Tests\WP\TestCase;
@@ -57,7 +59,8 @@ final class Is_Site_Kit_On_Boarded_Test extends TestCase {
 		$this->site_kit_consent_repository = new Site_Kit_Consent_Repository_Fake();
 		$configuration_repository          = new Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake();
 		$site_kit_is_connected_call        = new Site_Kit_Is_Connected_Call();
-		$this->instance                    = new Site_Kit( $this->site_kit_consent_repository, $configuration_repository, $site_kit_is_connected_call );
+		$site_kit_conditional              = new Google_Site_Kit_Feature_Conditional( new Options_Helper() );
+		$this->instance                    = new Site_Kit( $this->site_kit_consent_repository, $configuration_repository, $site_kit_is_connected_call, $site_kit_conditional );
 	}
 
 	/**

--- a/tests/WP/Dashboard/Infrastructure/Integrations/Is_Site_Kit_On_Boarded_Without_Site_Kit_Test.php
+++ b/tests/WP/Dashboard/Infrastructure/Integrations/Is_Site_Kit_On_Boarded_Without_Site_Kit_Test.php
@@ -2,8 +2,10 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\WP\Dashboard\Infrastructure\Integrations;
 
+use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Connection\Site_Kit_Is_Connected_Call;
 use Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake;
 use Yoast\WP\SEO\Tests\Unit\Dashboard\Infrastructure\Configuration\Site_Kit_Consent_Repository_Fake;
 use Yoast\WP\SEO\Tests\WP\TestCase;
@@ -39,7 +41,8 @@ final class Is_Site_Kit_On_Boarded_Without_Site_Kit_Test extends TestCase {
 		$site_kit_consent_repository = new Site_Kit_Consent_Repository_Fake();
 		$configuration_repository    = new Permanently_Dismissed_Site_Kit_Configuration_Repository_Fake();
 		$site_kit_is_connected_call  = new Site_Kit_Is_Connected_Call();
-		$this->instance              = new Site_Kit( $site_kit_consent_repository, $configuration_repository, $site_kit_is_connected_call );
+		$site_kit_conditional        = new Google_Site_Kit_Feature_Conditional( new Options_Helper() );
+		$this->instance              = new Site_Kit( $site_kit_consent_repository, $configuration_repository, $site_kit_is_connected_call, $site_kit_conditional );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change our `DEFINE` feature flag to an option.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the Google Site Kit feature flag to an options.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have this PR/an RC of the test helper: https://github.com/Yoast/yoast-test-helper/pull/242 and install this on a fresh site together with this PR/RC.
* Make sure the dashboard does not show the Site Kit widget.
* Go to `/wp-admin/tools.php?page=yoast-test-helper` and click `Reset Toogle Site Kit feature flag` (the reset is added by the plugin 🤦 ) . This turns it `ON` in this case.
* Make sure the widget is now on.
* Finish the setup and make sure you see working widgets (Or do this on a local system you know is fully configured).
* Click the `Reset Toogle Site Kit feature flag` and make sure everything is gone now.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
