### PR TITLE
Add graceful fallback when MyYoast API lacks expected structure for site info

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -712,8 +712,13 @@ class WPSEO_Addon_Manager {
 	 */
 	protected function request_current_sites() {
 		$api_request = new WPSEO_MyYoast_Api_Request( 'sites/current' );
+
 		if ( $api_request->fire() ) {
-			return $api_request->get_response();
+			$response = $api_request->get_response();
+
+			if ( isset( $response->url, $response->subscriptions ) && is_array( $response->subscriptions ) ) {
+				return $response;
+			}
 		}
 
 		return $this->get_site_information_default();


### PR DESCRIPTION
## Context
* This PR improves the robustness of the `request_current_sites()` method by ensuring that a fallback is triggered when the MyYoast API response is incomplete. This prevents potential site issues caused by missing or malformed data, an issue observed during the recent Cloudflare outage.
   * https://github.com/Yoast/wordpress-seo/issues/22346
   * https://wordpress.org/support/topic/fatal-error-4877/#:~:text=I%E2%80%99m%20sorry%20about%20your%20experience.%20There%20was%20a%20CloudFlare%20outage

## Summary
**changelog: bugfix**
This PR can be summarized in the following changelog entry:

* Fixes a bug where the plugin would not fall back to default site information when the MyYoast API response was incomplete, potentially causing a fatal error on the wp-admin.

## Relevant technical choices:

* Added additional validation to check that both URL and subscriptions are present in the API response before returning it.
* Falls back to `get_site_information_default()` when the API response is incomplete.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
* Mock the MyYoast API response to return incomplete data (e.g., missing subscriptions or URL).
* Ensure that the plugin gracefully falls back to default site information without errors.
* Test normal behavior when the API returns a valid response.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Simulate degraded API responses (missing fields in the response).
   Something like the response `{"statusCode":404,"error":"Not Found","message":"No sites found"}` with an HTTP status code 200
* Confirm the fallback logic behaves as expected without causing PHP errors or UI issues.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #22346
