### PR TITLE
Fix issues from disconnecting accounts via Site Kit dashboard

### DIFF
--- a/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
+++ b/tests/Unit/Dashboard/Infrastructure/Integrations/Site_Kit_To_Array_Test.php
@@ -17,7 +17,6 @@ use WP_User;
  * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_enabled
  * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_ga_connected
  * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_connected
- * @covers Yoast\WP\SEO\Dashboard\Infrastructure\Integrations\Site_Kit::is_setup_completed
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
@@ -42,7 +41,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 	 * @param bool                 $is_site_kit_activated If the Site Kit plugin is activated.
 	 * @param bool                 $is_consent_granted    If consent is granted to our integration.
 	 * @param bool                 $is_ga_connected       If the Google analytics setup is completed.
-	 * @param bool                 $is_setup_completed    If the Google search console setup is completed.
 	 * @param bool                 $is_config_dismissed   If the configuration widget is dismissed.
 	 * @param string               $access_role_needed    The needed role for using the widgets.
 	 * @param string               $access_role_user      The role the user has.
@@ -57,7 +55,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 		bool $is_site_kit_activated,
 		bool $is_consent_granted,
 		bool $is_ga_connected,
-		bool $is_setup_completed,
 		bool $is_config_dismissed,
 		string $access_role_needed,
 		string $access_role_user,
@@ -73,9 +70,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 		$this->site_kit_consent_repository->expects( 'is_consent_granted' )->once()->andReturn( $is_consent_granted );
 		if ( ! $is_site_kit_activated ) {
 			$this->site_kit_is_connected_call->expects( 'is_ga_connected' )->once()->andReturn( $is_ga_connected );
-			$this->site_kit_is_connected_call->expects( 'is_setup_completed' )
-				->once()
-				->andReturn( $is_setup_completed );
 		}
 		$this->configuration_repository->expects( 'is_site_kit_configuration_dismissed' )
 			->once()
@@ -107,9 +101,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 					'//core/modules/data/list' => [
 						'body' => $data_list,
 					],
-					'//core/site/data/connection' => [
-						'body' => [ 'setupCompleted' => $is_setup_completed ],
-					],
 				]
 			);
 		}
@@ -133,7 +124,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => true,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -178,11 +168,10 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'isRedirectedFromSiteKit'  => false,
 			],
 		];
