### PR TITLE
Adds check for exact usage count when premium is enabled

### DIFF
--- a/packages/js/src/ai-generator/components/sparks-limit-notification.js
+++ b/packages/js/src/ai-generator/components/sparks-limit-notification.js
@@ -91,21 +91,24 @@ const SparksLimitUpsellContent = ( {
  * @returns {JSX.Element} The element.
  */
 export const SparksLimitNotification = ( { className = "" } ) => {
-	const { isUsageCountLimitReached, usageCountLimit, isPremium, upsellLink } = useSelect( ( select ) => {
+	const { isUsageCountLimitReached, usageCount, usageCountLimit, isPremium, upsellLink } = useSelect( ( select ) => {
 		const aiSelect = select( STORE_NAME_AI );
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return ( {
 			isUsageCountLimitReached: aiSelect.isUsageCountLimitReached(),
+			usageCount: aiSelect.selectUsageCount(),
 			usageCountLimit: aiSelect.selectUsageCountLimit(),
 			isPremium: editorSelect.getIsPremium(),
 			upsellLink: editorSelect.selectLink( "https://yoa.st/ai-toast-out-of-free-sparks" ),
 		} );
 	}, [] );
-	const [ showNotification, , setShowNotification, , hideNotification ] = useToggleState( isUsageCountLimitReached );
+	const [ showNotification, , setShowNotification, , hideNotification ] = useToggleState( usageCount === usageCountLimit );
 
 	useEffect( () => {
-		setShowNotification( isUsageCountLimitReached );
-	}, [ isUsageCountLimitReached ] );
+		const showNotificationPremium = isPremium && usageCount === usageCountLimit;
+		const showNotificationFree = ! isPremium && isUsageCountLimitReached;
+		setShowNotification( showNotificationPremium || showNotificationFree );
+	}, [ usageCount, usageCountLimit ] );
 
 	return showNotification && (
 		<Notifications.Notification


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Enable limit reached notification in premium only exactly when limit reached and not after.

## Relevant technical choices:

* I'm checking if the limit reached and beyond for free to cover edge cases where somehow the sparks increased.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Without Yoast SEO Premium enabled.
* Edit a post and click on `Use AI`, click on "Try for Free" and then "Grant consent" and start using AI generator
* Click on "Generate 5 more" until you reach 10 sparks.
* Check you see the upsell notification, reopen the modal and check you see the upsell modal and not the toast notification.
* Enable Yoast SEO Premium and go back to edit a post.
* Click on use AI and when your sparks are under 10 and click "Generate 5 more" to reach 10.
* Check you see the toast notification for premium with the beta copy and not the upsell. Dismiss the notification
* Click on "Generate 5 more" again, check you don't see the toast again.
* Close the modal and reopen, check you still don't see the toast.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Disable toast notification only when limit reached and not after](https://github.com/Yoast/reserved-tasks/issues/628)
