### PR TITLE
Add copy and shortlink in feature card

### DIFF
--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -70,12 +70,6 @@ class Yoast_Feature_Toggles {
 								. '" target="_blank">' . esc_html__( 'See the XML sitemap.', 'wordpress-seo' ) . '</a>';
 		}
 
-		$llms_txt_extra = false;
-		if ( WPSEO_Options::get( 'enable_llms_txt' ) ) {
-			$llms_txt_extra = '<a href="' . esc_url( home_url( 'llms.txt' ) )
-								. '" target="_blank">' . esc_html__( 'See the Llms.txt.', 'wordpress-seo' ) . '</a>';
-		}
-
 		$feature_toggles = [
 			(object) [
 				'name'            => __( 'SEO analysis', 'wordpress-seo' ),
@@ -218,18 +212,6 @@ class Yoast_Feature_Toggles {
 				'premium_url'        => 'https://yoa.st/ai-generator-feature',
 				'premium_upsell_url' => 'https://yoa.st/get-ai-generator',
 				'order'              => 115,
-			],
-			(object) [
-				'name'               => __( 'LLMs.txt', 'wordpress-seo' ),
-				'premium'            => true,
-				'setting'            => 'enable_llms_txt',
-				'label'              => __( 'Placeholder text2', 'wordpress-seo' ),
-				'read_more_label'    => __( 'Learn more', 'wordpress-seo' ),
-				'extra'              => $llms_txt_extra,
-				'read_more_url'      => '#',
-				'premium_url'        => '#',
-				'premium_upsell_url' => '#',
-				'order'              => 120,
 			],
 		];
 

--- a/inc/options/class-wpseo-option-ms.php
+++ b/inc/options/class-wpseo-option-ms.php
@@ -128,7 +128,6 @@ class WPSEO_Option_MS extends WPSEO_Option {
 			"{$allow_prefix}search_cleanup_patterns"            => true,
 			"{$allow_prefix}redirect_search_pretty_urls"        => true,
 			"{$allow_prefix}algolia_integration_active"         => true,
-			"{$allow_prefix}enable_llms_txt"                    => true,
 		];
 
 		if ( is_multisite() ) {

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -432,14 +432,14 @@ const SiteFeatures = () => {
 								<p>{ __( "Boost the visibility of your content in AI searches. Automatically create an llms.txt file that lists a selection of your site's content. This helps LLMs access and provide your site's information more easily.", "wordpress-seo" ) }</p>
 								{ initialEnableLlmsTxt && enableLlmsTxt && <Button
 									as="a"
-									id="link-xml-sitemaps"
+									id="link-llms"
 									href={ llmsTxtUrl }
 									variant="secondary"
 									target="_blank"
 									rel="noopener"
 									className="yst-self-start"
 								>
-									{ __( "View the Llms.txt", "wordpress-seo" ) }
+									{ __( "View the llms.txt", "wordpress-seo" ) }
 									<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-5 yst-w-5 yst-text-slate-400 rtl:yst-rotate-[270deg]" />
 								</Button> }
 								<LearnMoreLink id="link-llms-txt" link="https://yoa.st/site-features-llmstxt-learn-more" ariaLabel={ __( "LLMs.txt", "wordpress-seo" ) } />

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -429,7 +429,7 @@ const SiteFeatures = () => {
 								imageSrc="/images/insights.png"
 								title={ __( "LLMs.txt", "wordpress-seo" ) }
 							>
-								<p>{ __( "Placeholder text", "wordpress-seo" ) }</p>
+								<p>{ __( "Boost the visibility of your content in AI searches. Automatically create an llms.txt file that lists a selection of your site's content. This helps LLMs access and provide your site's information more easily.", "wordpress-seo" ) }</p>
 								{ initialEnableLlmsTxt && enableLlmsTxt && <Button
 									as="a"
 									id="link-xml-sitemaps"
@@ -442,7 +442,7 @@ const SiteFeatures = () => {
 									{ __( "View the Llms.txt", "wordpress-seo" ) }
 									<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-5 yst-w-5 yst-text-slate-400 rtl:yst-rotate-[270deg]" />
 								</Button> }
-								<LearnMoreLink id="link-llms-txt" link="#" ariaLabel={ __( "LLMs.txt", "wordpress-seo" ) } />
+								<LearnMoreLink id="link-llms-txt" link="https://yoa.st/site-features-llmstxt-learn-more" ariaLabel={ __( "LLMs.txt", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -93,7 +93,7 @@ class Settings_Integration implements Integration_Interface {
 			'deny_ccbot_crawling',
 			'deny_google_extended_crawling',
 			'deny_gptbot_crawling',
-			'enable_llms_txt'
+			'enable_llms_txt',
 		],
 	];
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -93,6 +93,7 @@ class Settings_Integration implements Integration_Interface {
 			'deny_ccbot_crawling',
 			'deny_google_extended_crawling',
 			'deny_gptbot_crawling',
+			'enable_llms_txt'
 		],
 	];
 

--- a/tests/Unit/Admin/Views/Feature_Toggles_Test.php
+++ b/tests/Unit/Admin/Views/Feature_Toggles_Test.php
@@ -98,11 +98,6 @@ final class Feature_Toggles_Test extends TestCase {
 			'has_read_more' => true,
 			'has_after'     => false,
 		],
-		15 => [
-			'name'          => 'LLMs.txt',
-			'has_read_more' => true,
-			'has_after'     => false,
-		],
 	];
 
 	/**
@@ -184,7 +179,6 @@ final class Feature_Toggles_Test extends TestCase {
 			12 => 'Enhanced Slack sharing',
 			13 => 'IndexNow',
 			14 => 'AI title & description generator',
-			15 => 'LLMs.txt',
 		];
 
 		$this->stubEscapeFunctions();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the proper copy and shortlink in the feature card.
* Disables the feature for multisites.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO -> Settings and confirm that the copy is like this:
> LLMs.txt
>
> Boost the visibility of your content in AI searches. Automatically create an llms.txt file that lists a selection of your site’s content. This helps LLMs access and provide your site's information more easily.
>
> View llms.txt
* Confirm that the shortlink in the Learn more is this: `https://yoa.st/site-features-llmstxt-learn-more`

Also:
* Install the PR/RC in a fresh multisite installation
* Confirm that in the Yoast settings, you see the below:
![image](https://github.com/user-attachments/assets/2bda54fd-c9b0-4f93-8e46-da81e808e26c)
* Using WP Crontrol, confirm there's no `wpseo_llms_txt_population` action
* Confirm that there's no `llms.txt` file
* In the network Yoast settings, you see no feature toggle for the LLMs.txt feature
  * Enable and disable some of those network Yoast settings
  * Enable and disable some of the Yoast settings in a subsite
  * Make sure things work as expected and that you still dont see no `llms.txt` file and no `wpseo_llms_txt_population` action and the LLMs.txt setting is still disabled in Yoast settings in subsites.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Multisite Yoast settings

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/565
