### PR TITLE
586 create a notification for when the sparks run out

### DIFF
--- a/admin/taxonomy/class-taxonomy.php
+++ b/admin/taxonomy/class-taxonomy.php
@@ -184,7 +184,7 @@ class WPSEO_Taxonomy {
 				'metabox'               => $this->localize_term_scraper_script( $tag_id ),
 				'isTerm'                => true,
 				'postId'                => $tag_id,
-				'termType'              => $this->get_taxonomy(),
+				'postType'              => $this->get_taxonomy(),
 				'usedKeywordsNonce'     => wp_create_nonce( 'wpseo-keyword-usage' ),
 			];
 

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -215,7 +215,9 @@ export const App = ( { onUseAi } ) => {
 					{ ...MainModalCommonProps }
 					isOpen={ ! arePreconditionsMet }
 				>
-					<FeatureError currentSubscriptions={ currentSubscriptions } isSeoAnalysisActive={ isSeoAnalysisActive } />
+					<Modal.Container.Content className="yst-pt-6">
+						<FeatureError currentSubscriptions={ currentSubscriptions } isSeoAnalysisActive={ isSeoAnalysisActive } />
+					</Modal.Container.Content>
 				</MainModal>
 			</Fragment> }
 		</Fragment>

--- a/packages/js/src/ai-generator/components/feature-error.js
+++ b/packages/js/src/ai-generator/components/feature-error.js
@@ -1,6 +1,5 @@
 import { useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
-import { Modal } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { STORE_NAME_EDITOR } from "../constants";
 import { isWooActiveAndProductPostType } from "../helpers";
@@ -31,11 +30,7 @@ export const FeatureError = ( { currentSubscriptions, isSeoAnalysisActive = true
 	}
 
 	if ( invalidSubscriptions.length > 0 ) {
-		return (
-			<Modal.Container.Content className="yst-pt-6">
-				<SubscriptionError invalidSubscriptions={ invalidSubscriptions } />
-			</Modal.Container.Content>
-		);
+		return <SubscriptionError invalidSubscriptions={ invalidSubscriptions } />;
 	}
 
 	if ( ! isSeoAnalysisActive ) {

--- a/packages/js/src/ai-generator/components/feature-error.js
+++ b/packages/js/src/ai-generator/components/feature-error.js
@@ -3,7 +3,7 @@ import { useMemo } from "@wordpress/element";
 import { Modal } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { STORE_NAME_EDITOR } from "../constants";
-import { isWooActiveAndProductPostType } from "../helpers/is-woo-active-and-product-post-type";
+import { isWooActiveAndProductPostType } from "../helpers";
 import { useTypeContext } from "../hooks";
 import { SeoAnalysisInactiveError, SubscriptionError } from "./errors";
 

--- a/packages/js/src/ai-generator/components/google-content.js
+++ b/packages/js/src/ai-generator/components/google-content.js
@@ -41,8 +41,7 @@ export const GoogleContent = ( { title, description, status, titleForLength, sho
 			}
 			<div className="yst-pt-4">
 				<Label as="span" className="yst-flex-grow yst-cursor-default">
-					{ editType === EDIT_TYPE.title && __( "SEO title width", "wordpress-seo" ) }
-					{ editType === EDIT_TYPE.description && __( "Meta description length", "wordpress-seo" ) }
+					{ editType === EDIT_TYPE.title ? __( "SEO title width", "wordpress-seo" ) : __( "Meta description length", "wordpress-seo" ) }
 				</Label>
 				<LengthProgressBar
 					className="yst-mt-2"

--- a/packages/js/src/ai-generator/components/introduction.js
+++ b/packages/js/src/ai-generator/components/introduction.js
@@ -22,7 +22,7 @@ export const Introduction = ( { onStartGenerating } ) => {
 
 	const { storeAiGeneratorConsent } = useDispatch( STORE_NAME_AI );
 	const onGiveConsent = useCallback( async() => {
-		await storeAiGeneratorConsent( { consent: true, endpoint: consentEndpoint } );
+		await storeAiGeneratorConsent( true, consentEndpoint );
 		onStartGenerating();
 	}, [ storeAiGeneratorConsent, onStartGenerating, consentEndpoint ] );
 

--- a/packages/js/src/ai-generator/components/sparks-limit-notification.js
+++ b/packages/js/src/ai-generator/components/sparks-limit-notification.js
@@ -1,60 +1,137 @@
+import { LockOpenIcon } from "@heroicons/react/outline";
 import { useSelect } from "@wordpress/data";
-import { useEffect, useState, useCallback } from "@wordpress/element";
+import { useEffect } from "@wordpress/element";
 import { __, _n, sprintf } from "@wordpress/i18n";
-import PropTypes from "prop-types";
-import { STORE_NAME_AI } from "../constants";
-import { Button, Notifications } from "@yoast/ui-library";
+import { Button, Notifications, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
+
+const CLASSNAMES = {
+	paragraph: "yst-mt-1 yst-mb-3",
+	buttonContainer: "yst-flex yst-justify-end yst--me-8 yst-gap-3",
+};
+
+/**
+ * @param {Function} onClose Callback function to close the notification.
+ * @returns {JSX.Element} The content for the sparks limit notification.
+ */
+const SparksLimitContent = ( { onClose } ) => (
+	<>
+		<p className={ CLASSNAMES.paragraph }>
+			{ __( "As long as this is a beta feature, you get unlimited sparks.", "wordpress-seo" ) }
+		</p>
+		<div className={ CLASSNAMES.buttonContainer }>
+			<Button type="button" variant="primary" size="small" onClick={ onClose }>
+				{ __( "Got it!", "wordpress-seo" ) }
+			</Button>
+		</div>
+	</>
+);
+
+/**
+ * @param {Function} onClose Callback function to close the notification.
+ * @param {string} upsellLink The link to the upsell page.
+ * @param {string} [upsellLabel] The label for the upsell.
+ * @param {string} [ctbId] The click to buy ID for the upsell.
+ * @returns {JSX.Element} The content with upsell for the sparks limit notification.
+ */
+const SparksLimitUpsellContent = ( {
+	onClose,
+	upsellLink,
+	upsellLabel = sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "Unlock with %1$s", "wordpress-seo" ),
+		"Yoast SEO Premium"
+	),
+	ctbId = "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+} ) => {
+	const svgAriaProps = useSvgAria();
+
+	return (
+		<>
+			<p className={ CLASSNAMES.paragraph }>
+				{ sprintf(
+					/* translators: %s expands to Yoast SEO Premium. */
+					__( "Keep the momentum going, unlock unlimited sparks with %s!", "wordpress-seo" ),
+					"Yoast SEO Premium"
+				) }
+			</p>
+			<div className={ CLASSNAMES.buttonContainer }>
+				<Button type="button" variant="tertiary" size="small" onClick={ onClose }>
+					{ __( "Close", "wordpress-seo" ) }
+				</Button>
+				<Button
+					as="a"
+					size="small"
+					variant="upsell"
+					href={ upsellLink }
+					target="_blank"
+					rel="noopener noreferrer"
+					data-action="load-nfd-ctb"
+					data-ctb-id={ ctbId }
+				>
+					<LockOpenIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-me-2 yst-shrink-0" { ...svgAriaProps } />
+					{ upsellLabel }
+					<span className="yst-sr-only">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
+				</Button>
+			</div>
+		</>
+	);
+};
 
 /**
  * The notification component when the user has reached the limit of the AI.
  *
  * @param {string} [className=""] The class name.
- * @param {string} [size="default"] The size of the notification.
+ *
  * @returns {JSX.Element} The element.
  */
-export const SparksLimitNotification = ( { className = "", size = "default" } ) => {
-	const counts = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCount(), [] );
-	const limit = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCountLimit(), [] );
-	const [ showNotification, setShowNotification ] = useState( false );
+export const SparksLimitNotification = ( { className = "" } ) => {
+	const { isUsageCountLimitReached, usageCountLimit, isPremium, upsellLink } = useSelect( ( select ) => {
+		const aiSelect = select( STORE_NAME_AI );
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return ( {
+			isUsageCountLimitReached: aiSelect.isUsageCountLimitReached(),
+			usageCountLimit: aiSelect.selectUsageCountLimit(),
+			isPremium: editorSelect.getIsPremium(),
+			upsellLink: editorSelect.selectLink( "https://yoa.st/ai-toast-out-of-free-sparks" ),
+		} );
+	}, [] );
+	const [ showNotification, , setShowNotification, , hideNotification ] = useToggleState( isUsageCountLimitReached );
 
 	useEffect( () => {
-		setShowNotification( counts === limit );
-	}, [ counts, limit ] );
+		setShowNotification( isUsageCountLimitReached );
+	}, [ isUsageCountLimitReached ] );
 
-	const handleDismiss = useCallback( () => {
-		setShowNotification( false );
-	}, [] );
-
-	return showNotification &&
+	return showNotification && (
 		<Notifications.Notification
 			id="ai-sparks-limit"
-			variant="info"
-			size={ size }
-			dismissScreenReaderLabel={ __( "Got it!", "wordpress-seo" ) }
-			title={ sprintf(
-				/* translators: %s is the number of the sparks allowed. */
-				_n(
-					"You've used %s spark this month.",
-					"You've used %s sparks this month.",
-					limit,
-					"wordpress-seo-premium"
-				),
-				limit
-			) }
 			className={ className }
+			variant="info"
+			dismissScreenReaderLabel={ __( "Close", "wordpress-seo" ) }
+			title={ isPremium
+				? sprintf(
+					/* translators: %s is the number of the sparks. */
+					_n(
+						"You've used %s spark this month.",
+						"You've used %s sparks this month.",
+						usageCountLimit,
+						"wordpress-seo"
+					),
+					usageCountLimit
+				)
+				: __( "You're out of free sparks!", "wordpress-seo" )
+			}
+			size={ isPremium ? "default" : "large" }
 		>
-			<p>
-				{ __( "As long as this is a beta feature, you get unlimited sparks.", "wordpress-seo" ) }
-			</p>
-			<div className="yst-mt-3 yst--me-8 yst-justify-end yst-flex">
-				<Button type="button" variant="primary" size="small" onClick={ handleDismiss }>
-					{ __( "Got it!", "wordpress-seo" ) }
-				</Button>
-			</div>
-		</Notifications.Notification>;
-};
-
-SparksLimitNotification.propTypes = {
-	className: PropTypes.string,
-	size: PropTypes.string,
+			{ isPremium
+				? <SparksLimitContent onClose={ hideNotification } />
+				: <SparksLimitUpsellContent onClose={ hideNotification } upsellLink={ upsellLink } />
+			}
+		</Notifications.Notification>
+	);
 };

--- a/packages/js/src/ai-generator/components/sparks-limit-notification.js
+++ b/packages/js/src/ai-generator/components/sparks-limit-notification.js
@@ -8,11 +8,11 @@ import { Button, Notifications } from "@yoast/ui-library";
 /**
  * The notification component when the user has reached the limit of the AI.
  *
- * @param {string} className The class name.
- * @param {string} size The size of the notification.
+ * @param {string} [className=""] The class name.
+ * @param {string} [size="default"] The size of the notification.
  * @returns {JSX.Element} The element.
  */
-export const SparksLimitNotification = ( { className = "", size = "" } ) => {
+export const SparksLimitNotification = ( { className = "", size = "default" } ) => {
 	const counts = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCount(), [] );
 	const limit = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCountLimit(), [] );
 	const [ showNotification, setShowNotification ] = useState( false );

--- a/packages/js/src/ai-generator/components/tip-notification.js
+++ b/packages/js/src/ai-generator/components/tip-notification.js
@@ -4,7 +4,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { Button, Notifications, useToggleState } from "@yoast/ui-library";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { CONTENT_TYPE, EDIT_TYPE, MIN_CHARACTERS_DEFAULT, MIN_CHARACTERS_IRREGULAR, STORE_NAME_EDITOR } from "../constants";
-import { isWooActiveAndProductPostType } from "../helpers/is-woo-active-and-product-post-type";
+import { isWooActiveAndProductPostType } from "../helpers";
 import { useTypeContext } from "../hooks";
 
 const ALERT_KEY = "ai_generator_tip_notification";

--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -1,124 +1,65 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { AiGenerateTitlesAndDescriptionsUpsell } from "../../shared-admin/components";
-import { STORE_NAME_EDITOR, STORE_NAME_AI } from "../constants";
+import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
+import { useUpsellProps } from "../hooks";
 
 /**
- * The upsell props.
- * @typedef {Object} UpsellProps
- * @property {string} upsellLink The URL for the upsell.
- * @property {string} [upsellLabel] The label for the upsell.
- * @property {string} [newToText] The "new to" text for the upsell.
- * @property {JSX.Element} [bundleNote] A note about the bundle upsell.
- * @property {string} [ctbId] The CTB ID for the upsell.
- * @property {boolean} [isProductCopy] Whether the upsell is for product copy.
- * @property {function} setTryAi Callback to signal the generating should start.
- */
-
-/**
- * Retrieves the upsell props based on the active licenses.
- * @param {Object} upsellLinks An object containing the upsell links and their associated data.
- * @param {string} upsellLinks.premium The Yoast SEO Premium upsell link .
- * @param {string} upsellLinks.woo The Yoast WooCommerce SEO upsell link.
- * @param {string} upsellLinks.bundle The bundle upsell link.
- * @returns {UpsellProps} The upsell props.
- */
-export const getUpsellProps = ( upsellLinks ) => {
-	const isPremiumActive = useSelect( select => select( STORE_NAME_EDITOR ).getIsPremium(), [] );
-	const isWooSeoActive = useSelect( select => select( STORE_NAME_EDITOR ).getIsWooSeoActive(), [] );
-	const isWooCommerceActive = useSelect( select => select( STORE_NAME_EDITOR ).getIsWooCommerceActive(), [] );
-
-	const isProductPost = useSelect( select => select( STORE_NAME_EDITOR ).getIsProduct(), [] );
-	const isProductTerm = useSelect( select => select( STORE_NAME_EDITOR ).getIsProductTerm(), [] );
-
-	const upsellProps = {
-		upsellLink: upsellLinks.premium,
-		// The default ctbId is passed as a prop to the AiGenerateTitlesAndDescriptionsUpsell component.
-	};
-
-	// Use specific copy for product posts and terms, otherwise revert to the defaults.
-	if ( isWooCommerceActive && ( isProductPost || isProductTerm ) ) {
-		const upsellPremiumWooLabel = sprintf(
-			/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
-			__( "%1$s + %2$s", "wordpress-seo" ),
-			"Yoast SEO Premium",
-			"Yoast WooCommerce SEO"
-		);
-		upsellProps.newToText = sprintf(
-			/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
-			__( "New in %1$s", "wordpress-seo" ),
-			upsellPremiumWooLabel
-		);
-
-		if ( isPremiumActive ) {
-			upsellProps.upsellLabel = sprintf(
-				/* translators: %1$s expands to Yoast WooCommerce SEO. */
-				__( "Unlock with %1$s", "wordpress-seo" ),
-				"Yoast WooCommerce SEO"
-			);
-			upsellProps.upsellLink = upsellLinks.woo;
-			upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
-		} else if ( ! isWooSeoActive ) {
-			upsellProps.upsellLabel = `${ sprintf(
-				/* translators: %1$s expands to Woo Premium bundle. */
-				__( "Unlock with the %1$s", "wordpress-seo" ),
-				"Woo Premium bundle"
-			) }*`;
-			upsellProps.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
-				{ `*${ upsellPremiumWooLabel }` }
-			</div>;
-			upsellProps.upsellLink = upsellLinks.bundle;
-			upsellProps.ctbId = "c7e7baa1-2020-420c-a427-89701700b607";
-		}
-	}
-	return upsellProps;
-};
-
-/**
- *
- * @param {function} setTryAi Callback to signal the generating should start.
- *
+ * @param {Function} setTryAi Callback to signal the generating should start.
  * @returns {JSX.Element} The element.
  */
 export const UpsellModalContent = ( { setTryAi } ) => {
-	const upsellLinks = {
-		premium: useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-upsell" ), [] ),
-		bundle: useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ), [] ),
-		woo: useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ), [] ),
-	};
+	const {
+		premiumUpsellLink,
+		bundleUpsellLink,
+		wooUpsellLink,
+		isWooCommerceActive,
+		isProductPost,
+		learnMoreLink,
+		imageLink,
+		wistiaEmbedPermissionValue,
+		wistiaEmbedPermissionStatus,
+		isUsageCountLimitReached,
+	} = useSelect( ( select ) => {
+		const aiSelect = select( STORE_NAME_AI );
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			premiumUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell" ),
+			bundleUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ),
+			wooUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ),
+			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
+			isProductPost: editorSelect.getIsProduct(),
+			learnMoreLink: editorSelect.selectLink( "https://yoa.st/ai-generator-learn-more" ),
+			imageLink: editorSelect.selectImageLink( "ai-generator-preview.png" ),
+			wistiaEmbedPermissionValue: editorSelect.selectWistiaEmbedPermissionValue(),
+			wistiaEmbedPermissionStatus: editorSelect.selectWistiaEmbedPermissionStatus(),
+			isUsageCountLimitReached: aiSelect.isUsageCountLimitReached(),
+		};
+	}, [] );
 
