### PR TITLE
Analysis Report: Refactor defaultProps to be defaultArguments

### DIFF
--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -16,7 +16,7 @@
     "build:js": "babel src --out-dir build",
     "clean": "rm -rf build",
     "test": "jest",
-    "lint": "eslint . --max-warnings=8"
+    "lint": "eslint . --max-warnings=4"
   },
   "author": "Team Yoast",
   "license": "GPL-3.0",

--- a/packages/analysis-report/src/AnalysisList.js
+++ b/packages/analysis-report/src/AnalysisList.js
@@ -1,14 +1,9 @@
-/* External dependencies */
 import { __, sprintf } from "@wordpress/i18n";
+import { colors } from "@yoast/style-guide";
+import noop from "lodash/noop";
+import PropTypes from "prop-types";
 import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
-import noop from "lodash/noop";
-
-/* Yoast dependencies. */
-import { colors } from "@yoast/style-guide";
-
-/* Internal dependencies */
 import AnalysisResult from "./AnalysisResult";
 
 /**
@@ -45,32 +40,47 @@ export function renderRatingToColor( rating ) {
 /**
  * Renders a list of results based on the array of results.
  *
- * @param {Object}          props                               Component props.
- * @param {MappedResult[]}  props.results                       The results from YoastSEO.js
- * @param {string}          props.marksButtonActivatedResult    The currently activated result.
- * @param {string}          props.marksButtonStatus             The overall status of the mark buttons.
- * @param {string}          props.marksButtonClassName          A class name to set on the mark buttons.
- * @param {string}          props.editButtonClassName           A class name to set on the edit buttons.
- * @param {Function}        [props.markButtonFactory]           Injectable factory to create custom mark buttons.
- * @param {Function}        props.onMarksButtonClick            Function that is called when the user
- *                                                              clicks one of the mark buttons.
- * @param {Function}        props.onEditButtonClick             Function that is called when the user
- *                                                              clicks one of the edit buttons.
- * @param {bool}            props.isPremium                     Whether the Premium plugin is active or not.
+ * @param {MappedResult[]} results The results from YoastSEO.js.
+ * @param {string} [marksButtonActivatedResult] The currently activated result.
+ * @param {string} [marksButtonStatus] The overall status of the mark buttons.
+ * @param {string} [marksButtonClassName] A class name to set on the mark buttons.
+ * @param {string} [editButtonClassName] A class name to set on the edit buttons.
+ * @param {?Function} [markButtonFactory] Injectable factory to create custom mark buttons.
+ * @param {Function} [onMarksButtonClick] Function that is called when the user clicks one of the mark buttons.
+ * @param {Function} [onEditButtonClick] Function that is called when the user clicks one of the edit buttons.
+ * @param {boolean} [isPremium] Whether the Premium plugin is active or not.
+ * @param {Function} [onResultChange] Function that is called when the user changes the result.
+ * @param {boolean} [shouldUpsellHighlighting] Whether the highlighting upsell should be shown.
+ * @param {Function} [renderHighlightingUpsell] Function to render the highlighting upsell.
+ * @param {Function} [renderAIOptimizeButton] Function to render the AI optimize button.
  *
  * @returns {JSX.Element} The rendered list.
  */
