### PR TITLE
Add pronouns to user profile page and Person schema output.

### DIFF
--- a/admin/class-admin-user-profile.php
+++ b/admin/class-admin-user-profile.php
@@ -56,6 +56,7 @@ class WPSEO_Admin_User_Profile {
 
 		$wpseo_author_title                        = isset( $_POST['wpseo_author_title'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_author_title'] ) ) : '';
 		$wpseo_author_metadesc                     = isset( $_POST['wpseo_author_metadesc'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_author_metadesc'] ) ) : '';
+		$wpseo_author_pronouns                     = isset( $_POST['wpseo_author_pronouns'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_author_pronouns'] ) ) : '';
 		$wpseo_noindex_author                      = isset( $_POST['wpseo_noindex_author'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_noindex_author'] ) ) : '';
 		$wpseo_content_analysis_disable            = isset( $_POST['wpseo_content_analysis_disable'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_content_analysis_disable'] ) ) : '';
 		$wpseo_keyword_analysis_disable            = isset( $_POST['wpseo_keyword_analysis_disable'] ) ? sanitize_text_field( wp_unslash( $_POST['wpseo_keyword_analysis_disable'] ) ) : '';
@@ -63,6 +64,7 @@ class WPSEO_Admin_User_Profile {
 
 		update_user_meta( $user_id, 'wpseo_title', $wpseo_author_title );
 		update_user_meta( $user_id, 'wpseo_metadesc', $wpseo_author_metadesc );
+		update_user_meta( $user_id, 'wpseo_pronouns', $wpseo_author_pronouns );
 		update_user_meta( $user_id, 'wpseo_noindex_author', $wpseo_noindex_author );
 		update_user_meta( $user_id, 'wpseo_content_analysis_disable', $wpseo_content_analysis_disable );
 		update_user_meta( $user_id, 'wpseo_keyword_analysis_disable', $wpseo_keyword_analysis_disable );

--- a/admin/views/user-profile.php
+++ b/admin/views/user-profile.php
@@ -32,6 +32,10 @@ $wpseo_no_index_author_label = sprintf(
 		class="yoast-settings__textarea yoast-settings__textarea--medium"
 		name="wpseo_author_metadesc"><?php echo esc_textarea( get_the_author_meta( 'wpseo_metadesc', $user->ID ) ); ?></textarea><br>
 
+	<label for="wpseo_author_pronouns"><?php esc_html_e( 'Pronouns to use', 'wordpress-seo' ); ?></label>
+	<input id="wpseo_author_pronouns" class="yoast-settings__text regular-text" name="wpseo_author_pronouns"
+		value="<?php echo esc_attr( get_the_author_meta( 'wpseo_pronouns', $user->ID ) ); ?>" /><br>
+
 	<input class="yoast-settings__checkbox double" type="checkbox" id="wpseo_noindex_author"
 		name="wpseo_noindex_author"
 		value="on" <?php echo ( get_the_author_meta( 'wpseo_noindex_author', $user->ID ) === 'on' ) ? 'checked' : ''; ?> />

--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -142,8 +142,9 @@ class Person extends Abstract_Schema_Piece {
 			return $data;
 		}
 
-		$data['name'] = $this->helpers->schema->html->smart_strip_tags( $user_data->display_name );
-		$data         = $this->add_image( $data, $user_data, $add_hash );
+		$data['name']     = $this->helpers->schema->html->smart_strip_tags( $user_data->display_name );
+		$data['pronouns'] = $this->helpers->schema->html->smart_strip_tags( get_the_author_meta( 'wpseo_pronouns', $user_id ) );
+		$data             = $this->add_image( $data, $user_data, $add_hash );
 
 		if ( ! empty( $user_data->description ) ) {
 			$data['description'] = $this->helpers->schema->html->smart_strip_tags( $user_data->description );

--- a/src/user-meta/framework/custom-meta/author-pronouns.php
+++ b/src/user-meta/framework/custom-meta/author-pronouns.php
@@ -1,0 +1,110 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\User_Meta\Framework\Custom_Meta;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\User_Meta\Domain\Custom_Meta_Interface;
+
+/**
+ * The Author_Pronouns custom meta.
+ */
+class Author_Pronouns implements Custom_Meta_Interface {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Options_Helper $options_helper The options helper.
+	 */
+	public function __construct( Options_Helper $options_helper ) {
+		$this->options_helper = $options_helper;
+	}
+
+	/**
+	 * Returns the priority which the custom meta's form field should be rendered with.
+	 *
+	 * @return int The priority which the custom meta's form field should be rendered with.
+	 */
+	public function get_render_priority(): int {
+		return 300;
+	}
+
+	/**
+	 * Returns the db key of the Author_Pronouns custom meta.
+	 *
+	 * @return string The db key of the Author_Pronouns custom meta.
+	 */
+	public function get_key(): string {
+		return 'wpseo_pronouns';
+	}
+
+	/**
+	 * Returns the id of the custom meta's form field.
+	 *
+	 * @return string The id of the custom meta's form field.
+	 */
+	public function get_field_id(): string {
+		return 'wpseo_author_pronouns';
+	}
+
+	/**
+	 * Returns the meta value.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return string The meta value.
+	 */
+	public function get_value( $user_id ): string {
+		return \get_the_author_meta( $this->get_key(), $user_id );
+	}
+
+	/**
+	 * Returns whether the respective global setting is enabled.
+	 *
+	 * @return bool Whether the respective global setting is enabled.
+	 */
+	public function is_setting_enabled(): bool {
+		return ( ! $this->options_helper->get( 'disable-author' ) );
+	}
+
+	/**
+	 * Returns whether the custom meta is allowed to be empty.
+	 *
+	 * @return bool Whether the custom meta is allowed to be empty.
+	 */
+	public function is_empty_allowed(): bool {
+		return true;
+	}
+
+	/**
+	 * Renders the custom meta's field in the user form.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return void
+	 */
+	public function render_field( $user_id ): void {
+		echo '
+
+		<label for="' . \esc_attr( $this->get_field_id() ) . '">'
+			. \esc_html__( 'Pronouns to use', 'wordpress-seo' )
+		. '</label>';
+
+		echo '
+
+		<input
+			class="yoast-settings__text regular-text"
+			type="text" id="' . \esc_attr( $this->get_field_id() ) . '"
+			name="' . \esc_attr( $this->get_field_id() ) . '"
+			value="' . \esc_attr( $this->get_value( $user_id ) )
+		. '"/><br>'
+		. '<p class="description">' . \esc_html__( 'Enter the pronouns for the author, for example "she/her", "he/him", or "they/them".', 'wordpress-seo' ) . '</p>';
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In [this pull](https://github.com/schemaorg/schemaorg/pull/4450), `pronouns` was added to `Person` schema's pending state. This pull implements it for Yoast SEO.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Add a Pronouns field to the user profile and output these pronouns in the Schema.org output.

## Relevant technical choices:

* Implemented as a `Text` value, as Schema.org states:
  > We do not intend to enumerate all possible micro-syntaxes in all languages. 
* Implemented both in `admin/views/user-profile.php` (which seems unused?) and in a new file `src/user-meta/framework/custom-meta/author-pronouns.php`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to user profile page.
* Add pronouns.
* Check Schema `Person` output and see pronouns reflected in output.

#### Relevant test scenarios
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## UI changes

* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.
