### PR TITLE
Disable ai optimize button for classic.

### DIFF
--- a/packages/js/src/helpers/shouldRenderAIOptimizeButton.js
+++ b/packages/js/src/helpers/shouldRenderAIOptimizeButton.js
@@ -1,3 +1,5 @@
+import { select } from "@wordpress/data";
+
 /**
  * Checks whether AI Optimize button should be rendered.
  *
@@ -10,6 +12,6 @@ export const shouldRenderAIOptimizeButton = ( hasAIFixes, isElementor, isTerm ) 
 	const isElementorEditorPageActive = document.body.classList.contains( "elementor-editor-active" );
 	// Check if the current editor is either Elementor or the Elementor in-between screen. In that case, don't show the button.
 	const isNotElementorPage = ! isElementor && ! isElementorEditorPageActive;
-
-	return hasAIFixes && isNotElementorPage && ! isTerm;
+	const isClassic = select( "yoast-seo/editor" ).getEditorType() === "classicEditor";
+	return hasAIFixes && isNotElementorPage && ! isTerm && ! isClassic;
 };

--- a/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
+++ b/packages/js/tests/helpers/shouldRenderAIOptimizeButton.test.js
@@ -1,13 +1,35 @@
-// Import the function to test
+import { select } from "@wordpress/data";
 import { shouldRenderAIOptimizeButton } from "../../src/helpers/shouldRenderAIOptimizeButton";
+
+jest.mock( "@wordpress/data", () => ( {
+	select: jest.fn(),
+} ) );
 
 describe( "shouldRenderAIOptimizeButton", () => {
 	beforeEach( () => {
 		// Reset the document body class list before each test
 		document.body.className = "";
 	} );
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
 
-	it( "should return true when hasAIFixes is true, isElementor is false, isTerm is false, and not on an Elementor editor page", () => {
+	it( "should return false when editor type is classicEditor, regardless of other conditions", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "classicEditor",
+		} );
+
+		const hasAIFixes = true;
+		const isElementor = false;
+		const isTerm = false;
+
+		expect( shouldRenderAIOptimizeButton( hasAIFixes, isElementor, isTerm ) ).toBe( false );
+	} );
+
+	it( "should return true when hasAIFixes is true, isElementor is false, isTerm is false, not on an Elementor editor or Classic editor page", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "blockEditor",
+		} );
 		const hasAIFixes = true;
 		const isElementor = false;
 		const isTerm = false;
@@ -16,6 +38,9 @@ describe( "shouldRenderAIOptimizeButton", () => {
 	} );
 
 	it( "should return false when hasAIFixes is false, regardless of other conditions", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "blockEditor",
+		} );
 		const hasAIFixes = false;
 		const isElementor = false;
 		const isTerm = false;
@@ -24,6 +49,9 @@ describe( "shouldRenderAIOptimizeButton", () => {
 	} );
 
 	it( "should return false when isElementor is true, regardless of other conditions", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "blockEditor",
+		} );
 		const hasAIFixes = true;
 		const isElementor = true;
 		const isTerm = false;
@@ -32,6 +60,9 @@ describe( "shouldRenderAIOptimizeButton", () => {
 	} );
 
 	it( "should return false when isTerm is true, regardless of other conditions", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "blockEditor",
+		} );
 		const hasAIFixes = true;
 		const isElementor = false;
 		const isTerm = true;
@@ -40,6 +71,9 @@ describe( "shouldRenderAIOptimizeButton", () => {
 	} );
 
 	it( "should return false when on an Elementor editor page, regardless of other conditions", () => {
+		select.mockReturnValue( {
+			getEditorType: () => "blockEditor",
+		} );
 		document.body.classList.add( "elementor-editor-active" );
 		const hasAIFixes = true;
 		const isElementor = false;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to disable the sparks button in the analysis for the classic editor.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables the AI sparkle button in the classic editor.
 
## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Test this together with https://github.com/Yoast/wordpress-seo-premium/pull/4669
*  

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
