### PR TITLE
Add tests to free sparks route

### DIFF
--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Can_Edit_Posts_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Can_Edit_Posts_Test.php
@@ -18,8 +18,8 @@ final class Can_Edit_Posts_Test extends Abstract_Free_Sparks_Route_Test {
 
 	/**
 	 * Tests can_edit_posts returns false if no user is logged in.
-     * 
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_can_edit_posts_returns_false_when_no_user() {
 		Functions\expect( 'wp_get_current_user' )
@@ -31,8 +31,8 @@ final class Can_Edit_Posts_Test extends Abstract_Free_Sparks_Route_Test {
 
 	/**
 	 * Tests can_edit_posts returns false if user ID < 1.
-     * 
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_can_edit_posts_returns_false_when_user_id_less_than_1() {
 		$user     = Mockery::mock( WP_User::class );
@@ -46,8 +46,8 @@ final class Can_Edit_Posts_Test extends Abstract_Free_Sparks_Route_Test {
 
 	/**
 	 * Tests can_edit_posts returns true if user can edit posts.
-     * 
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_can_edit_posts_returns_true_when_user_can_edit_posts() {
 		$user     = Mockery::mock( WP_User::class );
@@ -65,8 +65,8 @@ final class Can_Edit_Posts_Test extends Abstract_Free_Sparks_Route_Test {
 
 	/**
 	 * Tests can_edit_posts returns false if user cannot edit posts.
-     * 
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_can_edit_posts_returns_false_when_user_cannot_edit_posts() {
 		$user     = Mockery::mock( WP_User::class );

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Can_Edit_Posts_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Can_Edit_Posts_Test.php
@@ -1,0 +1,84 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_User;
+
+/**
+ * Tests the Free_Sparks_Route's can_edit_posts method.
+ *
+ * @group ai-free-sparks
+ *
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::can_edit_posts
+ */
+final class Can_Edit_Posts_Test extends Abstract_Free_Sparks_Route_Test {
+
+	/**
+	 * Tests can_edit_posts returns false if no user is logged in.
+     * 
+     * @return void
+	 */
+	public function test_can_edit_posts_returns_false_when_no_user() {
+		Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( null );
+
+		$this->assertFalse( $this->instance->can_edit_posts() );
+	}
+
+	/**
+	 * Tests can_edit_posts returns false if user ID < 1.
+     * 
+     * @return void
+	 */
+	public function test_can_edit_posts_returns_false_when_user_id_less_than_1() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 0;
+		Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $user );
+
+		$this->assertFalse( $this->instance->can_edit_posts() );
+	}
+
+	/**
+	 * Tests can_edit_posts returns true if user can edit posts.
+     * 
+     * @return void
+	 */
+	public function test_can_edit_posts_returns_true_when_user_can_edit_posts() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 5;
+		Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $user );
+		Functions\expect( 'user_can' )
+			->once()
+			->with( $user, 'edit_posts' )
+			->andReturn( true );
+
+		$this->assertTrue( $this->instance->can_edit_posts() );
+	}
+
+	/**
+	 * Tests can_edit_posts returns false if user cannot edit posts.
+     * 
+     * @return void
+	 */
+	public function test_can_edit_posts_returns_false_when_user_cannot_edit_posts() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 5;
+		Functions\expect( 'wp_get_current_user' )
+			->once()
+			->andReturn( $user );
+		Functions\expect( 'user_can' )
+			->once()
+			->with( $user, 'edit_posts' )
+			->andReturn( false );
+
+		$this->assertFalse( $this->instance->can_edit_posts() );
+	}
+}

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Conditional_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Conditional_Test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Conditionals\AI_Conditional;
  *
  * @group ai-free-sparks
  *
- * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::_conditional
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::get_conditionals
  */
 final class Conditional_Test extends Abstract_Free_Sparks_Route_Test {
 
@@ -22,6 +22,6 @@ final class Conditional_Test extends Abstract_Free_Sparks_Route_Test {
 	 */
 	public function test_conditional() {
 		$expected = [ AI_Conditional::class ];
-		self::assertSame( $expected, Free_Sparks_Route::get_conditionals() );
+		$this->assertSame( $expected, Free_Sparks_Route::get_conditionals() );
 	}
 }

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Conditional_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Conditional_Test.php
@@ -1,0 +1,27 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+
+use Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+use Yoast\WP\SEO\Conditionals\AI_Conditional;
+
+/**
+ * Tests the Free_Sparks_Route's conditional.
+ *
+ * @group ai-free-sparks
+ *
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::_conditional
+ */
+final class Conditional_Test extends Abstract_Free_Sparks_Route_Test {
+
+	/**
+	 * Tests the conditional.
+	 *
+	 * @return void
+	 */
+	public function test_conditional() {
+		$expected = [ AI_Conditional::class ];
+		self::assertSame( $expected, Free_Sparks_Route::get_conditionals() );
+	}
+}

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Constructor_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Constructor_Test.php
@@ -1,0 +1,28 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+
+use Yoast\WP\SEO\AI_Free_Sparks\Application\Free_Sparks_Handler_Interface;
+
+/**
+ * Tests the Free_Sparks_Route's construct method.
+ *
+ * @group ai-free-sparks
+ *
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::__construct
+ */
+final class Constructor_Test extends Abstract_Free_Sparks_Route_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Free_Sparks_Handler_Interface::class,
+			$this->getPropertyValue( $this->instance, 'free_sparks_handler' )
+		);
+	}
+}

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Register_Routes_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Register_Routes_Test.php
@@ -1,0 +1,37 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the Free_Sparks_Route's register_routes method.
+ *
+ * @group ai-free-sparks
+ *
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::register_routes
+ */
+final class Register_Routes_Test extends Abstract_Free_Sparks_Route_Test {
+
+	/**
+	 * Tests that register_routes registers the expected route.
+	 *
+	 * @return void
+	 */
+	public function test_register_routes() {
+		Functions\expect( 'register_rest_route' )
+			->once()
+			->with(
+				'yoast/v1',
+				'/ai/free_sparks',
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this->instance, 'start' ],
+					'permission_callback' => [ $this->instance, 'can_edit_posts' ],
+				]
+			);
+
+		$this->instance->register_routes();
+	}
+}

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Start_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Start_Test.php
@@ -26,7 +26,7 @@ final class Start_Test extends Abstract_Free_Sparks_Route_Test {
 			->with( null )
 			->andReturn( true );
 
-		mockery::mock( WP_REST_Response::class );
+		mockery::mock( 'overload:' . WP_REST_Response::class );
 
 		$result = $this->instance->start();
 		$this->assertInstanceOf( WP_REST_Response::class, $result );
@@ -44,7 +44,7 @@ final class Start_Test extends Abstract_Free_Sparks_Route_Test {
 			->with( null )
 			->andReturn( false );
 
-		mockery::mock( WP_REST_Response::class );
+		mockery::mock( 'overload:' . WP_REST_Response::class );
 
 		$result = $this->instance->start();
 		$this->assertInstanceOf( WP_REST_Response::class, $result );

--- a/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Start_Test.php
+++ b/tests/Unit/AI_Free_Sparks/User_Interface/Free_Sparks_Route/Start_Test.php
@@ -1,0 +1,53 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI_Free_Sparks\User_Interface\Free_Sparks_Route;
+
+use Mockery;
+use WP_REST_Response;
+
+/**
+ * Tests the Free_Sparks_Route's start method.
+ *
+ * @group ai-free-sparks
+ *
+ * @covers \Yoast\WP\SEO\AI_Free_Sparks\User_Interface\Free_Sparks_Route::start
+ */
+final class Start_Test extends Abstract_Free_Sparks_Route_Test {
+
+	/**
+	 * Tests start method when successful.
+	 *
+	 * @return void
+	 */
+	public function test_start_success() {
+		$this->free_sparks_handler->expects( 'start' )
+			->once()
+			->with( null )
+			->andReturn( true );
+
+		mockery::mock( WP_REST_Response::class );
+
+		$result = $this->instance->start();
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertEquals( new WP_REST_Response( 'Free sparks successfully started.' ), $result );
+	}
+
+	/**
+	 * Tests start when fails.
+	 *
+	 * @return void
+	 */
+	public function test_start_fail() {
+		$this->free_sparks_handler->expects( 'start' )
+			->once()
+			->with( null )
+			->andReturn( false );
+
+		mockery::mock( WP_REST_Response::class );
+
+		$result = $this->instance->start();
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertEquals( new WP_REST_Response( 'Failed to start free sparks.', 500 ), $result );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds tests to the free sparks rest route.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
