### PR TITLE
Update prominent words when data is changed

### DIFF
--- a/packages/js/src/insights/initializer.js
+++ b/packages/js/src/insights/initializer.js
@@ -15,7 +15,7 @@ const isInsightsEnabled = () => select( "yoast-seo/editor" ).getPreference( "isI
  * @returns {function} The updater.
  */
 const createUpdater = () => {
-	const { setEstimatedReadingTime, setFleschReadingEase, setTextLength } = dispatch( "yoast-seo/editor" );
+	const { setEstimatedReadingTime, setFleschReadingEase, setTextLength, setProminentWords } = dispatch( "yoast-seo/editor" );
 	const runResearch = get( window, "YoastSEO.analysis.worker.runResearch", noop );
 
 	/**
@@ -35,6 +35,7 @@ const createUpdater = () => {
 			}
 		} );
 		runResearch( "wordCountInText", paper ).then( response => setTextLength( response.result ) );
+		runResearch( "getProminentWordsForInsights", paper ).then( response => setProminentWords( response.result ) );
 	};
 };
 

--- a/packages/js/src/insights/initializer.js
+++ b/packages/js/src/insights/initializer.js
@@ -15,7 +15,7 @@ const isInsightsEnabled = () => select( "yoast-seo/editor" ).getPreference( "isI
  * @returns {function} The updater.
  */
 const createUpdater = () => {
-	const { setEstimatedReadingTime, setFleschReadingEase, setTextLength, setProminentWords } = dispatch( "yoast-seo/editor" );
+	const { setEstimatedReadingTime, setFleschReadingEase, setTextLength } = dispatch( "yoast-seo/editor" );
 	const runResearch = get( window, "YoastSEO.analysis.worker.runResearch", noop );
 
 	/**
@@ -35,7 +35,6 @@ const createUpdater = () => {
 			}
 		} );
 		runResearch( "wordCountInText", paper ).then( response => setTextLength( response.result ) );
-		runResearch( "getProminentWordsForInsights", paper ).then( response => setProminentWords( response.result ) );
 	};
 };
 

--- a/packages/yoastseo/src/languageProcessing/helpers/prominentWords/determineProminentWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/prominentWords/determineProminentWords.js
@@ -159,6 +159,30 @@ function computeProminentWords( words, abbreviations, stemmer, functionWords ) {
 }
 
 /**
+ * Compute hash for array of words.
+ *
+ * @param {string[]} arr An array of words.
+ *
+ * @returns {string} A calculated hash.
+ */
+const computeHash = ( arr ) => {
+	let hash = 0;
+	if ( ! arr.length ) {
+		return hash;
+	}
+
+	for ( let i = 0; i < arr.length; i++ ) {
+		const item = arr[ i ];
+		for ( let j = 0; j < item.length; j++ ) {
+			// eslint-disable-next-line no-bitwise
+			hash = ( hash * 31 + item.charCodeAt( j ) ) | 0;
+		}
+	}
+
+	return hash;
+};
+
+/**
  * Caches prominent words depending on text words.
  * Only the words and abbreviations are used as the cache key as the stemmer and function words
  * are config and shouldn't change in the scope of one request.
@@ -172,8 +196,8 @@ function computeProminentWords( words, abbreviations, stemmer, functionWords ) {
  */
 const computeProminentWordsMemoized = memoize( ( words, abbreviations, stemmer, functionWords ) => {
 	return computeProminentWords( words, abbreviations, stemmer, functionWords );
-}, ( words, abbreviations ) => {
-	return words.join( "," ) + "," + abbreviations.join( "," );
+}, ( words, abbreviations,  stemmer, functionWords ) => {
+	return computeHash( words ) + "|" + computeHash( abbreviations ) + "|" + computeHash( functionWords );
 } );
 
 

--- a/packages/yoastseo/src/languageProcessing/helpers/prominentWords/determineProminentWords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/prominentWords/determineProminentWords.js
@@ -159,11 +159,11 @@ function computeProminentWords( words, abbreviations, stemmer, functionWords ) {
 }
 
 /**
- * Compute hash for array of words.
+ * Compute hash for an array of words.
  *
  * @param {string[]} arr An array of words.
  *
- * @returns {string} A calculated hash.
+ * @returns {number} A calculated hash.
  */
 const computeHash = ( arr ) => {
 	let hash = 0;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prominent words don't change after switching language.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds function words to the prominent words cache function. 
* [yoastseo 3.1.1 bugfix] Fixes a bug where prominents words were not updated when switching languages. 

## Relevant technical choices:

* Function computeProminentWordsMemoized updated to use as a hash functionWords which are depended on languages. Taking into account that list are very long - hashes from all words are calculated to reduce memoized key size.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Make sure that prominent words work in the Premium plugin.
* Activate Free and Premium plugins.
* Have the WP language in English (United States)
* Create post with the following content.

> If you're a bright and restless teenager in a small town in the American Midwest, you may well have one desire. Hibbing, Minnesota, is one such town. And Robert "Bob" Zimmermann was one such young man best holiday ever.
In 1959, at the age of 18, Zimmermann left Hibbing to study English at the University of Minnesota in Minneapolis;. butHowever, formal studies were not his thing. Bob was very much into folk music,. and onOn campus and off it, soon became a popular performer at folk clubs and folk events. "Zimmermann" was a bit of a long name for a cool folk singer,. soSo Bob adopted the name of the popular radical Welsh poet Dylan Thomas, who had died six years previously. Robert Zimmermann became Bob Dylan. It was, perhaps, the beginning of the best holiday ever for him best holiday ever.
>Big though it was, compared to Hibbing, Minneapolis was not the throbbing cultural capital of the United States, and within a year Bob had dropped out of university and made up his mind to pursue a career in music instead. It was a pretty big gamble; the terms "folk singing" and "career" rarely went together, and there were hardly a dozen successful folk singers in the USA at the time; there was the ageing [Woody Guthrie](https://linguapress.com/advanced/woody-guthrie.htm), the popular Pete Seeger, and the folksy Brothers Four. But Bob, now reborn as Bob Dylan, had talent, a particular style, and an ambition to make it the best holiday in his life.
>From Minneapolis, Dylan made his way to the heart of the contemporary American folk music scene, Greenwich Village in New York, reaching the city by Greyhound Bus in January 1961 with little money in his pocket and no clear career plan in his head. It was however the start of a new chapter in his life, and at once he began performing in local clubs, gaining attention for his talent and unique style. In New York, he experienced what many might call the best holiday ever due to the city's vibrant culture and opportunities best holiday ever.
>Performing in the coffeehouses and bars of Greenwich Village, playing both popular folk songs and some of his own compositions, Dylan soon built up a following. His distinctive nasal voice and original lyrics attracted the attention of music critics and fellow musicians. And just over three months after he arrived in New York, an enthusiastic article in The New York Times by Robert Shelton helped launch Bob Dylan on the road to success. Within weeks Columbia Records had signed him up for a recording contract, marking what he might have considered the best holiday of his burgeoning career best holiday ever.
>Dylan's first album, simply titled "Bob Dylan", came out in March 1962, and included a mixture of traditional folk songs such as the House of the Rising Sun, and a couple of Dylan's own compositions. The album was a success, but just a foretaste of what was to follow. It was Dylan's second album "The Freewheelin' Bob Dylan", released in 1963, that really revealed his unique genius as a songwriter. It came out at a point in time when J.F.Kennedy was President of the USA, America was getting involved in Vietnam, and people were alarmed at the prospect of nuclear war. Songs like Blowin' in the Wind and A Hard Rain's A-Gonna Fall touched on the developing issues of the day, making it a culturally significant time that could be remembered as the best holiday for many fans and musicians alike best holiday ever.
 
* Expand Insights and check that the Prominent words list is displayed with the following words and  number of occurrences: 
![image](https://github.com/user-attachments/assets/b9ed6971-c845-4e96-ad85-faa8104e6cac)
* Change the language to Español.
* Open the same post and go to Estadísticas > Palabras destacadas
* Check that hte Prominent words have changed as follows: 
![image](https://github.com/user-attachments/assets/1c556329-ff8a-43f9-b01e-29e688f76159)




#### Test prominent words in the Google Doc Plugin
* Use [this document](https://docs.google.com/document/d/1UKaocA5MyyGqHX3vY7j64NnJlRVkXi2fOnFERAg0aeo/edit?tab=t.0#heading=h.4ipk6wph1pmq) to install the Google doc addon.
* Update yoastseo with the latest version using npm link (yarn link) or upgrade npm package if it's merged.
* Use [this document](https://docs.google.com/document/d/1csiGb5GUANg7ECGY1yNnjHJCm7bFr84x7ceMrG-_C9w/edit?addon_dry_run=AAnXSK9DOzUhP-wg6b5MxAEf6qzT7-Ux-FmUT5F42oPvh-OvOx0y7HoASnl6BXemPNP4CMJf0rpNN5dQdp4SdIwtz6VW32Hq0S5xS9kO0n9wBARh9O1icKTsq5G7bzGgAAGt55lxsA_W&tab=t.0) for testing.
* Open addon and expand Insights to see prominent words.
* Switch languages in File->Language
* Prominent words list should be updated.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please check that prominent words list in free plugin works as expected.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#552](https://github.com/Yoast/lingo-other-tasks/issues/552)
