### PR TITLE
restore consent args and refactor upsell

### DIFF
--- a/packages/js/src/ai-consent/components/grant-consent.js
+++ b/packages/js/src/ai-consent/components/grant-consent.js
@@ -24,7 +24,7 @@ export const GrantConsent = ( { onStartGenerating } ) => {
 
 	const { storeAiGeneratorConsent } = useDispatch( STORE_NAME_AI_CONSENT );
 	const handleGiveConsent = useCallback( () => {
-		storeAiGeneratorConsent( true, endpoint );
+		storeAiGeneratorConsent( { consent: true, endpoint } );
 		onStartGenerating();
 	}, [ storeAiGeneratorConsent, onStartGenerating ] );
 

--- a/packages/js/src/ai-consent/components/revoke-consent.js
+++ b/packages/js/src/ai-consent/components/revoke-consent.js
@@ -24,7 +24,7 @@ export const RevokeConsent = ( { onClose } ) => {
 		setError( false );
 		setIsLoading( true );
 
-		const response = await storeAiGeneratorConsent( false, endpoint );
+		const response = await storeAiGeneratorConsent( { consent: false, endpoint } );
 		if ( response.consent === false ) {
 			setError( true );
 			setIsLoading( false );

--- a/packages/js/src/ai-generator/components/errors/subscription-error.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-error.js
@@ -12,7 +12,7 @@ import { STORE_NAME_EDITOR } from "../../constants";
  * @param {string[]} [invalidSubscriptions=[]] The array with the names of products with invalid subscription.
  * @returns {JSX.Element} The element.
  */
-export const SubscriptionError = ( { invalidSubscriptions } ) => {
+export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
 	const activatePremiumLink = useSelect(
 		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-activate-premium" ),
 		[]

--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -76,12 +76,11 @@ export const getUpsellProps = ( upsellLinks ) => {
 };
 
 /**
- *
- * @param {function} setTryAi Callback to signal the generating should start.
+ * Returns the upsell modal content.
  *
  * @returns {JSX.Element} The element.
  */
-export const UpsellModalContent = ( { setTryAi } ) => {
+export const UpsellModalContent = () => {
 	const upsellLinks = {
 		premium: useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] ),
 		bundle: useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] ),
@@ -119,14 +118,15 @@ export const UpsellModalContent = ( { setTryAi } ) => {
 	} ), [] );
 
 	const isLimitReached = counts >= limit;
+	const hideUpsell = useDispatch( STORE_NAME_AI ).hideUpsell;
 
 	return (
 		<AiGenerateTitlesAndDescriptionsUpsell
 			learnMoreLink={ learnMoreLink }
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
-			setTryAi={ setTryAi }
 			isLimitReached={ isLimitReached }
+			hideUpsell={ hideUpsell }
 			{ ...upsellProps }
 		/>
 	);

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -10,6 +10,7 @@ import { filterFocusKeyphraseErrors, initializePromptContent, updateInteractedWi
 import { registerStore } from "./store";
 import { PRODUCT_SUBSCRIPTIONS_NAME } from "./store/product-subscriptions";
 import { USAGE_COUNT_NAME } from "./store/usage-count";
+import { UPSELL } from "./store/upsell";
 
 // Ignore these post types. Attachments will require a different prompt.
 const IGNORED_POST_TYPES = [ POST_TYPE.attachment ];
@@ -89,6 +90,9 @@ const initializeAiGenerator = () => {
 			endpoint: "yoast/v1/ai_generator/get_usage",
 		},
 		[ PRODUCT_SUBSCRIPTIONS_NAME ]: get( window, "wpseoAiGenerator.productSubscriptions", {} ),
+		[ UPSELL ]: {
+			isUpsellOpen: get( window, "wpseoAiGenerator.hasConsent", false ) !== "1",
+		},
 	} );
 
 	window.jQuery( window ).on( "YoastSEO:ready", () => {

--- a/packages/js/src/ai-generator/store/index.js
+++ b/packages/js/src/ai-generator/store/index.js
@@ -60,6 +60,13 @@ import {
 	aiOptimizeNotificationStatusSelectors,
 	getInitialNotificationStatusState,
 } from "./ai-optimize-notification-status";
+import {
+	UPSELL,
+	upsellActions,
+	upsellReducer,
+	upsellSelectors,
+	getInitialUpsellState,
+} from "./upsell";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -78,6 +85,7 @@ const createStore = ( initialState ) => {
 			...appliedFixesStatusActions,
 			...usageCountActions,
 			...aiOptimizeNotificationStatusActions,
+			...upsellActions,
 		},
 		selectors: {
 			...hasAiGeneratorConsentSelectors,
@@ -88,6 +96,7 @@ const createStore = ( initialState ) => {
 			...appliedFixesStatusSelectors,
 			...UsageCountSelectors,
 			...aiOptimizeNotificationStatusSelectors,
+			...upsellSelectors,
 		},
 		initialState: merge(
 			{},
@@ -100,6 +109,7 @@ const createStore = ( initialState ) => {
 				[ APPLIED_FIXES_STATUS_NAME ]: getInitialAppliedFixesStatusState(),
 				[ USAGE_COUNT_NAME ]: getInitialUsageCount(),
 				[ AI_OPTIMIZE_NOTIFICATION_STATUS_NAME ]: getInitialNotificationStatusState(),
+				[ UPSELL ]: getInitialUpsellState(),
 			},
 			initialState
 		),
@@ -112,6 +122,7 @@ const createStore = ( initialState ) => {
 			[ APPLIED_FIXES_STATUS_NAME ]: appliedFixesStatusReducer,
 			[ USAGE_COUNT_NAME ]: usageCountReducer,
 			[ AI_OPTIMIZE_NOTIFICATION_STATUS_NAME ]: aiOptimizeNotificationStatusReducer,
+			[ UPSELL ]: upsellReducer,
 		} ),
 		controls: {
 			...hasAiGeneratorConsentControls,

--- a/packages/js/src/ai-generator/store/upsell.js
+++ b/packages/js/src/ai-generator/store/upsell.js
@@ -1,0 +1,26 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+export const UPSELL = "upsell";
+
+const slice = createSlice( {
+	name: UPSELL,
+	initialState: {
+		isUpsellOpen: true,
+	},
+	reducers: {
+		hideUpsell: ( state ) => {
+			state.isUpsellOpen = false;
+		},
+	},
+} );
+
+export const getInitialUpsellState = slice.getInitialState;
+
+export const upsellSelectors = {
+	selectIsUpsellOpen: state => get( state, [ UPSELL, "isUpsellOpen" ], getInitialUpsellState() ),
+};
+
+export const upsellActions = slice.actions;
+
+export const upsellReducer = slice.reducer;

--- a/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-generate-titles-and-descriptions-upsell.js
@@ -3,7 +3,6 @@ import { ArrowNarrowRightIcon } from "@heroicons/react/solid";
 import { __, sprintf } from "@wordpress/i18n";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { Badge, Button, useModalContext, Alert } from "@yoast/ui-library";
-import { useCallback } from "@wordpress/element";
 import { OutboundLink, VideoFlow } from ".";
 import { GradientButton } from "@yoast/ai-frontend";
 import classNames from "classnames";
@@ -33,7 +32,7 @@ import classNames from "classnames";
  * @param {string} newToText The new to text.
  * @param {string|JSX.Element} bundleNote The bundle note.
  * @param {string} ctbId The click to buy to register for this upsell instance.
- * @param {function} setTryAi The function to set the try AI state.
+ * @param {function} hideUpsell The function to hide the upsell.
  * @param {boolean} isLimitReached Whether the sparks limit is reached.
  * @returns {JSX.Element} The element.
  */
@@ -52,7 +51,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 	newToText = "Yoast SEO Premium",
 	bundleNote = "",
 	ctbId = "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
-	setTryAi,
+	hideUpsell,
 	isLimitReached = false,
 } ) => {
 	const { onClose, initialFocus } = useModalContext();
@@ -65,10 +64,6 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 		/>,
 		ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
 	};
-
-	const handleTryAi = useCallback( () => {
-		setTryAi( true );
-	}, [ setTryAi ] );
 
 	return (
 		<>
@@ -157,7 +152,7 @@ export const AiGenerateTitlesAndDescriptionsUpsell = ( {
 							}
 						</span>
 					</Button>
-					{ ! isLimitReached && <GradientButton onClick={ handleTryAi } className="yst-mt-2 yst-w-full yst-text-base yst-text-slate-800 yst-font-medium yst-h-11 hover:yst-bg-gradient-to-l hover:yst-from-indigo-100 hover:yst-to-primary-100">
+					{ ! isLimitReached && <GradientButton onClick={ hideUpsell } className="yst-mt-2 yst-w-full yst-text-base yst-text-slate-800 yst-font-medium yst-h-11 hover:yst-bg-gradient-to-l hover:yst-from-indigo-100 hover:yst-to-primary-100">
 						{ __( "Try for free", "wordpress-seo" ) }
 					</GradientButton> }
 				</div>

--- a/packages/js/src/shared-admin/store/ai-generator-has-consent.js
+++ b/packages/js/src/shared-admin/store/ai-generator-has-consent.js
@@ -14,7 +14,7 @@ const STORE_AI_GENERATOR_CONSENT_ACTION_NAME = `${ HAS_AI_GENERATOR_CONSENT_NAME
  *
  * @returns {Generator<{type: string}>} The current action object.
  */
-function* storeAiGeneratorConsent( consent, endpoint ) {
+function* storeAiGeneratorConsent( { consent, endpoint } ) {
 	try {
 		// Trigger the control flow.
 		yield{ type: STORE_AI_GENERATOR_CONSENT_ACTION_NAME, payload: { consent, endpoint } };


### PR DESCRIPTION
Created an upsell store to reduce prop drilling

fix lint

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes consent in editor after a fix was done in the profile page.

## Relevant technical choices:

* Adds `upsell` section to the `yoast-seo/ai-generator` store to avoid prop drilling.
* Dropped the `FeatureError` from the App since we are not checking the subscriptions. Keeping it in free, though we need to figure out if it's still required.
* Fixed lint in default props for subscription error. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post ( on local env, use [fake-ai-generator-api-response.patch](https://github.com/user-attachments/files/20522444/fake-ai-generator-api-response.patch)) 
* Click on "Use AI".
* Check you see the upsell, click on try for free button.
* Grant consent.
* Check you can use the AI generator.
* Refresh and click on "Use AI".
* Check you don't see the consent or the upsell.
* Go to Yoast SEO->Settings->Site features
* Disable "SEO analysis"
* Edit a page or post and click on "Use AI"
* Check you get an error message for the SEO analysis.
* Go to profile page and look for "AI feature", click on "Revoke consent" and save.
* Refresh and check it is saved.
* Grant consent, refresh and check it is saved.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
