### PR TITLE
Adds an upsell for AI Optimize on products

### DIFF
--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import { AiGenerateTitlesAndDescriptionsUpsell } from "../../shared-admin/components";
@@ -6,16 +5,26 @@ import { __, sprintf } from "@wordpress/i18n";
 
 const STORE = "yoast-seo/editor";
 
-/* eslint-disable max-statements */
 /**
- * @returns {JSX.Element} The element.
+ * The upsell props.
+ * @typedef {Object} UpsellProps
+ * @property {string} upsellLink The URL for the upsell.
+ * @property {string} [upsellLabel] The label for the upsell.
+ * @property {string} [newToText] The "new to" text for the upsell.
+ * @property {JSX.Element} [bundleNote] A note about the bundle upsell.
+ * @property {string} [ctbId] The CTB ID for the upsell.
+ * @property {boolean} [isProductCopy] Whether the upsell is for product copy.
  */
-export const ModalContent = () => {
-	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-learn-more" ), [] );
-	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] );
-	const upsellLinkWooPremiumBundle = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] );
-	const upsellLinkWoo = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] );
 
+/**
+ * Retrieves the upsell props based on the active licenses.
+ * @param {Object} upsellLinks An object containing the upsell links and their associated data.
+ * @param {string} upsellLinks.premium The Yoast SEO Premium upsell link .
+ * @param {string} upsellLinks.woo The Yoast WooCommerce SEO upsell link.
+ * @param {string} upsellLinks.bundle The bundle upsell link.
+ * @returns {UpsellProps} The upsell props.
+ */
+export const getUpsellProps = ( upsellLinks ) => {
 	const isPremiumActive = useSelect( select => select( STORE ).getIsPremium(), [] );
 	const isWooSeoActive = useSelect( select => select( STORE ).getIsWooSeoActive(), [] );
 	const isWooCommerceActive = useSelect( select => select( STORE ).getIsWooCommerceActive(), [] );
@@ -24,14 +33,9 @@ export const ModalContent = () => {
 	const isProductTerm = useSelect( select => select( STORE ).getIsProductTerm(), [] );
 
 	const upsellProps = {
-		upsellLink: upsellLinkPremium,
+		upsellLink: upsellLinks.premium,
+		// The default ctbId is passed as a prop to the AiGenerateTitlesAndDescriptionsUpsell component.
 	};
-
-	// Use specific copy for product posts.
-	if ( isWooCommerceActive && isProductPost ) {
-		upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
-		upsellProps.isProductCopy = true;
-	}
 
 	// Use specific copy for product posts and terms, otherwise revert to the defaults.
 	if ( isWooCommerceActive && ( isProductPost || isProductTerm ) ) {
@@ -53,7 +57,7 @@ export const ModalContent = () => {
 				__( "Unlock with %1$s", "wordpress-seo" ),
 				"Yoast WooCommerce SEO"
 			);
-			upsellProps.upsellLink = upsellLinkWoo;
+			upsellProps.upsellLink = upsellLinks.woo;
 			upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
 		} else if ( ! isWooSeoActive ) {
 			upsellProps.upsellLabel = `${sprintf(
@@ -64,10 +68,35 @@ export const ModalContent = () => {
 			upsellProps.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
 				{ `*${upsellPremiumWooLabel}` }
 			</div>;
-			upsellProps.upsellLink = upsellLinkWooPremiumBundle;
+			upsellProps.upsellLink = upsellLinks.bundle;
 			upsellProps.ctbId = "c7e7baa1-2020-420c-a427-89701700b607";
 		}
 	}
+	return upsellProps;
+};
+
+/**
+ * @returns {JSX.Element} The element.
+ */
+export const ModalContent = () => {
+	const upsellLinks = {
+		premium: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] ),
+		bundle: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] ),
+		woo: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] ),
+	};
+
+	const upsellProps = getUpsellProps( upsellLinks );
+
+	// Use specific copy for product posts.
+	const isWooCommerceActive = useSelect( select => select( STORE ).getIsWooCommerceActive(), [] );
+	const isProductPost = useSelect( select => select( STORE ).getIsProduct(), [] );
+
+	if ( isWooCommerceActive && isProductPost ) {
+		upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
+		upsellProps.isProductCopy = true;
+	}
+
+	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-generator-learn-more" ), [] );
 
 	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-generator-preview.png" ), [] );
 	const thumbnail = useMemo( () => ( {
@@ -90,4 +119,3 @@ export const ModalContent = () => {
 		/>
 	);
 };
-/* eslint-enable max-statements */

--- a/packages/js/src/ai-optimizer/components/ai-optimize-button.js
+++ b/packages/js/src/ai-optimizer/components/ai-optimize-button.js
@@ -43,12 +43,15 @@ const AIOptimizeButton = ( { id, isPremium } ) => {
 	// We continue to use "AIFixes" in the ID to keep it consistent with the Premium implementation.
 	const aiOptimizeId = id + "AIFixes";
 	const [ isModalOpen, , , setIsModalOpenTrue, setIsModalOpenFalse ] = useToggleState( false );
-	const { activeMarker, activeAIButtonId, editorType } = useSelect( ( select ) => ( {
+	const { activeMarker, activeAIButtonId, editorType, isWooSeoUpsellPost } = useSelect( ( select ) => ( {
 		activeMarker: select( "yoast-seo/editor" ).getActiveMarker(),
 		activeAIButtonId: select( "yoast-seo/editor" ).getActiveAIFixesButton(),
 		editorType: select( "yoast-seo/editor" ).getEditorType(),
+		isWooSeoUpsellPost: select( "yoast-seo/editor" ).getIsWooSeoUpsell(),
 	} ), [] );
 	const editorMode = getEditorMode();
+
+	const shouldShowUpsell = ! isPremium || isWooSeoUpsellPost;
 
 	const { setActiveAIFixesButton, setActiveMarker, setMarkerPauseStatus, setMarkerStatus } = useDispatch( "yoast-seo/editor" );
 	const focusElementRef = useRef( null );
@@ -137,11 +140,12 @@ const AIOptimizeButton = ( { id, isPremium } ) => {
 	};
 
 	const handleClick = useCallback( () => {
-		if ( isPremium ) {
+		// eslint-disable-next-line no-negated-condition -- Let's handle the happy path first.
+		if ( ! shouldShowUpsell ) {
 			doAction( "yoast.ai.fixAssessments", aiOptimizeId );
 			/* Only handle the pressed button state in Premium.
 			We don't want to change the background color of the button and other styling when it's pressed in Free.
-			This is because clicking on the button in Free will open the modal, and the button will not be in a pressed state. */
+			This is because clicking on the button in Free will open an upsell modal, and the button will not be in a pressed state. */
 			handlePressedButton();
 		} else {
 			setIsModalOpenTrue();
@@ -172,7 +176,7 @@ const AIOptimizeButton = ( { id, isPremium } ) => {
 			pressed={ isButtonPressed }
 			disabled={ ! isEnabled }
 		>
-			{ ! isPremium && <LockClosedIcon className="yst-fixes-button__lock-icon yst-text-amber-900" /> }
+			{ shouldShowUpsell && <LockClosedIcon className="yst-fixes-button__lock-icon yst-text-amber-900" /> }
 			<SparklesIcon pressed={ isButtonPressed } />
 			{
 				isModalOpen && <Modal className="yst-introduction-modal" isOpen={ isModalOpen } onClose={ setIsModalOpenFalse } initialFocus={ focusElementRef }>

--- a/packages/js/src/ai-optimizer/components/modal-content.js
+++ b/packages/js/src/ai-optimizer/components/modal-content.js
@@ -1,7 +1,7 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import { AIOptimizeUpsell } from "../../shared-admin/components";
-import { __, sprintf } from "@wordpress/i18n";
+import { getUpsellProps } from "../../ai-generator/components/modal-content";
 
 const STORE = "yoast-seo/editor";
 
@@ -9,18 +9,15 @@ const STORE = "yoast-seo/editor";
  * @returns {JSX.Element} The element.
  */
 export const ModalContent = () => {
-	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-learn-more" ), [] );
-	const upsellLinkPremium = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell" ), [] );
-
-	const postModalprops = {
-		upsellLink: upsellLinkPremium,
-		title: __( "Fix assessments with AI!", "wordpress-seo" ),
-		upsellLabel: sprintf(
-			/* translators: %1$s expands to Yoast SEO Premium. */
-			__( "Unlock with %1$s", "wordpress-seo" ),
-			"Yoast SEO Premium"
-		),
+	const upsellLinks = {
+		premium: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell" ), [] ),
+		bundle: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo-premium-bundle" ), [] ),
+		woo: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo" ), [] ),
 	};
+
+	const upsellProps = getUpsellProps( upsellLinks );
+
+	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-learn-more" ), [] );
 
 	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-fix-assessments-thumbnail.png" ), [] );
 	const thumbnail = useMemo( () => ( {
@@ -34,13 +31,12 @@ export const ModalContent = () => {
 	const { setWistiaEmbedPermission: set } = useDispatch( STORE );
 	const wistiaEmbedPermission = useMemo( () => ( { value, status, set } ), [ value, status, set ] );
 
-
 	return (
 		<AIOptimizeUpsell
 			learnMoreLink={ learnMoreLink }
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
-			{ ...postModalprops }
+			{ ...upsellProps }
 		/>
 	);
 };

--- a/packages/js/src/shared-admin/components/ai-optimize-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-optimize-upsell.js
@@ -12,6 +12,9 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {Object} wistiaEmbedPermission The value, status and set for the Wistia embed permission.
  * @param {string} upsellLink The upsell link.
  * @param {string} upsellLabel The upsell label.
+ * @param {string} newToText The new to text.
+ * @param {string|JSX.Element} bundleNote The bundle note.
+ * @param {string} ctbId The click to buy to register for this upsell instance.
  * @returns {JSX.Element} The element.
  */
 export const AIOptimizeUpsell = ( {
@@ -20,6 +23,9 @@ export const AIOptimizeUpsell = ( {
 	wistiaEmbedPermission,
 	upsellLink,
 	upsellLabel,
+	newToText,
+	bundleNote,
+	ctbId,
 } ) => {
 	const { onClose, initialFocus } = useModalContext();
 
@@ -49,7 +55,7 @@ export const AIOptimizeUpsell = ( {
 				<div className="yst-mt-6 yst-text-xs yst-font-medium yst-flex yst-flex-col yst-items-center">
 					<span className="yst-introduction-modal-uppercase yst-flex yst-gap-2 yst-items-center">
 						<span className="yst-logo-icon" />
-						Yoast SEO Premium
+						{ newToText }
 					</span>
 				</div>
 			</div>
@@ -91,7 +97,7 @@ export const AIOptimizeUpsell = ( {
 						target="_blank"
 						ref={ initialFocus }
 						data-action="load-nfd-ctb"
-						data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
+						data-ctb-id={ ctbId }
 					>
 						<LockOpenIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5" />
 						{ upsellLabel }
@@ -103,6 +109,7 @@ export const AIOptimizeUpsell = ( {
 						</span>
 					</Button>
 				</div>
+				{ bundleNote }
 				<Button
 					as="a"
 					className="yst-mt-4"
@@ -129,6 +136,12 @@ AIOptimizeUpsell.propTypes = {
 		set: PropTypes.func.isRequired,
 	} ).isRequired,
 	upsellLabel: PropTypes.string,
+	newToText: PropTypes.string,
+	bundleNote: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.element,
+	] ),
+	ctbId: PropTypes.string,
 };
 
 AIOptimizeUpsell.defaultProps = {
@@ -137,4 +150,7 @@ AIOptimizeUpsell.defaultProps = {
 		__( "Unlock with %1$s", "wordpress-seo" ),
 		"Yoast SEO Premium"
 	),
+	newToText: "Yoast SEO Premium",
+	bundleNote: "",
+	ctbId: "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 };

--- a/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
+++ b/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
@@ -81,7 +81,7 @@ describe( "AIOptimizeButton", () => {
 		expect( lockIcon ).toBeInTheDocument();
 	} );
 
-	test( "should find the button, but also a lock icon when Yoast WooCommerce SEO (on products)", () => {
+	test( "should find the button, but also a lock icon when Yoast WooCommerce SEO is not activated (on products)", () => {
 		mockSelect( "keyphraseDensityAIFixes", "visual", "blockEditor", [], "", true );
 		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
 

--- a/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
+++ b/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
@@ -29,9 +29,10 @@ global.window.YoastSEO = {
  * @param {string} editorType The editor type.
  * @param {object[]} blocks The blocks.
  * @param {string} activeMarker The active marker.
+ * @param {boolean} shouldUpsellWoo Whether to show the Yoast WooCommerce SEO upsell.
  * @returns {function} The mock.
  */
-const mockSelect = ( activeAIButton, editorMode = "visual", editorType = "blockEditor", blocks = [], activeMarker = "" ) => {
+const mockSelect = ( activeAIButton, editorMode = "visual", editorType = "blockEditor", blocks = [], activeMarker = "", shouldUpsellWoo = false ) => {
 	useSelect.mockImplementation( select => select( () => ( {
 		getActiveAIFixesButton: () => activeAIButton,
 		getActiveMarker: () => activeMarker,
@@ -40,12 +41,13 @@ const mockSelect = ( activeAIButton, editorMode = "visual", editorType = "blockE
 		getBlockMode: ( clientId ) => clientId === "htmlTest" ? "text" : "visual",
 		getEditorMode: () => editorMode,
 		getEditorType: () => editorType,
+		getIsWooSeoUpsell: () => shouldUpsellWoo,
 	} ) ) );
 
 	isTextViewActive.mockReturnValue( editorMode === "text" );
 };
 
-describe( "AIAssessmentFixesButton", () => {
+describe( "AIOptimizeButton", () => {
 	let setActiveAIFixesButton;
 	let setActiveMarker;
 	let setMarkerPauseStatus;
@@ -69,19 +71,33 @@ describe( "AIAssessmentFixesButton", () => {
 		jest.clearAllMocks();
 	} );
 
-	test( "should find the correct aria-label in the document", () => {
+	test( "should find the button, but also a lock icon when Yoast SEO Premium is not activated", () => {
 		mockSelect( "keyphraseDensityAIFixes" );
 		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ false } /> );
 
 		const labelText = document.querySelector( 'button[aria-label="Optimize with AI"]' );
 		expect( labelText ).toBeInTheDocument();
+		const lockIcon = document.querySelector( ".yst-fixes-button__lock-icon" );
+		expect( lockIcon ).toBeInTheDocument();
 	} );
 
-	test( "should find the correct button id", () => {
+	test( "should find the button, but also a lock icon when Yoast WooCommerce SEO (on products)", () => {
+		mockSelect( "keyphraseDensityAIFixes", "visual", "blockEditor", [], "", true );
+		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
+
+		const labelText = document.querySelector( 'button[aria-label="Optimize with AI"]' );
+		expect( labelText ).toBeInTheDocument();
+		const lockIcon = document.querySelector( ".yst-fixes-button__lock-icon" );
+		expect( lockIcon ).toBeInTheDocument();
+	} );
+
+	test( "should find the button without a lock if no upsell is needed", () => {
 		mockSelect( "keyphraseDensityAIFixes" );
 		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
 		const button = screen.getByRole( "button" );
 		expect( button ).toBeInTheDocument();
+		const lockIcon = document.querySelector( ".yst-fixes-button__lock-icon" );
+		expect( lockIcon ).not.toBeInTheDocument();
 	} );
 
 	test( "should find the button without tooltip when the button is NOT hovered", () => {
@@ -182,7 +198,7 @@ describe( "AIAssessmentFixesButton", () => {
 		expect( setMarkerStatus ).toHaveBeenCalledWith( "enabled" );
 	} );
 	test( "should remove the active marker if it's available when the AI button is clicked", () => {
-		mockSelect( "keyphraseDensityAIFixes", "visual", "blockEditor", [ { clientId: "test" } ], "test", "keyphraseDensity" );
+		mockSelect( "keyphraseDensityAIFixes", "visual", "blockEditor", [ { clientId: "test" } ], "test" );
 		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
 		const button = screen.getByRole( "button" );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add an upsell for AI Optimize on WooCommerce products. This follows the same logic as we have for the AI Generate functionality. This PR is a follow-up of #21417 and #22214. 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures that AI Optimize on WooCommerce products can only be used with Yoast SEO Premium and Yoast WooCommerce SEO active, shows an upsell otherwise.

## Relevant technical choices:

* We're reusing the code in AI Generate to retrieve the correct upsell properties.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

> [!NOTE]
> While testing the AI Optimize upsell, smoke test the AI Generate upsell as well, see #22214 for the testing steps.

#### Prerequisites
* Create a WooCommerce product that has any AI Optimize button active. 
* For example, create product that has an introduction, but a keyphrase that does not appear in that introduction. 

#### Test the Yoast SEO Premium upsell
* Make sure Yoast SEO Premium is deactivated, but Yoast WooCommerce SEO is activated.
* Confirm clicking the AI Optimize button opens an upsell modal. 
* It should prompt you to buy Yoast SEO Premium, like this: 
![Screenshot 2025-05-12 at 09 00 23](https://github.com/user-attachments/assets/a68bd067-9628-423a-839e-971f7c0d6573)
* Inspect the big yellow upsell button.
* Confirm the shortlink starts with `https://yoa.st/ai-fix-assessments-upsell`.
* Confirm the CTB id is `f6a84663-465f-4cb5-8ba5-f7a6d72224b2`.

#### Test the Yoast WooCommerce SEO upsell
* Make sure Yoast SEO Premium is activated, but Yoast WooCommerce SEO is activated.
* Confirm clicking the AI Optimize button opens an upsell modal. 
* It should prompt you to buy Yoast WooCommerce SEO, like this: 
![Screenshot 2025-05-12 at 09 00 43](https://github.com/user-attachments/assets/bc8a4180-6a0f-46e6-ab33-3d8dfe9e16b5)
* Inspect the big yellow upsell button.
* Confirm the shortlink starts with `https://yoa.st/ai-fix-assessments-upsell-woo-seo`.
* Confirm the CTB id is `5b32250e-e6f0-44ae-ad74-3cefc8e427f9`.

#### Test the bundle upsell
* Make sure Yoast SEO Premium and Yoast WooCommerce SEO are both deactivated.
* Confirm clicking the AI Optimize button opens an upsell modal. 
* It should prompt you to buy the bundle, like this: 
![Screenshot 2025-05-12 at 09 00 03](https://github.com/user-attachments/assets/b5caeeeb-be2b-4598-b3ce-827bd745c573)
* Inspect the big yellow upsell button.
* Confirm the shortlink starts with `https://yoa.st/ai-fix-assessments-upsell-woo-seo-premium-bundle`.
* Confirm the CTB id is `c7e7baa1-2020-420c-a427-89701700b607`.

#### Test the happy path
* Activate Yoast SEO Premium and Yoast WooCommerce SEO.
* Confirm the Toast loads when clicking the AI Optimize button. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The upsell modals for AI Generate and AI Optimize.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/4627
