### PR TITLE
Adjust applicability of 5 keyphrase seo assessments

### DIFF
--- a/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
+++ b/packages/yoastseo/spec/bundledPlugins/previouslyUsedKeywordsSpec.js
@@ -44,6 +44,14 @@ describe( "checks for keyword doubles", function() {
 			"<a href='http://search?keyword%2Fbla&post_type=post' target='_blank'>multiple times before</a>. " +
 			"<a href='https://yoa.st/33y' target='_blank'>Do not use your keyphrase more than once</a>." );
 	} );
+
+	it( "returns feedback when there is no keyphrase", function() {
+		const paper = new Paper( "text", { keyword: "" } );
+		const plugin = new PreviouslyUsedKeywords( app, args );
+		expect( plugin.scoreAssessment( {}, paper ).text ).toBe( "<a href='https://yoa.st/33x' " +
+			"target='_blank'>Previously used keyphrase</a>: No focus keyphrase was set for this page. " +
+			"<a href='https://yoa.st/33y' target='_blank'>Please add a focus keyphrase you haven't used before on other content</a>." );
+	} );
 } );
 
 describe( "checks for keyword doubles2", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -68,7 +68,6 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			" <a href='https://yoa.st/33f' target='_blank'>Fix that</a>!" );
 	} );
 
-
 	it( "returns keyphrase words not found within the first paragraph", function() {
 		const paper = new Paper( "Some text with some keyword. A keyphrase comes here.",
 			{ keyword: "ponies", synonyms: "doggies" } );
@@ -84,7 +83,38 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 			" Your keyphrase or its synonyms do not appear in the first paragraph. <a href='https://yoa.st/33f' target='_blank'>Make sure" +
 			" the topic is clear immediately</a>." );
 	} );
