### PR TITLE
Disable AI Optimize button in taxonomies

### DIFF
--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -143,14 +143,14 @@ class ReadabilityAnalysis extends Component {
 	 * @returns {void|JSX.Element} The AI Optimize button, or nothing if the button should not be shown.
 	 */
 	renderAIOptimizeButton = ( hasAIFixes, id ) => {
-		const { isElementor, isAiFeatureEnabled } = this.props;
+		const { isElementor, isAiFeatureEnabled, isTerm } = this.props;
 		const isPremium = getL10nObject().isPremium;
 
 		// Don't show the button if the AI feature is not enabled for Yoast SEO Premium users.
 		if ( isPremium && ! isAiFeatureEnabled ) {
 			return;
 		}
-		const shouldRenderAIButton = shouldRenderAIOptimizeButton( hasAIFixes, isElementor );
+		const shouldRenderAIButton = shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm );
 		// Show the button if the assessment can be fixed through Yoast AI Optimize, and we are not in the Elementor editor,
 		// WooCommerce Product pages or Taxonomy
 		return shouldRenderAIButton && ( <AIOptimizeButton id={ id } isPremium={ isPremium } /> );
@@ -223,6 +223,7 @@ ReadabilityAnalysis.propTypes = {
 	shouldUpsellHighlighting: PropTypes.bool,
 	isAiFeatureEnabled: PropTypes.bool,
 	isElementor: PropTypes.bool,
+	isTerm: PropTypes.bool,
 };
 
 ReadabilityAnalysis.defaultProps = {
@@ -231,6 +232,7 @@ ReadabilityAnalysis.defaultProps = {
 	shouldUpsellHighlighting: false,
 	isAiFeatureEnabled: false,
 	isElementor: false,
+	isTerm: false,
 };
 
 export default withSelect( select => {
@@ -239,6 +241,7 @@ export default withSelect( select => {
 		getMarkButtonStatus,
 		getIsElementorEditor,
 		getIsAiFeatureEnabled,
+		getIsTerm,
 	} = select( "yoast-seo/editor" );
 
 	return {
@@ -246,5 +249,6 @@ export default withSelect( select => {
 		marksButtonStatus: getMarkButtonStatus(),
 		isElementor: getIsElementorEditor(),
 		isAiFeatureEnabled: getIsAiFeatureEnabled(),
+		isTerm: getIsTerm(),
 	};
 } )( ReadabilityAnalysis );

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -205,14 +205,14 @@ class SeoAnalysis extends Component {
 	 * @returns {void|JSX.Element} The AI Optimize button, or nothing if the button should not be shown.
 	 */
 	renderAIOptimizeButton = ( hasAIFixes, id ) => {
-		const { isElementor, isAiFeatureEnabled, isPremium } = this.props;
+		const { isElementor, isAiFeatureEnabled, isPremium, isTerm } = this.props;
 
 		// Don't show the button if the AI feature is not enabled for Yoast SEO Premium users.
 		if ( isPremium && ! isAiFeatureEnabled ) {
 			return;
 		}
 
-		const shouldRenderAIButton = shouldRenderAIOptimizeButton( hasAIFixes, isElementor );
+		const shouldRenderAIButton = shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm );
 		// Show the button if the assessment can be fixed through Yoast AI Optimize, and we are not in the Elementor editor,
 		// WooCommerce Product pages or Taxonomy
 		return shouldRenderAIButton && ( <AIOptimizeButton id={ id } isPremium={ isPremium } /> );
@@ -303,6 +303,7 @@ SeoAnalysis.propTypes = {
 	isElementor: PropTypes.bool,
 	isAiFeatureEnabled: PropTypes.bool,
 	isPremium: PropTypes.bool,
+	isTerm: PropTypes.bool,
 };
 
 SeoAnalysis.defaultProps = {
@@ -316,6 +317,7 @@ SeoAnalysis.defaultProps = {
 	isElementor: false,
 	isAiFeatureEnabled: false,
 	isPremium: false,
+	isTerm: false,
 };
 
 export default withSelect( ( select, ownProps ) => {
@@ -326,6 +328,7 @@ export default withSelect( ( select, ownProps ) => {
 		getIsElementorEditor,
 		getIsPremium,
 		getIsAiFeatureEnabled,
+		getIsTerm,
 	} = select( "yoast-seo/editor" );
 
 	const keyword = getFocusKeyphrase();
@@ -337,5 +340,6 @@ export default withSelect( ( select, ownProps ) => {
 		isElementor: getIsElementorEditor(),
 		isPremium: getIsPremium(),
 		isAiFeatureEnabled: getIsAiFeatureEnabled(),
+		isTerm: getIsTerm(),
 	};
 } )( SeoAnalysis );

--- a/packages/js/src/helpers/shouldRenderAIOptimizeButton.js
+++ b/packages/js/src/helpers/shouldRenderAIOptimizeButton.js
@@ -3,12 +3,13 @@
  *
  * @param {boolean} hasAIFixes Whether the assessment has AI fixes.
  * @param {boolean} isElementor Whether the editor used is Elementor.
+ * @param {boolean} isTerm Whether the current page is a term page.
  * @returns {boolean} Whether AI Optimize button should be rendered.
  * */
-export const shouldRenderAIOptimizeButton = ( hasAIFixes, isElementor ) => {
+export const shouldRenderAIOptimizeButton = ( hasAIFixes, isElementor, isTerm ) => {
 	const isElementorEditorPageActive = document.body.classList.contains( "elementor-editor-active" );
 	// Check if the current editor is either Elementor or the Elementor in-between screen. In that case, don't show the button.
 	const isNotElementorPage = ! isElementor && ! isElementorEditorPageActive;
 
-	return hasAIFixes && isNotElementorPage;
+	return hasAIFixes && isNotElementorPage && ! isTerm;
 };

--- a/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
+++ b/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
@@ -47,12 +47,4 @@ describe( "shouldRenderAIOptimizeButton", () => {
 
 		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
 	} );
-
-	it( "should return false when all conditions are false", () => {
-		const hasAIFixes = false;
-		const isElementor = false;
-		const isTerm = false;
-
-		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
-	} );
 } );

--- a/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
+++ b/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
@@ -1,0 +1,58 @@
+// Import the function to test
+import { shouldRenderAIOptimizeButton } from "../../src/helpers/shouldRenderAIOptimizeButton";
+
+describe( "shouldRenderAIOptimizeButton", () => {
+	beforeEach( () => {
+		// Reset the document body class list before each test
+		document.body.className = "";
+	} );
+
+	it( "should return true when hasAIFixes is true, isElementor is false, isTerm is false, and not on an Elementor editor page", () => {
+		const hasAIFixes = true;
+		const isElementor = false;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( true );
+	} );
+
+	it( "should return false when hasAIFixes is false, regardless of other conditions", () => {
+		const hasAIFixes = false;
+		const isElementor = false;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+
+	it( "should return false when isElementor is true, regardless of other conditions", () => {
+		const hasAIFixes = true;
+		const isElementor = true;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+
+	it( "should return false when isTerm is true, regardless of other conditions", () => {
+		const hasAIFixes = true;
+		const isElementor = false;
+		const isTerm = true;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+
+	it( "should return false when on an Elementor editor page, regardless of other conditions", () => {
+		document.body.classList.add( "elementor-editor-active" );
+		const hasAIFixes = true;
+		const isElementor = false;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+
+	it( "should return false when all conditions are false", () => {
+		const hasAIFixes = false;
+		const isElementor = false;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to make the AI Optimize feature available in terms for now. This PR ensures that the AI Optimize button is not shown in terms (in Free).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes AI Optimize button from taxonomies.

## Relevant technical choices:

* In Premium, through the `Post_Conditional`, we already ensured the AI Optimize integration is not loaded. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test only in Free
* Install and activate Yoast SEO
* Install and activate Classic editor
##### Taxonomies
* Create a taxonomy
   * The test should be executed in tags, categories, custom taxonomies, WooCommerce Brands, WooCommerce categories, WooCommerce tags, and WooCommerce  attributes
* Set the focus keyphrase
* Add some contents so that you get 🔴 red or 🟠 orange feedback for the following assessments: Keyphrase density, keyphrase in introduction, sentence length and paragraph length assessment
* Confirm that you don't see the AI Optimize button for the aforementioned assessments
##### Smoke test in non-taxonomies
* Create a post
* Set the focus keyphrase
* Add some contents so that you get 🔴 red or 🟠 orange feedback for the following assessments: Keyphrase density, keyphrase in introduction, sentence length and paragraph length assessment
* Confirm that you still see the AI Optimize button for the aforementioned assessments
* Clicking on the AI button will display the upsell modal
##### Smoke test in non-classic editor
* Deactivate Classic editor
* Create a post
* Set the focus keyphrase
* Add some contents so that you get 🔴 red or 🟠 orange feedback for the following assessments: Keyphrase density, keyphrase in introduction, sentence length and paragraph length assessment
* Confirm that you still see the AI Optimize button for the aforementioned assessments
* Clicking on the AI button will display the upsell modal

> [!NOTE]
>  Smoke testing only in Free should be sufficient

#### Test with Premium
* Install and activate Yoast SEO
* Install and activate Yoast SEO Premium
   * Acceptance test/CR: Please pair this branch with `feature/ai-optimize-classic` branch in Premium. Refer to [this page ](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/2921201669/AI+Generate+Optimize+how+to+test+the+functionality+with+staging+API)for information on how to test the AI feature in staging 
* Install and activate Classic editor
##### Taxonomies
* Create a taxonomy
   * The test should be executed in tags, categories, custom taxonomies, WooCommerce Brands, WooCommerce categories, WooCommerce tags, and WooCommerce  attributes
* Set the focus keyphrase
* Add some contents so that you get 🔴 red or 🟠 orange feedback for the following assessments: Keyphrase density, keyphrase distribution, keyphrase in introduction, sentence length and paragraph length assessment
* Confirm that you don't see the AI Optimize button for the aforementioned assessments

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* See the testing instruction. No further impact other than what's covered in the testing instruction

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.
   * I've updated [the relevant documentation in this feature documentation 
](https://docs.google.com/document/d/1gaM9CS3BmnlcwZ5IvFynRTJE4C_mJjnW20ZOi6Qkd4k/edit?tab=t.y5wa42xq8brg#heading=h.wsge03i9ixp4)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4614
