### PR TITLE
Add warning for when the LLMs.txt cannot be generated in our dashboard.

### DIFF
--- a/src/llms-txt/application/file/file-failure-notification-presenter.php
+++ b/src/llms-txt/application/file/file-failure-notification-presenter.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Llms_Txt\Application\File;
 
 use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Populate_File_Command_Handler;
 use Yoast\WP\SEO\Presenters\Abstract_Presenter;
 
 /**
@@ -30,15 +31,29 @@ class File_Failure_Notification_Presenter extends Abstract_Presenter {
 	 * @return string The message.
 	 */
 	protected function get_message() {
+		$reason = \get_option( Populate_File_Command_Handler::GENERATION_FAILURE_OPTION, false );
+		switch ( $reason ) {
+			case 'not_managed_by_yoast_seo':
+				$message = \sprintf(
+				/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
+					\esc_html__( 'It looks like there is an llms.txt file already that wasn\'t created by Yoast, or the llms.txt file created by Yoast has been edited manually. We don\'t want to overwrite this file\'s content, so if you want to let Yoast keep auto-generating the llms.txt file, you can %1$smanually delete the existing one%2$s. Otherwise, consider disabling the Yoast feature.', 'wordpress-seo' ),
+					'<a href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/llms-txt-file-deletion' ) ) . '">',
+					'</a>'
+				);
+				break;
+			case 'filesystem_permissions':
+				$message =
+					\__( 'You have activated the Yoast llms.txt feature, but we couldn\'t generate an llms.txt file. It looks like there aren\'t sufficient permissions on the web server\'s filesystem.', 'wordpress-seo' );
+				break;
+			default:
+				$message = \__( 'You have activated the Yoast llms.txt feature, but we couldn\'t generate an llms.txt file, for unknown reasons.', 'wordpress-seo' );
+				break;
+		}
+
 		return \sprintf(
 			'<strong>%1$s</strong> %2$s',
 			\esc_html__( 'Your llms.txt file couldn\'t be auto-generated', 'wordpress-seo' ),
-			\sprintf(
-			/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
-				\esc_html__( 'It looks like there is an llms.txt file already that wasn\'t created by Yoast, or the llms.txt file created by Yoast has been edited manually. We don\'t want to overwrite this file\'s content, so if you want to let Yoast keep auto-generating the llms.txt file, you can %1$smanually delete the existing one%2$s. Otherwise, consider disabling the Yoast feature.', 'wordpress-seo' ),
-				'<a href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/llms-txt-file-deletion' ) ) . '">',
-				'</a>'
-			)
+			$message
 		);
 	}
 }

--- a/src/llms-txt/application/file/file-failure-notification-presenter.php
+++ b/src/llms-txt/application/file/file-failure-notification-presenter.php
@@ -1,0 +1,44 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Llms_Txt\Application\File;
+
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Presenters\Abstract_Presenter;
+
+/**
+ * Class File_Failure_Notification_Presenter.
+ */
+class File_Failure_Notification_Presenter extends Abstract_Presenter {
+
+	/**
+	 * Returns the notification as an HTML string.
+	 *
+	 * @return string The notification in an HTML string representation.
+	 */
+	public function present() {
+		$notification_text  = '<p>';
+		$notification_text .= $this->get_message();
+		$notification_text .= '</p>';
+
+		return $notification_text;
+	}
+
+	/**
+	 * Returns the message to show.
+	 *
+	 * @return string The message.
+	 */
+	protected function get_message() {
+		return \sprintf(
+			'<strong>%1$s</strong> %2$s',
+			\esc_html__( 'Your llms.txt file couldn\'t be auto-generated', 'wordpress-seo' ),
+			\sprintf(
+			/* translators: 1: Link start tag to the WordPress Reading Settings page, 2: Link closing tag. */
+				\esc_html__( 'It looks like there is an llms.txt file already that wasn\'t created by Yoast, or the llms.txt file created by Yoast has been edited manually. We don\'t want to overwrite this file\'s content, so if you want to let Yoast keep auto-generating the llms.txt file, you can %1$smanually delete the existing one%2$s. Otherwise, consider disabling the Yoast feature.', 'wordpress-seo' ),
+				'<a href="' . \esc_url( WPSEO_Shortlinker::get( 'https://yoa.st/llms-txt-file-deletion' ) ) . '">',
+				'</a>'
+			)
+		);
+	}
+}

