### PR TITLE
Move `@yoast/ai-frontend` to own entry

### DIFF
--- a/config/webpack/externals.js
+++ b/config/webpack/externals.js
@@ -18,22 +18,15 @@ const additionalPackages = [
 	"chart.js",
 ];
 
-// Yoast packages to exclude. Resulting in them being bundled per entry.
-const excludePackages = [
-	"@yoast/ai-frontend",
-];
-
 const YOAST_PACKAGE_NAMESPACE = "@yoast/";
 
 // Fetch all packages from the dependencies list.
-const yoastPackages = Object.keys( dependencies )
-	.filter(
-		( packageName ) =>
-			packageName.startsWith( YOAST_PACKAGE_NAMESPACE ) ||
-			legacyYoastPackages.includes( packageName ) ||
-			additionalPackages.includes( packageName )
-	)
-	.filter( ( name ) => ! excludePackages.includes( name ) );
+const yoastPackages = Object.keys( dependencies ).filter(
+	( packageName ) =>
+		packageName.startsWith( YOAST_PACKAGE_NAMESPACE ) ||
+		legacyYoastPackages.includes( packageName ) ||
+		additionalPackages.includes( packageName )
+);
 
 /**
  * Convert Yoast packages to externals configuration.

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -7,13 +7,10 @@ const { join, resolve } = require( "path" );
 const root = join( __dirname, "../../" );
 
 // Internal dependencies
-const paths       = require( "./paths" );
+const paths = require( "./paths" );
 const packageJson = require( root + "package.json" );
-const baseConfig  = require( "./webpack.config.base" );
-const {
-	yoastPackages,
-	yoastExternals,
-} = require( "./externals" );
+const baseConfig = require( "./webpack.config.base" );
+const { yoastPackages, yoastExternals } = require( "./externals" );
 
 const languages = readdirSync( root + "node_modules/yoastseo/src/languageProcessing/languages" );
 const pluginVersion = packageJson.yoast.pluginVersion;
@@ -21,59 +18,61 @@ const pluginVersionSlug = paths.flattenVersionForFile( pluginVersion );
 const outputFilename = "[name].js";
 
 module.exports = [
-	baseConfig(
-		{
-			entry: paths.entry,
-			output: {
-				path: paths.jsDist,
-				filename: outputFilename,
-			},
-			combinedOutputFile: root + "src/generated/assets/plugin.php",
-			cssExtractFileName: "../../../css/dist/plugin-" + pluginVersionSlug + ".css",
-			plugins: [
-				new CopyWebpackPlugin( {
-					patterns: [
-						{
-							from: "**/block.json",
-							context: "packages/js/src",
-							to: resolve( "blocks" ),
-						},
-					],
-				} ),
-			],
-		}
-	),
-	baseConfig(
-		{
-			entry: yoastPackages.reduce( ( memo, packageName ) => {
-				memo[ yoastExternals[ packageName ] ] = "./node_modules/" + packageName;
+	baseConfig( {
+		entry: paths.entry,
+		output: {
+			path: paths.jsDist,
+			filename: outputFilename,
+		},
+		combinedOutputFile: root + "src/generated/assets/plugin.php",
+		cssExtractFileName: "../../../css/dist/plugin-" + pluginVersionSlug + ".css",
+		plugins: [
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: "**/block.json",
+						context: "packages/js/src",
+						to: resolve( "blocks" ),
+					},
+				],
+			} ),
+		],
+	} ),
+	baseConfig( {
+		entry: yoastPackages.reduce( ( memo, packageName ) => {
+			if ( packageName === "@yoast/ai-frontend" ) {
+				// The @yoast/ai-frontend includes CSS in the JS. However, we would prefer the CSS outside of the JS.
+				// This allows us to skip the CSS extraction step below.
+				memo[ yoastExternals[ packageName ] ] = "./node_modules/" + packageName + "/dist/build.js";
 				return memo;
-			}, {} ),
-			output: {
-				path: paths.jsDist + "/externals",
-				filename: outputFilename,
-				library: [ "yoast", "[name]" ],
-				libraryTarget: "window",
-			},
-			combinedOutputFile: root + "src/generated/assets/externals.php",
-			cssExtractFileName: "../../../css/dist/monorepo-" + pluginVersionSlug + ".css",
-		}
-	),
-	baseConfig(
-		{
-			entry: languages.reduce( ( memo, language ) => {
-				const name = ( language === "_default" ) ? "default" : language;
-				memo[ name ] = "./node_modules/yoastseo/src/languageProcessing/languages/" + language + "/Researcher";
-				return memo;
-			}, {} ),
-			output: {
-				path: paths.jsDist + "/languages",
-				filename: outputFilename,
-				library: [ "yoast", "Researcher" ],
-				libraryTarget: "window",
-			},
-			combinedOutputFile: root + "src/generated/assets/languages.php",
-			cssExtractFileName: "../../../css/dist/languages-" + pluginVersionSlug + ".css",
-		}
-	),
+			}
+			memo[ yoastExternals[ packageName ] ] = "./node_modules/" + packageName;
+			return memo;
+		}, {} ),
+		output: {
+			path: paths.jsDist + "/externals",
+			filename: outputFilename,
+			library: [ "yoast", "[name]" ],
+			libraryTarget: "window",
+		},
+		combinedOutputFile: root + "src/generated/assets/externals.php",
+		// Due to the filename being hardcoded this can be for only ONE entry: the @yoast/components' CSS.
+		// If any other entry also outputs CSS the build will fail.
+		cssExtractFileName: "../../../css/dist/monorepo-" + pluginVersionSlug + ".css",
+	} ),
+	baseConfig( {
+		entry: languages.reduce( ( memo, language ) => {
+			const name = ( language === "_default" ) ? "default" : language;
+			memo[ name ] = "./node_modules/yoastseo/src/languageProcessing/languages/" + language + "/Researcher";
+			return memo;
+		}, {} ),
+		output: {
+			path: paths.jsDist + "/languages",
+			filename: outputFilename,
+			library: [ "yoast", "Researcher" ],
+			libraryTarget: "window",
+		},
+		combinedOutputFile: root + "src/generated/assets/languages.php",
+		cssExtractFileName: "../../../css/dist/languages-" + pluginVersionSlug + ".css",
+	} ),
 ];

--- a/packages/js/src/editor-modules.js
+++ b/packages/js/src/editor-modules.js
@@ -46,12 +46,12 @@ window.yoast.editorModules = {
 			Introduction,
 			SuggestionError,
 			SparksLimitNotification,
-			FeatureError
+			FeatureError,
 		},
 		helpers: {
 			removesLocaleVariantSuffixes,
 			fetchSuggestions,
-		}
+		},
 	},
 	components: {
 		HelpLink,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Instead of bundling `@yoast/ai-frontend` in 3 separate entries. Add its own entry to re-use. This saves zip space.

> [!NOTE]
> Somehow all the Hero Icons are bundled -- that was the case before this PR too (so at least not 3 times now? 😅 )

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Moves the `@yoast/ai-frontend` to its own file instead of bundling in individual files.

## Relevant technical choices:

* Use the build where the CSS is not included, so we don't have to process the CSS via our JS tooling. As that is geared towards just `@yoast/components` for ages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Does it still build?
* You could check `yarn webpack-analyze-bundle`
  * Before it `ai-frontend` would be there 3 times (each editor file)
  * Now it is there alongside our other packages


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/584