-	it( "returns `hasAIFixes` to be true when the result is BAD", function() {
+
+	it( "returns feedback when there is no keyphrase and no text", function() {
+		const paper = new Paper( "");
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +
+			" <a href='https://yoa.st/33f' target='_blank'>Please add both a keyphrase and an introduction containing the keyphrase</a>." );
+	} );
+
+	it( "returns feedback when no keyphrase is set", function() {
+		const paper = new Paper( "Some text with some keyword. A keyphrase comes here.");
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +
+			" <a href='https://yoa.st/33f' target='_blank'>Please add both a keyphrase and an introduction containing the keyphrase</a>." );
+	} );
+
+	it( "returns feedback when there is no text", function() {
+		const paper = new Paper( "", { keyword: "ponies" } );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33e' target='_blank'>Keyphrase in introduction</a>:" +
+			" <a href='https://yoa.st/33f' target='_blank'>Please add both a keyphrase and an introduction containing the keyphrase</a>." );
+	} );
+
+	it( "returns `hasAIFixes` to be true when the result is BAD and the paper has text and a keyphrase", function() {
 		const paper = new Paper( "Some text with some keyword. A keyphrase comes here.",
 			{ keyword: "ponies", synonyms: "doggies" } );
 		const researcher = Factory.buildMockResearcher( {
@@ -97,14 +127,32 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 		expect( assessment.getScore() ).toBe( 3 );
 		expect( assessment.hasAIFixes() ).toBeTruthy();
 	} );
-	it( "returns no score if no keyword is defined", function() {
-		const isApplicableResult = new IntroductionKeywordAssessment().isApplicable( new Paper( "some text" ) );
-		expect( isApplicableResult ).toBe( false );
+
+	it( "returns `hasAIFixes` to be false when the result is BAD and the paper doesn't have text or a keyphrase", function() {
+		const paper = new Paper( "" );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.hasAIFixes() ).toBeFalsy();
 	} );
 
-	it( "returns no score if no text is defined", function() {
-		const isApplicableResult = new IntroductionKeywordAssessment().isApplicable( new Paper( "", { keyword: "some keyword" } ) );
-		expect( isApplicableResult ).toBe( false );
+	it( "returns `hasAIFixes` to be false when the result is BAD and the paper doesn't have text", function() {
+		const paper = new Paper( "", { keyword: "ponies" } );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.hasAIFixes() ).toBeFalsy();
+	} );
+
+	it( "returns `hasAIFixes` to be false when the result is BAD and the paper doesn't have a keyphrase", function() {
+		const paper = new Paper( "text" );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.hasAIFixes() ).toBeFalsy();
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/IntroductionKeywordAssessmentSpec.js
@@ -85,7 +85,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 	} );
 
 	it( "returns feedback when there is no keyphrase and no text", function() {
-		const paper = new Paper( "");
+		const paper = new Paper( "" );
 		const researcher = Factory.buildMockResearcher( {} );
 		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
 
@@ -95,7 +95,7 @@ describe( "An assessment for finding the keyword in the first paragraph", functi
 	} );
 
 	it( "returns feedback when no keyphrase is set", function() {
-		const paper = new Paper( "Some text with some keyword. A keyphrase comes here.");
+		const paper = new Paper( "Some text with some keyword. A keyphrase comes here." );
 		const researcher = Factory.buildMockResearcher( {} );
 		const assessment = new IntroductionKeywordAssessment().getResult( paper, researcher );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
@@ -152,7 +152,7 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 	} );
 
 	it( "returns a bad result when the paper has no keyphrase", function() {
-		const paper = new Paper( "", { title: "title"} );
+		const paper = new Paper( "", { title: "title" } );
 		const assessment = new KeyphraseInSEOTitleAssessment().getResult( paper, Factory.buildMockResearcher() );
 
 		expect( assessment.getScore() ).toBe( 2 );
@@ -164,7 +164,7 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 	} );
 
 	it( "returns a bad result when the paper has no title", function() {
-		const paper = new Paper( "", { keyphrase: "keyphrase"} );
+		const paper = new Paper( "", { keyphrase: "keyphrase" } );
 		const assessment = new KeyphraseInSEOTitleAssessment().getResult( paper, Factory.buildMockResearcher() );
 
 		expect( assessment.getScore() ).toBe( 2 );

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
@@ -141,10 +141,7 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 
 	it( "returns a bad result when the paper has no keyphrase and no title", function() {
 		const paper = new Paper( "" );
-		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
-			paper,
-			Factory.buildMockResearcher( )
-		);
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult( paper, Factory.buildMockResearcher() );
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
@@ -156,10 +153,7 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 
 	it( "returns a bad result when the paper has no keyphrase", function() {
 		const paper = new Paper( "", { title: "title"} );
-		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
-			paper,
-			Factory.buildMockResearcher( )
-		);
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult( paper, Factory.buildMockResearcher() );
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
@@ -171,10 +165,7 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 
 	it( "returns a bad result when the paper has no title", function() {
 		const paper = new Paper( "", { keyphrase: "keyphrase"} );
-		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
-			paper,
-			Factory.buildMockResearcher( )
-		);
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult( paper, Factory.buildMockResearcher() );
 
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(

--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInSEOTitleAssessmentSpec.js
@@ -138,25 +138,50 @@ describe( "an assessment to check if the keyword is in the SEO title", function(
 			"focus keyphrase appears at the beginning of the SEO title. Good job!"
 		);
 	} );
-} );
 
-describe( "a test to check for the assessment's applicability", () => {
-	it( "returns false isApplicable for a paper without SEO title", function() {
-		const paper = new Paper( "", { keyword: "some keyword", title: "" } );
-		const isApplicableResult = new KeyphraseInSEOTitleAssessment().isApplicable( paper );
-		expect( isApplicableResult ).toBe( false );
+	it( "returns a bad result when the paper has no keyphrase and no title", function() {
+		const paper = new Paper( "" );
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
+			paper,
+			Factory.buildMockResearcher( )
+		);
+
+		expect( assessment.getScore() ).toBe( 2 );
+		expect( assessment.getText() ).toBe(
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in SEO title</a>: " +
+			"<a href='https://yoa.st/33h' target='_blank'>Please add both a keyphrase and an SEO title beginning with the keyphrase</a>."
+		);
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 
-	it( "returns false isApplicable for a paper without keyword", function() {
-		const paper = new Paper( "", { keyword: "", title: "some title" } );
-		const isApplicableResult = new KeyphraseInSEOTitleAssessment().isApplicable( paper );
-		expect( isApplicableResult ).toBe( false );
+	it( "returns a bad result when the paper has no keyphrase", function() {
+		const paper = new Paper( "", { title: "title"} );
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
+			paper,
+			Factory.buildMockResearcher( )
+		);
+
+		expect( assessment.getScore() ).toBe( 2 );
+		expect( assessment.getText() ).toBe(
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in SEO title</a>: " +
+			"<a href='https://yoa.st/33h' target='_blank'>Please add both a keyphrase and an SEO title beginning with the keyphrase</a>."
+		);
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 
-	it( "returns true isApplicable for a paper with keyword and SEO title", function() {
-		const paper = new Paper( "", { keyword: "keyword", title: "some title" } );
-		const isApplicableResult = new KeyphraseInSEOTitleAssessment().isApplicable( paper );
-		expect( isApplicableResult ).toBe( true );
+	it( "returns a bad result when the paper has no title", function() {
+		const paper = new Paper( "", { keyphrase: "keyphrase"} );
+		const assessment = new KeyphraseInSEOTitleAssessment().getResult(
+			paper,
+			Factory.buildMockResearcher( )
+		);
+
+		expect( assessment.getScore() ).toBe( 2 );
+		expect( assessment.getText() ).toBe(
+			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in SEO title</a>: " +
+			"<a href='https://yoa.st/33h' target='_blank'>Please add both a keyphrase and an SEO title beginning with the keyphrase</a>."
+		);
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/MetaDescriptionKeywordAssessmentSpec.js
@@ -13,7 +13,7 @@ const morphologyData = getMorphologyData( "en" );
 
 describe( "a test for the meta description keyword assessment", function() {
 	it( "returns a bad result when the meta description doesn't contain the keyword", function() {
-		const mockPaper = new Paper();
+		const mockPaper = new Paper( "", { keyword: "keyword", description: "description" } );
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherNoMatches );
 
 		expect( assessment.getScore() ).toBe( 3 );
@@ -26,7 +26,7 @@ describe( "a test for the meta description keyword assessment", function() {
 
 	it( "returns a good result and an appropriate feedback message when at least one sentence contains every keyword term " +
 		"at least once in the same sentence.", function() {
-		const mockPaper = new Paper();
+		const mockPaper = new Paper( "", { keyword: "keyword", description: "description" } );
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherOneMatch );
 
 		expect( assessment.getScore() ).toBe( 9 );
@@ -37,7 +37,7 @@ describe( "a test for the meta description keyword assessment", function() {
 
 	it( "returns a good result and an appropriate feedback message when the meta description contains the keyword " +
 		"two times in the same sentence", function() {
-		const mockPaper = new Paper();
+		const mockPaper = new Paper( "", { keyword: "keyword", description: "description" } );
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherTwoMatches );
 
 		expect( assessment.getScore() ).toBe( 9 );
@@ -47,7 +47,7 @@ describe( "a test for the meta description keyword assessment", function() {
 	} );
 
 	it( "returns a bad result when the meta description contains the keyword three times in the same sentence", function() {
-		const mockPaper = new Paper();
+		const mockPaper = new Paper( "", { keyword: "keyword", description: "description" } );
 		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, mockResearcherThreeMatches );
 
 		expect( assessment.getScore() ).toBe( 3 );
@@ -56,20 +56,34 @@ describe( "a test for the meta description keyword assessment", function() {
 			"of 2 times. <a href='https://yoa.st/33l' target='_blank'>Limit that</a>!" );
 	} );
 
-	it( "is not applicable when the paper doesn't have a keyword", function() {
-		const isApplicableResult = new MetaDescriptionKeywordAssessment().isApplicable( new Paper( "text", { description: "description" } ) );
-		expect( isApplicableResult ).toBe( false );
+	it( "returns a bad result when there is no keyphrase and no meta description", function() {
+		const mockPaper = new Paper( "" );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, Factory.buildMockResearcher() );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +
+			"description</a>: <a href='https://yoa.st/33l' target='_blank'>Please add both a keyphrase and a meta description containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 
-	it( "is not applicable when the paper doesn't have a meta description", function() {
-		const isApplicableResult = new MetaDescriptionKeywordAssessment().isApplicable( new Paper( "text", { keyword: "keyword" } ) );
-		expect( isApplicableResult ).toBe( false );
+	it( "returns a bad result when there is no keyphrase", function() {
+		const mockPaper = new Paper( "", { description: "description" } );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, Factory.buildMockResearcher() );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +
+			"description</a>: <a href='https://yoa.st/33l' target='_blank'>Please add both a keyphrase and a meta description containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 
-	it( "is  applicable when the paper has a meta description and a keyword", function() {
-		const isApplicableResult = new MetaDescriptionKeywordAssessment().isApplicable( new Paper( "text",
-			{ keyword: "keyword", description: "description" } ) );
-		expect( isApplicableResult ).toBe( true );
+	it( "returns a bad result when there is no meta description", function() {
+		const mockPaper = new Paper( "", { keyword: "keyword", description: "" } );
+		const assessment = new MetaDescriptionKeywordAssessment().getResult( mockPaper, Factory.buildMockResearcher() );
+
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/33k' target='_blank'>Keyphrase in meta " +
+			"description</a>: <a href='https://yoa.st/33l' target='_blank'>Please add both a keyphrase and a meta description containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
 	} );
 } );
 

--- a/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
@@ -90,6 +90,45 @@ describe( "A keyword in slug count assessment", function() {
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: " +
 			"(Part of) your keyphrase does not appear in the slug. <a href='https://yoa.st/33p' target='_blank'>Change that</a>!" );
 	} );
+
+	it( "assesses a paper with no keyphrase and no slug", function() {
+		const paper = new Paper( "", );
+		const assessment = keywordCountInSlug.getResult(
+			paper,
+			Factory.buildMockResearcher()
+		);
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: " +
+			"<a href='https://yoa.st/33p' target='_blank'>Please add both a keyphrase and a slug containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
+	} );
+
+	it( "assesses a paper with no keyphrase", function() {
+		const paper = new Paper( "", { slug: "sample-with-keyword" });
+		const assessment = keywordCountInSlug.getResult(
+			paper,
+			Factory.buildMockResearcher()
+		);
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: " +
+			"<a href='https://yoa.st/33p' target='_blank'>Please add both a keyphrase and a slug containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
+	} );
+
+	it( "assesses a paper with no slug", function() {
+		const paper = new Paper( "", { keyphrase: "keyphrase" });
+		const assessment = keywordCountInSlug.getResult(
+			paper,
+			Factory.buildMockResearcher()
+		);
+
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/33o' target='_blank'>Keyphrase in slug</a>: " +
+			"<a href='https://yoa.st/33p' target='_blank'>Please add both a keyphrase and a slug containing the keyphrase</a>." );
+		expect( assessment.hasJumps() ).toBeFalsy();
+	} );
 } );
 
 describe( "tests for the assessment applicability.", function() {
@@ -97,11 +136,11 @@ describe( "tests for the assessment applicability.", function() {
 		window.wpseoScriptData = { };
 	} );
 
-	it( "returns false when there is no keyword and slug found.", function() {
+	it( "returns true when there is no keyword and slug found.", function() {
 		const paper = new Paper( "sample keyword" );
 		const researcher = new DefaultResearcher( paper );
 
-		expect( keywordCountInSlug.isApplicable( paper, researcher ) ).toBe( false );
+		expect( keywordCountInSlug.isApplicable( paper, researcher ) ).toBe( true );
 	} );
 
 	it( "returns true when the paper has keyword and slug.", function() {

--- a/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/UrlKeywordAssessmentSpec.js
@@ -92,7 +92,7 @@ describe( "A keyword in slug count assessment", function() {
 	} );
 
 	it( "assesses a paper with no keyphrase and no slug", function() {
-		const paper = new Paper( "", );
+		const paper = new Paper( "" );
 		const assessment = keywordCountInSlug.getResult(
 			paper,
 			Factory.buildMockResearcher()
@@ -105,7 +105,7 @@ describe( "A keyword in slug count assessment", function() {
 	} );
 
 	it( "assesses a paper with no keyphrase", function() {
-		const paper = new Paper( "", { slug: "sample-with-keyword" });
+		const paper = new Paper( "", { slug: "sample-with-keyword" } );
 		const assessment = keywordCountInSlug.getResult(
 			paper,
 			Factory.buildMockResearcher()
@@ -118,7 +118,7 @@ describe( "A keyword in slug count assessment", function() {
 	} );
 
 	it( "assesses a paper with no slug", function() {
-		const paper = new Paper( "", { keyphrase: "keyphrase" });
+		const paper = new Paper( "", { keyphrase: "keyphrase" } );
 		const assessment = keywordCountInSlug.getResult(
 			paper,
 			Factory.buildMockResearcher()

--- a/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
+++ b/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
@@ -22,7 +22,12 @@ export function checkAssessmentAvailability( assessor ) {
 		assessor.assess( new Paper( "", { keyword: "a" } ) );
 		const assessments = getResults( assessor.getValidResults() );
 
-		expect( assessments ).toContain( "functionWordsInKeyphrase" );
+		expect( assessments ).toEqual( [
+			"introductionKeyword",
+			"keyphraseLength",
+			"metaDescriptionKeyword",
+			"functionWordsInKeyphrase",
+		] );
 	} );
 
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {

--- a/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
+++ b/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
@@ -22,7 +22,7 @@ export function checkAssessmentAvailability( assessor ) {
 		assessor.assess( new Paper( "", { keyword: "a" } ) );
 		const assessments = getResults( assessor.getValidResults() );
 
-		expect( assessments ).toContain("functionWordsInKeyphrase" );
+		expect( assessments ).toContain( "functionWordsInKeyphrase" );
 	} );
 
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {

--- a/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
+++ b/packages/yoastseo/spec/specHelpers/scoring/relatedKeyphraseAssessorTests.js
@@ -12,48 +12,17 @@ export function checkAssessmentAvailability( assessor ) {
 		const assessments = getResults( assessor.getValidResults() );
 
 		expect( assessments ).toEqual( [
-			"keyphraseLength",
-		] );
-	} );
-
-	it( "runs assessments that only require a keyword", function() {
-		assessor.assess( new Paper( "", { keyword: "keyword" } ) );
-		const assessments = getResults( assessor.getValidResults() );
-
-		expect( assessments ).toEqual( [
-			"keyphraseLength",
-		] );
-	} );
-
-	it( "runs assessments that only require a keyword that consists of function words only", function() {
-		assessor.assess( new Paper( "", { keyword: "a" } ) );
-		const assessments = getResults( assessor.getValidResults() );
-
-		expect( assessments ).toEqual( [
-			"keyphraseLength",
-			"functionWordsInKeyphrase",
-		] );
-	} );
-
-	it( "additionally runs assessments that require a text and a keyword", function() {
-		assessor.assess( new Paper( "text", { keyword: "keyword" } ) );
-		const assessments = getResults( assessor.getValidResults() );
-
-		expect( assessments ).toEqual( [
-			"introductionKeyword",
-			"keyphraseLength",
-		] );
-	} );
-
-	it( "additionally runs assessments that require a text, a keyword, and a meta description", function() {
-		assessor.assess( new Paper( "text", { keyword: "keyword", description: "description" } ) );
-		const assessments = getResults( assessor.getValidResults() );
-
-		expect( assessments ).toEqual( [
 			"introductionKeyword",
 			"keyphraseLength",
 			"metaDescriptionKeyword",
 		] );
+	} );
+
+	it( "additionally runs assessments that only require a keyword that consists of function words only", function() {
+		assessor.assess( new Paper( "", { keyword: "a" } ) );
+		const assessments = getResults( assessor.getValidResults() );
+
+		expect( assessments ).toContain("functionWordsInKeyphrase" );
 	} );
 
 	it( "additionally runs assessments that require a text of at least 100 words and a keyword", function() {
@@ -72,6 +41,7 @@ export function checkAssessmentAvailability( assessor ) {
 			"introductionKeyword",
 			"keyphraseLength",
 			"keyphraseDensity",
+			"metaDescriptionKeyword",
 		] );
 	} );
 }

--- a/packages/yoastseo/spec/specHelpers/scoring/seoAssessorTests.js
+++ b/packages/yoastseo/spec/specHelpers/scoring/seoAssessorTests.js
@@ -37,13 +37,12 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 		} ) );
 	}
 
-	// Now, let's define two different sets of assessments:
-	// 1. defaultAssessments - Assessments that are available in (almost) all assessors, as they don't require any specific attributes on the Paper.
-	// 2. keyphraseRequiredAssessments - The assessments that additionally require a keyword attribute on the Paper.
-
-	let defaultAssessments = [ "keyphraseLength", "metaDescriptionLength", "titleWidth", "textLength" ];
+	// defaultAssessments - Assessments that are available in (almost) all assessors, as they don't require any specific attributes on the Paper.
+	let defaultAssessments = [ "introductionKeyword", "keyphraseInSEOTitle", "keyphraseLength", "metaDescriptionKeyword",
+										"metaDescriptionLength", "slugKeyword", "titleWidth", "textLength" ];
 	if ( isStoreBlog ) {
-		defaultAssessments.pop();
+		// The introduction keyword and text length assessments are not available on store blogs.
+		defaultAssessments = defaultAssessments.slice( 1, -1 )
 	}
 
 	let extraDefaultAssessments = [ "images", "externalLinks", "internalLinks" ];
@@ -55,11 +54,6 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 	}
 
 	defaultAssessments = [ ...defaultAssessments, ...extraDefaultAssessments ];
-
-	const keyphraseRequiredAssessments = defaultAssessments.concat( "introductionKeyword" );
-	if ( isStoreBlog ) {
-		keyphraseRequiredAssessments.pop();
-	}
 
 	// Now, let's run those tests!
 
@@ -78,13 +72,6 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 		expect( assessments.sort() ).toEqual( expected.sort() );
 	} );
 
-	it( "additionally runs assessments that only require a text and a keyword", function() {
-		const paper = new Paper( "text", { keyword: "keyword" } );
-		const assessments = assess( paper );
-
-		expect( assessments.sort() ).toEqual( keyphraseRequiredAssessments.sort() );
-	} );
-
 	it( "additionally runs assessments that only require a keyword that contains function words only", function() {
 		const paper = new Paper( "", { keyword: "a" } );
 		const assessments = assess( paper );
@@ -97,23 +84,8 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 		const paper = new Paper( text, { keyword: "keyword", synonyms: "synonym" } );
 		const assessments = assess( paper );
 
-		const expected = isStoreBlog ? keyphraseRequiredAssessments : keyphraseRequiredAssessments.concat( "keyphraseDensity" );
+		const expected = isStoreBlog ? defaultAssessments : defaultAssessments.concat( "keyphraseDensity" );
 		expect( assessments.sort() ).toEqual( expected.sort() );
-	} );
-
-	it( "additionally runs assessments that require a text and a super-long slug with stop words", function() {
-		const paper = new Paper( "text",
-			{ slug: "a-sample-slug-a-sample-slug-a-sample-slug-a-sample-slug-a-sample-slug-a-sample-slug-a-sample-slug-a-sample-slug" } );
-		const assessments = assess( paper );
-
-		expect( assessments.sort() ).toEqual( defaultAssessments.sort() );
-	} );
-
-	it( "additionally runs assessments that require a text, a slug and a keyword", function() {
-		const paper = new Paper( "text", { keyword: "keyword", slug: "sample-slug" } );
-		const assessments = assess( paper );
-
-		expect( assessments.sort() ).toEqual( keyphraseRequiredAssessments.concat( "slugKeyword" ).sort() );
 	} );
 
 	// These specifications will additionally trigger the largest keyword distance assessment.
@@ -134,7 +106,7 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 		const assessments = assess( paper );
 
 		const keyphraseAssessments = isProductAssessor ? [ "keyphraseDistribution", "keyphraseDensity" ] : [ "keyphraseDensity" ];
-		const expected = isStoreBlog ? keyphraseRequiredAssessments : [ ...keyphraseRequiredAssessments, ...keyphraseAssessments ];
+		const expected = isStoreBlog ? defaultAssessments : [ ...defaultAssessments, ...keyphraseAssessments ];
 		expect( assessments.sort() ).toEqual( expected.sort() );
 	} );
 
@@ -155,7 +127,7 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 		const assessments = assess( paper );
 
 		const keyphraseAssessments = isProductAssessor ? [ "keyphraseDistribution", "keyphraseDensity" ] : [ "keyphraseDensity" ];
-		const expected = isStoreBlog ? keyphraseRequiredAssessments : [ ...keyphraseRequiredAssessments, ...keyphraseAssessments ];
+		const expected = isStoreBlog ? defaultAssessments : [ ...defaultAssessments, ...keyphraseAssessments ];
 		expect( assessments.sort() ).toEqual( expected.sort() );
 	} );
 }

--- a/packages/yoastseo/spec/specHelpers/scoring/seoAssessorTests.js
+++ b/packages/yoastseo/spec/specHelpers/scoring/seoAssessorTests.js
@@ -39,10 +39,10 @@ export function checkAssessmentAvailability( assessor, isProductAssessor = false
 
 	// defaultAssessments - Assessments that are available in (almost) all assessors, as they don't require any specific attributes on the Paper.
 	let defaultAssessments = [ "introductionKeyword", "keyphraseInSEOTitle", "keyphraseLength", "metaDescriptionKeyword",
-										"metaDescriptionLength", "slugKeyword", "titleWidth", "textLength" ];
+		"metaDescriptionLength", "slugKeyword", "titleWidth", "textLength" ];
 	if ( isStoreBlog ) {
 		// The introduction keyword and text length assessments are not available on store blogs.
-		defaultAssessments = defaultAssessments.slice( 1, -1 )
+		defaultAssessments = defaultAssessments.slice( 1, -1 );
 	}
 
 	let extraDefaultAssessments = [ "images", "externalLinks", "internalLinks" ];

--- a/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
+++ b/packages/yoastseo/src/scoring/assessments/SCORING SEO.md
@@ -29,7 +29,7 @@ Thus, this calculation make the overall score work on a 0-100/0-10 scale rather 
 
 **Uses synonyms**: yes
 
-**When it applies**: If there is a text and a keyword.
+**When it applies**: Always.
 
 **Name in code**: IntroductionKeywordAssessment
 
@@ -37,11 +37,12 @@ Thus, this calculation make the overall score work on a 0-100/0-10 scale rather 
 
 **Call to action URL**: [https://yoa.st/33f](https://yoast.com/focus-keyphrase-in-introduction/#utm_source=yoast-seo&utm_medium=software&utm_term=introduction-has-keyword-cta&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-| Traffic light   	      | Score	     | Criterion | Feedback |
-|------------	|------------------	|---------------------	|---------------	|
-| Red   	      | 3	     | Not all content words are found in the first paragraph	 | **Keyphrase in introduction**: Your keyphrase or its synonyms do not appear in the first paragraph. **Make sure the topic is clear immediately**. |
-| Orange   	      | 6	     | All content words are found in the first paragraph, but not in the same sentence	 | **Keyphrase in introduction**: Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. **Fix that**! |
-| Green   	      | 9	     | All content words from the keyphrase or synonym phrase are within one sentence in the first paragraph	 | **Keyphrase in introduction**: Well done! |
+| Traffic light   	      | Score	     | Criterion                                                                                             | Feedback                                                                                                                                            |
+|------------	|------------------	|-------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Red   	      | 3	     | There is no keyphrase and/or content	                                                                 | **Keyphrase in introduction**: **Please add both a keyphrase and an introduction containing the keyphrase**.                                        |
+| Red   	      | 3	     | Not all content words are found in the first paragraph	                                               | **Keyphrase in introduction**: Your keyphrase or its synonyms do not appear in the first paragraph. **Make sure the topic is clear immediately**.   |
+| Orange   	      | 6	     | All content words are found in the first paragraph, but not in the same sentence	                     | **Keyphrase in introduction**: Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. **Fix that**! |
+| Green   	      | 9	     | All content words from the keyphrase or synonym phrase are within one sentence in the first paragraph	 | **Keyphrase in introduction**: Well done!                                                                                                           |
 
 ### 2) Keyphrase length
 **What it does**: Checks whether the number of (content) words in the keyphrase is within the recommended limit. For languages with function word support only content words are considered. For languages without function word support all words are considered.
@@ -92,7 +93,7 @@ A simple model shows that as the text length (in words) goes up, the keyphrase d
 
 **Uses synonyms**: yes
 
-**When it applies**: If there is a meta description and a keyword.
+**When it applies**: Always.
 
 **Name in code**: MetaDescriptionKeywordAssessment
 
@@ -100,11 +101,12 @@ A simple model shows that as the text length (in words) goes up, the keyphrase d
 
 **Call to action URL**: [https://yoa.st/33l](https://yoast.com/meta-descriptions/#utm_source=yoast-seo&utm_medium=software&utm_term=metadescriptionkeyword-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-| Traffic light   	      | Score	     | Criterion | Feedback |
-|------------	|------------------	|---------------------	|---------------	|
-| Red	| 3	| 0 keyword matches		| **Keyphrase in meta description**: The metadescription has been specified, but it does not contain the keyphrase. **Fix that!** |
-| Red	| 3	| >2 found matches		| **Keyphrase in meta description**: The meta description contains the keyphrase __ times, which is over the advised maximum of 2 times. **Limit that!** |
-| Green	| 9	| 1-2 sentences with a found match		| **Keyphrase in meta description**: Keyphrase or synonym appear in the metadescription. Well done! |
+| Traffic light   	      | Score	     | Criterion                                       | Feedback                                                                                                                                               |
+|------------	|------------------	|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Red	| 3	| There is no keyphrase and/or meta description		 | **Keyphrase in meta description**: **Please add both a keyphrase and a meta description containing the keyphrase.**                                    |
+| Red	| 3	| 0 keyword matches		                             | **Keyphrase in meta description**: The metadescription has been specified, but it does not contain the keyphrase. **Fix that!**                        |
+| Red	| 3	| >2 found matches		                              | **Keyphrase in meta description**: The meta description contains the keyphrase __ times, which is over the advised maximum of 2 times. **Limit that!** |
+| Green	| 9	| 1-2 sentences with a found match		              | **Keyphrase in meta description**: Keyphrase or synonym appear in the metadescription. Well done!                                                      |
 
 ### 5) Keyphrase in subheadings
 **What it does**: Checks whether H2 and H3 subheadings reflect the topic of the copy (based on keyphrase or synonyms). For languages with function word support, a subheading is considered to reflect the topic if at least half of words from the keyphrase are used in it. For languages without function word support, a subheading is considered to reflect the topic if all content words from the keyphrase are used in it.
@@ -182,7 +184,7 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 
 **Uses synonyms**: no
 
-**When it applies**: If there is a title and a keyword.
+**When it applies**: Always.
 
 **Name in code**: TitleKeywordAssessment
 
@@ -190,20 +192,21 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 
 **Call to action URL**: [https://yoa.st/33h](https://yoast.com/page-titles-seo/#utm_source=yoast-seo&utm_medium=software&utm_term=title-keyword-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-| Traffic light   	      | Score	     | Criterion | Feedback |
-|------------	|------------------	|---------------------	|---------------	|
-| Red	| 2	| You haven't used all the content words from your keyphrase and your keyphrase isn’t at the beginning		| **Keyphrase in SEO title**: Not all the words from your keyphrase 'your_keyphrase_here' appear in the SEO title. **For the best SEO results write the exact match of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title.** |
-| Red	| 2	| You haven’t used your exact keyphrase, when the keyphrase is enclosed in quotation marks		| **Keyphrase in SEO title**: Does not contain the exact match. **Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.** |
-| Orange	| 6	| The exact match of the keyphrase doesn’t appear at the beginning of the SEO title		| **Keyphrase in SEO title**: The exact match of the focus keyphrase appears in the SEO title, but not at the beginning. **Move it to the beginning for the best results.** |
-| Orange	| 6	| SEO title does not contain an exact match of your keyphrase		| **Keyphrase in SEO title**: Does not contain the exact match. **Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.** |
-| Green	| 9	| SEO title contains the exact match of the focus keyphrase at beginning		| **Keyphrase in SEO title**: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job! |
+| Traffic light   	      | Score	     | Criterion                                                                                              | Feedback                                                                                                                                                                                                                                                     |
+|------------	|------------------	|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Red	| 2	| There is no keyphrase and/or SEO title		                                                               | **Keyphrase in SEO title**: **Please add both a keyphrase and an SEO title beginning with the keyphrase**.                                                                                                                                                   |
+| Red	| 2	| You haven't used all the content words from your keyphrase and your keyphrase isn’t at the beginning		 | **Keyphrase in SEO title**: Not all the words from your keyphrase 'your_keyphrase_here' appear in the SEO title. **For the best SEO results write the exact match of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title.** |
+| Red	| 2	| You haven’t used your exact keyphrase, when the keyphrase is enclosed in quotation marks		             | **Keyphrase in SEO title**: Does not contain the exact match. **Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.**                                                                                  |
+| Orange	| 6	| The exact match of the keyphrase doesn’t appear at the beginning of the SEO title		                    | **Keyphrase in SEO title**: The exact match of the focus keyphrase appears in the SEO title, but not at the beginning. **Move it to the beginning for the best results.**                                                                                    |
+| Orange	| 6	| SEO title does not contain an exact match of your keyphrase		                                          | **Keyphrase in SEO title**: Does not contain the exact match. **Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.**                                                                                  |
+| Green	| 9	| SEO title contains the exact match of the focus keyphrase at beginning		                               | **Keyphrase in SEO title**: The exact match of the focus keyphrase appears at the beginning of the SEO title. Good job!                                                                                                                                      |
 
 ### 9) Keyphrase in slug
 **What it does**: Checks if the keyphrase is used in the slug.
 
 **Uses synonyms**: no
 
-**When it applies**: If there is a slug and a keyword.
+**When it applies**: Always.
 
 **Name in code**: SlugKeywordAssessment
 
@@ -211,13 +214,14 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 
 **Call to action URL**: [https://yoa.st/33p](https://yoast.com/slug/#utm_source=yoast-seo&utm_medium=software&utm_term=urlkeyword-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-| Traffic light   	      | Score	     | Criterion | Feedback |
-|------------	|------------------	|---------------------	|---------------	|
-| Orange (in cornerstone: Red)		| 6 (in cornerstone: 3)		| Not all content words are in the slug		| **Keyphrase in slug**: (Part of) your keyphrase does not appear in the slug. **Change that!** |
-| Green	| 9	| For short keyphrases (1-2 content words): All content words are in the slug			| **Keyphrase in slug**: Great work! |
-| Green	| 9	| For longer keyphrases (>2 content words): More than half content words are in the slug		| **Keyphrase in slug**: More than half of your keyphrase appears in the slug. That's great! |
+| Traffic light   	              | Score	                  | Criterion                                                                                | Feedback                                                                                      |
+|--------------------------------|-------------------------|------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
+| Red		                          | 3		                     | There is no keyphrase and/or slug		                                                      | **Keyphrase in slug**: **Please add both a keyphrase and a slug containing the keyphrase**.   |
+| Orange (in cornerstone: Red)		 | 6 (in cornerstone: 3)		 | Not all content words are in the slug		                                                  | **Keyphrase in slug**: (Part of) your keyphrase does not appear in the slug. **Change that!** |
+| Green	                         | 9	                      | For short keyphrases (1-2 content words): All content words are in the slug			           | **Keyphrase in slug**: Great work!                                                            |
+| Green	                         | 9	                      | For longer keyphrases (>2 content words): More than half content words are in the slug		 | **Keyphrase in slug**: More than half of your keyphrase appears in the slug. That's great!    |
 
-### 10) Previously used keywords
+### 10) Previously used keywords (only in WordPress)
 **What it does**: Checks if the words from the keyphrase were previously used in a keyphrase for a different post.
 
 **Uses synonyms**: no
@@ -230,11 +234,12 @@ With the example keyphrase `cat and dog` the following criteria would apply to c
 
 **Call to action URL**: [https://yoa.st/33y](https://yoast.com/use-focus-keyword-once/#utm_source=yoast-seo&utm_medium=software&utm_term=previously-used-keywords-name&utm_content=content-analysis) (link placement is in bold in the feedback strings)
 
-| Traffic light   	      | Score	     | Criterion | Feedback |
-|------------	|------------------	|---------------------	|---------------	|
-| Red	| 1	| The keyphrase is previously used more than once	| **Previously used keyphrase**: You've used this keyphrase X times before. **Do not use your keyphrase more than once.**	|
-| Orange	| 6	| The keyphrase is previously used once	| **Previously used keyphrase**: You've used this keyphrase once before. **Do not use your keyphrase more than once.**	|
-| Green	| 9	| The keyphrase hasn't been used before	|  **Previously used keyphrase**: You've not used this keyphrase before, very good.	|
+| Traffic light   	      | Score	     | Criterion                                        | Feedback                                                                                                                                             |
+|------------	|------------------	|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Red	| 1	| There is no keyphrase	                           | **Previously used keyphrase**: No focus keyphrase was set for this page. **Please add a focus keyphrase you haven't used before on other content**.	 |
+| Red	| 1	| The keyphrase is previously used more than once	 | **Previously used keyphrase**: You've used this keyphrase X times before. **Do not use your keyphrase more than once.**	                             |
+| Orange	| 6	| The keyphrase is previously used once	           | **Previously used keyphrase**: You've used this keyphrase once before. **Do not use your keyphrase more than once.**	                                |
+| Green	| 9	| The keyphrase hasn't been used before	           | **Previously used keyphrase**: You've not used this keyphrase before, very good.	                                                                    |
 
 ### 11) Keyphrase distribution (only in Premium)
 **What it does**: Checks how well the words from the keyphrase are distributed throughout the text. For exact implementation check out https://github.com/Yoast/YoastSEO.js/issues/1558 and https://github.com/Yoast/YoastSEO.js/issues/1868.

--- a/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
@@ -52,17 +52,17 @@ export default class IntroductionKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
-		let shouldSetAIFixes = false;
+		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasText() ) {
 			this._firstParagraphMatches = researcher.getResearch( "findKeywordInFirstParagraph" );
-			shouldSetAIFixes = true;
+			this._canAssess = true;
 		}
 		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( calculatedResult.score < 9 && shouldSetAIFixes ) {
+		if ( calculatedResult.score < 9 && this._canAssess ) {
 			assessmentResult.setHasAIFixes( true );
 		}
 		return assessmentResult;
@@ -74,7 +74,7 @@ export default class IntroductionKeywordAssessment extends Assessment {
 	 * @returns {{score: number, resultText: string}} result object with a score and translation text.
 	 */
 	calculateResult() {
-		if ( ! this._firstParagraphMatches ) {
+		if ( ! this._canAssess ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: sprintf(

--- a/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
@@ -2,23 +2,28 @@ import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash";
 
 import Assessment from "../assessment";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import AssessmentResult from "../../../values/AssessmentResult";
+
+/**
+ * @typedef {import("../../../languageProcessing/AbstractResearcher").default } Researcher
+ * @typedef {import("../../../values/").Paper } Paper
+ */
 
 /**
  * Assessment to check whether the keyphrase or synonyms are encountered in the first paragraph of the article.
  */
-class IntroductionKeywordAssessment extends Assessment {
+export default class IntroductionKeywordAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
 	 * @param {Object} [config] The configuration to use.
+	 * @param {Object} [config.scores] The scores to use.
 	 * @param {number} [config.scores.good] The score to return if there is a match within one sentence in the first paragraph.
 	 * @param {number} [config.scores.okay] The score to return if all words are matched in the first paragraph.
 	 * @param {number} [config.scores.bad] The score to return if not all words are matched in the first paragraph.
-	 * @param {string} [config.url] The URL to the relevant article on Yoast.com.
-	 *
-	 * @returns {void}
+	 * @param {string} [config.urlTitle] The URL to the relevant article on Yoast.com to add to the title of the assessment in the feedback.
+	 * @param {string} [config.urlCallToAction] The URL to the relevant article on Yoast.com to add to the call to action in the assessment feedback.
 	 */
 	constructor( config = {} ) {
 		super();
@@ -47,35 +52,44 @@ class IntroductionKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
+		let hasAIFixes = false;
 
-		this._firstParagraphMatches = researcher.getResearch( "findKeywordInFirstParagraph" );
+		if ( paper.hasKeyword() && paper.hasText() ) {
+			this._firstParagraphMatches = researcher.getResearch( "findKeywordInFirstParagraph" );
+			hasAIFixes = true;
+		}
 		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
 		if ( calculatedResult.score < 9 ) {
-			assessmentResult.setHasAIFixes( true );
+			assessmentResult.setHasAIFixes( hasAIFixes );
 		}
 		return assessmentResult;
 	}
 
 	/**
-	 * Checks if the paper has both keyword and text.
-	 *
-	 * @param {Paper} paper The paper to be analyzed.
-	 *
-	 * @returns {boolean} Whether the assessment is applicable or not.
-	 */
-	isApplicable( paper ) {
-		return paper.hasKeyword() && paper.hasText();
-	}
-
-	/**
 	 * Returns a result based on the number of occurrences of keyphrase in the first paragraph.
 	 *
-	 * @returns {Object} result object with a score and translation text.
+	 * @returns {{score: number, resultText: string}} result object with a score and translation text.
 	 */
 	calculateResult() {
+		if ( ! this._firstParagraphMatches ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: sprintf(
+					/* translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag. */
+					__(
+						"%1$sKeyphrase in introduction%3$s: %2$sPlease add both a keyphrase and an introduction containing the keyphrase%3$s.",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
 		if ( this._firstParagraphMatches.foundInOneSentence ) {
 			return {
 				score: this._config.scores.good,
@@ -122,5 +136,3 @@ class IntroductionKeywordAssessment extends Assessment {
 		};
 	}
 }
-
-export default IntroductionKeywordAssessment;

--- a/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
@@ -52,6 +52,7 @@ export default class IntroductionKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
+		// Whether the paper has the data needed to return meaningful feedback (keyphrase and text).
 		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasText() ) {

--- a/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/IntroductionKeywordAssessment.js
@@ -52,18 +52,18 @@ export default class IntroductionKeywordAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const assessmentResult = new AssessmentResult();
-		let hasAIFixes = false;
+		let shouldSetAIFixes = false;
 
 		if ( paper.hasKeyword() && paper.hasText() ) {
 			this._firstParagraphMatches = researcher.getResearch( "findKeywordInFirstParagraph" );
-			hasAIFixes = true;
+			shouldSetAIFixes = true;
 		}
 		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( calculatedResult.score < 9 ) {
-			assessmentResult.setHasAIFixes( hasAIFixes );
+		if ( calculatedResult.score < 9 && shouldSetAIFixes ) {
+			assessmentResult.setHasAIFixes( true );
 		}
 		return assessmentResult;
 	}

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
@@ -70,12 +70,12 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const language = getLanguage( paper.getLocale() );
-		let shouldSetJumps = false;
+		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasTitle() ) {
 			this._keyphraseMatches = researcher.getResearch( "findKeyphraseInSEOTitle" );
 			this._keyphrase = escape( paper.getKeyword() );
-			shouldSetJumps = true;
+			this._canAssess = true;
 		}
 
 		const assessmentResult = new AssessmentResult();
@@ -83,7 +83,7 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 		const calculatedResult = this.calculateResult( this._keyphrase, language );
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( assessmentResult.getScore() < 9 && shouldSetJumps ) {
+		if ( assessmentResult.getScore() < 9 && this._canAssess ) {
 			assessmentResult.setHasJumps( true );
 			assessmentResult.setEditFieldName( __( "SEO title", "wordpress-seo" ) );
 		}
@@ -104,7 +104,7 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 	calculateResult( keyphrase, language ) {
 		const assessmentLink = this._config.urlTitle + this.name + "</a>";
 
-		if( ! this._keyphraseMatches ) {
+		if( ! this._canAssess ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: sprintf(

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
@@ -3,24 +3,32 @@ import { escape, merge } from "lodash";
 import getLanguage from "../../../languageProcessing/helpers/language/getLanguage";
 
 import Assessment from "../assessment";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import AssessmentResult from "../../../values/AssessmentResult";
+
+/**
+ * @typedef {import("../../../languageProcessing/AbstractResearcher").default } Researcher
+ * @typedef {import("../../../values/").Paper } Paper
+ */
 
 /**
  * Assessment to check whether the keyphrase is included in (the beginning of) the SEO title.
  */
-class KeyphraseInSEOTitleAssessment extends Assessment {
+export default class KeyphraseInSEOTitleAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
 	 * @param {Object} [config] The configuration to use.
+	 * @param {number} [config.parameters] The parameters to use.
 	 * @param {number} [config.parameters.recommendedPosition] The recommended position of the keyphrase within the SEO title.
+	 * @param {Object} [config.scores] The scores to use.
 	 * @param {number} [config.scores.good] The score to return if the keyphrase is found at the recommended position.
 	 * @param {number} [config.scores.okay] The score to return if the keyphrase is found, but not at the recommended position.
 	 * @param {number} [config.scores.bad] The score to return if there are fewer keyphrase occurrences than the recommended minimum.
-	 * @param {string} [config.url] The URL to the relevant article on Yoast.com.
-	 *
-	 * @returns {void}
+	 * @param {string} [config.urlTitle] The URL to the relevant article on Yoast.com to add to the title of the assessment in the feedback.
+	 * @param {string} [config.urlCallToAction] The URL to the relevant article on Yoast.com to add to the call to action in the assessment feedback.
+	 * @param {Object} [config.feedbackStrings] The feedback strings to use.
+	 * @param {string} [config.feedbackStrings.bad] The feedback string to use when the assessment gives a bad score.
 	 */
 	constructor( config = {} ) {
 		super();
@@ -62,31 +70,25 @@ class KeyphraseInSEOTitleAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const language = getLanguage( paper.getLocale() );
-		this._keyphraseMatches = researcher.getResearch( "findKeyphraseInSEOTitle" );
-		this._keyphrase = escape( paper.getKeyword() );
+		let shouldSetJumps = false;
+
+		if ( paper.hasKeyword() && paper.hasTitle() ) {
+			this._keyphraseMatches = researcher.getResearch( "findKeyphraseInSEOTitle" );
+			this._keyphrase = escape( paper.getKeyword() );
+			shouldSetJumps = true;
+		}
 
 		const assessmentResult = new AssessmentResult();
 
 		const calculatedResult = this.calculateResult( this._keyphrase, language );
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( assessmentResult.getScore() < 9  ) {
+		if ( assessmentResult.getScore() < 9 && shouldSetJumps ) {
 			assessmentResult.setHasJumps( true );
 			assessmentResult.setEditFieldName( __( "SEO title", "wordpress-seo" ) );
 		}
 
 		return assessmentResult;
-	}
-
-	/**
-	 * Checks whether the assessment is applicable to the paper
-	 *
-	 * @param {Paper} paper The Paper object to assess.
-	 *
-	 * @returns {boolean} Whether the paper has a keyphrase and an SEO title.
-	 */
-	isApplicable( paper ) {
-		return paper.hasKeyword() && paper.hasTitle();
 	}
 
 	/**
@@ -97,9 +99,28 @@ class KeyphraseInSEOTitleAssessment extends Assessment {
 	 * @param {string}  keyphrase   The keyphrase of the paper (to be returned in the feedback strings).
 	 * @param {string}  language    The language to check.
 	 *
-	 * @returns {Object} Object with score and text.
+	 * @returns {{score: number, resultText: string}} Object with score and text.
 	 */
 	calculateResult( keyphrase, language ) {
+		const assessmentLink = this._config.urlTitle + this.name + "</a>";
+
+		if( ! this._keyphraseMatches ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: sprintf(
+					/* translators: %1$s expands to the title of the "Keyphrase in SEO title" assessment (translated to the current language)
+					 and links to an article on yoast.com. %2$s expands to a link on yoast.com, %3$s expands to the anchor end tag. */
+					__(
+						"%1$s: %2$sPlease add both a keyphrase and an SEO title beginning with the keyphrase%3$s.",
+						"wordpress-seo"
+					),
+					assessmentLink,
+					this._config.urlCallToAction,
+					"</a>",
+				),
+			};
+		}
+
 		const feedbackStrings = this._config.feedbackStrings;
 		if ( language === "ja" ) {
 			feedbackStrings.bad = __( "For the best SEO results include all words of your keyphrase in the SEO title, " +
@@ -109,8 +130,6 @@ class KeyphraseInSEOTitleAssessment extends Assessment {
 		const position = this._keyphraseMatches.position;
 		const allWordsFound = this._keyphraseMatches.allWordsFound;
 		const exactMatchKeyphrase = this._keyphraseMatches.exactMatchKeyphrase;
-
-		const assessmentLink = this._config.urlTitle + this.name + "</a>";
 
 		if ( exactMatchFound === true ) {
 			if ( position === 0 ) {
@@ -228,5 +247,3 @@ class KeyphraseInSEOTitleAssessment extends Assessment {
 		};
 	}
 }
-
-export default KeyphraseInSEOTitleAssessment;

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInSEOTitleAssessment.js
@@ -70,6 +70,7 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 	 */
 	getResult( paper, researcher ) {
 		const language = getLanguage( paper.getLocale() );
+		// Whether the paper has the data needed to return meaningful feedback (keyphrase and SEO title).
 		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasTitle() ) {
@@ -104,7 +105,7 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 	calculateResult( keyphrase, language ) {
 		const assessmentLink = this._config.urlTitle + this.name + "</a>";
 
-		if( ! this._canAssess ) {
+		if ( ! this._canAssess ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: sprintf(
@@ -116,7 +117,7 @@ export default class KeyphraseInSEOTitleAssessment extends Assessment {
 					),
 					assessmentLink,
 					this._config.urlCallToAction,
-					"</a>",
+					"</a>"
 				),
 			};
 		}

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -49,10 +49,10 @@ export default class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {AssessmentResult} The assessment result.
 	 */
 	getResult( paper, researcher ) {
+		// Whether the paper has the data needed to return meaningful feedback (keyphrase and meta description).
 		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasDescription() ) {
-			console.log( "has keyword and description" );
 			this._keyphraseCounts = researcher.getResearch( "metaDescriptionKeyword" );
 			this._canAssess = true;
 		}
@@ -76,7 +76,7 @@ export default class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {{score: number, resultText: string}} Result object with score and text.
 	 */
 	calculateResult() {
-		if( ! this._canAssess ) {
+		if ( ! this._canAssess ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: sprintf(

--- a/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/MetaDescriptionKeywordAssessment.js
@@ -2,34 +2,34 @@ import { __, sprintf } from "@wordpress/i18n";
 import { merge } from "lodash";
 
 import Assessment from "../assessment";
-import { createAnchorOpeningTag } from "../../../helpers/shortlinker";
+import { createAnchorOpeningTag } from "../../../helpers";
 import AssessmentResult from "../../../values/AssessmentResult";
+
+/**
+ * @typedef {import("../../../languageProcessing/AbstractResearcher").default } Researcher
+ * @typedef {import("../../../values/").Paper } Paper
+ */
 
 /**
  * Assessment for checking the keyword matches in the meta description.
  */
-class MetaDescriptionKeywordAssessment extends Assessment {
+export default class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
 	 * Sets the identifier and the config.
 	 *
 	 * @param {Object} [config] The configuration to use.
-	 * @param {number} [config.parameters.recommendedMinimum] The recommended minimum of keyword occurrences in the meta description.
 	 * @param {number} [config.scores.good] The score to return if there are enough keyword occurrences in the meta description.
-	 * @param {number} [config.scores.bad] The score to return if there aren't enough keyword occurrences in the meta description.
-	 * @param {string} [config.url] The URL to the relevant article on Yoast.com.
+	 * @param {number} [config.scores.bad] The score to return if there are no or too many keyword occurrences in the meta description.
+	 * @param {string} [config.urlTitle] The URL to the relevant article on Yoast.com to add to the title of the assessment in the feedback.
+	 * @param {string} [config.urlCallToAction] The URL to the relevant article on Yoast.com to add to the call to action in the assessment feedback.
 	 *
-	 * @returns {void}
 	 */
 	constructor( config = {} ) {
 		super();
 
 		const defaultConfig = {
-			parameters: {
-				recommendedMinimum: 1,
-			},
 			scores: {
 				good: 9,
-				ok: 6,
 				bad: 3,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/33k" ),
@@ -49,13 +49,20 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	 * @returns {AssessmentResult} The assessment result.
 	 */
 	getResult( paper, researcher ) {
-		this._keyphraseCounts = researcher.getResearch( "metaDescriptionKeyword" );
+		this._canAssess = false;
+
+		if ( paper.hasKeyword() && paper.hasDescription() ) {
+			console.log( "has keyword and description" );
+			this._keyphraseCounts = researcher.getResearch( "metaDescriptionKeyword" );
+			this._canAssess = true;
+		}
+
 		const assessmentResult = new AssessmentResult();
 		const calculatedResult = this.calculateResult();
 
 		assessmentResult.setScore( calculatedResult.score );
 		assessmentResult.setText( calculatedResult.resultText );
-		if ( assessmentResult.getScore() < 9  ) {
+		if ( assessmentResult.getScore() < 9 && this._canAssess  ) {
 			assessmentResult.setHasJumps( true );
 			assessmentResult.setEditFieldName( __( "meta description", "wordpress-seo" ) );
 		}
@@ -66,9 +73,25 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 	/**
 	 * Returns the result object based on the number of keyword matches in the meta description.
 	 *
-	 * @returns {Object} Result object with score and text.
+	 * @returns {{score: number, resultText: string}} Result object with score and text.
 	 */
 	calculateResult() {
+		if( ! this._canAssess ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: sprintf(
+					/* translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
+					__(
+						"%1$sKeyphrase in meta description%3$s: %2$sPlease add both a keyphrase and a meta description containing the keyphrase%3$s.",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
+		}
+
 		// GOOD result when the meta description contains a keyphrase or synonym 1 or 2 times.
 		if ( this._keyphraseCounts === 1 || this._keyphraseCounts === 2 ) {
 			return {
@@ -109,7 +132,7 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 			};
 		}
 
-		// BAD if the keyphrases is not contained in the meta description.
+		// BAD if the keyphrase is not contained in the meta description.
 		return {
 			score: this._config.scores.bad,
 			resultText: sprintf(
@@ -129,17 +152,4 @@ class MetaDescriptionKeywordAssessment extends Assessment {
 			),
 		};
 	}
-
-	/**
-	 * Checks whether the paper has a keyword and a meta description.
-	 *
-	 * @param {Paper} paper The paper to use for the assessment.
-	 *
-	 * @returns {boolean} True if the paper has a keyword and a meta description.
-	 */
-	isApplicable( paper ) {
-		return paper.hasKeyword() && paper.hasDescription();
-	}
 }
-
-export default MetaDescriptionKeywordAssessment;

--- a/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/UrlKeywordAssessment.js
@@ -51,10 +51,11 @@ export default class SlugKeywordAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment, containing both a score and a descriptive text.
 	 */
 	getResult( paper, researcher ) {
+		// Whether the paper has the data needed to return meaningful feedback (keyphrase and slug).
 		this._canAssess = false;
 
 		if ( paper.hasKeyword() && paper.hasSlug() ) {
-			this._keywordInSlug = researcher.getResearch("keywordCountInSlug");
+			this._keywordInSlug = researcher.getResearch( "keywordCountInSlug" );
 			this._canAssess = true;
 		}
 
@@ -89,7 +90,7 @@ export default class SlugKeywordAssessment extends Assessment {
 	 * @returns {{score: number, resultText: string}} The object with calculated score and resultText.
 	 */
 	calculateResult() {
-		if( ! this._canAssess ) {
+		if ( ! this._canAssess ) {
 			return {
 				score: this._config.scores.bad,
 				resultText: sprintf(

--- a/packages/yoastseo/src/scoring/assessors/assessor.js
+++ b/packages/yoastseo/src/scoring/assessors/assessor.js
@@ -86,6 +86,9 @@ class Assessor {
 	 * @returns {boolean} Whether or not the Assessment is applicable.
 	 */
 	isApplicable( assessment, paper, researcher ) {
+		if ( typeof assessment.isApplicable === "undefined" ) {
+			return true;
+		}
 		return assessment.isApplicable( paper, researcher );
 	}
 

--- a/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
@@ -1,6 +1,4 @@
 import CollectionRelatedKeywordAssessor from "../relatedKeywordAssessor.js";
-import MetaDescriptionKeywordAssessment from "../../../assessments/seo/MetaDescriptionKeywordAssessment.js";
-import { createAnchorOpeningTag } from "../../../../helpers";
 
 /**
  * The CollectionCornerstoneRelatedKeywordAssessor class is used for the related keyword analysis for cornerstone collections.

--- a/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
@@ -16,7 +16,6 @@ export default class CollectionCornerstoneRelatedKeywordAssessor extends Collect
 		this.type = "collectionRelatedKeywordAssessor";
 
 		this.addAssessment( "metaDescriptionKeyword", new MetaDescriptionKeywordAssessment( {
-			parameters: { recommendedMinimum: 1 }, scores: { good: 9, bad: 3 },
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
 		} ) );

--- a/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
+++ b/packages/yoastseo/src/scoring/assessors/collectionPages/cornerstone/relatedKeywordAssessor.js
@@ -14,10 +14,5 @@ export default class CollectionCornerstoneRelatedKeywordAssessor extends Collect
 	constructor( researcher, options ) {
 		super( researcher, options );
 		this.type = "collectionRelatedKeywordAssessor";
-
-		this.addAssessment( "metaDescriptionKeyword", new MetaDescriptionKeywordAssessment( {
-			urlTitle: createAnchorOpeningTag( "https://yoa.st/shopify14" ),
-			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/shopify15" ),
-		} ) );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove the guard on the _keyphrase in introduction_, _keyphrase in meta description_, _keyphrase in SEO title_, _keyphrase in slug_ and _previously used keyphrase_ assessments to show them even when there is no content added. This better shows our content analysis capabilities off the bat.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the following SEO assessments available in the analysis by default, even when no content has been added: _keyphrase in introduction_, _keyphrase in meta description_, _keyphrase in SEO title_, _keyphrase in slug_ and _previously used keyphrase_.
* [shopify-seo] Makes the following SEO assessments available in the analysis by default, even when no content has been added: _keyphrase in introduction_, _keyphrase in meta description_, _keyphrase in SEO title_, _keyphrase in slug_.
* [yoastseo] Makes the following SEO assessments available in the analysis by default, even when no content has been added: _keyphrase in introduction_, _keyphrase in meta description_, _keyphrase in SEO title_, _keyphrase in slug_ and _previously used keyphrase_.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and Yoast SEO Premium

### Keyphrase in introduction
* Create a new post (or product in Shopify)
* Confirm that the keyphrase in introduction assessment shows a red traffic light and the following feedback:
     * [Keyphrase in introduction](https://yoa.st/33e?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): [Please add both a keyphrase and an introduction containing the keyphrase](https://yoa.st/33f?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US). 
* Confirm that no AI Optimize button appears (not relevant for Shopify)
* Add a keyphrase and confirm the feedback stays the same, and that the AI Optimize button is still not there
* Remove the keyphrase and add some text
* Confirm the feedback stays the same, and that the AI Optimize button is still not there
* Set the keyphrase to something that's not in the introduction
* Confirm the feedback changes to: 
     * [Keyphrase in introduction](https://yoa.st/33e?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): Your keyphrase or its synonyms do not appear in the first paragraph. [Make sure the topic is clear immediately](https://yoa.st/33f?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
* Confirm that the AI Optimize button appears (only in WP)

### Keyphrase in SEO title
* Create a new post
* Confirm that the keyphrase in SEO title assessment shows a red traffic light and the following feedback:
     * [Keyphrase in SEO title](https://yoa.st/33g?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): [Please add both a keyphrase and an SEO title beginning with the keyphrase](https://yoa.st/33h?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
 * Confirm that the edit button doesn't appear next to the assessment feedback (not relevant for Shopify)
 * Add a keyphrase that does not include your site title
 * Confirm that the feedback changes to:
      *  [Keyphrase in SEO title](https://yoa.st/33g?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): Not all the words from your keyphrase [your keyphrase] appear in the SEO title. [For the best SEO results write the exact match of your keyphrase in the SEO title, and put the keyphrase at the beginning of the title](https://yoa.st/33h?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US). 
      * This should be the behavior if you are using the default replacement variables for the SEO title, which includes the Site title. If that's not the case, add the Site title manually.
* Confirm that the edit button shows up next to the assessment (only in WP)
* Make the SEO title empty by removing all replacement variables from the SEO title
     * Shopify: I'm not sure if that is possible - if I remove all replacement variables from the SEO title, it somehow defaults to still using the site title as the SEO title. And if I add a replacement variable that doesn't have a value, then the title consists of a space instead of being empty. 
* Confirm that the feedback changes to:
     * [Keyphrase in SEO title](https://yoa.st/33g?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): [Please add both a keyphrase and an SEO title beginning with the keyphrase](https://yoa.st/33h?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
 * Confirm the edit button doesn't appear
 * Remove the keyphrase and confirm that the feedback stays the same.

### Keyphrase in meta description
* Create a post
* Confirm that the keyphrase in meta description assessment shows a red traffic light and the following feedback:
     * [Keyphrase in meta description](https://yoa.st/33k?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): [Please add both a keyphrase and a meta description containing the keyphrase](https://yoa.st/33l?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
* Confirm that the edit button doesn't appear next to the assessment feedback (not relevant for Shopify)
* Add a keyphrase and confirm the feedback stays the same
* Remove the keyphrase and add a meta description
* Confirm the feedback stays the same
* Add a keyphrase and a meta description that doesn't include the keyphrase
* Confirm that the feedback changes to:
     * [Keyphrase in meta description](https://yoa.st/33k?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): The meta description has been specified, but it does not contain the keyphrase. [Fix that](https://yoa.st/33l?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US)!
* Confirm that the edit button shows up next to the assessment (only in WP)

#### Additional instructions for Shopify (to test this change https://github.com/Yoast/wordpress-seo/pull/22219/commits/1c512c59dfc6bb752fa1de3212591dcfe0ed3078)
* Create a new collection and set it to cornerstone
* Add a **related** keyphrase and a meta description that doesn't contain the keyphrase
* Confirm that the meta description keyphrase shows a red traffic light and the following feedback:
     * Keyphrase in meta description: The meta description has been specified, but it does not contain the keyphrase. Fix that!
* Add the keyphrase to the meta description and confirm the assessment returns a green traffic light and the following feedback:
     * Keyphrase in meta description: Keyphrase or synonym appear in the meta description. Well done! 

### Keyphrase in slug
* Create a post
* Confirm that the keyphrase in slug assessment shows a red traffic light and the following feedback:
     * [Keyphrase in slug](https://yoa.st/33o?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): [Please add both a keyphrase and a slug containing the keyphrase](https://yoa.st/33p?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
* Confirm that the edit button doesn't appear next to the assessment feedback
* Add a keyphrase
* Shopify: remove the slug (in WP, it should already be empty on an unsaved post)
* Confirm the feedback stays the same
* Remove the keyphrase and add a slug
* Confirm the feedback stays the same
* Add a keyphrase and a slug that doesn't include the keyphrase
* Confirm that the feedback changes to:
     * [Keyphrase in slug](https://yoa.st/33o?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): (Part of) your keyphrase does not appear in the slug. [Change that](https://yoa.st/33p?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US)!
* Confirm that the edit button shows up next to the assessment (only in WP)

### Previously used keyphrase (not available in Shopify)
* Create a post
* Confirm that the previously used keyphrase assessment shows a red traffic light and the following feedback:
     * [Previously used keyphrase](https://yoa.st/33x?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): No focus keyphrase was set for this page. [Please add a focus keyphrase you haven't used before on other content](https://yoa.st/33y?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).
 * Add a keyphrase you have used once before on your site (make sure the other post where you've used it is published)
 * Confirm the assessment returns an orange traffic light and the feedback changes to:
      * [Previously used keyphrase](https://yoa.st/33x?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US): You've used this keyphrase once before. [Do not use your keyphrase more than once](https://yoa.st/33y?php_version=8.1&platform=wordpress&platform_version=6.8&software=premium&software_version=25.0-RC1&days_active=726&user_language=en_US).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/lingo-other-tasks/issues/546
