### PR TITLE
623 create the free and premium ai generate flow

### DIFF
--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -1,85 +1,102 @@
 import { QuestionMarkCircleIcon } from "@heroicons/react/solid";
 import { useDispatch, useSelect } from "@wordpress/data";
-import { Fragment, useCallback, useRef, useState } from "@wordpress/element";
+import { Fragment, useCallback, useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { Badge, Link, Modal, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { noop } from "lodash";
 import PropTypes from "prop-types";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
 import { focusFocusKeyphraseInput, isConsideredEmpty } from "../helpers";
 import { useLocation, useMeasuredRef, useModalTitle, useTypeContext } from "../hooks";
+import { FETCH_USAGE_COUNT_SUCCESS_ACTION_NAME } from "../store/usage-count";
 import { FeatureError } from "./feature-error";
 import { Introduction } from "./introduction";
 import { ModalContent } from "./modal-content";
 import { UpsellModalContent } from "./upsell-modal-content";
 
 /**
- * Checks whether all required subscriptions are valid.
- *
- * @param {string} postType The post type.
- * @param {boolean} hasValidPremiumSubscription Whether the Yoast SEO Premium subscription is valid.
- * @param {boolean} hasValidWooSubscription Whether the Yoast WooCommerce SEO subscription is valid.
- * @param {boolean} isSeoAnalysisActive Whether the SEO analysis feature is active.
- * @param {boolean} isWooCommerceActive Whether the WooCommerce plugin is active.
- * @returns {boolean} whether all required subscriptions are valid.
- */
-
-/**
  * Component abstracting the main modal.
  *
  * @param {boolean} isOpen Whether the modal is open.
- * @param {func} onClose Callback for when the modal is closed.
- * @param {func} panelRef The reference to the panel.
+ * @param {function} onClose Callback for when the modal is closed.
  * @param {string} closeButtonScreenReaderText The screen reader text for the close button.
+ * @param {React.Ref} panelRef The reference to the panel.
  * @param {string} title The title of the modal.
  * @param {string} aiModalHelperLink The link to the AI modal helper.
- * @param {object} svgAriaProps The SVG aria properties.
- * @param {JSX.Node} children The children of the modal.
+ * @param {React.ReactNode} children The children of the modal.
  *
  * @returns {JSX.Element} The main modal.
  */
-const MainModal = ( { isOpen, onClose, panelRef, closeButtonScreenReaderText, title, aiModalHelperLink, svgAriaProps, children } ) => (
+const MainModal = ( { isOpen, onClose, closeButtonScreenReaderText, panelRef, title, aiModalHelperLink, children } ) => {
+	const svgAriaProps = useSvgAria();
+
+	return (
+		<Modal
+			className="yst-ai-modal"
+			isOpen={ isOpen }
+			onClose={ onClose }
+		>
+			<Modal.Panel ref={ panelRef } className="yst-max-w-3xl yst-relative" closeButtonScreenReaderText={ closeButtonScreenReaderText }>
+				<Modal.Container>
+					<Modal.Container.Header>
+						<div className="yst-flex yst-items-center">
+							<span className="yst-logo-icon yst-h-5 yst-w-5" />
+							<Modal.Title className="yst-ms-3 yst-me-1.5" as="h1" size="2">{ title }</Modal.Title>
+							<Link
+								id="ai-modal-learn-more"
+								href={ aiModalHelperLink }
+								variant="primary"
+								className="yst-no-underline yst-me-2"
+								target="_blank"
+								rel="noopener"
+								/* translators: Hidden accessibility text. */
+								aria-label={ __( "Learn more about AI (Opens in a new browser tab)", "wordpress-seo" ) }
+							>
+								<QuestionMarkCircleIcon { ...svgAriaProps } className="yst-w-4 yst-h-4 yst-text-slate-500 yst-shrink-0" />
+							</Link>
+							<Badge variant="info">{ __( "Beta", "wordpress-seo" ) }</Badge>
+						</div>
+						<hr className="yst-mt-6 yst--mx-6" />
+					</Modal.Container.Header>
+					{ children }
+				</Modal.Container>
+			</Modal.Panel>
+		</Modal>
+	);
+};
+
+/**
+ * Component abstracting the introduction modal.
+ *
+ * @param {boolean} isOpen Whether the modal is open.
+ * @param {function} onClose Callback for when the modal is closed.
+ * @param {string} closeButtonScreenReaderText The screen reader text for the close button.
+ * @param {React.ReactNode} children The children of the modal.
+ *
+ * @returns {JSX.Element} The introduction modal.
+ */
+const IntroductionModal = ( { isOpen, onClose, closeButtonScreenReaderText, children } ) => (
 	<Modal
-		className="yst-ai-modal"
+		className="yst-introduction-modal"
 		isOpen={ isOpen }
 		onClose={ onClose }
 	>
-		<Modal.Panel ref={ panelRef } className="yst-max-w-3xl yst-relative" closeButtonScreenReaderText={ closeButtonScreenReaderText }>
-			<Modal.Container>
-				<Modal.Container.Header>
-					<div className="yst-flex yst-items-center">
-						<span className="yst-logo-icon yst-h-5 yst-w-5" />
-						<Modal.Title className="yst-ms-3 yst-me-1.5" as="h1" size="2">{ title }</Modal.Title>
-						<Link
-							id="ai-modal-learn-more"
-							href={ aiModalHelperLink }
-							variant="primary"
-							className="yst-no-underline yst-me-2"
-							target="_blank"
-							rel="noopener"
-							/* translators: Hidden accessibility text. */
-							aria-label={ __( "Learn more about AI (Opens in a new browser tab)", "wordpress-seo" ) }
-						>
-							<QuestionMarkCircleIcon { ...svgAriaProps } className={ "yst-w-4 yst-h-4 yst-text-slate-500" } />
-						</Link>
-						<Badge variant="info">{ __( "Beta", "wordpress-seo" ) }</Badge>
-					</div>
-					<hr className="yst-mt-6 yst--mx-6" />
-				</Modal.Container.Header>
-				{ children }
-			</Modal.Container>
+		<Modal.Panel
+			className="yst-max-w-lg yst-p-0 yst-rounded-3xl"
+			closeButtonScreenReaderText={ closeButtonScreenReaderText }
+		>
+			{ children }
 		</Modal.Panel>
 	</Modal>
 );
-MainModal.propTypes = {
-	isOpen: PropTypes.bool.isRequired,
-	onClose: PropTypes.func.isRequired,
-	panelRef: PropTypes.func.isRequired,
-	closeButtonScreenReaderText: PropTypes.string.isRequired,
-	title: PropTypes.string.isRequired,
-	aiModalHelperLink: PropTypes.string.isRequired,
-	svgAriaProps: PropTypes.object.isRequired,
-	children: PropTypes.node.isRequired,
+
+const DISPLAY = {
+	buttonOnly: "buttonOnly",
+	askConsent: "askConsent",
+	upsell: "upsell",
+	error: "error",
+	generate: "generate",
 };
 
 /**
@@ -90,47 +107,63 @@ export const App = ( { onUseAi } ) => {
 	const { editType } = useTypeContext();
 	const location = useLocation();
 	const title = useModalTitle();
-	const [ isModalOpen, , , openModal, closeModal ] = useToggleState( false );
-	const focusElementRef = useRef( null );
 	const {
-		focusKeyphrase,
-		isSeoAnalysisActive,
-		aiModalHelperLink,
 		hasConsent,
 		promptContentInitialized,
 		currentSubscriptions,
 		usageCount,
 		usageCountLimit,
+		usageCountEndpoint,
+		hasValidPremiumSubscription,
+		hasValidWooSubscription,
+		focusKeyphrase,
+		isPremium,
+		isWooSeoActive,
+		isWooCommerceActive,
+		isSeoAnalysisActive,
+		aiModalHelperLink,
+		isProductEntity,
 		isFreeSparks,
-	} = useSelect( select => ( {
-		focusKeyphrase: select( STORE_NAME_EDITOR ).getFocusKeyphrase(),
-		isSeoAnalysisActive: select( STORE_NAME_EDITOR ).getPreference( "isKeywordAnalysisActive", true ),
-		aiModalHelperLink: select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-help-button-modal" ),
-		hasConsent: select( STORE_NAME_AI ).selectHasAiGeneratorConsent(),
-		promptContentInitialized: select( STORE_NAME_AI ).selectPromptContentInitialized(),
-		currentSubscriptions: select( STORE_NAME_AI ).selectProductSubscriptions(),
-		usageCount: select( STORE_NAME_AI ).selectUsageCount(),
-		usageCountLimit: select( STORE_NAME_AI ).selectUsageCountLimit(),
-		isFreeSparks: select( STORE_NAME_AI ).selectIsFreeSparks(),
-	} ), [] );
+	} = useSelect( select => {
+		const aiSelect = select( STORE_NAME_AI );
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			hasConsent: aiSelect.selectHasAiGeneratorConsent(),
+			promptContentInitialized: aiSelect.selectPromptContentInitialized(),
+			currentSubscriptions: aiSelect.selectProductSubscriptions(),
+			usageCount: aiSelect.selectUsageCount(),
+			usageCountLimit: aiSelect.selectUsageCountLimit(),
+			usageCountEndpoint: aiSelect.selectUsageCountEndpoint(),
+			hasValidPremiumSubscription: aiSelect.selectPremiumSubscription(),
+			hasValidWooSubscription: aiSelect.selectWooCommerceSubscription(),
+			focusKeyphrase: editorSelect.getFocusKeyphrase(),
+			isPremium: editorSelect.getIsPremium(),
+			isWooSeoActive: editorSelect.getIsWooSeoActive(),
+			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
+			isSeoAnalysisActive: editorSelect.getPreference( "isKeywordAnalysisActive", true ),
+			aiModalHelperLink: editorSelect.selectLink( "https://yoa.st/ai-generator-help-button-modal" ),
+			isProductEntity: editorSelect.getIsProductEntity(),
+			isFreeSparks: select( STORE_NAME_AI ).selectIsFreeSparks(),
+		};
+	}, [] );
+	const [ isOpen, , , setOpen ] = useToggleState( false );
+	const [ display, setDisplay ] = useState( DISPLAY.buttonOnly );
+	const { fetchUsageCount } = useDispatch( STORE_NAME_AI );
 	const { closeEditorModal } = useDispatch( STORE_NAME_EDITOR );
 
 	/* translators: Hidden accessibility text. */
 	const closeButtonScreenReaderText = __( "Close modal", "wordpress-seo" );
-	const svgAriaProps = useSvgAria();
 	const [ panelHeight, setPanelHeight ] = useState( 0 );
 	const handlePanelMeasureChange = useCallback( entry => setPanelHeight( entry.borderBoxSize[ 0 ].blockSize ), [ setPanelHeight ] );
 	const panelRef = useMeasuredRef( handlePanelMeasureChange );
 
-	const arePreconditionsMet = isSeoAnalysisActive;
+	const closeModal = useCallback( () => {
+		setDisplay( DISPLAY.buttonOnly );
+	}, [] );
 
-	const MainModalCommonProps = {
+	const commonModalProps = {
 		onClose: closeModal,
-		aiModalHelperLink,
-		svgAriaProps,
-		panelRef,
 		closeButtonScreenReaderText,
-		title,
 	};
 
 	const checkFocusKeyphrase = useCallback( () => {
@@ -139,82 +172,142 @@ export const App = ( { onUseAi } ) => {
 			closeEditorModal();
 			// Give JS time to close the modals (with focus traps) before trying to focus the input field.
 			setTimeout( () => focusFocusKeyphraseInput( location ), 0 );
+			return false;
+		}
+		return true;
+	}, [ focusKeyphrase, closeModal, closeEditorModal, location ] );
+
+	const checkSparks = useCallback( async() => {
+		const { type, payload } = fetchUsageCount( { endpoint: usageCountEndpoint } );
+		if ( type !== FETCH_USAGE_COUNT_SUCCESS_ACTION_NAME ) {
+			return false;
+		}
+		return payload.count < payload.limit;
+	}, [ fetchUsageCount, usageCountEndpoint ] );
+
+	const checkSubscriptions = useCallback( () => {
+		if ( isWooSeoActive && isWooCommerceActive && isProductEntity ) {
+			return hasValidWooSubscription;
+		}
+		if ( isPremium ) {
+			return hasValidPremiumSubscription;
+		}
+		return true;
+	}, [ hasValidPremiumSubscription, hasValidWooSubscription, isPremium, isWooSeoActive && isWooCommerceActive && isProductEntity ] );
+
+	// eslint-ignore-line complexity -- this is a complex component with multiple states and conditions.
+	useEffect( () => {
+		if ( ! isOpen ) {
 			return;
 		}
-		openModal();
-	}, [ focusKeyphrase, openModal, closeModal, closeEditorModal, location ] );
 
-	const handleStartGenerating = useCallback( () => {
-		if ( isSeoAnalysisActive ) {
-			checkFocusKeyphrase();
-		} else {
-			// At this point in the execution, the AiModalContent contains the SeoAnalysisInactiveError.
-			openModal();
-		}
-	}, [ checkFocusKeyphrase, isSeoAnalysisActive, openModal ] );
-
-	const handleUseAi = useCallback( () => {
+		// Notify that the user has interacted with the feature.
 		onUseAi();
-		openModal();
-		if ( hasConsent && isSeoAnalysisActive ) {
-			// Check the focus keyphrase when we have consent and the focus keyphrase is present.
-			checkFocusKeyphrase();
+
+		// Can the user have free sparks?
+		if ( ! isPremium && ! isFreeSparks ) {
+			// If the user has not used the AI feature before, we show the upsell modal.
+			setDisplay( DISPLAY.upsell );
+			return;
 		}
-	}, [ onUseAi, openModal, hasConsent, isSeoAnalysisActive, checkFocusKeyphrase ] );
+
+		// Do we have consent?
+		if ( ! hasConsent ) {
+			// If the user has not granted consent, we open the modal to ask for it.
+			setDisplay( DISPLAY.askConsent );
+			return;
+		}
+
+		// Are the subscriptions valid?
+		if ( isPremium && ! checkSubscriptions() ) {
+			// If the subscriptions are invalid, show an error message.
+			setDisplay( DISPLAY.error );
+			return;
+		}
+
+		// Is the SEO analysis active?
+		if ( ! isSeoAnalysisActive ) {
+			// If the SEO analysis is not active, show an error message.
+			setDisplay( DISPLAY.error );
+			return;
+		}
+
+		// Do we have a focus keyphrase?
+		if ( ! checkFocusKeyphrase() ) {
+			return;
+		}
+
+		// Are we in trial mode?
+		if ( ! isPremium && isFreeSparks ) {
+			// If we are in trial mode, we check if the user has enough sparks left.
+			if ( ! checkSparks() ) {
+				// If the user has no more sparks left, we show the upsell modal.
+				setDisplay( DISPLAY.upsell );
+				return;
+			}
+		}
+
+		setDisplay( DISPLAY.generate );
+	}, [
+		isOpen,
+		onUseAi,
+		setDisplay,
+		hasConsent,
+		isPremium,
+		isFreeSparks,
+		checkSubscriptions,
+		isSeoAnalysisActive,
+		checkFocusKeyphrase,
+		checkSparks,
+	] );
 
 	return (
-		<Fragment>
+		<>
 			<button
 				type="button"
 				id={ `yst-replacevar__use-ai-button__${ editType }__${ location }` }
 				className="yst-replacevar__use-ai-button"
-				onClick={ handleUseAi }
+				onClick={ setOpen }
 				disabled={ ! promptContentInitialized }
 			>
 				{ __( "Use AI", "wordpress-seo" ) }
 			</button>
-			{ isModalOpen && <Fragment>
-				<Modal
-					className="yst-introduction-modal"
-					isOpen={ ! hasConsent && arePreconditionsMet }
-					onClose={ closeModal }
-					initialFocus={ focusElementRef }
-				>
-					<Modal.Panel
-						className="yst-max-w-lg yst-p-0 yst-rounded-3xl"
-						closeButtonScreenReaderText={ closeButtonScreenReaderText }
-					>
 
-						{ isFreeSparks ? <Introduction
-							onStartGenerating={ handleStartGenerating }
-							focusElementRef={ focusElementRef }
-						/> : <UpsellModalContent /> }
-					</Modal.Panel>
-				</Modal>
+			<IntroductionModal
+				{ ...commonModalProps }
+				isOpen={ [ DISPLAY.askConsent, DISPLAY.upsell ].includes( display ) }
+			>
+				{ display === DISPLAY.askConsent && (
+					<Introduction onStartGenerating={ noop } />
+				) }
+				{ display === DISPLAY.upsell && (
+					<UpsellModalContent />
+				) }
+			</IntroductionModal>
 
-				<MainModal
-					{ ...MainModalCommonProps }
-					isOpen={ arePreconditionsMet && hasConsent }
-				>
-					<UsageCounter
-						limit={ usageCountLimit }
-						requests={ usageCount }
-						isSkeleton={ false }
-						className={ "yst-absolute yst-top-[-11px] yst-end-12 sm:yst-end-16" }
-					/>
-					<ModalContent height={ panelHeight } />
-				</MainModal>
-
-				<MainModal
-					{ ...MainModalCommonProps }
-					isOpen={ ! arePreconditionsMet }
-				>
-					<Modal.Container.Content className="yst-pt-6">
-						<FeatureError currentSubscriptions={ currentSubscriptions } isSeoAnalysisActive={ isSeoAnalysisActive } />
-					</Modal.Container.Content>
-				</MainModal>
-			</Fragment> }
-		</Fragment>
+			<MainModal
+				{ ...commonModalProps }
+				isOpen={ [ DISPLAY.error, DISPLAY.generate ].includes( display ) }
+				helpLink={ aiModalHelperLink }
+				panelRef={ panelRef }
+				title={ title }
+			>
+				{ display === DISPLAY.error && (
+					<FeatureError currentSubscriptions={ currentSubscriptions } isSeoAnalysisActive={ isSeoAnalysisActive } />
+				) }
+				{ display === DISPLAY.generate && (
+					<>
+						<UsageCounter
+							limit={ usageCountLimit }
+							requests={ usageCount }
+							isSkeleton={ false }
+							className={ "yst-absolute yst-top-[-11px] yst-end-12 sm:yst-end-16" }
+						/>
+						<ModalContent height={ panelHeight } />
+					</>
+				) }
+			</MainModal>
+		</>
 	);
 };
 App.propTypes = {

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import { QuestionMarkCircleIcon } from "@heroicons/react/solid";
 import { useDispatch, useSelect } from "@wordpress/data";
-import { Fragment, useCallback, useState } from "@wordpress/element";
+import { useCallback, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { Badge, Link, Modal, Spinner, useSvgAria } from "@yoast/ui-library";
@@ -92,7 +92,7 @@ const IntroductionModal = ( { isOpen, onClose, closeButtonScreenReaderText, chil
 	</Modal>
 );
 
-const DISPLAY = {
+export const DISPLAY = {
 	inactive: "inactive",
 	askConsent: "askConsent",
 	upsell: "upsell",
@@ -254,10 +254,10 @@ export const App = ( { onUseAi } ) => {
 				isOpen={ [ DISPLAY.askConsent, DISPLAY.upsell ].includes( display ) }
 			>
 				{ display === DISPLAY.askConsent && (
-					<Introduction onStartGenerating={ handleUseAi } />
+					<Introduction setDisplay={ setDisplay } />
 				) }
 				{ display === DISPLAY.upsell && (
-					<UpsellModalContent />
+					<UpsellModalContent setDisplay={ setDisplay } />
 				) }
 			</IntroductionModal>
 

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -126,7 +126,7 @@ export const App = ( { onUseAi } ) => {
 		isSeoAnalysisActive,
 		aiModalHelperLink,
 		isProductEntity,
-		isFreeSparksStart,
+		isFreeSparksActive,
 	} = useSelect( select => {
 		const aiSelect = select( STORE_NAME_AI );
 		const editorSelect = select( STORE_NAME_EDITOR );
@@ -147,7 +147,7 @@ export const App = ( { onUseAi } ) => {
 			isSeoAnalysisActive: editorSelect.getPreference( "isKeywordAnalysisActive", true ),
 			aiModalHelperLink: editorSelect.selectLink( "https://yoa.st/ai-generator-help-button-modal" ),
 			isProductEntity: editorSelect.getIsProductEntity(),
-			isFreeSparksStart: select( STORE_NAME_AI ).selectIsFreeSparksStart(),
+			isFreeSparksActive: select( STORE_NAME_AI ).selectIsFreeSparksActive(),
 		};
 	}, [] );
 	const { fetchUsageCount } = useDispatch( STORE_NAME_AI );
@@ -199,7 +199,7 @@ export const App = ( { onUseAi } ) => {
 	const handleUseAi = useCallback( async() => {
 		onUseAi();
 
-		if ( ! isPremium && ! isFreeSparksStart ) {
+		if ( ! isPremium && ! isFreeSparksActive ) {
 			setDisplay( DISPLAY.upsell );
 			return;
 		}
@@ -232,7 +232,7 @@ export const App = ( { onUseAi } ) => {
 		}
 
 		setDisplay( DISPLAY.generate );
-	}, [ onUseAi, isPremium, isFreeSparksStart, hasConsent, isSeoAnalysisActive, checkFocusKeyphrase, showFocusKeyphrase, checkSparks ] );
+	}, [ onUseAi, isPremium, isFreeSparksActive, hasConsent, isSeoAnalysisActive, checkFocusKeyphrase, showFocusKeyphrase, checkSparks ] );
 
 	return (
 		<>

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -123,7 +123,7 @@ export const App = ( { onUseAi } ) => {
 		isSeoAnalysisActive,
 		aiModalHelperLink,
 		isProductEntity,
-		isFreeSparks,
+		isFreeSparksStart,
 	} = useSelect( select => {
 		const aiSelect = select( STORE_NAME_AI );
 		const editorSelect = select( STORE_NAME_EDITOR );
@@ -143,7 +143,7 @@ export const App = ( { onUseAi } ) => {
 			isSeoAnalysisActive: editorSelect.getPreference( "isKeywordAnalysisActive", true ),
 			aiModalHelperLink: editorSelect.selectLink( "https://yoa.st/ai-generator-help-button-modal" ),
 			isProductEntity: editorSelect.getIsProductEntity(),
-			isFreeSparks: select( STORE_NAME_AI ).selectIsFreeSparks(),
+			isFreeSparksStart: select( STORE_NAME_AI ).selectIsFreeSparksStart(),
 		};
 	}, [] );
 	const [ isOpen, , , setOpen ] = useToggleState( false );
@@ -205,7 +205,7 @@ export const App = ( { onUseAi } ) => {
 		onUseAi();
 
 		// Can the user have free sparks?
-		if ( ! isPremium && ! isFreeSparks ) {
+		if ( ! isPremium && ! isFreeSparksStart ) {
 			// If the user has not used the AI feature before, we show the upsell modal.
 			setDisplay( DISPLAY.upsell );
 			return;

--- a/packages/js/src/ai-generator/components/errors/subscription-error.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-error.js
@@ -12,7 +12,7 @@ import { STORE_NAME_EDITOR } from "../../constants";
  * @param {string[]} [invalidSubscriptions=[]] The array with the names of products with invalid subscription.
  * @returns {JSX.Element} The element.
  */
-export const SubscriptionError = ( { invalidSubscriptions } ) => {
+export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
 	const activatePremiumLink = useSelect(
 		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-activate-premium" ),
 		[]

--- a/packages/js/src/ai-generator/components/feature-error.js
+++ b/packages/js/src/ai-generator/components/feature-error.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import PropTypes from "prop-types";
@@ -15,18 +16,26 @@ import { SeoAnalysisInactiveError, SubscriptionError } from "./errors";
  */
 export const FeatureError = ( { currentSubscriptions, isSeoAnalysisActive = true } ) => {
 	const { postType } = useTypeContext();
-	const isWooCommerceActive = useSelect( select => select( STORE_NAME_EDITOR ).getIsWooCommerceActive(), [] );
+	const { isPremium, isWooCommerceActive } = useSelect( ( select ) => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			isPremium: editorSelect.getIsPremium(),
+			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
+		};
+	}, [] );
 	const missingWooSeo = useMemo( () => {
 		return ! currentSubscriptions.wooCommerceSubscription && isWooActiveAndProductPostType( isWooCommerceActive, postType );
 	}, [ isWooCommerceActive, postType, currentSubscriptions.wooCommerceSubscription ] );
 
 	const invalidSubscriptions = [];
-	if ( ! currentSubscriptions.premiumSubscription ) {
-		invalidSubscriptions.push( "Yoast SEO Premium" );
-	}
+	if ( isPremium ) {
+		if ( ! currentSubscriptions.premiumSubscription ) {
+			invalidSubscriptions.push( "Yoast SEO Premium" );
+		}
 
-	if ( missingWooSeo ) {
-		invalidSubscriptions.push( "Yoast WooCommerce SEO" );
+		if ( missingWooSeo ) {
+			invalidSubscriptions.push( "Yoast WooCommerce SEO" );
+		}
 	}
 
 	if ( invalidSubscriptions.length > 0 ) {

--- a/packages/js/src/ai-generator/components/introduction.js
+++ b/packages/js/src/ai-generator/components/introduction.js
@@ -3,12 +3,13 @@ import { useCallback } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { AiConsent } from "../../shared-admin/components";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
+import { DISPLAY } from "./app";
 
 /**
- * @param {Function} onStartGenerating Callback to signal the generating should start.
+ * @param {Function} setDisplay Callback to set the display state.
  * @returns {JSX.Element} The element.
  */
-export const Introduction = ( { onStartGenerating } ) => {
+export const Introduction = ( { setDisplay } ) => {
 	const { termsOfServiceLink, privacyPolicyLink, learnMoreLink, imageLink, consentEndpoint } = useSelect(
 		select => ( {
 			termsOfServiceLink: select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-terms-of-service" ),
@@ -23,8 +24,8 @@ export const Introduction = ( { onStartGenerating } ) => {
 	const { storeAiGeneratorConsent } = useDispatch( STORE_NAME_AI );
 	const onGiveConsent = useCallback( async() => {
 		await storeAiGeneratorConsent( true, consentEndpoint );
-		onStartGenerating();
-	}, [ storeAiGeneratorConsent, onStartGenerating, consentEndpoint ] );
+		setDisplay( DISPLAY.generate );
+	}, [ storeAiGeneratorConsent, setDisplay, consentEndpoint ] );
 
 	return (
 		<AiConsent
@@ -37,5 +38,5 @@ export const Introduction = ( { onStartGenerating } ) => {
 	);
 };
 Introduction.propTypes = {
-	onStartGenerating: PropTypes.func.isRequired,
+	setDisplay: PropTypes.func.isRequired,
 };

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -145,8 +145,11 @@ export const ModalContent = ( { height } ) => {
 		 * Do not add one when the last generate resulted in an error, because the total pages is adjusted for that.
 		 */
 		setCurrentPage( suggestions.status === ASYNC_ACTION_STATUS.error ? totalPages : totalPages + 1 );
-		addUsageCount();
-		fetchSuggestions();
+		fetchSuggestions().then( ( status ) => {
+			if ( status === FETCH_RESPONSE_STATUS.success ) {
+				addUsageCount();
+			}
+		} );
 	}, [ fetchSuggestions, suggestions.status, totalPages, setCurrentPage, setSelectedSuggestion ] );
 	const handleRetryInitialFetch = useCallback( () => setInitialFetch( "" ), [ setInitialFetch ] );
 
@@ -163,11 +166,14 @@ export const ModalContent = ( { height } ) => {
 
 	useEffect( () => {
 		if ( initialFetch === "" ) {
-			fetchSuggestions().then( status => {
+			fetchSuggestions().then( ( status ) => {
 				setInitialFetch( status );
+				if ( status === FETCH_RESPONSE_STATUS.success ) {
+					addUsageCount();
+				}
 			} );
 		}
-	}, [ initialFetch, fetchSuggestions ] );
+	}, [ initialFetch, addUsageCount, fetchSuggestions ] );
 
 	// Initial fetch gone wrong OR subscription error on any request.
 	if ( initialFetch === FETCH_RESPONSE_STATUS.error || ( suggestions.status === ASYNC_ACTION_STATUS.error && suggestions.error.code === 402 ) ) {

--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -10,11 +10,14 @@ import { Badge, Button, useModalContext, Alert } from "@yoast/ui-library";
 import { OutboundLink, VideoFlow } from "../../shared-admin/components";
 import { GradientButton } from "@yoast/ai-frontend";
 import classNames from "classnames";
+import { DISPLAY } from "./app";
 
 /**
+ * @param {Function} setDisplay The function to set the display state..
+ *
  * @returns {JSX.Element} The element.
  */
-export const UpsellModalContent = () => {
+export const UpsellModalContent = ( { setDisplay } ) => {
 	const {
 		premiumUpsellLink,
 		bundleUpsellLink,
@@ -74,7 +77,8 @@ export const UpsellModalContent = () => {
 
 	const handleStartTrial = useCallback( () => {
 		activateFreeSparks( { endpoint: activateFreeSparksEndpoint } );
-	}, [ activateFreeSparks, activateFreeSparksEndpoint ] );
+		setDisplay( DISPLAY.askConsent );
+	}, [ activateFreeSparks, activateFreeSparksEndpoint, onClose ] );
 
 	const learnMoreLinkStructure = {
 		a: <OutboundLink

--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -26,7 +26,7 @@ export const UpsellModalContent = () => {
 		wistiaEmbedPermissionValue,
 		wistiaEmbedPermissionStatus,
 		isUsageCountLimitReached,
-		startFreeSparksEndpoint,
+		activateFreeSparksEndpoint,
 	} = useSelect( ( select ) => {
 		const aiSelect = select( STORE_NAME_AI );
 		const editorSelect = select( STORE_NAME_EDITOR );
@@ -41,7 +41,7 @@ export const UpsellModalContent = () => {
 			wistiaEmbedPermissionValue: editorSelect.selectWistiaEmbedPermissionValue(),
 			wistiaEmbedPermissionStatus: editorSelect.selectWistiaEmbedPermissionStatus(),
 			isUsageCountLimitReached: aiSelect.isUsageCountLimitReached(),
-			startFreeSparksEndpoint: aiSelect.selectFreeSparksStartEndpoint(),
+			activateFreeSparksEndpoint: aiSelect.selectFreeSparksActiveEndpoint(),
 		};
 	}, [] );
 	const { onClose, initialFocus } = useModalContext();
@@ -64,7 +64,7 @@ export const UpsellModalContent = () => {
 	} ), [ imageLink ] );
 
 	const { setWistiaEmbedPermission } = useDispatch( STORE_NAME_EDITOR );
-	const { startFreeSparks } = useDispatch( STORE_NAME_AI );
+	const { activateFreeSparks } = useDispatch( STORE_NAME_AI );
 
 	const wistiaEmbedPermission = useMemo( () => ( {
 		value: wistiaEmbedPermissionValue,
@@ -73,8 +73,8 @@ export const UpsellModalContent = () => {
 	} ), [ wistiaEmbedPermissionValue, wistiaEmbedPermissionStatus, setWistiaEmbedPermission ] );
 
 	const handleStartTrial = useCallback( () => {
-		startFreeSparks( { endpoint: startFreeSparksEndpoint } );
-	}, [ startFreeSparks, startFreeSparksEndpoint ] );
+		activateFreeSparks( { endpoint: activateFreeSparksEndpoint } );
+	}, [ activateFreeSparks, activateFreeSparksEndpoint ] );
 
 	const learnMoreLinkStructure = {
 		a: <OutboundLink

--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -41,7 +41,7 @@ export const UpsellModalContent = () => {
 			wistiaEmbedPermissionValue: editorSelect.selectWistiaEmbedPermissionValue(),
 			wistiaEmbedPermissionStatus: editorSelect.selectWistiaEmbedPermissionStatus(),
 			isUsageCountLimitReached: aiSelect.isUsageCountLimitReached(),
-			startFreeSparksEndpoint: aiSelect.selectFreeSparksEndpoint(),
+			startFreeSparksEndpoint: aiSelect.selectFreeSparksStartEndpoint(),
 		};
 	}, [] );
 	const { onClose, initialFocus } = useModalContext();

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -91,7 +91,7 @@ const initializeAiGenerator = () => {
 		},
 		[ PRODUCT_SUBSCRIPTIONS_NAME ]: get( window, "wpseoAiGenerator.productSubscriptions", {} ),
 		[ FREE_SPARKS_NAME ]: {
-			isFreeSparksStart: get( window, "wpseoAiGenerator.isFreeSparks", false ) === "1",
+			isFreeSparksActive: get( window, "wpseoAiGenerator.isFreeSparks", false ) === "1",
 			endpoint: "yoast/v1/ai/free_sparks",
 		},
 	} );

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -91,8 +91,8 @@ const initializeAiGenerator = () => {
 		},
 		[ PRODUCT_SUBSCRIPTIONS_NAME ]: get( window, "wpseoAiGenerator.productSubscriptions", {} ),
 		[ FREE_SPARKS_NAME ]: {
+			isFreeSparksStart: get( window, "wpseoAiGenerator.isFreeSparks", false ) === "1",
 			endpoint: "yoast/v1/ai/free_sparks",
-			isFreeSparks: get( window, "wpseoAiGenerator.isFreeSparks", false ) === "1",
 		},
 	} );
 

--- a/packages/js/src/ai-generator/readme.md
+++ b/packages/js/src/ai-generator/readme.md
@@ -27,7 +27,7 @@ flowchart TB
   HasSparksLeft{Does the site have sparks left?}
   LastSpark{Was this your last spark?}
   SaveFreeSparks{{Save the timestamp as a wpseo option: ai_free_sparks_started_on}}
-  PreventAI{{Prevent the user from generating more. But instead ensure the toast above is visible / show again if dismissed}}
+  PreventAI{{Prevent the user from generating more. Disable the “generate 5 more” button}}
   End((End flow))
   UseAI --> IsFreeSparks
   IsFreeSparks -->|Yes| HasConsent

--- a/packages/js/src/ai-generator/readme.md
+++ b/packages/js/src/ai-generator/readme.md
@@ -13,7 +13,7 @@ This button is not added on:
 ## Flow to the AI generator in the editor
 
 ```mermaid
-flowchart LR
+flowchart TB
   UseAI[User tries to use a Yoast AI Generate feature]
   ShowConsent[Show the AI consent modal]
   ShowUpsellWithTry[Show the AI upsell modal with a “Try for free” button]

--- a/packages/js/src/ai-generator/store/free-sparks.js
+++ b/packages/js/src/ai-generator/store/free-sparks.js
@@ -4,17 +4,17 @@ import { get } from "lodash";
 import { ASYNC_ACTION_NAMES } from "../../shared-admin/constants";
 
 export const FREE_SPARKS_NAME = "freeSparks";
-export const START_FREE_SPARKS_ACTION_NAME = "startFreeSparks";
+export const START_FREE_SPARKS_ACTION_NAME = "activateFreeSparks";
 
 const slice = createSlice( {
 	name: FREE_SPARKS_NAME,
 	initialState: {
-		isFreeSparksStart: false,
+		isFreeSparksActive: false,
 		endpoint: "yoast/v1/ai/free_sparks",
 	},
 	extraReducers: ( builder ) => {
 		builder.addCase( `${ START_FREE_SPARKS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state ) => {
-			state.isFreeSparksStart = true;
+			state.isFreeSparksActive = true;
 		} );
 	},
 } );
@@ -22,15 +22,15 @@ const slice = createSlice( {
 export const getInitialFreeSparks = slice.getInitialState;
 
 export const freeSparksSelectors = {
-	selectFreeSparksStartEndpoint: state => get( state, [ FREE_SPARKS_NAME, "endpoint" ], slice.getInitialState().endpoint ),
-	selectIsFreeSparksStart: state => get( state, [ FREE_SPARKS_NAME, "isFreeSparksStart" ], slice.getInitialState().isFreeSparksStart ),
+	selectFreeSparksActiveEndpoint: state => get( state, [ FREE_SPARKS_NAME, "endpoint" ], slice.getInitialState().endpoint ),
+	selectIsFreeSparksActive: state => get( state, [ FREE_SPARKS_NAME, "isFreeSparksActive" ], slice.getInitialState().isFreeSparksActive ),
 };
 
 /**
  * @param {string} endpoint The endpoint to start the free sparks from.
  * @returns {Object} Success or error action object.
  */
-export function* startFreeSparks( { endpoint } ) {
+export function* activateFreeSparks( { endpoint } ) {
 	try {
 		yield{ type: START_FREE_SPARKS_ACTION_NAME, payload: endpoint };
 	} catch ( error ) {
@@ -41,7 +41,7 @@ export function* startFreeSparks( { endpoint } ) {
 
 export const freeSparksActions = {
 	...slice.actions,
-	startFreeSparks,
+	activateFreeSparks,
 };
 
 export const freeSparksControls = {

--- a/packages/js/src/ai-generator/store/free-sparks.js
+++ b/packages/js/src/ai-generator/store/free-sparks.js
@@ -9,12 +9,12 @@ export const START_FREE_SPARKS_ACTION_NAME = "startFreeSparks";
 const slice = createSlice( {
 	name: FREE_SPARKS_NAME,
 	initialState: {
-		isFreeSparks: false,
+		isFreeSparksStart: false,
 		endpoint: "yoast/v1/ai/free_sparks",
 	},
 	extraReducers: ( builder ) => {
 		builder.addCase( `${ START_FREE_SPARKS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state ) => {
-			state.isFreeSparks = true;
+			state.isFreeSparksStart = true;
 		} );
 	},
 } );
@@ -22,12 +22,12 @@ const slice = createSlice( {
 export const getInitialFreeSparks = slice.getInitialState;
 
 export const freeSparksSelectors = {
-	selectFreeSparksEndpoint: state => get( state, [ FREE_SPARKS_NAME, "endpoint" ], slice.getInitialState().endpoint ),
-	selectIsFreeSparks: state => get( state, [ FREE_SPARKS_NAME, "isFreeSparks" ], slice.getInitialState().isFreeSparks ),
+	selectFreeSparksStartEndpoint: state => get( state, [ FREE_SPARKS_NAME, "endpoint" ], slice.getInitialState().endpoint ),
+	selectIsFreeSparksStart: state => get( state, [ FREE_SPARKS_NAME, "isFreeSparksStart" ], slice.getInitialState().isFreeSparksStart ),
 };
 
 /**
- * @param {string} endpoint The endpoint to start the freeSparks from.
+ * @param {string} endpoint The endpoint to start the free sparks from.
  * @returns {Object} Success or error action object.
  */
 export function* startFreeSparks( { endpoint } ) {

--- a/packages/js/src/ai-generator/store/usage-count.js
+++ b/packages/js/src/ai-generator/store/usage-count.js
@@ -11,6 +11,7 @@ import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/cons
 
 export const USAGE_COUNT_NAME = "usageCount";
 export const FETCH_USAGE_COUNT_ACTION_NAME = "fetchUsageCount";
+export const FETCH_USAGE_COUNT_SUCCESS_ACTION_NAME = `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`;
 
 const slice = createSlice( {
 	name: USAGE_COUNT_NAME,
@@ -38,7 +39,7 @@ const slice = createSlice( {
 		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
 			state.status = ASYNC_ACTION_STATUS.loading;
 		} );
-		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
+		builder.addCase( FETCH_USAGE_COUNT_SUCCESS_ACTION_NAME, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.success;
 			state.count = payload.count;
 			state.limit = payload.limit;

--- a/packages/js/src/ai-generator/store/usage-count.js
+++ b/packages/js/src/ai-generator/store/usage-count.js
@@ -53,9 +53,10 @@ const slice = createSlice( {
 export const getInitialUsageCount = slice.getInitialState;
 
 export const usageCountSelectors = {
-	selectUsageCount: state => get( state, [ USAGE_COUNT_NAME, "count" ], slice.getInitialState().count ),
-	selectUsageCountLimit: state => get( state, [ USAGE_COUNT_NAME, "limit" ], slice.getInitialState().limit ),
-	selectUsageCountEndpoint: state => get( state, [ USAGE_COUNT_NAME, "endpoint" ], slice.getInitialState().endpoint ),
+	selectUsageCountStatus: ( state ) => get( state, [ USAGE_COUNT_NAME, "status" ], slice.getInitialState() ),
+	selectUsageCount: ( state ) => get( state, [ USAGE_COUNT_NAME, "count" ], slice.getInitialState().count ),
+	selectUsageCountLimit: ( state ) => get( state, [ USAGE_COUNT_NAME, "limit" ], slice.getInitialState().limit ),
+	selectUsageCountEndpoint: ( state ) => get( state, [ USAGE_COUNT_NAME, "endpoint" ], slice.getInitialState().endpoint ),
 };
 usageCountSelectors.selectUsageCountRemaining = createSelector(
 	[

--- a/packages/js/tests/ai-generator/components/upsell-modal-content.test.js
+++ b/packages/js/tests/ai-generator/components/upsell-modal-content.test.js
@@ -50,7 +50,7 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => false,
-						selectFreeSparksEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};
@@ -85,7 +85,7 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => false,
-						selectFreeSparksEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};
@@ -113,7 +113,7 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => true,
-						selectFreeSparksEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};

--- a/packages/js/tests/ai-generator/components/upsell-modal-content.test.js
+++ b/packages/js/tests/ai-generator/components/upsell-modal-content.test.js
@@ -13,10 +13,11 @@ jest.mock( "@wordpress/data", () => {
 } );
 
 describe( "UpsellModalContent", () => {
-	let startFreeSparksMock;
+	let activateFreeSparksMock;
 	let setWistiaEmbedPermissionMock;
+	const setDisplayMock = jest.fn();
 	beforeEach( () => {
-		startFreeSparksMock = jest.fn();
+		activateFreeSparksMock = jest.fn();
 		setWistiaEmbedPermissionMock = jest.fn();
 
 		useDispatch.mockImplementation( storeName => {
@@ -24,7 +25,7 @@ describe( "UpsellModalContent", () => {
 				return { setWistiaEmbedPermission: setWistiaEmbedPermissionMock };
 			}
 			if ( storeName === "yoast-seo/ai-generator" ) {
-				return { startFreeSparks: startFreeSparksMock };
+				return { activateFreeSparks: activateFreeSparksMock };
 			}
 			return {};
 		} );
@@ -50,13 +51,13 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => false,
-						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksActiveEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};
 			} );
 		} );
-		const { getByText } = render( <UpsellModalContent /> );
+		const { getByText } = render( <UpsellModalContent setDisplay={ setDisplayMock } /> );
 		expect( getByText( "Let AI do some of the thinking for you and help you save time. Get high-quality suggestions for titles and meta descriptions to make your content rank high and look good on social media." ) ).toBeInTheDocument();
 		expect( getByText( "Yoast SEO Premium" ) ).toBeInTheDocument();
 		expect( getByText( "Unlock with Yoast SEO Premium" ) ).toBeInTheDocument();
@@ -85,16 +86,17 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => false,
-						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksActiveEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};
 			} );
 		} );
-		const { getByText } = render( <UpsellModalContent /> );
+		const { getByText } = render( <UpsellModalContent setDisplay={ setDisplayMock } /> );
 		const tryButton = getByText( "Try for free" );
 		fireEvent.click( tryButton );
-		expect( startFreeSparksMock ).toHaveBeenCalledWith( { endpoint: "/free-sparks-endpoint" } );
+		expect( setDisplayMock ).toHaveBeenCalledWith( "askConsent" );
+		expect( activateFreeSparksMock ).toHaveBeenCalledWith( { endpoint: "/free-sparks-endpoint" } );
 	} );
 
 	it( "should show the alert when isUsageCountLimitReached is true and the 'try for free' button is not rendered", () => {
@@ -113,13 +115,13 @@ describe( "UpsellModalContent", () => {
 				if ( storeName === "yoast-seo/ai-generator" ) {
 					return {
 						isUsageCountLimitReached: () => true,
-						selectFreeSparksStartEndpoint: () => "/free-sparks-endpoint",
+						selectFreeSparksActiveEndpoint: () => "/free-sparks-endpoint",
 					};
 				}
 				return {};
 			} );
 		} );
-		const { getByText, queryByText } = render( <UpsellModalContent /> );
+		const { getByText, queryByText } = render( <UpsellModalContent setDisplay={ setDisplayMock } /> );
 		expect( getByText( "Oh no! Its seems like you're out of free Sparks. Keep the momentum going, unlock unlimited sparks with Yoast SEO Premium!" ) ).toBeInTheDocument();
 		expect( queryByText( "Try for free" ) ).not.toBeInTheDocument();
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Implements the flow for the free sparks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post ( on local environment use this patch [fake-api.patch](https://github.com/user-attachments/files/20710157/fake-api.patch)).
* Click on `Use AI` button and check you see the upsell modal with the button to try for free.
* Click on the `Try for free` button and check you now see the consent modal.
* Grant consent and check you can see the AI generator
* Generate titles until you reach 10 sparks
* Check you see the toast notification and the "Generate 5 more" button is disabled.
![Screenshot 2025-06-12 at 16 41 46](https://github.com/user-attachments/assets/922ae7b6-59b6-4c25-8675-cb3c623e3c99)
* Close the modal 
* Click on the "Use AI" button and check you now see the upsell modal without the "Try for free" button and with an alert:
![Screenshot 2025-06-12 at 16 36 50](https://github.com/user-attachments/assets/5e6711de-4d7f-4017-8561-da636bffb28f)


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Create the Free and Premium AI generate flow](https://github.com/Yoast/reserved-tasks/issues/623)
