### PR TITLE
Introduce filter that edits the file path of the llms.txt file

### DIFF
--- a/src/llms-txt/application/file/commands/populate-file-command-handler.php
+++ b/src/llms-txt/application/file/commands/populate-file-command-handler.php
@@ -101,7 +101,7 @@ class Populate_File_Command_Handler {
 		/**
 		 * Filter: 'wpseo_llmstxt_encoding_prefix' - Allows editing the Byte Order Mark (BOM) for UTF-8 we prepend to the llmst.txt file.
 		 *
-		 * @param array $encoding_prefix The Byte Order Mark (BOM) for UTF-8 we prepend to the llmst.txt file.
+		 * @param string $encoding_prefix The Byte Order Mark (BOM) for UTF-8 we prepend to the llmst.txt file.
 		 */
 		$encoding_prefix = \apply_filters( 'wpseo_llmstxt_encoding_prefix', "\xEF\xBB\xBF" );
 

--- a/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
+++ b/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
@@ -98,12 +98,12 @@ class WordPress_File_System_Adapter implements Llms_File_System_Interface {
 	private function get_llms_file_path(): string {
 
 		/**
-		 * Filter: 'wpseo_llmstxt_file_path' - Allows editing the file path of the llmst.txt file to account for server restrictions to the filesystem.
+		 * Filter: 'wpseo_llmstxt_filesystem_path' - Allows editing the filesystem path of the llmst.txt file to account for server restrictions to the filesystem.
 		 *
-		 * @param string $llms_file_path The file path of the llmst.txt file that defaults to get_home_path().
+		 * @param string $llms_filesystem_path The filesystem path of the llmst.txt file that defaults to get_home_path().
 		 */
-		$llms_file_path = \apply_filters( 'wpseo_llmstxt_file_path', \trailingslashit( \get_home_path() ) . 'llms.txt' );
+		$llms_filesystem_path = \apply_filters( 'wpseo_llmstxt_filesystem_path', \get_home_path() );
 
-		return $llms_file_path;
+		return \trailingslashit( $llms_filesystem_path ) . 'llms.txt';
 	}
 }

--- a/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
+++ b/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
@@ -96,6 +96,14 @@ class WordPress_File_System_Adapter implements Llms_File_System_Interface {
 	 * @return string
 	 */
 	private function get_llms_file_path(): string {
-		return \trailingslashit( \get_home_path() ) . 'llms.txt';
+
+		/**
+		 * Filter: 'wpseo_llmstxt_file_path' - Allows editing the file path of the llmst.txt file to account for server restrictions to the filesystem.
+		 *
+		 * @param string $llms_file_path The file path of the llmst.txt file that defaults to get_home_path().
+		 */
+		$llms_file_path = \apply_filters( 'wpseo_llmstxt_file_path', \trailingslashit( \get_home_path() ) . 'llms.txt' );
+
+		return $llms_file_path;
 	}
 }

--- a/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
+++ b/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
@@ -97,12 +97,15 @@ class WordPress_File_System_Adapter implements Llms_File_System_Interface {
 	 */
 	private function get_llms_file_path(): string {
 
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- Reason: This is how we used this for the robots.txt file as well.
+		$llms_filesystem_path = \is_writable( \get_home_path() ) ? \get_home_path() : $_SERVER['DOCUMENT_ROOT'];
+
 		/**
 		 * Filter: 'wpseo_llmstxt_filesystem_path' - Allows editing the filesystem path of the llmst.txt file to account for server restrictions to the filesystem.
 		 *
-		 * @param string $llms_filesystem_path The filesystem path of the llmst.txt file that defaults to get_home_path().
+		 * @param string $llms_filesystem_path The filesystem path of the llmst.txt file that defaults to get_home_path() or the $_SERVER['DOCUMENT_ROOT'] if the home path is not writeable.
 		 */
-		$llms_filesystem_path = \apply_filters( 'wpseo_llmstxt_filesystem_path', \get_home_path() );
+		$llms_filesystem_path = \apply_filters( 'wpseo_llmstxt_filesystem_path', $llms_filesystem_path );
 
 		return \trailingslashit( $llms_filesystem_path ) . 'llms.txt';
 	}

--- a/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
+++ b/src/llms-txt/infrastructure/file/wordpress-file-system-adapter.php
@@ -97,8 +97,13 @@ class WordPress_File_System_Adapter implements Llms_File_System_Interface {
 	 */
 	private function get_llms_file_path(): string {
 
+		$llms_filesystem_path = \get_home_path();
+
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput -- Reason: This is how we used this for the robots.txt file as well.
-		$llms_filesystem_path = \is_writable( \get_home_path() ) ? \get_home_path() : $_SERVER['DOCUMENT_ROOT'];
+		if ( ! \is_writable( $llms_filesystem_path ) && ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
+			$llms_filesystem_path = $_SERVER['DOCUMENT_ROOT'];
+		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput
 
 		/**
 		 * Filter: 'wpseo_llmstxt_filesystem_path' - Allows editing the filesystem path of the llmst.txt file to account for server restrictions to the filesystem.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo bugfix] Fixes a bug where the llmst.txt file wouldn't be able to be generated in wp.com.
* Introduces the `wpseo_llmstxt_filesystem_path` filter that allows editing the file path of the llmst.txt file, to help users in servers with filesystem restrictions.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Re-generate the llms.txt file and confirm that you see it being created in the webroot of your filesytem (aka, the place it was created before this change) (aka, the directory that contains the wp-config.php file)
* Add the following snippet:
```
add_filter( 'wpseo_llmstxt_filesystem_path', 'custom_llmstxt_file_path', 10 );
function custom_llmstxt_file_path() {
    return WP_CONTENT_DIR ;
}
```
* Re-generate the file and confirm that you find it in the directory of the wp-content.

For WP.com:
* Let's please test in wp.com also to cover the cases where `get_home_path()` is not writeable.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
