### PR TITLE
Adjust applicability for Image keyphrase and Image alt attributes assessments

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/seo/KeyphraseInImageTextAssessmentSpec.js
@@ -1,11 +1,43 @@
 import KeyphraseInImagesAssessment from "../../../../src/scoring/assessments/seo/KeyphraseInImageTextAssessment";
 import Paper from "../../../../src/values/Paper.js";
 import Factory from "../../../../src/helpers/factory.js";
+import KeyphraseLengthAssessment from "../../../../src/scoring/assessments/seo/KeyphraseLengthAssessment";
+import EnglishResearcher from "../../../../src/languageProcessing/languages/en/Researcher";
 // import JapaneseResearcher from "../../../../src/languageProcessing/languages/ja/Researcher";   // Variable is used in language specific test (and thus removed)
 
 const keyphraseInImagesAssessment = new KeyphraseInImagesAssessment();
 
 describe( "An image count assessment", function() {
+	it( "should show feedback for a page without a text", function() {
+		const paper = new Paper( "" );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new KeyphraseInImagesAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>:  This page does not have images, a keyphrase, or both. " +
+			"<a href='https://yoa.st/4f6' target='_blank'>Add some images with alt attributes that include the keyphrase or synonyms</a>!" );
+	} );
+
+	it( "should show feedback for a page without a text and keyphrase", function() {
+		const paper = new Paper( "", { keyword: "" } );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new KeyphraseInImagesAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>:  This page does not have images, a keyphrase, or both. " +
+			"<a href='https://yoa.st/4f6' target='_blank'>Add some images with alt attributes that include the keyphrase or synonyms</a>!" );
+	} );
+
+	it( "should show feedback for a page with a keyphrase and without a text", function() {
+		const paper = new Paper( "These are just five words.", { keyword: "" } );
+		const researcher = Factory.buildMockResearcher( {} );
+		const assessment = new KeyphraseInImagesAssessment().getResult( paper, researcher );
+
+		expect( assessment.getScore() ).toEqual( 6 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/4f7' target='_blank'>Image Keyphrase</a>:  This page does not have images, a keyphrase, or both. " +
+			"<a href='https://yoa.st/4f6' target='_blank'>Add some images with alt attributes that include the keyphrase or synonyms</a>!" );
+	} );
+
 	it( "assesses a single image, without a keyword, but with an alt-tag set", function() {
 		const mockPaper = new Paper( "These are just five words <img src='image.jpg' alt='image' />" );
 

--- a/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/ImageAltTagsAssessment.js
@@ -60,19 +60,6 @@ export default class ImageAltTagsAssessment extends Assessment {
 	}
 
 	/**
-	 * Checks whether the paper has text with at least 1 image.
-	 *
-	 * @param {Paper}       paper       The paper to use for the assessment.
-	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 *
-	 * @returns {boolean} True when there is text.
-	 */
-	isApplicable( paper, researcher ) {
-		this.imageCount = researcher.getResearch( "imageCount" );
-		return paper.hasText() && this.imageCount > 0;
-	}
-
-	/**
 	 * Calculates the result based on the availability of images in the text.
 	 *
 	 * @returns {Object} The calculated result.
@@ -80,7 +67,16 @@ export default class ImageAltTagsAssessment extends Assessment {
 	calculateResult() {
 		// The number of images with no alt tags.
 		const imagesNoAlt = this.altTagsProperties.noAlt;
-		const { good: goodResultText, noneHasAltBad, someHaveAltBad } = this.getFeedbackStrings();
+		const { good: goodResultText,  noneHaveImagesBad, noneHasAltBad, someHaveAltBad } = this.getFeedbackStrings();
+
+		// There are no images
+		if ( this.imageCount === 0 ) {
+			return {
+				score: this._config.scores.bad,
+				resultText: noneHaveImagesBad,
+			};
+		}
+
 
 		// None of the images has alt tags.
 		if ( imagesNoAlt === this.imageCount ) {
@@ -110,10 +106,11 @@ export default class ImageAltTagsAssessment extends Assessment {
 	 * If you want to override the feedback strings, you can do so by providing a custom callback in the config: `this._config.callbacks.getResultTexts`.
 	 * This callback function should return an object with the following properties:
 	 * - good: string
+	 * - noneHaveImagesBad: string
 	 * - noneHasAltBad: string
 	 * - someHaveAltBad: string
 	 *
-	 * @returns {{good: string, noneHasAltBad: string, someHaveAltBad: string}} The feedback strings.
+	 * @returns {{good: string, noneHaveImagesBad: string, noneHasAltBad: string, someHaveAltBad: string}} The feedback strings.
 	 */
 	getFeedbackStrings() {
 		// `urlTitleAnchorOpeningTag` represents the anchor opening tag with the URL to the article about this assessment.
@@ -129,6 +126,9 @@ export default class ImageAltTagsAssessment extends Assessment {
 				noneHasAltBad: "%1$sImage alt tags%3$s: None of the images has alt attributes. %2$sAdd alt attributes to your images%3$s!",
 				someHaveAltBad: "%1$sImage alt tags%3$s: Some images don't have alt attributes. %2$sAdd alt attributes to your images%3$s!",
 			};
+			if (  this.imageCount === 0 ) {
+				defaultResultTexts.noneHaveImagesBad = "%1$sImage alt attributes%3$s: This page does not have images with alt attributes. %2$sAdd some%3$s!";
+			}
 			if ( numberOfImagesWithoutAlt === 1 ) {
 				defaultResultTexts.someHaveAltBad = "%1$sImage alt tags%3$s: One image doesn't have alt attributes. %2$sAdd alt attributes to your images%3$s!";
 			}

--- a/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInImageTextAssessment.js
+++ b/packages/yoastseo/src/scoring/assessments/seo/KeyphraseInImageTextAssessment.js
@@ -32,6 +32,7 @@ export default class KeyphraseInImagesAssessment extends Assessment {
 				withAltNonKeyword: 6,
 				withAlt: 6,
 				noAlt: 6,
+				noImagesOrKeyphrase: 6,
 			},
 			urlTitle: createAnchorOpeningTag( "https://yoa.st/4f7" ),
 			urlCallToAction: createAnchorOpeningTag( "https://yoa.st/4f6" ),
@@ -64,19 +65,7 @@ export default class KeyphraseInImagesAssessment extends Assessment {
 
 		return assessmentResult;
 	}
-
-	/**
-	 * Checks whether the paper has text with at least 1 image.
-	 *
-	 * @param {Paper}       paper       The paper to use for the assessment.
-	 * @param {Researcher}  researcher  The Researcher object containing all available researches.
-	 *
-	 * @returns {boolean} True when there is text.
-	 */
-	isApplicable( paper, researcher ) {
-		this.imageCount = researcher.getResearch( "imageCount" );
-		return paper.hasText() && this.imageCount > 0;
-	}
+	// Checks whether a keyphrase is set
 
 	/**
 	 * Checks whether there are too few alt tags with keywords. This check is applicable when there are
@@ -116,11 +105,30 @@ export default class KeyphraseInImagesAssessment extends Assessment {
 
 
 	/**
-	 * Calculate the result based on the current image count and current image alt-tag count.
+	 * Calculate the result based on whether there is a keyphrase, the current image count, and current image alt-tag count.
+	 *
+	 * @param {Paper} paper The paper to use for the assessment.
+	 *
+	 * @returns {boolean} True if the paper has a keyword.
 	 *
 	 * @returns {Object} The calculated result.
 	 */
-	calculateResult() {
+	calculateResult( paper  ) {
+		// No images added or no keyphrase set
+		if ( ! paper.hasKeyword() || this.imageCount === 0  )
+			return {
+				score: this._config.scores.noImagesOrKeyphrase,
+				resultText: sprintf(
+					/* translators: %1$s and %2$s expand to links on yoast.com, %3$s expands to the anchor end tag */
+					__(
+						"%1$sImage Keyphrase%3$s:  This page does not have images, a keyphrase, or both. %2$sAdd some images with alt attributes that include the keyphrase or synonyms%3$s!",
+						"wordpress-seo"
+					),
+					this._config.urlTitle,
+					this._config.urlCallToAction,
+					"</a>"
+				),
+			};
 		// Has alt-tags, but no keyword is set.
 		if ( this.altProperties.withAlt > 0 ) {
 			return {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove the guard on the _images in keyphrase_ and _image alt attributes_ assessments to show them even when there is no content added. This better shows our content analysis capabilities off the bat.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the _images in keyphrase assessment_  available when no content has been added.
* [shopify-seo] Makes the _images in keyphrase_ and _image alt attributes_  available when no content has been added.
* [shopify-seo] Renames the _image alt tags assessment_ to _image alt attributes assessment_.
* [yoastseo] Makes the _images in keyphrase_ and _image alt attributes_  available when no content has been added.

## Relevant technical choices:

* For images with alt attributes, we added a new condition for when no images and/or text is available. The [score](https://github.com/Yoast/wordpress-seo/blob/add-documentation-on-ecommerce-assessments/packages/yoastseo/src/scoring/assessments/SCORING%20SEO%20PRODUCT.md) for this condition (red) is made to be the same as for when none or not all of the images have alt attributes.
* For Image keyphrase assessment, we added a new condition for when no keyphrase, images and/or text is available. The [score](https://github.com/Yoast/wordpress-seo/blob/trunk/packages/yoastseo/src/scoring/assessments/SCORING%20SEO.md) for this condition (orange for non-cornerstone content) is made to be similar to the condition when the image(s) has no alt attributes.

The choice of feedback strings are explained [here](https://docs.google.com/spreadsheets/d/14UXfK84rI62PQMVy6da-YhbZGG5T7DuV26DgFK8VvwU/edit?usp=sharing). The scoring was not yet discussed so if there are different opinions it can be adjusted before the PR is merged. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Wordpress**

* Open a new (empty) post.
*  Confirm that you see the Image keyphrase assessment is shown with the following feedback: 🔴_Image Keyphrase: This page does not have images, a keyphrase, or both. Add some images with alt attributes that include the keyphrase or synonyms._
* Make sure both links ([first one](https://yoast.com/image-seo-alt-tag-and-title-tag-optimization/#utm_source=yoast-seo&utm_medium=software&utm_term=images-keyphrase-name&utm_content=content-analysis&php_version=8.1&platform=wordpress&platform_version=6.8&software=free&software_version=25.0-RC1&days_active=469&shortlink=4f7) and [the call-to-action](https://yoast.com/how-to-add-a-keyphrase-to-your-image/#utm_source=yoast-seo&utm_medium=software&utm_term=images-keyphrase-cta&utm_content=content-analysis&php_version=8.1&platform=wordpress&platform_version=6.8&software=free&software_version=25.0-RC1&days_active=469&shortlink=4f6) one) in the feedback lead to the relevant pages.
* Add a text to the post and make sure the feedback does not change.
* Add a keyphrase to the keyphrase field and make sure the feedback does not change.
* Add an image and make sure the feedback string changes to _Images on this page do not have alt attributes that reflect the topic of your text. Add your keyphrase or synonyms to the alt tags of relevant images!_, while the bullet stays red.


**Woocommerce and Shopify**
* Repeat the steps above for the Image keyphrase assessment.
* Open a new (empty) post.
* Confirm that you see the Image alt attributes assessment with the following feedback:
 🟠  _Image alt attributes: This page does not have images with alt attributes. Add some!_
 * Add a text (with no images)
 * Confirm that the feedback for Image alt attributes assessment does not change.
 * Add an image
 Confim that the image alt attribute assessment shows the following feedback:
 🟠  Image alt tags: None of the images has alt attributes. Add alt attributes to your images!



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
