### PR TITLE
Fix deprecation warning by checking for null before stripslashes() in Meta_Description_Presenter

### DIFF
--- a/src/presenters/meta-description-presenter.php
+++ b/src/presenters/meta-description-presenter.php
@@ -57,6 +57,9 @@ class Meta_Description_Presenter extends Abstract_Indexable_Tag_Presenter {
 		 * @param Indexable_Presentation $presentation     The presentation of an indexable.
 		 */
 		$meta_description = \apply_filters( 'wpseo_metadesc', $meta_description, $this->presentation );
+		if ( ! is_string( $meta_description ) ) {
+		    $meta_description = '';
+		}
 		$meta_description = $this->helpers->string->strip_all_tags( \stripslashes( $meta_description ) );
 		return \trim( $meta_description );
 	}


### PR DESCRIPTION
### Context
This PR fixes a deprecation warning introduced in PHP 8.1+ where `stripslashes()` throws a warning when passed null. The issue occurs in `Meta_Description_Presenter` when `$meta_description` is null before being passed to `stripslashes()`. This can prevent pages using ACF Flexible Content fields from saving properly, showing a "The response is not a valid JSON response" error.

### Summary
**Changelog:**
`changelog: bugfix
`Fixes a bug where saving posts with ACF flexible content fields could fail with a JSON error due to a deprecation warning in PHP 8.1+ (`stripslashes(null)` in `Meta_Description_Presenter`).

### Relevant technical choices
Added a null check before calling stripslashes():


```
$meta_description = $this->helpers->string->strip_all_tags(
	$meta_description === null ? null : \stripslashes( $meta_description )
);
```
### Test instructions

1. Install ACF and create a field group using Flexible Content fields.
2. On PHP 8.1 or later, try saving a post using these fields with the current Yoast plugin — confirm that you get the JSON error and see a deprecation warning related to stripslashes()
3. Apply this PR.
4. Save the post again — confirm the error and warning are gone.

### Impact check
This PR affects how meta descriptions are handled in Yoast SEO, specifically in `Meta_Description_Presenter`. Any code that relies on filtering or modifying meta descriptions could be impacted. Regression testing is advised around:

- Meta description outputs
- Open Graph description tags
- Meta description previews in the editor