### PR TITLE
Introduce filter to allow changing the requested dates in the Site Kit integration

### DIFF
--- a/src/dashboard/user-interface/time-based-seo-metrics/time-based-seo-metrics-route.php
+++ b/src/dashboard/user-interface/time-based-seo-metrics/time-based-seo-metrics-route.php
@@ -243,11 +243,11 @@ final class Time_Based_SEO_Metrics_Route implements Route_Interface {
 	 * @return Parameters The request parameters with configured date range.
 	 */
 	public function set_date_range_parameters( Parameters $request_parameters ): Parameters {
-		$date = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$date = $this->get_base_date();
 		$date->modify( '-28 days' );
 		$start_date = $date->format( 'Y-m-d' );
 
-		$date = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$date = $this->get_base_date();
 		$date->modify( '-1 days' );
 		$end_date = $date->format( 'Y-m-d' );
 
@@ -265,7 +265,7 @@ final class Time_Based_SEO_Metrics_Route implements Route_Interface {
 	 * @return Parameters The request parameters with configured comparison date range.
 	 */
 	public function set_comparison_date_range_parameters( Parameters $request_parameters ): Parameters {
-		$date = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$date = $this->get_base_date();
 		$date->modify( '-29 days' );
 		$compare_end_date = $date->format( 'Y-m-d' );
 
@@ -276,6 +276,26 @@ final class Time_Based_SEO_Metrics_Route implements Route_Interface {
 		$request_parameters->set_compare_end_date( $compare_end_date );
 
 		return $request_parameters;
+	}
+
+	/**
+	 * Gets the base date.
+	 *
+	 * @return DateTime The base date.
+	 */
+	private function get_base_date() {
+		/**
+		 * Filter: 'wpseo_custom_site_kit_base_date' - Allow the base date for Site Kit requests to be dynamically set.
+		 *
+		 * @param string $base_date The custom base date for Site Kit requests, defaults to 'now'.
+		 */
+		$base_date = \apply_filters( 'wpseo_custom_site_kit_base_date', 'now' );
+
+		try {
+			return new DateTime( $base_date, new DateTimeZone( 'UTC' ) );
+		} catch ( Exception $e ) {
+			return new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		}
 	}
 
 	/**

--- a/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Metrics_Test.php
+++ b/tests/Unit/Dashboard/User_Interface/Time_Based_SEO_Metrics/Time_Based_SEO_Metrics_Route_Get_Metrics_Test.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Tests\Unit\Dashboard\User_Interface\Time_Based_SEO_Metrics;
 
+use Brain\Monkey;
 use DateTime;
 use Mockery;
 use WP_REST_Request;
@@ -19,6 +20,7 @@ use Yoast\WP\SEO\Dashboard\Infrastructure\Search_Console\Search_Console_Paramete
  * @covers Yoast\WP\SEO\Dashboard\User_Interface\Time_Based_SEO_Metrics\Time_Based_SEO_Metrics_Route::get_time_based_seo_metrics
  * @covers Yoast\WP\SEO\Dashboard\User_Interface\Time_Based_SEO_Metrics\Time_Based_SEO_Metrics_Route::set_date_range_parameters
  * @covers Yoast\WP\SEO\Dashboard\User_Interface\Time_Based_SEO_Metrics\Time_Based_SEO_Metrics_Route::set_comparison_date_range_parameters
+ * @covers Yoast\WP\SEO\Dashboard\User_Interface\Time_Based_SEO_Metrics\Time_Based_SEO_Metrics_Route::get_base_date
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
@@ -35,6 +37,8 @@ final class Time_Based_SEO_Metrics_Route_Get_Metrics_Test extends Abstract_Time_
 	 * @param int    $organic_sessions_daily_count   The times we ask for the organic sessions daily repository.
 	 * @param int    $organic_sessions_compare_count The times we ask for the organic sessions compare repository.
 	 * @param int    $search_ranking_compare_count   The times we ask for the search ranking compare repository.
+	 * @param string $base_date_filter_count         The times we filter the base date.
+	 * @param string $filtered_base_date             The filtered base date.
 	 *
 	 * @return void
 	 */
@@ -44,7 +48,9 @@ final class Time_Based_SEO_Metrics_Route_Get_Metrics_Test extends Abstract_Time_
 		$top_queries_count,
 		$organic_sessions_daily_count,
 		$organic_sessions_compare_count,
-		$search_ranking_compare_count
+		$search_ranking_compare_count,
+		$base_date_filter_count,
+		$filtered_base_date
 	) {
 
 		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
@@ -162,6 +168,11 @@ final class Time_Based_SEO_Metrics_Route_Get_Metrics_Test extends Abstract_Time_
 			->times( ( $top_queries_count === 1 || $top_pages_count === 1 ) ? 1 : 0 )
 			->andReturn( 5 );
 
+		Monkey\Functions\expect( 'apply_filters' )
+			->times( $base_date_filter_count )
+			->with( 'wpseo_custom_site_kit_base_date', 'now' )
+			->andReturn( $filtered_base_date );
+
 		$this->assertInstanceOf(
 			'WP_REST_Response',
 			$this->instance->get_time_based_seo_metrics( $wp_rest_request )
@@ -205,29 +216,35 @@ final class Time_Based_SEO_Metrics_Route_Get_Metrics_Test extends Abstract_Time_
 	 */
 	public static function data_get_time_based_seo_metrics() {
 		return [
-			'Top pages route'          => [
+			'Top pages route' => [
 				'page',
 				1,
 				0,
 				0,
 				0,
 				0,
+				2,
+				'now',
 			],
-			'Top queries route'        => [
+			'Top queries route' => [
 				'query',
 				0,
 				1,
 				0,
 				0,
 				0,
+				2,
+				'now',
 			],
-			'Daily organic sessions'   => [
+			'Daily organic sessions' => [
 				'organicSessionsDaily',
 				0,
 				0,
 				1,
 				0,
 				0,
+				2,
+				'now',
 			],
 			'Compare organic sessions' => [
 				'organicSessionsCompare',
@@ -236,14 +253,58 @@ final class Time_Based_SEO_Metrics_Route_Get_Metrics_Test extends Abstract_Time_
 				0,
 				1,
 				0,
+				3,
+				'now',
 			],
-			'Compare search rankings'  => [
+			'Compare search rankings' => [
 				'searchRankingCompare',
 				0,
 				0,
 				0,
 				0,
 				1,
+				3,
+				'now',
+			],
+			'Daily organic sessions with custom base date' => [
+				'organicSessionsDaily',
+				0,
+				0,
+				1,
+				0,
+				0,
+				2,
+				'2023-01-01',
+			],
+			'Compare search rankings with custom base date' => [
+				'searchRankingCompare',
+				0,
+				0,
+				0,
+				0,
+				1,
+				3,
+				'2023-01-01',
+			],
+			'Daily organic sessions with invalid custom base date' => [
+				'organicSessionsDaily',
+				0,
+				0,
+				1,
+				0,
+				0,
+				2,
+				'2023-44-01',
+			],
+			'Compare search rankings with invalid custom base date' => [
+				'searchRankingCompare',
+				0,
+				0,
+				0,
+				0,
+				1,
+				3,
+				'2023-41-01',
 			],
 		];
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a filter to allow changing the requested dates in the Site Kit integration. Will be used for automated testing.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Quickly double check that the data you see in the Yoast Dashboard with and without this PR are the same (make sure you test in different tabs, to avoid cache)
* Add the following filter in your site:
```
add_filter( 'wpseo_custom_site_kit_base_date', 'custom_site_kit_base_date', 10 );
function custom_site_kit_base_date() {
    return 'now';
}
```
* In a new tab, confirm you still get the same data as before.
* Add the following filter in your site:
```
add_filter( 'wpseo_custom_site_kit_base_date', 'custom_site_kit_base_date', 10 );
function custom_site_kit_base_date() {
    return '2025-02-28';
}
```
* Go to the Yoast dashboard in a new tab and check that the data have changed
* Confirm that the data you see in the dashboard agree with the data you see for those dates in the SC and A4 platforms
  * So, if you used the `2025-02-28` date in the above filter, the dates you should use are "2025-01-31" & "2025-02-27" (and "2025-01-30" & "2025-01-03", for the compare dates)
* To make sure the filter is used properly and when it doesn't, it's not used, add the following invalid date:
```
add_filter( 'wpseo_custom_site_kit_base_date', 'custom_site_kit_base_date', 10 );
function custom_site_kit_base_date() {
    return '2025-42-28';
}
```
* Go to the Yoast dashboard in a new tab and confirm that the data are the same with if you didn't use a filter

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Included in the test instructions

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/524