-export default function AnalysisList( props ) {
+export default function AnalysisList( {
+	results,
+	marksButtonActivatedResult = "",
+	marksButtonStatus = "enabled",
+	marksButtonClassName = "",
+	editButtonClassName = "",
+	markButtonFactory = null,
+	onMarksButtonClick = noop,
+	onEditButtonClick = noop,
+	isPremium = false,
+	onResultChange = noop,
+	shouldUpsellHighlighting = false,
+	renderHighlightingUpsell = noop,
+	renderAIOptimizeButton = noop,
+} ) {
 	return <AnalysisListBase role="list">
-		{ props.results.map( ( result ) => {
+		{ results.map( ( result ) => {
 			const color = renderRatingToColor( result.rating );
-			const isMarkButtonPressed = result.markerId === props.marksButtonActivatedResult;
+			const isMarkButtonPressed = result.markerId === marksButtonActivatedResult;
 
 			const markButtonId = result.id + "Mark";
 			const editButtonId = result.id + "Edit";
 
 			let ariaLabelMarks = "";
-			if ( props.marksButtonStatus === "disabled" ) {
+			if ( marksButtonStatus === "disabled" ) {
 				ariaLabelMarks = __( "Highlighting is currently disabled", "wordpress-seo" );
 			} else if ( isMarkButtonPressed ) {
 				ariaLabelMarks = __( "Remove highlight from the text", "wordpress-seo" );
@@ -81,8 +91,7 @@ export default function AnalysisList( props ) {
 			const editFieldName = result.editFieldName;
 			const ariaLabelEdit = editFieldName === "" ? ""
 				: sprintf(
-					/* Translators: %1$s refers to the name of the field that should be edited (keyphrase, meta description,
-					   slug or SEO title). */
+					/* Translators: %1$s refers to the name of the field that should be edited (keyphrase, meta description, slug or SEO title). */
 					__( "Edit your %1$s", "wordpress-seo" ), editFieldName );
 
 			return <AnalysisResult
@@ -100,18 +109,18 @@ export default function AnalysisList( props ) {
 				suppressedText={ result.rating === "upsell" }
 				buttonIdMarks={ markButtonId }
 				buttonIdEdit={ editButtonId }
-				onButtonClickMarks={ () => props.onMarksButtonClick( result.id, result.marker ) }
-				onButtonClickEdit={ () => props.onEditButtonClick( result.id ) }
-				marksButtonClassName={ props.marksButtonClassName }
-				editButtonClassName={ props.editButtonClassName }
-				marksButtonStatus={ props.marksButtonStatus }
+				onButtonClickMarks={ () => onMarksButtonClick( result.id, result.marker ) }
+				onButtonClickEdit={ () => onEditButtonClick( result.id ) }
+				marksButtonClassName={ marksButtonClassName }
+				editButtonClassName={ editButtonClassName }
+				marksButtonStatus={ marksButtonStatus }
 				hasBetaBadgeLabel={ result.hasBetaBadge }
-				isPremium={ props.isPremium }
-				onResultChange={ props.onResultChange }
-				markButtonFactory={ props.markButtonFactory }
-				shouldUpsellHighlighting={ props.shouldUpsellHighlighting }
-				renderAIOptimizeButton={ props.renderAIOptimizeButton }
-				renderHighlightingUpsell={ props.renderHighlightingUpsell }
+				isPremium={ isPremium }
+				onResultChange={ onResultChange }
+				markButtonFactory={ markButtonFactory }
+				shouldUpsellHighlighting={ shouldUpsellHighlighting }
+				renderAIOptimizeButton={ renderAIOptimizeButton }
+				renderHighlightingUpsell={ renderHighlightingUpsell }
 			/>;
 		} ) }
 	</AnalysisListBase>;
@@ -131,18 +140,4 @@ AnalysisList.propTypes = {
 	shouldUpsellHighlighting: PropTypes.bool,
 	renderHighlightingUpsell: PropTypes.func,
 	renderAIOptimizeButton: PropTypes.func,
-};
-
-AnalysisList.defaultProps = {
-	marksButtonActivatedResult: "",
-	marksButtonStatus: "enabled",
-	marksButtonClassName: "",
-	editButtonClassName: "",
-	onMarksButtonClick: noop,
-	onEditButtonClick: noop,
-	isPremium: false,
-	onResultChange: noop,
-	shouldUpsellHighlighting: false,
-	renderHighlightingUpsell: noop,
-	renderAIOptimizeButton: noop,
 };

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-import { noop } from "lodash";
-import { SvgIcon, IconButtonToggle, IconCTAEditButton, BetaBadge } from "@yoast/components";
+import { BetaBadge, IconButtonToggle, IconCTAEditButton, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import React, { useCallback, useEffect, useState } from "react";
+import styled from "styled-components";
 
 const { stripTagsFromHtmlString } = strings;
 
@@ -41,13 +41,12 @@ const AnalysisResultText = styled.p`
 /**
  * Determines whether the mark buttons should be hidden.
  *
- * @param {Object} props The component's props.
- * @param {String} props.marksButtonStatus The status for the mark buttons.
- * @param {boolean} props.hasMarksButton Whether a mark button exists.
+ * @param {boolean} hasMarksButton Whether a mark button exists.
+ * @param {string} marksButtonStatus The status for the mark buttons.
  * @returns {boolean} True if mark buttons should be hidden.
  */
-const areMarkButtonsHidden = function( props ) {
-	return ( ! props.hasMarksButton ) || props.marksButtonStatus === "hidden";
+const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
+	return ! hasMarksButton || marksButtonStatus === "hidden";
 };
 
 /**
@@ -84,38 +83,61 @@ const createMarkButton = ( {
 /**
  * Returns an AnalysisResult component.
  *
- * @param {object} props Component props.
- * @param {Function} [markButtonFactory] Injectable factory to create mark button.
+ * @param {string} text The text to be displayed in the result.
+ * @param {boolean} [suppressedText=false] Whether the text should be suppressed.
+ * @param {string} bulletColor The color of the bullet icon.
+ * @param {boolean} hasMarksButton Whether the result has a marks button.
+ * @param {boolean} [hasEditButton=false] Whether the result has an edit button.
+ * @param {boolean} [hasAIFixes=false] Whether the result has AI fixes.
+ * @param {string} buttonIdMarks The id of the marks button.
+ * @param {string} [buttonIdEdit=""] The id of the edit button.
+ * @param {boolean} pressed Whether the marks button is pressed.
+ * @param {string} ariaLabelMarks The aria-label for the marks button.
+ * @param {string} [ariaLabelEdit=""] The aria-label for the edit button.
+ * @param {Function} onButtonClickMarks The function to call when the marks button is clicked.
+ * @param {Function} [onButtonClickEdit=noop] The function to call when the edit button is clicked.
+ * @param {string} [marksButtonStatus="enabled"] The status of the marks button.
+ * @param {string} [marksButtonClassName=""] The class name for the marks button.
+ * @param {Function} [markButtonFactory=null] Injectable factory to create mark button.
+ * @param {string} [editButtonClassName=""] The class name for the edit button.
+ * @param {boolean} [hasBetaBadgeLabel=false] Whether the result has a beta badge label.
+ * @param {boolean} [isPremium=false] Whether the user has a premium subscription.
+ * @param {Function} [onResultChange=noop] The function to call when the result changes.
+ * @param {string} [id=""] The id of the result.
+ * @param {Function|array} [marker=noop] The function or array to mark the result.
+ * @param {boolean} [shouldUpsellHighlighting=false] Whether to show the upsell for highlighting.
+ * @param {Function} [renderHighlightingUpsell=noop] The function to render the highlighting upsell.
+ * @param {Function} [renderAIOptimizeButton=noop] The function to render the AI optimize button.
  *
  * @returns {ReactElement} The rendered AnalysisResult component.
  */
-const AnalysisResult = ( { markButtonFactory, ...props } ) => {
-	const {
-		ariaLabelMarks,
-		ariaLabelEdit,
-		bulletColor,
-		buttonIdMarks,
-		buttonIdEdit,
-		editButtonClassName,
-		hasAIFixes,
-		hasBetaBadgeLabel,
-		hasEditButton,
-		hasMarksButton,
-		id,
-		isPremium,
-		marker,
-		marksButtonStatus,
-		marksButtonClassName,
-		onButtonClickMarks,
-		onButtonClickEdit,
-		onResultChange,
-		pressed,
-		renderHighlightingUpsell,
-		renderAIOptimizeButton,
-		shouldUpsellHighlighting,
-		suppressedText,
-		text,
-	} = props;
+const AnalysisResult = ( {
+	ariaLabelMarks,
+	ariaLabelEdit = "",
+	bulletColor,
+	buttonIdMarks,
+	buttonIdEdit = "",
+	editButtonClassName = "",
+	hasAIFixes = false,
+	hasBetaBadgeLabel = false,
+	hasEditButton = false,
+	hasMarksButton,
+	id = "",
+	isPremium = false,
+	marker = noop,
+	markButtonFactory = null,
+	marksButtonStatus = "enabled",
+	marksButtonClassName = "",
+	onButtonClickMarks,
+	onButtonClickEdit = noop,
+	onResultChange = noop,
+	pressed,
+	renderHighlightingUpsell = noop,
+	renderAIOptimizeButton = noop,
+	shouldUpsellHighlighting = false,
+	suppressedText = false,
+	text,
+} ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
@@ -124,7 +146,7 @@ const AnalysisResult = ( { markButtonFactory, ...props } ) => {
 	markButtonFactory = markButtonFactory || createMarkButton;
 
 	let marksButton = null;
-	if ( ! areMarkButtonsHidden( props ) ) {
+	if ( ! areMarkButtonsHidden( hasMarksButton, marksButtonStatus ) ) {
 		marksButton = markButtonFactory(
 			{
 				onClick: shouldUpsellHighlighting ? openModal : onButtonClickMarks,
@@ -183,7 +205,6 @@ AnalysisResult.propTypes = {
 	bulletColor: PropTypes.string.isRequired,
 	hasMarksButton: PropTypes.bool.isRequired,
 	hasEditButton: PropTypes.bool,
-	hasAIButton: PropTypes.bool,
 	hasAIFixes: PropTypes.bool,
 	buttonIdMarks: PropTypes.string.isRequired,
 	buttonIdEdit: PropTypes.string,
@@ -207,26 +228,6 @@ AnalysisResult.propTypes = {
 	shouldUpsellHighlighting: PropTypes.bool,
 	renderHighlightingUpsell: PropTypes.func,
 	renderAIOptimizeButton: PropTypes.func,
-};
-
-AnalysisResult.defaultProps = {
-	suppressedText: false,
-	marksButtonStatus: "enabled",
-	marksButtonClassName: "",
-	editButtonClassName: "",
-	hasBetaBadgeLabel: false,
-	hasEditButton: false,
-	hasAIFixes: false,
-	buttonIdEdit: "",
-	ariaLabelEdit: "",
-	onButtonClickEdit: noop,
-	isPremium: false,
-	onResultChange: noop,
-	id: "",
-	marker: noop,
-	shouldUpsellHighlighting: false,
-	renderHighlightingUpsell: noop,
-	renderAIOptimizeButton: noop,
 };
 
 export default AnalysisResult;

--- a/packages/analysis-report/src/SiteSEOReport.js
+++ b/packages/analysis-report/src/SiteSEOReport.js
@@ -1,8 +1,7 @@
-import React from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-
 import { ScoreAssessments as SiteSEOReportAssessments, StackedProgressBar } from "@yoast/components";
+import PropTypes from "prop-types";
+import React from "react";
+import styled from "styled-components";
 
 /**
  * SeoAssessment container.
@@ -20,28 +19,36 @@ const SiteSEOReportText = styled.p`
 /**
  * The Dashboard Seo Assessment component.
  *
- * @param {object} props The component props.
+ * @param {string} [className="seo-assessment"] The class name to use.
+ * @param {string} [seoAssessmentText="SEO Assessment"] The text to show.
+ * @param {{html: string, value: number, color: string}[]|null} [seoAssessmentItems=null] The items to show in the assessment.
+ * @param {string} [barHeight="24px"] The height of the progress bar.
  *
  * @returns {ReactElement} The react component.
  */
-const SiteSEOReport = ( props ) => {
+const SiteSEOReport = ( {
+	className = "seo-assessment",
+	seoAssessmentText = "SEO Assessment",
+	seoAssessmentItems = null,
+	barHeight = "24px",
+} ) => {
 	return (
 		<SiteSEOReportContainer
-			className={ props.className }
+			className={ className }
 		>
 			<SiteSEOReportText
-				className={ `${ props.className }__text` }
+				className={ `${ className }__text` }
 			>
-				{ props.seoAssessmentText }
+				{ seoAssessmentText }
 			</SiteSEOReportText>
 			<StackedProgressBar
 				className="progress"
-				items={ props.seoAssessmentItems }
-				barHeight={ props.barHeight }
+				items={ seoAssessmentItems }
+				barHeight={ barHeight }
 			/>
 			<SiteSEOReportAssessments
 				className="assessments"
-				items={ props.seoAssessmentItems }
+				items={ seoAssessmentItems }
 			/>
 		</SiteSEOReportContainer>
 	);
@@ -58,13 +65,6 @@ SiteSEOReport.propTypes = {
 		} )
 	),
 	barHeight: PropTypes.string,
-};
-
-SiteSEOReport.defaultProps = {
-	className: "seo-assessment",
-	seoAssessmentText: "SEO Assessment",
-	seoAssessmentItems: null,
-	barHeight: "24px",
 };
 
 export default SiteSEOReport;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

> [!IMPORTANT]
> Based of https://github.com/Yoast/wordpress-seo/pull/22256
> The merge base should be updated to trunk automatically if that is merged first

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/analysis-report 0.1.0] Refactors the `defaultProps` to be `defaultArguments` instead.

## Relevant technical choices:

[Refactor defaultProps to defaultArguments](https://github.com/Yoast/wordpress-seo/commit/a4ed8374ae5032a73f6d79a40c1df7807a8145d3) 
* fix JS doc
* use prop spreading
* specify which props in "areMarkButtonsHidden"
* remove unused "hasAIButton" prop
* remove import comments (as they interfere with my auto ordering)

[Decrease allowed warning count](https://github.com/Yoast/wordpress-seo/pull/22263/commits/8a2c84c7ee2d38fd5a0455b0d07672c271980796) 
Still 2 more than before the ESLint config bump. The defaults count as complexity, due to their if/else nature I suppose.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Smoke test the analysis results in each editor.
* Smoke test the SiteSEOReport on the WP dashboard:
![image](https://github.com/user-attachments/assets/c45ee586-85d6-4826-b65f-d24be3232f9a)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/570