### PR TITLE
Replace flushing cache group with firing action instead

### DIFF
--- a/src/builders/indexable-link-builder.php
+++ b/src/builders/indexable-link-builder.php
@@ -572,9 +572,13 @@ class Indexable_Link_Builder {
 		}
 
 		$counts = $this->seo_links_repository->get_incoming_link_counts_for_indexable_ids( $related_indexable_ids );
-		if ( \wp_cache_supports( 'flush_group' ) ) {
-			\wp_cache_flush_group( 'orphaned_counts' );
-		}
+
+		/**
+		 * Fires to signal that incoming link counts for related indexables were updated.
+		 *
+		 * @internal
+		 */
+		\do_action( 'wpseo_related_indexables_incoming_links_updated' );
 
 		foreach ( $counts as $count ) {
 			$this->indexable_repository->update_incoming_link_count( $count['target_indexable_id'], $count['incoming'] );

--- a/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Build_Test.php
@@ -214,8 +214,7 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 			);
 		$this->indexable_repository->expects( 'update_incoming_link_count' )->once()->with( 3, 0 );
 
-		Functions\expect( 'wp_cache_supports' )->once()->andReturnTrue();
-		Functions\expect( 'wp_cache_flush_group' )->once()->andReturnTrue();
+		Functions\expect( 'do_action' )->once()->with( 'wpseo_related_indexables_incoming_links_updated' );
 
 		$links = $this->instance->build( $indexable, $content );
 
@@ -344,8 +343,7 @@ final class Build_Test extends Abstract_Indexable_Link_Builder_TestCase {
 			->with( $target_indexable->permalink )
 			->andReturn( $target_indexable->object_id );
 
-		Functions\expect( 'wp_cache_supports' )->once()->andReturnTrue();
-		Functions\expect( 'wp_cache_flush_group' )->once()->andReturnTrue();
+		Functions\expect( 'do_action' )->once()->with( 'wpseo_related_indexables_incoming_links_updated' );
 
 		$links = $this->instance->build( $indexable, $content );
 

--- a/tests/Unit/Builders/Indexable_Link_Builder/Delete_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Delete_Test.php
@@ -85,8 +85,7 @@ final class Delete_Test extends Abstract_Indexable_Link_Builder_TestCase {
 			->with( 3, 7 )
 			->once();
 
-		Functions\expect( 'wp_cache_supports' )->once()->andReturnTrue();
-		Functions\expect( 'wp_cache_flush_group' )->once()->andReturnTrue();
+		Functions\expect( 'do_action' )->once()->with( 'wpseo_related_indexables_incoming_links_updated' );
 
 		$this->instance->delete( $indexable );
 	}

--- a/tests/Unit/Builders/Indexable_Link_Builder/Patch_Seo_Links_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Patch_Seo_Links_Test.php
@@ -120,8 +120,7 @@ final class Patch_Seo_Links_Test extends Abstract_Indexable_Link_Builder_TestCas
 			->times( $update_target_indexable_id_times )
 			->andReturn( [] );
 
-		Functions\expect( 'wp_cache_supports' )->times( $update_target_indexable_id_times )->andReturnTrue();
-		Functions\expect( 'wp_cache_flush_group' )->times( $update_target_indexable_id_times )->andReturnTrue();
+		Functions\expect( 'do_action' )->times( $update_target_indexable_id_times )->with( 'wpseo_related_indexables_incoming_links_updated' );
 
 		$this->instance->patch_seo_links( $indexable );
 	}

--- a/tests/Unit/Builders/Indexable_Link_Builder/Update_Incoming_Links_For_Related_Test.php
+++ b/tests/Unit/Builders/Indexable_Link_Builder/Update_Incoming_Links_For_Related_Test.php
@@ -110,8 +110,7 @@ final class Update_Incoming_Links_For_Related_Test extends Abstract_Indexable_Li
 				->once();
 		}
 
-		Functions\expect( 'wp_cache_supports' )->times( $get_incoming_link_counts_for_indexable_ids_times )->andReturnTrue();
-		Functions\expect( 'wp_cache_flush_group' )->times( $get_incoming_link_counts_for_indexable_ids_times )->andReturnTrue();
+		Functions\expect( 'do_action' )->times( $get_incoming_link_counts_for_indexable_ids_times )->with( 'wpseo_related_indexables_incoming_links_updated' );
 
 		$this->instance->exposed_update_incoming_links_for_related_indexables( $related_indexable_ids );
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes redundant flushing of cache groups when incoming links for posts change.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions of https://github.com/Yoast/wordpress-seo-premium/pull/4666

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
