### PR TITLE
Create new option for the llms.txt feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2413",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2418",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=252",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2418",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2417",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=252",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/options/class-wpseo-option-llmstxt.php
+++ b/inc/options/class-wpseo-option-llmstxt.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * WPSEO plugin file.
+ *
+ * @package WPSEO\Internals\Options
+ */
+
+/**
+ * Option: wpseo_llmstxt.
+ */
+class WPSEO_Option_Llmstxt extends WPSEO_Option {
+
+	/**
+	 * Option name.
+	 *
+	 * @var string
+	 */
+	public $option_name = 'wpseo_llmstxt';
+
+	/**
+	 * Array of defaults for the option.
+	 *
+	 * Shouldn't be requested directly, use $this->get_defaults();
+	 *
+	 * @var array
+	 */
+	protected $defaults = [
+		'ids_to_include' => [],
+	];
+
+	/**
+	 * Get the singleton instance of this class.
+	 *
+	 * @return object
+	 */
+	public static function get_instance() {
+		if ( ! ( self::$instance instanceof self ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * All concrete classes must contain a validate_option() method which validates all
+	 * values within the option.
+	 *
+	 * @param array $dirty New value for the option.
+	 * @param array $clean Clean value for the option, normally the defaults.
+	 * @param array $old   Old value of the option.
+	 *
+	 * @return array The clean option with the saved value.
+	 */
+	protected function validate_option( $dirty, $clean, $old ) {
+
+		foreach ( $clean as $key => $value ) {
+			switch ( $key ) {
+				case 'ids_to_include':
+					$clean[ $key ] = $old[ $key ];
+
+					if ( isset( $dirty[ $key ] ) ) {
+						$items = $dirty[ $key ];
+						if ( ! is_array( $items ) ) {
+							$items = json_decode( $dirty[ $key ], true );
+						}
+
+						if ( is_array( $items ) ) {
+							$clean[ $key ] = $dirty[ $key ];
+						}
+					}
+
+					break;
+			}
+		}
+
+		return $clean;
+	}
+}

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -30,6 +30,7 @@ class WPSEO_Options {
 		'wpseo_social'        => 'WPSEO_Option_Social',
 		'wpseo_ms'            => 'WPSEO_Option_MS',
 		'wpseo_taxonomy_meta' => 'WPSEO_Taxonomy_Meta',
+		'wpseo_llmstxt'       => 'WPSEO_Option_Llmstxt',
 	];
 
 	/**

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends YoastTestCase {
 	/**
 	 * Options being mocked.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected $mocked_options = [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms', 'wpseo_llmstxt' ];
 

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -23,7 +23,7 @@ abstract class TestCase extends YoastTestCase {
 	 *
 	 * @var array
 	 */
-	protected $mocked_options = [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms' ];
+	protected $mocked_options = [ 'wpseo', 'wpseo_titles', 'wpseo_taxonomy_meta', 'wpseo_social', 'wpseo_ms', 'wpseo_llmstxt' ];
 
 	/**
 	 * Sets up the test fixtures.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds another wpseo option in the database, one that's specific to the llms.txt feature.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Either upgrade to this PR/RC or install and activate it in a fresh site
* Search in your DB and confirm you find the `wpseo_llmstxt` option
* Specifically, that option should have at least the `ids_to_include` sub-setting in it.
* Do the same in a multisite, with the difference that the `wpseo_llmstxt` option will appear in a subsite's separate `wp_X_options` table, only after we visit that subsite after the upgrade/activation of the PR/RC

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