-		yield 'Installed not setup' => [
+		yield 'Installed not activated' => [
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => false,
 			'is_consent_granted'      => false,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => false,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -209,7 +198,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'setupUrl'                 => 'url=url%3D',
 				'updateUrl'                => 'url=url',
 				'dashboardUrl'             => 'url=',
-				'isAnalyticsConnected'     => true,
+				'isAnalyticsConnected'     => false,
 				'isFeatureEnabled'         => true,
 				'isSetupWidgetDismissed'   => true,
 				'capabilities'             => [
@@ -231,7 +220,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => false,
 			'is_site_kit_activated'   => false,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -269,7 +257,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'connectionStepsStatuses'  => [
 					'isInstalled'      => false,
 					'isActive'         => false,
-					'isSetupCompleted' => true,
+					'isSetupCompleted' => false,
 					'isConsentGranted' => true,
 				],
 				'isVersionSupported'       => false,
@@ -280,7 +268,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => true,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -329,7 +316,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => true,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -367,7 +353,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'connectionStepsStatuses'  => [
 					'isInstalled'      => true,
 					'isActive'         => true,
-					'isSetupCompleted' => true,
+					'isSetupCompleted' => false,
 					'isConsentGranted' => true,
 				],
 				'isVersionSupported'       => false,
@@ -379,7 +365,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => true,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -429,7 +414,6 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 			'is_site_kit_installed'   => true,
 			'is_site_kit_activated'   => true,
 			'is_consent_granted'      => true,
-			'is_setup_completed'      => true,
 			'is_ga_connected'         => true,
 			'is_config_dismissed'     => true,
 			'access_role_needed'      => 'admin',
@@ -468,7 +452,7 @@ final class Site_Kit_To_Array_Test extends Abstract_Site_Kit_Test {
 				'connectionStepsStatuses'                           => [
 					'isInstalled'      => true,
 					'isActive'         => true,
-					'isSetupCompleted' => true,
+					'isSetupCompleted' => false,
 					'isConsentGranted' => true,
 				],
 				'isVersionSupported'                                => false,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the UX of the Site Kit integration for cases where there's no access to Google services.

## Relevant technical choices:

* We changed the concept of what `Is Site Kit set up` means.
  * It used to mean whether Site Kit was set up once in the site from any user, even if that user was now disconnected.
  * It now means whether the current user has access to either the SC module or the Analytics module.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The first bug:
* Go through the onboarding process in a fresh site
* Go to Site Kit and disconnect the user (disconnect from the upper right corner. if you reset Site Kit, using the relevant button, the bug is not there):
![Image](https://github.com/user-attachments/assets/2160f711-2c14-4bfb-ae69-5b4edfc9f1f6)
* Go to Yoast dashboard (preferrably in a new tab, to avoid cache)
**With the fix:**
* the onboarding widget appears again, in the 3rd step (prompting users to set up Site Kit)
**Without the fix:**
* No onboarding widget
* The 5 widgets showing, with errors (since we don't have our users connected to Site Kit)

The second bug:
* 1st admin sets up Site Kit and gives viewing rights to admins
* 2nd admin goes to Yoast Dashboard and sees widgets with data
* 1st admin disconnects from Site Kit (disconnect from the upper right corner. if you reset Site Kit, using the relevant button, the bug is not there):
![Image](https://github.com/user-attachments/assets/2160f711-2c14-4bfb-ae69-5b4edfc9f1f6)
**With this fix:**
* 2nd admin goes to Yoast Dashboard and sees the onboarding widget
* **Without the fix:**
* 2nd admin goes to Yoast Dashboard and sees widgets with error

A minor improvement when consent hasn't been given:
* admin1 sets up Site Kit but doesn't connect Site Kit to Yoast
* admin2 goes to Yoast dashboard
**With this fix:**
* sees the 3rd step of the onboarding widget (set up site kit) and is able to complete it
**Without the fix:**
* sees the 4th step of the onboarding widget with a disabled button (which doesn't make sense because he's an admin and should have been able to connect Site Kit to Yoast)

Test also https://github.com/Yoast/wordpress-seo/issues/22157 with a twist:
* Set up Site Kit (without setting up Analytics) with user A
* Don't give viewing rights to any role
* Go to Yoast dashboard with user B and confirm that you don't see the Site Kit widgets, **but you do see the onboarding widget**
  * Use the onboarding widget to connect user B's google account to Site Kit (Search Console only, not Analytics)
  * Re-visit Yoast dashboard and confirm that you now see the 4 widgets properly
  * Disconnect user B's google account from Site Kit.
* With user A, give viewing rights to Search Console to admins
* User B now can see the Search Console widgets in Yoast dashboard
* Revert viewing rights to none, to continue our tests
* With user B, go and set up Site Kit with a different account
* Go to Yoast dashboard with user B and confirm that you see the Site Kit widgets that are for Search Console
* With user A, go and set up Analytics but don't give viewing rights to it, to any role
* Go to Yoast dashboard with user A and confirm that you see the Organic Sessions widget too
* Go to Yoast dashboard with user B and confirm that you see see the Organic Sessions widget too but you get a `You don't have permission` error
* If user A gives viewing rights to admin for Analytics and user refreshes the Yoast dashboard, they will see the Organic Sessions widget with no errors. Revert the viewing rights of Analytics to no role.
* With user B, go and set up Analytics (first you will need to go to the Analytics account of user A and give access to your account as per this: https://support.google.com/analytics/answer/9305788?hl=en#Add&zippy=%2Cin-this-article)
  * After you gave access to your account as per the article, go to Site Kit->Settings, edit the Analytics settings and save your account
* Go to Yoast dashboard with user B and confirm that you see the Organic Sessions widget with no errors
* Now repeat the test in a fresh site, but this time set up Site Kit with user A and set up Analytics at the beginning (before doing anything with user B). User B should not see any widgets (aside from the onboarding widget) until either user A gives viewing rights or user B sets up Site Kit with their own Google account:
  * First have user A give viewing rights for Search Console to admins
  * Go to Yoast dashboard with user B and confirm you see all widgets with no errors except Organic Sessions which you can't see at all
  * Then have user A give viewing rights for Analytics to admins
  * Go to Yoast dashboard with user B and confirm you see all widgets including Organic Sessions 
  * Revoke viewing rights for Search Console
  * Go to Yoast dashboard with user B and confirm you see only the Organic Sessions widget with no errors there
  * Now revoke viewing rights for Analytics too
  * GO to Yoast dashboard with user B and confirm you see no Site Kit related widgets, **but you do see the onboarding widget**
  * Have user B set up Site Kit with their own Google account and then confirm that in the Yoast dashboard they see all Site Kit widgets.

Test also https://github.com/Yoast/wordpress-seo/pull/22091 with a twist:
* Have the Site Kit Feature flag enabled.
* Log in as an SEO manager, go to Yoast SEO-> Integrations and later Yoast SEO->general and check you see the warnings:
> Please contact your WordPress admin to install, activate, and set up the Site Kit by Google plugin. 
* Check the install button is disabled, try to click it and check it has disabled styling.
* Log in as an admin and install the site kit plugin, log in again as seo manager and check you see the same message in the integration card and the set up widget. Check the buttons are disabled.
* Log in as an admin and activate the site kit plugin, log in again as seo manager and check you see the same message in the integration card and the set up widget. Check the buttons are disabled.
* Log in as admin and set up the site kit and analytics and log in again as seo manager and check you see the same message.
* Check the button is disabled in both integration card and widget.
* Log in as an admin and connect site kit to yoast, log in again as seo manager and check you see the same message in the integration card and the onboarding widget.
* Log in as an admin and add the SEO manager role to the search console sharing.
* Log in as the seo manager again and check you can see the site kit widgets and you can disconnect and connect to yoast site kit from the integrations page.
* Check you don't see the Organic sessions widget.
* Log in as admin and add the seo manager in the sharing settings for analytics.
* Log in again as SEO manager and check you now see the organic sessions widget.
* Log in as admin and revoke all viewing rights and only give viewing rights to PageSpeed Insights.
* Log in as SEO manager and check that you don't see any Site Kit widgets in the Yoast dashboard.

Regression testing:
* Please repeat all test instructions of https://github.com/Yoast/wordpress-seo/pull/22120 
  * ignore the https://github.com/Yoast/wordpress-seo/issues/22157 parts, because we tested it already above, with a twist
  * ignore the https://github.com/Yoast/wordpress-seo/pull/22091 parts, because we tested it already above, with a twist

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/526