--- a/src/llms-txt/user-interface/file-failure-llms-txt-notification-integration.php
+++ b/src/llms-txt/user-interface/file-failure-llms-txt-notification-integration.php
@@ -94,7 +94,7 @@ class File_Failure_Llms_Txt_Notification_Integration implements Integration_Inte
 	 * @return bool
 	 */
 	private function should_show_file_failure_notification(): bool {
-		return \get_option( Populate_File_Command_Handler::GENERATION_FAILURE_OPTION, false ) !== false;
+		return $this->options_helper->get( 'enable_llms_txt', false ) && \get_option( Populate_File_Command_Handler::GENERATION_FAILURE_OPTION, false ) !== false;
 	}
 
 	/**

--- a/src/llms-txt/user-interface/file-failure-llms-txt-notification-integration.php
+++ b/src/llms-txt/user-interface/file-failure-llms-txt-notification-integration.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Yoast\WP\SEO\Llms_Txt\User_Interface;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Populate_File_Command_Handler;
+use Yoast\WP\SEO\Llms_Txt\Application\File\File_Failure_Notification_Presenter;
+use Yoast_Notification;
+use Yoast_Notification_Center;
+
+/**
+ * Watches and handles changes to the LLMS.txt file failure option.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class File_Failure_Llms_Txt_Notification_Integration implements Integration_Interface {
+	use No_Conditionals;
+
+	/**
+	 * The notification ID.
+	 */
+	public const NOTIFICATION_ID = 'wpseo-llms-txt-generation-failure';
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The notification center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	private $notification_center;
+
+	/**
+	 * The notification presenter.
+	 *
+	 * @var File_Failure_Notification_Presenter
+	 */
+	private $presenter;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Options_Helper                      $options_helper      The options helper.
+	 * @param Yoast_Notification_Center           $notification_center The notification center.
+	 * @param File_Failure_Notification_Presenter $presenter           The notification presenter.
+	 */
+	public function __construct(
+		Options_Helper $options_helper,
+		Yoast_Notification_Center $notification_center,
+		File_Failure_Notification_Presenter $presenter
+	) {
+		$this->options_helper      = $options_helper;
+		$this->notification_center = $notification_center;
+		$this->presenter           = $presenter;
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'maybe_show_notification' ], 10, 2 );
+	}
+
+	/**
+	 * Manage the search engines discouraged notification.
+	 *
+	 * Shows the notification if needed and deletes it if needed.
+	 *
+	 * @return void
+	 */
+	public function maybe_show_notification() {
+		if ( ! $this->should_show_file_failure_notification() ) {
+			$this->remove_file_failure_notification_if_exists();
+		}
+		else {
+			$this->maybe_add_file_failure_notification();
+		}
+	}
+
+	/**
+	 * Whether the file failure notification should be shown.
+	 *
+	 * @return bool
+	 */
+	private function should_show_file_failure_notification(): bool {
+		return \get_option( Populate_File_Command_Handler::GENERATION_FAILURE_OPTION, false ) !== false;
+	}
+
+	/**
+	 * Remove the search engines discouraged notification if it exists.
+	 *
+	 * @return void
+	 */
+	private function remove_file_failure_notification_if_exists() {
+		$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+	}
+
+	/**
+	 * Add the search engines discouraged notification if it does not exist yet.
+	 *
+	 * @return void
+	 */
+	private function maybe_add_file_failure_notification() {
+		if ( ! $this->notification_center->get_notification_by_id( self::NOTIFICATION_ID ) ) {
+			$notification = new Yoast_Notification(
+				$this->presenter->present(),
+				[
+					'type'         => Yoast_Notification::ERROR,
+					'id'           => self::NOTIFICATION_ID,
+					'capabilities' => 'wpseo_manage_options',
+					'priority'     => 1,
+				]
+			);
+			$this->notification_center->restore_notification( $notification );
+			$this->notification_center->add_notification( $notification );
+		}
+	}
+}