-	const upsellProps = getUpsellProps( upsellLinks );
+	const upsellProps = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink, bundle: bundleUpsellLink } );
 
 	// Use specific copy for product posts.
-	const isWooCommerceActive = useSelect( select => select( STORE_NAME_EDITOR ).getIsWooCommerceActive(), [] );
-	const isProductPost = useSelect( select => select( STORE_NAME_EDITOR ).getIsProduct(), [] );
-
 	if ( isWooCommerceActive && isProductPost ) {
 		upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
 		upsellProps.isProductCopy = true;
+	} else {
+		upsellProps.title = __( "Use AI to generate your titles & descriptions!", "wordpress-seo" );
 	}
 
-	const learnMoreLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-learn-more" ), [] );
-
-	const imageLink = useSelect( select => select( STORE_NAME_EDITOR ).selectImageLink( "ai-generator-preview.png" ), [] );
 	const thumbnail = useMemo( () => ( {
 		src: imageLink,
 		width: "432",
 		height: "244",
 	} ), [ imageLink ] );
 
-	const value = useSelect( select => select( STORE_NAME_EDITOR ).selectWistiaEmbedPermissionValue(), [] );
-	const status = useSelect( select => select( STORE_NAME_EDITOR ).selectWistiaEmbedPermissionStatus(), [] );
-	const { setWistiaEmbedPermission: set } = useDispatch( STORE_NAME_EDITOR );
-	const wistiaEmbedPermission = useMemo( () => ( { value, status, set } ), [ value, status, set ] );
-
-	const { counts, limit } = useSelect( ( select ) => ( {
-		counts: select( STORE_NAME_AI ).selectUsageCount(),
-		limit: select( STORE_NAME_AI ).selectUsageCountLimit(),
-	} ), [] );
-
-	const isLimitReached = counts >= limit;
+	const { setWistiaEmbedPermission } = useDispatch( STORE_NAME_EDITOR );
+	const wistiaEmbedPermission = useMemo( () => ( {
+		value: wistiaEmbedPermissionValue,
+		status: wistiaEmbedPermissionStatus,
+		set: setWistiaEmbedPermission,
+	} ), [ wistiaEmbedPermissionValue, wistiaEmbedPermissionStatus, setWistiaEmbedPermission ] );
 
 	return (
 		<AiGenerateTitlesAndDescriptionsUpsell
@@ -126,7 +67,7 @@ export const UpsellModalContent = ( { setTryAi } ) => {
 			thumbnail={ thumbnail }
 			wistiaEmbedPermission={ wistiaEmbedPermission }
 			setTryAi={ setTryAi }
-			isLimitReached={ isLimitReached }
+			isLimitReached={ isUsageCountLimitReached }
 			{ ...upsellProps }
 		/>
 	);

--- a/packages/js/src/ai-generator/helpers/index.js
+++ b/packages/js/src/ai-generator/helpers/index.js
@@ -1,7 +1,7 @@
 export { applyPluggableReplacementVariables } from "./apply-pluggable-replacement-variables";
-export { fetchSuggestions } from "./fetch-suggestions";
-export { removesLocaleVariantSuffixes } from "./fetch-suggestions";
 export { enforceTitleVariable } from "./enforce-title-variable";
+export { fetchSuggestions, removesLocaleVariantSuffixes } from "./fetch-suggestions";
 export { focusFocusKeyphraseInput } from "./focus-focus-keyphrase-input";
 export { isConsideredEmpty } from "./is-considered-empty";
+export { isWooActiveAndProductPostType } from "./is-woo-active-and-product-post-type";
 export { preparePromptContent } from "./prepare-prompt-content";

--- a/packages/js/src/ai-generator/hooks/index.js
+++ b/packages/js/src/ai-generator/hooks/index.js
@@ -13,3 +13,4 @@ export { useSuggestions } from "./use-suggestions";
 export { useTitleOrDescriptionLengthProgress } from "./use-title-or-description-length-progress";
 export { useTitleTemplate } from "./use-title-template";
 export { useTypeContext } from "./use-type-context";
+export { useUpsellProps } from "./use-upsell-props";

--- a/packages/js/src/ai-generator/hooks/use-location.js
+++ b/packages/js/src/ai-generator/hooks/use-location.js
@@ -1,7 +1,5 @@
-import { createContext, useContext } from "@wordpress/element";
-import { get } from "lodash";
-
-const LocationContext = get( window, "yoast.editorModules.components.contexts.location.LocationContext", createContext( "unknown" ) );
+import { useContext } from "@wordpress/element";
+import { LocationContext } from "@yoast/externals/contexts";
 
 /**
  * @returns {string} The location.

--- a/packages/js/src/ai-generator/hooks/use-upsell-props.js
+++ b/packages/js/src/ai-generator/hooks/use-upsell-props.js
@@ -22,14 +22,13 @@ import { STORE_NAME_EDITOR } from "../constants";
  * @returns {UpsellProps} The upsell props.
  */
 export const useUpsellProps = ( upsellLinks ) => {
-	const { isPremiumActive, isWooSeoActive, isWooCommerceActive, isProductPost, isProductTerm } = useSelect( select => {
+	const { isPremiumActive, isWooSeoActive, isWooCommerceActive, isProductEntity } = useSelect( select => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
 			isPremiumActive: editorSelect.getIsPremium(),
 			isWooSeoActive: editorSelect.getIsWooSeoActive(),
 			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
-			isProductPost: editorSelect.getIsProduct(),
-			isProductTerm: editorSelect.getIsProductTerm(),
+			isProductEntity: editorSelect.getIsProductEntity(),
 		};
 	}, [] );
 
@@ -47,7 +46,7 @@ export const useUpsellProps = ( upsellLinks ) => {
 		};
 
 		// Use specific copy for product posts and terms, otherwise revert to the defaults.
-		if ( isWooCommerceActive && ( isProductPost || isProductTerm ) ) {
+		if ( isWooCommerceActive && isProductEntity ) {
 			const upsellPremiumWooLabel = sprintf(
 				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
 				__( "%1$s + %2$s", "wordpress-seo" ),
@@ -84,13 +83,12 @@ export const useUpsellProps = ( upsellLinks ) => {
 
 		return upsellProps;
 	}, [
-		isWooCommerceActive,
-		isProductPost,
-		isProductTerm,
 		isPremiumActive,
 		isWooSeoActive,
+		isWooCommerceActive,
+		isProductEntity,
 		upsellLinks.premium,
 		upsellLinks.woo,
-		upsellLinks.woo,
+		upsellLinks.bundle,
 	] );
 };

--- a/packages/js/src/ai-generator/hooks/use-upsell-props.js
+++ b/packages/js/src/ai-generator/hooks/use-upsell-props.js
@@ -1,0 +1,96 @@
+import { useSelect } from "@wordpress/data";
+import { useMemo } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
+import { STORE_NAME_EDITOR } from "../constants";
+
+/**
+ * The upsell props.
+ * @typedef {Object} UpsellProps
+ * @property {string} upsellLink The URL for the upsell.
+ * @property {string} [upsellLabel] The label for the upsell.
+ * @property {string} [newToText] The "new to" text for the upsell.
+ * @property {React.ReactNode} [bundleNote] A note about the bundle upsell.
+ * @property {string} [ctbId] The CTB ID for the upsell.
+ */
+
+/**
+ * Retrieves the upsell props based on the active licenses.
+ * @param {Object} upsellLinks An object containing the upsell links and their associated data.
+ * @param {string} upsellLinks.premium The Yoast SEO Premium upsell link .
+ * @param {string} upsellLinks.woo The Yoast WooCommerce SEO upsell link.
+ * @param {string} upsellLinks.bundle The bundle upsell link.
+ * @returns {UpsellProps} The upsell props.
+ */
+export const useUpsellProps = ( upsellLinks ) => {
+	const { isPremiumActive, isWooSeoActive, isWooCommerceActive, isProductPost, isProductTerm } = useSelect( select => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			isPremiumActive: editorSelect.getIsPremium(),
+			isWooSeoActive: editorSelect.getIsWooSeoActive(),
+			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
+			isProductPost: editorSelect.getIsProduct(),
+			isProductTerm: editorSelect.getIsProductTerm(),
+		};
+	}, [] );
+
+	return useMemo( () => {
+		const upsellProps = {
+			upsellLink: upsellLinks.premium,
+			upsellLabel: sprintf(
+				/* translators: %1$s expands to Yoast SEO Premium. */
+				__( "Unlock with %1$s", "wordpress-seo" ),
+				"Yoast SEO Premium"
+			),
+			newToText: "Yoast SEO Premium",
+			bundleNote: "",
+			ctbId: "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
+		};
+
+		// Use specific copy for product posts and terms, otherwise revert to the defaults.
+		if ( isWooCommerceActive && ( isProductPost || isProductTerm ) ) {
+			const upsellPremiumWooLabel = sprintf(
+				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
+				__( "%1$s + %2$s", "wordpress-seo" ),
+				"Yoast SEO Premium",
+				"Yoast WooCommerce SEO"
+			);
+			upsellProps.newToText = sprintf(
+				/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
+				__( "New in %1$s", "wordpress-seo" ),
+				upsellPremiumWooLabel
+			);
+
+			if ( isPremiumActive ) {
+				upsellProps.upsellLabel = sprintf(
+					/* translators: %1$s expands to Yoast WooCommerce SEO. */
+					__( "Unlock with %1$s", "wordpress-seo" ),
+					"Yoast WooCommerce SEO"
+				);
+				upsellProps.upsellLink = upsellLinks.woo;
+				upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
+			} else if ( ! isWooSeoActive ) {
+				upsellProps.upsellLabel = `${ sprintf(
+					/* translators: %1$s expands to Woo Premium bundle. */
+					__( "Unlock with the %1$s", "wordpress-seo" ),
+					"Woo Premium bundle"
+				) }*`;
+				upsellProps.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
+					{ `*${ upsellPremiumWooLabel }` }
+				</div>;
+				upsellProps.upsellLink = upsellLinks.bundle;
+				upsellProps.ctbId = "c7e7baa1-2020-420c-a427-89701700b607";
+			}
+		}
+
+		return upsellProps;
+	}, [
+		isWooCommerceActive,
+		isProductPost,
+		isProductTerm,
+		isPremiumActive,
+		isWooSeoActive,
+		upsellLinks.premium,
+		upsellLinks.woo,
+		upsellLinks.woo,
+	] );
+};

--- a/packages/js/src/ai-generator/store/index.js
+++ b/packages/js/src/ai-generator/store/index.js
@@ -11,6 +11,20 @@ import {
 } from "../../shared-admin/store";
 import { STORE_NAME_AI } from "../constants";
 import {
+	AI_OPTIMIZE_NOTIFICATION_STATUS_NAME,
+	aiOptimizeNotificationStatusActions,
+	aiOptimizeNotificationStatusReducer,
+	aiOptimizeNotificationStatusSelectors,
+	getInitialNotificationStatusState,
+} from "./ai-optimize-notification-status";
+import {
+	APPLIED_FIXES_STATUS_NAME,
+	appliedFixesStatusActions,
+	appliedFixesStatusReducer,
+	appliedFixesStatusSelectors,
+	getInitialAppliedFixesStatusState,
+} from "./applied-assessment-fixes-status";
+import {
 	APPLIED_SUGGESTIONS_NAME,
 	appliedSuggestionsActions,
 	appliedSuggestionsReducer,
@@ -34,32 +48,18 @@ import {
 import {
 	getInitialPromptContentFixAssessmentsState,
 	PROMPT_CONTENT_FIX_ASSESSMENTS_NAME,
-	promptContentFixAssessmentsSelectors,
 	promptContentFixAssessmentsActions,
 	promptContentFixAssessmentsReducer,
+	promptContentFixAssessmentsSelectors,
 } from "./prompt-content-fix-assessments";
 import {
-	APPLIED_FIXES_STATUS_NAME,
-	appliedFixesStatusActions,
-	appliedFixesStatusReducer,
-	appliedFixesStatusSelectors,
-	getInitialAppliedFixesStatusState,
-} from "./applied-assessment-fixes-status";
-import {
+	getInitialUsageCount,
 	USAGE_COUNT_NAME,
 	usageCountActions,
-	usageCountReducer,
-	UsageCountSelectors,
-	getInitialUsageCount,
 	usageCountControls,
+	usageCountReducer,
+	usageCountSelectors,
 } from "./usage-count";
-import {
-	AI_OPTIMIZE_NOTIFICATION_STATUS_NAME,
-	aiOptimizeNotificationStatusActions,
-	aiOptimizeNotificationStatusReducer,
-	aiOptimizeNotificationStatusSelectors,
-	getInitialNotificationStatusState,
-} from "./ai-optimize-notification-status";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -86,7 +86,7 @@ const createStore = ( initialState ) => {
 			...promptContentSelectors,
 			...promptContentFixAssessmentsSelectors,
 			...appliedFixesStatusSelectors,
-			...UsageCountSelectors,
+			...usageCountSelectors,
 			...aiOptimizeNotificationStatusSelectors,
 		},
 		initialState: merge(

--- a/packages/js/src/ai-generator/store/usage-count.js
+++ b/packages/js/src/ai-generator/store/usage-count.js
@@ -51,22 +51,22 @@ const slice = createSlice( {
 
 export const getInitialUsageCount = slice.getInitialState;
 
-export const UsageCountSelectors = {
+export const usageCountSelectors = {
 	selectUsageCount: state => get( state, [ USAGE_COUNT_NAME, "count" ], slice.getInitialState().count ),
 	selectUsageCountLimit: state => get( state, [ USAGE_COUNT_NAME, "limit" ], slice.getInitialState().limit ),
 	selectUsageCountEndpoint: state => get( state, [ USAGE_COUNT_NAME, "endpoint" ], slice.getInitialState().endpoint ),
 };
-UsageCountSelectors.selectUsageCountRemaining = createSelector(
+usageCountSelectors.selectUsageCountRemaining = createSelector(
 	[
-		UsageCountSelectors.selectUsageCount,
-		UsageCountSelectors.selectUsageCountLimit,
+		usageCountSelectors.selectUsageCount,
+		usageCountSelectors.selectUsageCountLimit,
 	],
 	( count, limit ) => Math.max( limit - count, 0 )
 );
-UsageCountSelectors.isUsageCountLimitReached = createSelector(
+usageCountSelectors.isUsageCountLimitReached = createSelector(
 	[
-		UsageCountSelectors.selectUsageCount,
-		UsageCountSelectors.selectUsageCountLimit,
+		usageCountSelectors.selectUsageCount,
+		usageCountSelectors.selectUsageCountLimit,
 	],
 	( count, limit ) => count >= limit
 );

--- a/packages/js/src/ai-generator/store/usage-count.js
+++ b/packages/js/src/ai-generator/store/usage-count.js
@@ -1,42 +1,50 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import apiFetch from "@wordpress/api-fetch";
-import { get } from "lodash";
-import { ASYNC_ACTION_NAMES } from "../../shared-admin/constants";
+import { get, isNumber } from "lodash";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+
+/**
+ * @typedef {Object} UsageCount
+ * @property {number} count The current usage count.
+ * @property {number} limit The limit for the usage count.
+ */
 
 export const USAGE_COUNT_NAME = "usageCount";
-
 export const FETCH_USAGE_COUNT_ACTION_NAME = "fetchUsageCount";
-
 
 const slice = createSlice( {
 	name: USAGE_COUNT_NAME,
 	initialState: {
-		currentUsageCount: 0,
-		currentLimit: 10,
+		status: ASYNC_ACTION_STATUS.idle,
+		count: 0,
+		limit: 10,
 		endpoint: "yoast/v1/ai_generator/get_usage",
 	},
 	reducers: {
 		addUsageCount: ( state, { payload = 1 } ) => {
-			state.currentUsageCount = state.currentUsageCount + payload;
+			state.count += payload;
+		},
+		setUsageCount: ( state, { payload } ) => {
+			state.count = payload;
 		},
 		setUsageCountEndpoint: ( state, { payload } ) => {
 			state.endpoint = payload;
 		},
 		setUsageCountLimit: ( state, { payload } ) => {
-			state.currentLimit = payload;
+			state.limit = payload;
 		},
 	},
 	extraReducers: ( builder ) => {
-		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, state => {
-			state.currentUsageCount = 0;
+		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.loading;
 		} );
-		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, action ) => {
-			state.currentUsageCount = get( action, "payload.totalUsed.license", 0 );
-			state.currentLimit = get( action, "payload.totalUsed.limit", 10 );
+		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.success;
+			state.count = payload.count;
+			state.limit = payload.limit;
 		} );
-
-		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, state => {
-			state.currentUsageCount = 0;
+		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
 		} );
 	},
 } );
@@ -44,9 +52,51 @@ const slice = createSlice( {
 export const getInitialUsageCount = slice.getInitialState;
 
 export const UsageCountSelectors = {
-	selectUsageCount: state => get( state, [ USAGE_COUNT_NAME, "currentUsageCount" ], slice.getInitialState().currentUsageCount ),
-	selectUsageCountLimit: state => get( state, [ USAGE_COUNT_NAME, "currentLimit" ], slice.getInitialState().limit ),
+	selectUsageCount: state => get( state, [ USAGE_COUNT_NAME, "count" ], slice.getInitialState().count ),
+	selectUsageCountLimit: state => get( state, [ USAGE_COUNT_NAME, "limit" ], slice.getInitialState().limit ),
 	selectUsageCountEndpoint: state => get( state, [ USAGE_COUNT_NAME, "endpoint" ], slice.getInitialState().endpoint ),
+};
+UsageCountSelectors.selectUsageCountRemaining = createSelector(
+	[
+		UsageCountSelectors.selectUsageCount,
+		UsageCountSelectors.selectUsageCountLimit,
+	],
+	( count, limit ) => Math.max( limit - count, 0 )
+);
+UsageCountSelectors.isUsageCountLimitReached = createSelector(
+	[
+		UsageCountSelectors.selectUsageCount,
+		UsageCountSelectors.selectUsageCountLimit,
+	],
+	( count, limit ) => count >= limit
+);
+
+/**
+ * Validates the response structure of the usage count.
+ *
+ * Expected structure:
+ * {
+ *   totalUsed: {
+ *     license: number, // The current usage count
+ *     limit: number,   // The limit for the usage count
+ *   }
+ * }
+ *
+ * @param {any} result The result object returned from the API.
+ * @returns {UsageCount} The validated count and limit.
+ */
+const validateUsageCountResponse = ( result ) => {
+	const count = get( result, "totalUsed.license", null );
+	const limit = get( result, "totalUsed.limit", null );
+
+	if ( ! isNumber( count ) || count < 0 ) {
+		throw new Error( "Invalid usage count: must be a number of zero or higher." );
+	}
+	if ( ! isNumber( limit ) || limit < -1 || limit === 0 ) {
+		throw new Error( "Invalid usage count limit: must be a number of -1 or higher than 1" );
+	}
+
+	return { count, limit };
 };
 
 /**
@@ -56,9 +106,14 @@ export const UsageCountSelectors = {
 export function* fetchUsageCount( { endpoint } ) {
 	yield{ type: `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }` };
 	try {
-		// Trigger the fetch users control flow.
-		const counts = yield{ type: FETCH_USAGE_COUNT_ACTION_NAME, payload: endpoint };
-		return { type: `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, payload: counts };
+		// Throws an error if the response structure is invalid.
+		const payload = validateUsageCountResponse(
+			// Trigger the fetch users control flow.
+			yield{ type: FETCH_USAGE_COUNT_ACTION_NAME, payload: endpoint }
+		);
+
+		// Update the store with the fetched usage count.
+		return { type: `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, payload };
 	} catch ( error ) {
 		return { type: `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, payload: error };
 	}

--- a/packages/js/src/ai-optimizer/components/modal-content.js
+++ b/packages/js/src/ai-optimizer/components/modal-content.js
@@ -1,35 +1,48 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
+import { STORE_NAME_EDITOR } from "../../ai-generator/constants";
+import { useUpsellProps } from "../../ai-generator/hooks";
 import { AIOptimizeUpsell } from "../../shared-admin/components";
-import { getUpsellProps } from "../../ai-generator/components/upsell-modal-content";
-
-const STORE = "yoast-seo/editor";
 
 /**
  * @returns {JSX.Element} The element.
  */
 export const ModalContent = () => {
-	const upsellLinks = {
-		premium: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell" ), [] ),
-		bundle: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo-premium-bundle" ), [] ),
-		woo: useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo" ), [] ),
-	};
+	const {
+		premiumUpsellLink,
+		bundleUpsellLink,
+		wooUpsellLink,
+		learnMoreLink,
+		imageLink,
+		wistiaEmbedPermissionValue,
+		wistiaEmbedPermissionStatus,
+	} = useSelect( ( select ) => {
+		const storeSelect = select( STORE_NAME_EDITOR );
+		return {
+			premiumUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell" ),
+			bundleUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo-premium-bundle" ),
+			wooUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo" ),
+			learnMoreLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-learn-more" ),
+			imageLink: storeSelect.selectImageLink( "ai-fix-assessments-thumbnail.png" ),
+			wistiaEmbedPermissionValue: storeSelect.selectWistiaEmbedPermissionValue(),
+			wistiaEmbedPermissionStatus: storeSelect.selectWistiaEmbedPermissionStatus(),
+		};
+	}, [] );
 
-	const upsellProps = getUpsellProps( upsellLinks );
+	const upsellProps = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink, bundle: bundleUpsellLink } );
 
-	const learnMoreLink = useSelect( select => select( STORE ).selectLink( "https://yoa.st/ai-fix-assessments-upsell-learn-more" ), [] );
-
-	const imageLink = useSelect( select => select( STORE ).selectImageLink( "ai-fix-assessments-thumbnail.png" ), [] );
 	const thumbnail = useMemo( () => ( {
 		src: imageLink,
 		width: "432",
 		height: "244",
 	} ), [ imageLink ] );
 
-	const value = useSelect( select => select( STORE ).selectWistiaEmbedPermissionValue(), [] );
-	const status = useSelect( select => select( STORE ).selectWistiaEmbedPermissionStatus(), [] );
-	const { setWistiaEmbedPermission: set } = useDispatch( STORE );
-	const wistiaEmbedPermission = useMemo( () => ( { value, status, set } ), [ value, status, set ] );
+	const { setWistiaEmbedPermission } = useDispatch( STORE_NAME_EDITOR );
+	const wistiaEmbedPermission = useMemo( () => ( {
+		value: wistiaEmbedPermissionValue,
+		status: wistiaEmbedPermissionStatus,
+		set: setWistiaEmbedPermission,
+	} ), [ wistiaEmbedPermissionValue, wistiaEmbedPermissionStatus, setWistiaEmbedPermission ] );
 
 	return (
 		<AIOptimizeUpsell

--- a/packages/js/src/redux/reducers/editorContext.js
+++ b/packages/js/src/redux/reducers/editorContext.js
@@ -15,7 +15,6 @@ function getDefaultState() {
 		noIndex: get( window, "wpseoAdminL10n.noIndex", "0" ) === "1",
 		postTypeNameSingular: get( window, "wpseoAdminL10n.postTypeNameSingular", "" ),
 		postTypeNamePlural: get( window, "wpseoAdminL10n.postTypeNamePlural", "" ),
-		termType: get( window, "wpseoScriptData.termType", "" ),
 		postStatus: get( window, "wpseoScriptData.postStatus", "" ),
 		isFrontPage: get( window, "wpseoScriptData.isFrontPage", "0" ) === "1",
 		postType: get( window, "wpseoScriptData.postType", "" ),

--- a/packages/js/src/redux/selectors/editorContext.js
+++ b/packages/js/src/redux/selectors/editorContext.js
@@ -1,3 +1,4 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
 /**
@@ -23,17 +24,6 @@ export function getPostOrPageString( state ) {
 }
 
 /**
- * Returns whether you're editing a product.
- *
- * @param {Object} state The state.
- *
- * @returns {boolean} Whether you're editing a product.
- */
-export function getIsProduct( state ) {
-	return get( state, "editorContext.postType" ) === "product";
-}
-
-/**
  * Returns post type.
  *
  * @param {Object} state The state.
@@ -45,16 +35,40 @@ export function getPostType( state ) {
 }
 
 /**
+ * Returns whether you're editing a product.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} Whether you're editing a product.
+ */
+export const getIsProduct = createSelector(
+	[ getPostType ],
+	( postType ) => postType === "product"
+);
+
+/**
  * Returns whether you're editing a product term.
  *
  * @param {Object} state The state.
  *
  * @returns {boolean} Whether you're editing a product term.
  */
-export function getIsProductTerm( state ) {
-	const termType = get( state, "editorContext.termType" );
-	return termType === "product_cat" || termType === "product_tag";
-}
+export const getIsProductTerm = createSelector(
+	[ getPostType ],
+	( postType ) => [ "product_cat", "product_tag" ].includes( postType )
+);
+
+/**
+ * Returns whether you're editing a product entity.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {boolean} Whether you're editing a product entity.
+ */
+export const getIsProductEntity = createSelector(
+	[ getIsProduct, getIsProductTerm ],
+	( isProduct, isProductTerm ) => isProduct || isProductTerm
+);
 
 /**
  * Returns whether this is the block editor or not.

--- a/packages/js/src/redux/selectors/preferences.js
+++ b/packages/js/src/redux/selectors/preferences.js
@@ -1,6 +1,7 @@
-import { get } from "lodash";
+import { createSelector } from "@reduxjs/toolkit";
 import { select } from "@wordpress/data";
-import { getIsProduct, getIsProductTerm } from "./editorContext";
+import { get } from "lodash";
+import { getIsProductEntity, getIsProductTerm } from "./editorContext";
 
 /**
  * Gets a preference.
@@ -48,18 +49,15 @@ export const getIsWooCommerceActive = state => getPreference( state, "isWooComme
 export const getIsWooSeoActive = state => getPreference( state, "isWooCommerceSeoActive", false );
 
 /**
- * Determines whether the WooCommerce SEO addon is not active in a product page.
+ * Determines whether the WooCommerce SEO addon is not active in a product entity.
  *
  * @param {Object} state The state.
- * @returns {Boolean} Whether the WooCommerce SEO addon is not active in a product page.
+ * @returns {Boolean} Whether the WooCommerce SEO addon is not active in a product entity.
  */
-export const getIsWooSeoUpsell = ( state ) => {
-	const isWooSeoActive = getIsWooSeoActive( state );
-	const isWooCommerceActive = getIsWooCommerceActive( state );
-	const isProductPage = getIsProduct( state );
-
-	return ! isWooSeoActive && isWooCommerceActive && isProductPage;
-};
+export const getIsWooSeoUpsell = createSelector(
+	[ getIsWooSeoActive, getIsWooCommerceActive, getIsProductEntity ],
+	( isWooSeoActive, isWooCommerceActive, isProduct ) => ! isWooSeoActive && isWooCommerceActive && isProduct
+);
 
 /**
  * Determines whether the WooCommerce SEO addon is not active in a product term.
@@ -67,13 +65,10 @@ export const getIsWooSeoUpsell = ( state ) => {
  * @param {Object} state The state.
  * @returns {Boolean} Whether the WooCommerce SEO addon is not active in a product term.
  */
-export const getIsWooSeoUpsellTerm = ( state ) => {
-	const isWooSeoActive = getIsWooSeoActive( state );
-	const isWooCommerceActive = getIsWooCommerceActive( state );
-	const isProductTerm = getIsProductTerm( state );
-
-	return ! isWooSeoActive && isWooCommerceActive && isProductTerm;
-};
+export const getIsWooSeoUpsellTerm = createSelector(
+	[ getIsWooSeoActive, getIsWooCommerceActive, getIsProductTerm ],
+	( isWooSeoActive, isWooCommerceActive, isProductTerm ) => ! isWooSeoActive && isWooCommerceActive && isProductTerm
+);
 
 /**
  * @deprecated This function is deprecated and will be removed in future versions.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WIP 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors ai upsell modal, usage counter and spark notification.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post ( on local env, use [fake-ai-notification.patch](https://github.com/user-attachments/files/20628349/fake-ai-notification.patch))
* Click on "Use AI".
* Check you see the upsell, click on try for free button.
* Grant consent.
* Check you can use the AI generator.
* Refresh and click on "Use AI".
* Check you don't see the consent or the upsell.
* Go to Yoast SEO->Settings->Site features
* Disable "SEO analysis"
* Edit a page or post and click on "Use AI"
* Check you get an error message for the SEO analysis.
* Go to profile page and look for "AI feature", click on "Revoke consent" and save.
* Refresh and check it is saved.
* Grant consent, refresh and check it is saved.
* Enable SEO analysis and edit a post
* Click on "Use AI"
* You should see the AI generator with dummy suggestions from the fake API 
* Check you reached 10 sparks and the upsell notification is visible:
 ![Screenshot 2025-06-06 at 15 42 35](https://github.com/user-attachments/assets/c70acb07-a046-4983-9af4-de893e0d965f)
* Revoke consent.
* Edit a WooCommerce product and Click on "Use AI"
* Check you see an upsell for WOO and premium bundle.
* Activate Woo SEO and check the upsell button is for Premium.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
