### PR TITLE
Feature/improve indexation performance

### DIFF
--- a/src/actions/indexing/abstract-link-indexing-action.php
+++ b/src/actions/indexing/abstract-link-indexing-action.php
@@ -71,7 +71,7 @@ abstract class Abstract_Link_Indexing_Action extends Abstract_Indexing_Action {
 
 		$indexables = [];
 		foreach ( $objects as $object ) {
-			$indexable = $this->repository->find_by_id_and_type( $object->id, $object->type );
+			$indexable = $this->repository->find_by_id_and_type( intval( $object->id ), $object->type );
 			if ( $indexable ) {
 				$this->link_builder->build( $indexable, $object->content );
 				$this->indexable_helper->save_indexable( $indexable );

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -79,6 +79,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
+			    AND LENGTH( P.post_content ) > 0
 				AND P.post_status = 'publish'
 				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')',
 			$public_post_types
@@ -120,6 +121,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 				AND L.target_post_id IS NOT NULL
 				AND L.target_post_id != 0
 			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
+			    AND LENGTH( P.post_content ) > 0
 				AND P.post_status = 'publish'
 				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ")
 			$limit_query",

--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -50,21 +50,8 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 	 * @return array Objects to be indexed.
 	 */
 	protected function get_objects() {
-		$query = $this->get_select_query( $this->get_limit() );
-
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
-		$posts = $this->wpdb->get_results( $query );
-
-		return \array_map(
-			static function ( $post ) {
-				return (object) [
-					'id'      => (int) $post->ID,
-					'type'    => 'post',
-					'content' => $post->post_content,
-				];
-			},
-			$posts
-		);
+		return $this->wpdb->get_results( $this->get_select_query( $this->get_limit() ) ) ?? [];
 	}
 
 	/**
@@ -120,7 +107,7 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
 		return $this->wpdb->prepare(
 			"
-			SELECT P.ID, P.post_content
+			SELECT P.ID as id, 'post' as type, P.post_content as content
 			FROM {$this->wpdb->posts} AS P
 			LEFT JOIN $indexable_table AS I
 				ON P.ID = I.object_id

--- a/src/actions/indexing/term-link-indexing-action.php
+++ b/src/actions/indexing/term-link-indexing-action.php
@@ -57,18 +57,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Function get_select_query returns a prepared query.
-		$terms = $this->wpdb->get_results( $query );
-
-		return \array_map(
-			static function ( $term ) {
-				return (object) [
-					'id'      => (int) $term->term_id,
-					'type'    => 'term',
-					'content' => $term->description,
-				];
-			},
-			$terms
-		);
+		return $this->wpdb->get_results( $query );
 	}
 
 	/**
@@ -127,7 +116,7 @@ class Term_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
 		return $this->wpdb->prepare(
 			"
-			SELECT T.term_id, T.description
+			SELECT T.term_id, 'term' as type, T.description as content
 			FROM {$this->wpdb->term_taxonomy} AS T
 			LEFT JOIN $indexable_table AS I
 				ON T.term_id = I.object_id

--- a/src/commands/index-command.php
+++ b/src/commands/index-command.php
@@ -257,6 +257,7 @@ class Index_Command implements Command_Interface {
 		if ( $total > 0 ) {
 			$limit    = $indexation_action->get_limit();
 			$progress = Utils\make_progress_bar( 'Indexing ' . $name, $total );
+			$progress->display();
 			do {
 				$indexables = $indexation_action->index();
 				$count      = \count( $indexables );

--- a/src/config/migrations/20250613120000_AddObjectTypeVersionIndexToIndexable.php
+++ b/src/config/migrations/20250613120000_AddObjectTypeVersionIndexToIndexable.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * AddObjectTypeVersionIndexToIndexable class.
+ */
+class AddObjectTypeVersionIndexToIndexable extends Migration {
+
+	const INDEX_NAME = 'indexable_index';
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The column names for the index.
+	 *
+	 * @var string[] $index_columns The columns to index.
+	 */
+	protected $index_columns = [
+		'object_type',
+		'object_sub_type',
+		'version',
+		'link_count',
+		'object_id',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$this->add_index(
+			$this->get_table_name(),
+			$this->index_columns,
+			[
+				'name' => self::INDEX_NAME,
+			]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$this->remove_index(
+			$this->get_table_name(),
+			$this->index_columns,
+			[
+				'name' => self::INDEX_NAME,
+			]
+		);
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/config/migrations/20250614120000_ImproveIndexCardinalityOnIndexable.php
+++ b/src/config/migrations/20250614120000_ImproveIndexCardinalityOnIndexable.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * ImproveIndexCardinalityOnIndexable class.
+ */
+class ImproveIndexCardinalityOnIndexable extends Migration {
+
+	const FIRST_INDEX_NAME  = 'permalink_hash_and_object_type';
+	const SECOND_INDEX_NAME = 'object_id_and_type';
+
+	const UPDATED_FIRST_INDEX_NAME  = 'object_type_and_permalink_hash';
+	const UPDATED_SECOND_INDEX_NAME = 'object_type_and_object_id';
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The column names of the first index we're updating.
+	 *
+	 * @var string[] $first_index_original_columns The index columns.
+	 */
+	protected $first_index_original_columns = [
+		'permalink_hash',
+		'object_type',
+	];
+
+	/**
+	 * The updated column names and order for the first index.
+	 *
+	 * @var string[] $first_index_updated_columns The updated index columns.
+	 */
+	protected $first_index_updated_columns = [
+		'object_type',
+		'permalink_hash',
+	];
+
+	/**
+	 * The column names of the second index we're updating.
+	 *
+	 * @var string[] $second_index_original_columns The index columns.
+	 */
+	protected $second_index_original_columns = [
+		'object_id',
+		'object_type',
+	];
+
+	/**
+	 * The updated column names and order for the second index.
+	 *
+	 * @var string[] $second_index_updated_columns The updated index columns.
+	 */
+	protected $second_index_updated_columns = [
+		'object_type',
+		'object_id',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$adapter = $this->get_adapter();
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->first_index_original_columns, [ 'name' => self::FIRST_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->first_index_original_columns,
+				[
+					'name' => self::FIRST_INDEX_NAME,
+				]
+			);
+
+			// Column order is important when creating indexes. RDBMSes rely on low cardinality to determine which index to use.
+			// Columns that have the smallest number of discrete values should be placed first.
+			$this->add_index(
+				$this->get_table_name(),
+				$this->first_index_updated_columns,
+				[
+					'name' => self::UPDATED_FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->second_index_original_columns, [ 'name' => self::SECOND_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->second_index_original_columns,
+				[
+					'name' => self::SECOND_INDEX_NAME,
+				]
+			);
+
+			$this->add_index(
+				$this->get_table_name(),
+				$this->second_index_updated_columns,
+				[
+					'name' => self::UPDATED_SECOND_INDEX_NAME,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$adapter = $this->get_adapter();
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->first_index_updated_columns, [ 'name' => self::UPDATED_FIRST_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->first_index_updated_columns,
+				[
+					'name' => self::UPDATED_FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( ! $adapter->has_index( $this->get_table_name(), [], [ 'name' => self::FIRST_INDEX_NAME ] ) ) {
+			$this->add_index(
+				$this->get_table_name(),
+				$this->first_index_original_columns,
+				[
+					'name' => self::FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->second_index_updated_columns, [ 'name' => self::UPDATED_SECOND_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->second_index_updated_columns,
+				[
+					'name' => self::UPDATED_SECOND_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( ! $adapter->has_index( $this->get_table_name(), $this->second_index_original_columns, [ 'name' => self::SECOND_INDEX_NAME ] ) ) {
+			$this->add_index(
+				$this->get_table_name(),
+				$this->second_index_original_columns,
+				[
+					'name' => self::SECOND_INDEX_NAME,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/config/migrations/20250615120000_AddTypeTargetPostIdTargetIndexableIdIndexableIdPostIdToSEOLinks.php
+++ b/src/config/migrations/20250615120000_AddTypeTargetPostIdTargetIndexableIdIndexableIdPostIdToSEOLinks.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * AddTypePostIdTargetPostIdIndexableIdTargetIndexableIdToSEOLinks class.
+ */
+class AddTypePostIdTargetPostIdIndexableIdTargetIndexableIdToSEOLinks extends Migration {
+
+	const INDEX_NAME = 'type_based_index';
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The column names for the index.
+	 *
+	 * @var string[] $index_columns The columns to index.
+	 */
+	protected $index_columns = [
+		'type',
+		'target_post_id',
+		'target_indexable_id',
+		'indexable_id',
+		'post_id',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$this->add_index(
+			$this->get_table_name(),
+			$this->index_columns,
+			[
+				'name' => self::INDEX_NAME,
+			]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$this->remove_index(
+			$this->get_table_name(),
+			$this->index_columns,
+			[
+				'name' => self::INDEX_NAME,
+			]
+		);
+	}
+
+	/**
+	 * Retrieves the table name to use for storing SEO links.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'SEO_Link' );
+	}
+}

--- a/src/config/migrations/20250616120000_ImproveIndexCardinalityOnSEOLinks.php
+++ b/src/config/migrations/20250616120000_ImproveIndexCardinalityOnSEOLinks.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * ImproveIndexCardinalityOnSEOLinks class.
+ */
+class ImproveIndexCardinalityOnSEOLinks extends Migration {
+
+	const FIRST_INDEX_NAME  = 'link_direction';
+	const SECOND_INDEX_NAME = 'indexable_link_direction';
+
+	const UPDATED_FIRST_INDEX_NAME  = 'link_direction_type_and_post_id';
+	const UPDATED_SECOND_INDEX_NAME = 'indexable_link_direction_type_and_indexable_id';
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * The column names of the first index we're updating.
+	 *
+	 * @var string[] $first_index_original_columns The index columns.
+	 */
+	protected $first_index_original_columns = [
+		'post_id',
+		'type',
+	];
+
+	/**
+	 * The updated column names and order for the first index.
+	 *
+	 * @var string[] $first_index_updated_columns The updated index columns.
+	 */
+	protected $first_index_updated_columns = [
+		'type',
+		'post_id',
+	];
+
+	/**
+	 * The column names of the second index we're updating.
+	 *
+	 * @var string[] $second_index_original_columns The index columns.
+	 */
+	protected $second_index_original_columns = [
+		'indexable_id',
+		'type',
+	];
+
+	/**
+	 * The updated column names and order for the second index.
+	 *
+	 * @var string[] $second_index_updated_columns The updated index columns.
+	 */
+	protected $second_index_updated_columns = [
+		'type',
+		'indexable_id',
+	];
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$adapter = $this->get_adapter();
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->first_index_original_columns, [ 'name' => self::FIRST_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->first_index_original_columns,
+				[
+					'name' => self::FIRST_INDEX_NAME,
+				]
+			);
+
+			// Column order is important when creating indexes. RDBMSes rely on low cardinality to determine which index to use.
+			// Columns that have the smallest number of discrete values should be placed first.
+			$this->add_index(
+				$this->get_table_name(),
+				$this->first_index_updated_columns,
+				[
+					'name' => self::UPDATED_FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->second_index_original_columns, [ 'name' => self::SECOND_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->second_index_original_columns,
+				[
+					'name' => self::SECOND_INDEX_NAME,
+				]
+			);
+
+			$this->add_index(
+				$this->get_table_name(),
+				$this->second_index_updated_columns,
+				[
+					'name' => self::UPDATED_SECOND_INDEX_NAME,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$adapter = $this->get_adapter();
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->first_index_updated_columns, [ 'name' => self::UPDATED_FIRST_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->first_index_updated_columns,
+				[
+					'name' => self::UPDATED_FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( ! $adapter->has_index( $this->get_table_name(), [], [ 'name' => self::FIRST_INDEX_NAME ] ) ) {
+			$this->add_index(
+				$this->get_table_name(),
+				$this->first_index_original_columns,
+				[
+					'name' => self::FIRST_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( $adapter->has_index( $this->get_table_name(), $this->second_index_updated_columns, [ 'name' => self::UPDATED_SECOND_INDEX_NAME ] ) ) {
+			$this->remove_index(
+				$this->get_table_name(),
+				$this->second_index_updated_columns,
+				[
+					'name' => self::UPDATED_SECOND_INDEX_NAME,
+				]
+			);
+		}
+
+		if ( ! $adapter->has_index( $this->get_table_name(), $this->second_index_original_columns, [ 'name' => self::SECOND_INDEX_NAME ] ) ) {
+			$this->add_index(
+				$this->get_table_name(),
+				$this->second_index_original_columns,
+				[
+					'name' => self::SECOND_INDEX_NAME,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the table name to use for storing SEO links.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'SEO_Links' );
+	}
+}


### PR DESCRIPTION
## Context
While dealing with a database with more than 450K+ published posts, I could not get the command which reindexes Yoast data `wp yoast index --reindex` to finish running. Diving deeper into the root cause, I found a few different areas of the indexation code base which would be improved to reduce the number of loops done on data (thereby reducing the total time to completion).

## Summary

This PR can be summarized in the following changelog entry:

changelog: enhancement

## Relevant technical choices:

- Two indices in `wp_yoast_indexable` were updated to improve cardinality
- Two indices in `wp_yoast_seo_links` were updated to improve cardinality
- A new index was added to `wp_yoast_indexable` to help with the query that gets run here.
- A new index was added to `wp_yoast_seo_links` to help with the query that gets run here.
- Tried to reduce the overall number of loops done over the same set of objects, as well as reduce the number of objects that need to get processed in the first place.

## Test instructions
Prerequisite
You must get your hands on a sufficiently large WordPress database. There should be at least 100K+ published posts.

Steps:
1. Run `wp yoast index --reindex --skip-confirmation` to completion
2. Note total runtime. Also note the total number of rows created in both `wp_yoast_indexable` and `wp_yoast_seo_links`
3. Checkout this branch.
4. Repeat steps 1-2.
5. The total runtime should be far less than the original runtime **and** the number of rows in `wp_yoast_indexable` and `wp_yoast_seo_links` should be the same as the original run.

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [X] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [X] Changes should be tested on different browsers
* [X] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
I'm not exactly sure if there are any implications for multi-site setups, so I think we should test it to find out.

With regards to the other test scenarios I marked, because this PR makes quite a few adjustments to indices on Yoast related tables, I think it would be wise for us to test basic behavior so that we can make sure that relevant, pertinent, data is still being handled correctly (e.g. no insert failures because of the index changes).

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

This PR affects the following parts of the plugin, which may require extra testing:

- Indexation, especially of Post Links and Terms

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [X] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