--- a/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Abstract_File_Failure_Llms_Txt_Notification_Integration_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Abstract_File_Failure_Llms_Txt_Notification_Integration_Test.php
@@ -1,0 +1,68 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration;
+
+use Mockery;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Llms_Txt\Application\File\File_Failure_Notification_Presenter;
+use Yoast\WP\SEO\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
+
+/**
+ * Abstract class for the Content_Types_Collector tests.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ *
+ * @group llms.txt
+ */
+abstract class Abstract_File_Failure_Llms_Txt_Notification_Integration_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var File_Failure_Llms_Txt_Notification_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * The notification center mock.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * The options helper mock.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
+	 * The file failure notification presenter mock.
+	 *
+	 * @var Mockery\MockInterface|File_Failure_Notification_Presenter
+	 */
+	protected $file_failure_notification_presenter;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->notification_center                 = Mockery::mock( Yoast_Notification_Center::class );
+		$this->options_helper                      = Mockery::mock( Options_Helper::class );
+		$this->file_failure_notification_presenter = Mockery::mock( File_Failure_Notification_Presenter::class );
+
+		$this->instance = new File_Failure_Llms_Txt_Notification_Integration(
+			$this->options_helper,
+			$this->notification_center,
+			$this->file_failure_notification_presenter
+		);
+	}
+}

--- a/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Constructor_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Constructor_Test.php
@@ -1,0 +1,38 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Llms_Txt\Application\File\File_Failure_Notification_Presenter;
+use Yoast_Notification_Center;
+
+/**
+ * Tests the File_Failure_Llms_Txt_Notification_Integration constructor.
+ *
+ * @group llms.txt
+ *
+ * @covers Yoast\WP\SEO\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration::__construct
+ */
+final class Constructor_Test extends Abstract_File_Failure_Llms_Txt_Notification_Integration_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' )
+		);
+		$this->assertInstanceOf(
+			Yoast_Notification_Center::class,
+			$this->getPropertyValue( $this->instance, 'notification_center' )
+		);
+		$this->assertInstanceOf(
+			File_Failure_Notification_Presenter::class,
+			$this->getPropertyValue( $this->instance, 'presenter' )
+		);
+	}
+}

--- a/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Maybe_Show_Notification_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Maybe_Show_Notification_Test.php
@@ -25,6 +25,7 @@ final class Maybe_Show_Notification_Test extends Abstract_File_Failure_Llms_Txt_
 			->with( 'wpseo_llms_txt_file_failure', false )
 			->andReturn( 'failure' );
 		Monkey\Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		$this->options_helper->expects( 'get' )->with( 'enable_llms_txt', false )->andReturnTrue();
 		$this->notification_center->expects( 'get_notification_by_id' )->andReturnFalse();
 		$this->notification_center->expects( 'restore_notification' );
 		$this->notification_center->expects( 'add_notification' );
@@ -43,6 +44,7 @@ final class Maybe_Show_Notification_Test extends Abstract_File_Failure_Llms_Txt_
 			->with( 'wpseo_llms_txt_file_failure', false )
 			->andReturn( 'failure' );
 		Monkey\Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		$this->options_helper->expects( 'get' )->with( 'enable_llms_txt', false )->andReturnTrue();
 		$this->notification_center->expects( 'get_notification_by_id' )->andReturnTrue();
 		$this->notification_center->expects( 'restore_notification' )->never();
 		$this->notification_center->expects( 'add_notification' )->never();
@@ -61,6 +63,20 @@ final class Maybe_Show_Notification_Test extends Abstract_File_Failure_Llms_Txt_
 			->once()
 			->with( 'wpseo_llms_txt_file_failure', false )
 			->andReturn( false );
+		$this->options_helper->expects( 'get' )->with( 'enable_llms_txt', false )->andReturnTrue();
+		$this->instance->maybe_show_notification();
+	}
+
+	/**
+	 * Tests the maybe_show_notification when the feature is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_show_notification_feature_not_enabled() {
+		$this->notification_center->expects( 'remove_notification_by_id' )->with( 'wpseo-llms-txt-generation-failure' );
+		Monkey\Functions\expect( 'get_option' )
+			->never();
+		$this->options_helper->expects( 'get' )->with( 'enable_llms_txt', false )->andReturnFalse();
 		$this->instance->maybe_show_notification();
 	}
 }

--- a/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Maybe_Show_Notification_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Maybe_Show_Notification_Test.php
@@ -1,0 +1,66 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration;
+
+use Brain\Monkey;
+
+/**
+ * Tests the File_Failure_Llms_Txt_Notification_Integration maybe_show_notification.
+ *
+ * @group llms.txt
+ *
+ * @covers Yoast\WP\SEO\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration::maybe_show_notification
+ */
+final class Maybe_Show_Notification_Test extends Abstract_File_Failure_Llms_Txt_Notification_Integration_Test {
+
+	/**
+	 * Tests the maybe_show_notification when there is a failure.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_show_notification_option_set_no_notification() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'wpseo_llms_txt_file_failure', false )
+			->andReturn( 'failure' );
+		Monkey\Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		$this->notification_center->expects( 'get_notification_by_id' )->andReturnFalse();
+		$this->notification_center->expects( 'restore_notification' );
+		$this->notification_center->expects( 'add_notification' );
+		$this->file_failure_notification_presenter->expects( 'present' );
+		$this->instance->maybe_show_notification();
+	}
+
+	/**
+	 * Tests the maybe_show_notification when there is a failure but the notification already exists.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_show_notification_option_set_notification_exists() {
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'wpseo_llms_txt_file_failure', false )
+			->andReturn( 'failure' );
+		Monkey\Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		$this->notification_center->expects( 'get_notification_by_id' )->andReturnTrue();
+		$this->notification_center->expects( 'restore_notification' )->never();
+		$this->notification_center->expects( 'add_notification' )->never();
+
+		$this->instance->maybe_show_notification();
+	}
+
+	/**
+	 * Tests the maybe_show_notification without failure.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_show_notification_option_not_set() {
+		$this->notification_center->expects( 'remove_notification_by_id' )->with( 'wpseo-llms-txt-generation-failure' );
+		Monkey\Functions\expect( 'get_option' )
+			->once()
+			->with( 'wpseo_llms_txt_file_failure', false )
+			->andReturn( false );
+		$this->instance->maybe_show_notification();
+	}
+}

--- a/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Register_Hooks_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/File_Failure_Llms_Txt_Notification_Integration/Register_Hooks_Test.php
@@ -1,0 +1,31 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration;
+
+/**
+ * Tests the File_Failure_Llms_Txt_Notification_Integration register_hooks.
+ *
+ * @group llms.txt
+ *
+ * @covers Yoast\WP\SEO\Llms_Txt\User_Interface\File_Failure_Llms_Txt_Notification_Integration::register_hooks
+ */
+final class Register_Hooks_Test extends Abstract_File_Failure_Llms_Txt_Notification_Integration_Test {
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertEquals(
+			10,
+			\has_action(
+				'admin_init',
+				[ $this->instance, 'maybe_show_notification' ]
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to notify customers when we cannot generate a llms.txt for them.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enhances the UX of the llms.txt feature, by informing users for potential issues with generating the file, via Yoast's alert center.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Remove your llms.txt file if you have it and make sure our feature is disabled.
* Go to our `alert center` and make sure there are no `problems` relating to the llms.txt feature.
* Enable the feature and make sure it works.
* Go to our `alert center` and make sure there are no `problems` relating to the llms.txt feature.
* Edit your llms.txt file and add a character. This makes it so we no longer `control` the file.
* Either disable and re-enable the feature or run the cron job to regenerate it.
* Go to our `alert center` and make sure there is now `problem` relating to the llms.txt feature. Make sure it looks like what is in the issue.
* Remove the llms.txt file and regenerate it and make sure the `alert center` is empty again.
* Now add the following filter:
```php 
add_filter( 'filesystem_method', 'disable_filesystem_method' );

function disable_filesystem_method( $url ) {
	return false;
}
```

* Regenerate the file and make sure you see :
![image](https://github.com/user-attachments/assets/fba2dd93-b85a-43b7-ba54-3e85bf669f16)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
