### PR TITLE
641 create the dropdowns for the manual page selection

### DIFF
--- a/inc/options/class-wpseo-option-llmstxt.php
+++ b/inc/options/class-wpseo-option-llmstxt.php
@@ -25,7 +25,13 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 	 * @var array
 	 */
 	protected $defaults = [
-		'ids_to_include' => [],
+		'llms_txt_selection_mode'  => 'auto',
+		'about_us_page'  => 0,
+		'contact_page'  => 0,
+		'terms_page'  => 0,
+		'privacy_policy_page'  => 0,
+		'shop_page'  => 0,
+		'other_included_pages' => [],
 	];
 
 	/**
@@ -55,7 +61,7 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 
 		foreach ( $clean as $key => $value ) {
 			switch ( $key ) {
-				case 'ids_to_include':
+				case 'other_included_pages':
 					$clean[ $key ] = $old[ $key ];
 
 					if ( isset( $dirty[ $key ] ) ) {
@@ -69,6 +75,29 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 						}
 					}
 
+					break;
+				case 'about_us_page':
+				case 'contact_page':
+				case 'terms_page':
+				case 'privacy_policy_page':
+				case 'shop_page':
+					if ( isset( $dirty[ $key ] ) ) {
+						$int = WPSEO_Utils::validate_int( $dirty[ $key ] );
+						if ( $int !== false && $int >= 0 ) {
+							$clean[ $key ] = $int;
+						}
+					}
+					elseif ( isset( $old[ $key ] ) ) {
+						$int = WPSEO_Utils::validate_int( $old[ $key ] );
+						if ( $int !== false && $int >= 0 ) {
+							$clean[ $key ] = $int;
+						}
+					}
+					break;
+				case 'llms_txt_selection_mode':
+					if ( isset( $dirty[ $key ] ) ) {
+						$clean[ $key ] = $dirty[ $key ];
+					}
 					break;
 			}
 		}

--- a/inc/options/class-wpseo-option-llmstxt.php
+++ b/inc/options/class-wpseo-option-llmstxt.php
@@ -22,16 +22,16 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 	 *
 	 * Shouldn't be requested directly, use $this->get_defaults();
 	 *
-	 * @var array
+	 * @var array<string, int|string|array<int>>
 	 */
 	protected $defaults = [
-		'llms_txt_selection_mode'  => 'auto',
-		'about_us_page'  => 0,
-		'contact_page'  => 0,
-		'terms_page'  => 0,
-		'privacy_policy_page'  => 0,
-		'shop_page'  => 0,
-		'other_included_pages' => [],
+		'llms_txt_selection_mode' => 'auto',
+		'about_us_page'           => 0,
+		'contact_page'            => 0,
+		'terms_page'              => 0,
+		'privacy_policy_page'     => 0,
+		'shop_page'               => 0,
+		'other_included_pages'    => [],
 	];
 
 	/**

--- a/inc/options/class-wpseo-option-llmstxt.php
+++ b/inc/options/class-wpseo-option-llmstxt.php
@@ -62,8 +62,7 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 		foreach ( $clean as $key => $value ) {
 			switch ( $key ) {
 				case 'other_included_pages':
-					$clean[ $key ] = $old[ $key ];
-
+					// @TODO: Investigate whether going through this every time an option is saved is too much overhead.
 					if ( isset( $dirty[ $key ] ) ) {
 						$items = $dirty[ $key ];
 						if ( ! is_array( $items ) ) {
@@ -71,7 +70,15 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 						}
 
 						if ( is_array( $items ) ) {
-							$clean[ $key ] = $dirty[ $key ];
+							foreach ( $items as $item ) {
+								$validated_id = WPSEO_Utils::validate_int( $item );
+
+								if ( $validated_id === false || $validated_id === 0 ) {
+									continue;
+								}
+
+								$clean[ $key ][] = $validated_id;
+							}
 						}
 					}
 

--- a/inc/options/class-wpseo-option-llmstxt.php
+++ b/inc/options/class-wpseo-option-llmstxt.php
@@ -102,7 +102,7 @@ class WPSEO_Option_Llmstxt extends WPSEO_Option {
 					}
 					break;
 				case 'llms_txt_selection_mode':
-					if ( isset( $dirty[ $key ] ) ) {
+					if ( isset( $dirty[ $key ] ) && in_array( $dirty[ $key ], [ 'auto', 'manual' ], true ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}
 					break;

--- a/inc/options/class-wpseo-option-wpseo.php
+++ b/inc/options/class-wpseo-option-wpseo.php
@@ -148,7 +148,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 		'site_kit_tracking_setup_widget_permanently_dismissed' => 'no',
 		'google_site_kit_feature_enabled'                      => false,
 		'enable_llms_txt'                                      => false,
-		'llms_txt_selection_mode'                              => 'auto',
 	];
 
 	/**
@@ -337,7 +336,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 				case 'wincher_website_id':
 				case 'clean_permalinks_extra_variables':
 				case 'indexables_overview_state':
-				case 'llms_txt_selection_mode':
 					if ( isset( $dirty[ $key ] ) ) {
 						$clean[ $key ] = $dirty[ $key ];
 					}
@@ -597,7 +595,6 @@ class WPSEO_Option_Wpseo extends WPSEO_Option {
 			'algolia_integration_active'         => false,
 			'google_site_kit_feature_enabled'    => false,
 			'enable_llms_txt'                    => false,
-			'llms_txt_selection_mode'            => false,
 		];
 
 		// We can reuse this logic from the base class with the above defaults to parse with the correct feature values.

--- a/packages/js/src/settings/components/formik-indexable-page-select-field.js
+++ b/packages/js/src/settings/components/formik-indexable-page-select-field.js
@@ -1,5 +1,4 @@
 /* eslint-disable complexity */
-import { DocumentAddIcon } from "@heroicons/react/outline";
 import { useCallback, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { AutocompleteField, Spinner } from "@yoast/ui-library";
@@ -74,7 +73,9 @@ const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
 	}, [ setValue, setTouched ] );
 	const handleQueryChange = useCallback( event => debouncedFetchIndexablePages( event.target.value ), [ debouncedFetchIndexablePages ] );
 	const selectableIndexablePages = useMemo( () => isEmpty( queriedIndexablePageIds ) ? map( indexablePages, "id" ) : queriedIndexablePageIds, [ queriedIndexablePageIds, indexablePages ] );
-	const hasNoIndexablePages = useMemo( () => ( status === ASYNC_ACTION_STATUS.success && isEmpty( queriedIndexablePageIds ) ), [ queriedIndexablePageIds, status ] );
+	const hasNoIndexablePages = useMemo( () => (
+		status === ASYNC_ACTION_STATUS.success && isEmpty( queriedIndexablePageIds )
+	), [ queriedIndexablePageIds, status ] );
 
 	return (
 		<AutocompleteField
@@ -84,7 +85,7 @@ const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
 			// Hack to force re-render of Headless UI Combobox.Input component when selectedPage changes.
 			value={ selectedIndexablePage ? value : 0 }
 			onChange={ handleChange }
-			placeholder={ __( "Select a page...", "wordpress-seo" ) }
+			placeholder={ __( "Select a page…", "wordpress-seo" ) }
 			selectedLabel={ selectedIndexablePage?.name }
 			onQueryChange={ handleQueryChange }
 			nullable={ true }

--- a/packages/js/src/settings/components/formik-indexable-page-select-field.js
+++ b/packages/js/src/settings/components/formik-indexable-page-select-field.js
@@ -1,0 +1,129 @@
+/* eslint-disable complexity */
+import { DocumentAddIcon } from "@heroicons/react/outline";
+import { useCallback, useMemo, useState } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { AutocompleteField, Spinner } from "@yoast/ui-library";
+import classNames from "classnames";
+import { useField } from "formik";
+import { debounce, find, isEmpty, map, values } from "lodash";
+import PropTypes from "prop-types";
+import { ASYNC_ACTION_STATUS, FETCH_DELAY } from "../../shared-admin/constants";
+import { useDispatchSettings, useSelectSettings } from "../hooks";
+
+/**
+ * @param {JSX.node} children The children.
+ * @param {string} [className] The className.
+ * @returns {JSX.Element} The indexable page select options content decorator component.
+ */
+const IndexablePageSelectOptionsContent = ( { children, className = "" } ) => (
+	<div className={ classNames( "yst-flex yst-items-center yst-justify-center yst-gap-2 yst-py-2 yst-px-3", className ) }>
+		{ children }
+	</div>
+);
+
+IndexablePageSelectOptionsContent.propTypes = {
+	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};
+
+/**
+ * @param {Object} props The props object.
+ * @param {string} props.name The field name.
+ * @param {string} props.id The field id.
+ * @returns {JSX.Element} The indexable page select component.
+ */
+const FormikIndexablePageSelectField = ( { name, id, ...props } ) => {
+	const llmTxtPages = useSelectSettings( "selectPreference", [], "llmTxtPages", {} );
+		console.log( "llmTxtPages", llmTxtPages );
+	const indexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages ) );
+	const { fetchIndexablePages } = useDispatchSettings();
+	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );
+	const [ status, setStatus ] = useState( ASYNC_ACTION_STATUS.idle );
+	const [ queriedIndexablePageIds, setQueriedIndexablePageIds ] = useState( [] );
+
+	const selectedIndexablePage = useMemo( () => {
+		const indexablePageObjects = values( indexablePages );
+		return find( indexablePageObjects, [ "id", value ] );
+	}, [ value, indexablePages ] );
+
+	const debouncedFetchIndexablePages = useCallback( debounce( async search => {
+		try {
+			setStatus( ASYNC_ACTION_STATUS.loading );
+
+			const response = await fetchIndexablePages( { search } );
+
+			setQueriedIndexablePageIds( map( response.payload, "id" ) );
+			setStatus( ASYNC_ACTION_STATUS.success );
+		} catch ( error ) {
+			if ( error instanceof DOMException && error.name === "AbortError" ) {
+				// Expected abort errors can be ignored.
+				return;
+			}
+			setQueriedIndexablePageIds( [] );
+			setStatus( ASYNC_ACTION_STATUS.error );
+		}
+	}, FETCH_DELAY ), [ setQueriedIndexablePageIds, setStatus, fetchIndexablePages ] );
+
+	const handleChange = useCallback( newValue => {
+		setTouched( true, false );
+		setValue( newValue );
+	}, [ setValue, setTouched ] );
+	const handleQueryChange = useCallback( event => debouncedFetchIndexablePages( event.target.value ), [ debouncedFetchIndexablePages ] );
+	const selectableIndexablePages = useMemo( () => isEmpty( queriedIndexablePageIds ) ? map( indexablePages, "id" ) : queriedIndexablePageIds, [ queriedIndexablePageIds, indexablePages ] );
+	const hasNoIndexablePages = useMemo( () => ( status === ASYNC_ACTION_STATUS.success && isEmpty( queriedIndexablePageIds ) ), [ queriedIndexablePageIds, status ] );
+
+	return (
+		<AutocompleteField
+			{ ...field }
+			name={ name }
+			id={ id }
+			// Hack to force re-render of Headless UI Combobox.Input component when selectedPage changes.
+			value={ selectedIndexablePage ? value : 0 }
+			onChange={ handleChange }
+			placeholder={ __( "None", "wordpress-seo" ) }
+			selectedLabel={ selectedIndexablePage?.name }
+			onQueryChange={ handleQueryChange }
+			nullable={ true }
+			/* translators: Hidden accessibility text. */
+			clearButtonScreenReaderText={ __( "Clear selection", "wordpress-seo" ) }
+			{ ...props }
+		>
+			<>
+				{ ( status === ASYNC_ACTION_STATUS.idle || status === ASYNC_ACTION_STATUS.success ) && (
+					<>
+						{ hasNoIndexablePages ? (
+							<IndexablePageSelectOptionsContent>
+								{ __( "No pages found.", "wordpress-seo" ) }
+							</IndexablePageSelectOptionsContent>
+						) : map( selectableIndexablePages, indexablePageId => {
+							const indexablePage = indexablePages?.[ indexablePageId ];
+							return indexablePage ? (
+								<AutocompleteField.Option key={ indexablePage?.id } value={ indexablePage?.id }>
+									{ indexablePage?.name }
+								</AutocompleteField.Option>
+							) : null;
+						} ) }
+					</>
+				) }
+				{ status === ASYNC_ACTION_STATUS.loading && (
+					<IndexablePageSelectOptionsContent>
+						<Spinner variant="primary" />
+						{ __( "Searching pages…", "wordpress-seo" ) }
+					</IndexablePageSelectOptionsContent>
+				) }
+				{ status === ASYNC_ACTION_STATUS.error && (
+					<IndexablePageSelectOptionsContent className="yst-text-red-600">
+						{ __( "Failed to retrieve pages.", "wordpress-seo" ) }
+					</IndexablePageSelectOptionsContent>
+				) }
+			</>
+		</AutocompleteField>
+	);
+};
+
+FormikIndexablePageSelectField.propTypes = {
+	name: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+};
+
+export default FormikIndexablePageSelectField;

--- a/packages/js/src/settings/components/formik-indexable-page-select-field.js
+++ b/packages/js/src/settings/components/formik-indexable-page-select-field.js
@@ -30,11 +30,11 @@ IndexablePageSelectOptionsContent.propTypes = {
  * @param {Object} props The props object.
  * @param {string} props.name The field name.
  * @param {string} props.id The field id.
+ * @param {boolean} props.disabled Whether the field is disabled.
  * @returns {JSX.Element} The indexable page select component.
  */
-const FormikIndexablePageSelectField = ( { name, id, ...props } ) => {
+const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
 	const llmTxtPages = useSelectSettings( "selectPreference", [], "llmTxtPages", {} );
-		console.log( "llmTxtPages", llmTxtPages );
 	const indexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages ) );
 	const { fetchIndexablePages } = useDispatchSettings();
 	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );
@@ -80,10 +80,11 @@ const FormikIndexablePageSelectField = ( { name, id, ...props } ) => {
 			// Hack to force re-render of Headless UI Combobox.Input component when selectedPage changes.
 			value={ selectedIndexablePage ? value : 0 }
 			onChange={ handleChange }
-			placeholder={ __( "None", "wordpress-seo" ) }
+			placeholder={ __( "Select a page...", "wordpress-seo" ) }
 			selectedLabel={ selectedIndexablePage?.name }
 			onQueryChange={ handleQueryChange }
 			nullable={ true }
+			disabled={ disabled }
 			/* translators: Hidden accessibility text. */
 			clearButtonScreenReaderText={ __( "Clear selection", "wordpress-seo" ) }
 			{ ...props }

--- a/packages/js/src/settings/components/formik-indexable-page-select-field.js
+++ b/packages/js/src/settings/components/formik-indexable-page-select-field.js
@@ -36,6 +36,7 @@ IndexablePageSelectOptionsContent.propTypes = {
 const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
 	const llmTxtPages = useSelectSettings( "selectPreference", [], "llmTxtPages", {} );
 	const indexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages ) );
+	const otherIndexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages.other_included_pages ) );
 	const { fetchIndexablePages } = useDispatchSettings();
 	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );
 	const [ status, setStatus ] = useState( ASYNC_ACTION_STATUS.idle );
@@ -43,8 +44,11 @@ const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
 
 	const selectedIndexablePage = useMemo( () => {
 		const indexablePageObjects = values( indexablePages );
-		return find( indexablePageObjects, [ "id", value ] );
-	}, [ value, indexablePages ] );
+		const otherIndexablePageObjects = values( otherIndexablePages );
+		const allIndexablePageObjects = [ ...indexablePageObjects, ...otherIndexablePageObjects ];
+
+		return find( allIndexablePageObjects, [ "id", value ] );
+	}, [ value, indexablePages, otherIndexablePages ] );
 
 	const debouncedFetchIndexablePages = useCallback( debounce( async search => {
 		try {

--- a/packages/js/src/settings/components/formik-indexable-page-select-field.js
+++ b/packages/js/src/settings/components/formik-indexable-page-select-field.js
@@ -33,21 +33,20 @@ IndexablePageSelectOptionsContent.propTypes = {
  * @returns {JSX.Element} The indexable page select component.
  */
 const FormikIndexablePageSelectField = ( { name, id, disabled, ...props } ) => {
-	const llmTxtPages = useSelectSettings( "selectPreference", [], "llmTxtPages", {} );
-	const indexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages ) );
-	const otherIndexablePages = useSelectSettings( "selectIndexablePagesWith", [ llmTxtPages ], values( llmTxtPages.other_included_pages ) );
+	const selectedPages = useSelectSettings( "selectPreference", [], "llmTxtPages", {} );
+	const indexablePages = useSelectSettings( "selectIndexablePages", [] );
 	const { fetchIndexablePages } = useDispatchSettings();
 	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );
 	const [ status, setStatus ] = useState( ASYNC_ACTION_STATUS.idle );
 	const [ queriedIndexablePageIds, setQueriedIndexablePageIds ] = useState( [] );
 
 	const selectedIndexablePage = useMemo( () => {
-		const indexablePageObjects = values( indexablePages );
-		const otherIndexablePageObjects = values( otherIndexablePages );
-		const allIndexablePageObjects = [ ...indexablePageObjects, ...otherIndexablePageObjects ];
-
-		return find( allIndexablePageObjects, [ "id", value ] );
-	}, [ value, indexablePages, otherIndexablePages ] );
+		const page = find( values( indexablePages ), [ "id", value ] );
+		if ( page ) {
+			return page;
+		}
+		return find( values( selectedPages ), [ "id", value ] );
+	}, [ value, indexablePages, selectedPages ] );
 
 	const debouncedFetchIndexablePages = useCallback( debounce( async search => {
 		try {

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -34,6 +34,7 @@ PageSelectOptionsContent.propTypes = {
  */
 const FormikPageSelectField = ( { name, id, ...props } ) => {
 	const siteBasicsPolicies = useSelectSettings( "selectPreference", [], "siteBasicsPolicies", {} );
+			console.log( "siteBasicsPolicies", siteBasicsPolicies );
 	const pages = useSelectSettings( "selectPagesWith", [ siteBasicsPolicies ], values( siteBasicsPolicies ) );
 	const { fetchPages } = useDispatchSettings();
 	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -34,7 +34,6 @@ PageSelectOptionsContent.propTypes = {
  */
 const FormikPageSelectField = ( { name, id, ...props } ) => {
 	const siteBasicsPolicies = useSelectSettings( "selectPreference", [], "siteBasicsPolicies", {} );
-			console.log( "siteBasicsPolicies", siteBasicsPolicies );
 	const pages = useSelectSettings( "selectPagesWith", [ siteBasicsPolicies ], values( siteBasicsPolicies ) );
 	const { fetchPages } = useDispatchSettings();
 	const [ { value, ...field }, , { setTouched, setValue } ] = useField( { type: "select", name, id, ...props } );

--- a/packages/js/src/settings/components/index.js
+++ b/packages/js/src/settings/components/index.js
@@ -6,6 +6,7 @@ export { default as FormikReplacementVariableEditorField } from "./formik-replac
 export { default as FormikTagField } from "./formik-tag-field";
 export { default as FormikUserSelectField } from "./formik-user-select-field";
 export { default as FormikPageSelectField } from "./formik-page-select-field";
+export { default as FormikIndexablePageSelectField } from "./formik-indexable-page-select-field.js";
 export { default as FormikValueChangeField } from "./formik-value-change-field";
 export { default as FormikAutocompleteField } from "./formik-autocomplete-field";
 export { default as FormikWithErrorField } from "./formik-with-error-field";

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -80,8 +80,8 @@ const LlmTxt = () => {
 	) );
 
 	const handleAddPage = useCallback( async( arrayHelpers ) => {
-		await arrayHelpers.push( "" );
-		document.getElementById( `input-wpseo_llmstxt-other_included_pages-${ otherIncludedPages.length }` )?.focus();
+		await arrayHelpers.push( 0 );
+		document.querySelector( `[data-id="input-wpseo_llmstxt-other_included_pages-${ otherIncludedPages.length }"]` )?.click();
 	}, [ otherIncludedPages ] );
 
 	useEffect( () => {

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -79,8 +79,8 @@ const LlmTxt = () => {
 		}
 	) );
 
-	const handleAddPage = useCallback( async( pageArrayHelpers ) => {
-		await pageArrayHelpers.push( "" );
+	const handleAddPage = useCallback( async( arrayHelpers ) => {
+		await arrayHelpers.push( "" );
 		document.getElementById( `input-wpseo_llmstxt-other_included_pages-${ otherIncludedPages.length }` )?.focus();
 	}, [ otherIncludedPages ] );
 
@@ -216,47 +216,14 @@ const LlmTxt = () => {
 								/>
 								<hr class="yst-my-8 yst-max-w-md" />
 								<FieldArray name="wpseo_llmstxt.other_included_pages">
-									{ pageArrayHelpers => (
+									{ arrayHelpers => (
 										<>
 											<h4 className="yst-text-lg yst-font-semibold yst-mb-4">
 												{ __( "Content pages", "wordpress-seo" ) }
 											</h4>
-											<Transition
-												key={ `wpseo_llmstxt.other_included_pages.0` }
-												as={ Fragment }
-												appear={ true }
-												show={ true }
-												enter="yst-transition yst-ease-out yst-duration-300"
-												enterFrom="yst-transform yst-opacity-0"
-												enterTo="yst-transform yst-opacity-100"
-												leave="yst-transition yst-ease-out yst-duration-300"
-												leaveFrom="yst-transform yst-opacity-100"
-												leaveTo="yst-transform yst-opacity-0"
-											>
-												<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
-													<FormikIndexablePageSelectField
-														name={ `wpseo_llmstxt.other_included_pages.0` }
-														id={ `input-wpseo_llmstxt.other_included_pages.0` }
-														label={ __( "Content page 1", "wordpress-seo" ) }
-														className="yst-max-w-sm yst-flex-grow"
-														disabled={ llmsTxtSelectionMode === "auto" }
-													/>
-													<Button
-														variant="secondary"
-														// eslint-disable-next-line react/jsx-no-bind
-														onClick={ pageArrayHelpers.remove.bind( null, 0 ) }
-														className="yst-mt-7 yst-p-2.5"
-														// translators: %1$s expands to 1.
-														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), 1 ) }
-														disabled={ llmsTxtSelectionMode === "auto" }
-													>
-														<TrashIcon className="yst-h-5 yst-w-5" />
-													</Button>
-												</div>
-											</Transition>
 											{ otherIncludedPages.map( ( _, index ) => (
 												<Transition
-													key={ `wpseo_llmstxt.other_included_pages.${ index + 1 }` }
+													key={ `wpseo_llmstxt.other_included_pages.${ index }` }
 													as={ Fragment }
 													appear={ true }
 													show={ true }
@@ -269,20 +236,20 @@ const LlmTxt = () => {
 												>
 													<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
 														<FormikIndexablePageSelectField
-															name={ `wpseo_llmstxt.other_included_pages.${ index + 1 }` }
-															id={ `input-wpseo_llmstxt-other_included_pages-${ index + 1 }` }
+															name={ `wpseo_llmstxt.other_included_pages.${ index }` }
+															id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
 															// translators: %1$s expands to array index + 2.
-															label={ sprintf( __( "Content Page %1$s", "wordpress-seo" ), index + 1 + 1 ) }
+															label={ sprintf( __( "Content Page %1$s", "wordpress-seo" ), index + 1 ) }
 															className="yst-max-w-sm yst-flex-grow"
 															disabled={ llmsTxtSelectionMode === "auto" }
 														/>
 														<Button
 															variant="secondary"
 															// eslint-disable-next-line react/jsx-no-bind
-															onClick={ pageArrayHelpers.remove.bind( null, index + 1 ) }
+															onClick={ arrayHelpers.remove.bind( null, index ) }
 															className="yst-mt-7 yst-p-2.5"
 															// translators: %1$s expands to array index + 2.
-															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 + 1 ) }
+															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
 															disabled={ llmsTxtSelectionMode === "auto" }
 														>
 															<TrashIcon className="yst-h-5 yst-w-5" />
@@ -294,7 +261,7 @@ const LlmTxt = () => {
 											<Button
 												id="button-add-page"
 												variant="secondary"
-												onClick={ ()=>handleAddPage( pageArrayHelpers ) }
+												onClick={ ()=>handleAddPage( arrayHelpers ) }
 												disabled={ llmsTxtSelectionMode === "auto" }
 											>
 												<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -49,7 +49,7 @@ const LlmTxt = () => {
 	// eslint-disable-next-line no-console
 	console.log( "generationFailureReason", generationFailureReason );
 	// eslint-disable-next-line no-console
-	console.log( "llmsTxtSelectionMode", llmsTxtSelectionMode );
+	console.log( "otherIncludedPages", otherIncludedPages );
 
 	const activeTxtButton = useMemo( () => (
 		initialIsLlmsTxtEnabled && isLlmsTxtEnabled
@@ -184,19 +184,79 @@ const LlmTxt = () => {
 									id={ `input-wpseo_llmstxt-about_us_page` }
 									label={ __( "About us page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
+									disabled={ llmsTxtSelectionMode === "auto" }
 								/>
 								<FormikIndexablePageSelectField
 									name={ `wpseo_llmstxt.contact_page` }
 									id={ `input-wpseo_llmstxt-contact_page` }
 									label={ __( "Contact page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
+									disabled={ llmsTxtSelectionMode === "auto" }
 								/>
+								<FormikIndexablePageSelectField
+									name={ `wpseo_llmstxt.terms_page` }
+									id={ `input-wpseo_llmstxt-terms_page` }
+									label={ __( "Terms page", "wordpress-seo" ) }
+									className="yst-max-w-sm"
+									disabled={ llmsTxtSelectionMode === "auto" }
+								/>
+								<FormikIndexablePageSelectField
+									name={ `wpseo_llmstxt.privacy_policy_page` }
+									id={ `input-wpseo_llmstxt-privacy_policy_page` }
+									label={ __( "Privacy Policy", "wordpress-seo" ) }
+									className="yst-max-w-sm"
+									disabled={ llmsTxtSelectionMode === "auto" }
+								/>
+								<FormikIndexablePageSelectField
+									name={ `wpseo_llmstxt.shop_page` }
+									id={ `input-wpseo_llmstxt-shop_page` }
+									label={ __( "Shop page", "wordpress-seo" ) }
+									className="yst-max-w-sm"
+									disabled={ llmsTxtSelectionMode === "auto" }
+								/>
+								<hr class="yst-my-8 yst-max-w-md" />
 								<FieldArray name="wpseo_llmstxt.other_included_pages">
 									{ pageArrayHelpers => (
 										<>
+											<h4 className="yst-text-lg yst-font-semibold yst-mb-4">
+												{ __( "Content pages", "wordpress-seo" ) }
+											</h4>
+											<Transition
+												key={ `wpseo_llmstxt.other_included_pages.0` }
+												as={ Fragment }
+												appear={ true }
+												show={ true }
+												enter="yst-transition yst-ease-out yst-duration-300"
+												enterFrom="yst-transform yst-opacity-0"
+												enterTo="yst-transform yst-opacity-100"
+												leave="yst-transition yst-ease-out yst-duration-300"
+												leaveFrom="yst-transform yst-opacity-100"
+												leaveTo="yst-transform yst-opacity-0"
+											>
+												<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
+													<FormikIndexablePageSelectField
+														name={ `wpseo_llmstxt.other_included_pages.0` }
+														id={ `input-wpseo_llmstxt.other_included_pages.0` }
+														label={ __( "Content page 1", "wordpress-seo" ) }
+														className="yst-max-w-sm yst-flex-grow"
+														disabled={ llmsTxtSelectionMode === "auto" }
+													/>
+													<Button
+														variant="secondary"
+														// eslint-disable-next-line react/jsx-no-bind
+														onClick={ pageArrayHelpers.remove.bind( null, 0 ) }
+														className="yst-mt-7 yst-p-2.5"
+														// translators: %1$s expands to 1.
+														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), 1 ) }
+														disabled={ llmsTxtSelectionMode === "auto" }
+													>
+														<TrashIcon className="yst-h-5 yst-w-5" />
+													</Button>
+												</div>
+											</Transition>
 											{ otherIncludedPages.map( ( _, index ) => (
 												<Transition
-													key={ `wpseo_llmstxt.other_included_pages.${ index + 2 }` }
+													key={ `wpseo_llmstxt.other_included_pages.${ index + 1 }` }
 													as={ Fragment }
 													appear={ true }
 													show={ true }
@@ -209,19 +269,21 @@ const LlmTxt = () => {
 												>
 													<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
 														<FormikIndexablePageSelectField
-															name={ `wpseo_llmstxt.other_included_pages.${ index + 2 }` }
-															id={ `input-wpseo_llmstxt-other_included_pages-${ index + 2 }` }
-															// translators: %1$s expands to array index + 3.
-															label={ sprintf( __( "Content Page %1$s", "wordpress-seo" ), index + 2 + 1 ) }
-															className="yst-max-w-sm"
+															name={ `wpseo_llmstxt.other_included_pages.${ index + 1 }` }
+															id={ `input-wpseo_llmstxt-other_included_pages-${ index + 1 }` }
+															// translators: %1$s expands to array index + 2.
+															label={ sprintf( __( "Content Page %1$s", "wordpress-seo" ), index + 1 + 1 ) }
+															className="yst-max-w-sm yst-flex-grow"
+															disabled={ llmsTxtSelectionMode === "auto" }
 														/>
 														<Button
 															variant="secondary"
 															// eslint-disable-next-line react/jsx-no-bind
-															onClick={ pageArrayHelpers.remove.bind( null, index + 2 ) }
+															onClick={ pageArrayHelpers.remove.bind( null, index + 1 ) }
 															className="yst-mt-7 yst-p-2.5"
-															// translators: %1$s expands to array index + 3.
-															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 2 + 1 ) }
+															// translators: %1$s expands to array index + 2.
+															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 + 1 ) }
+															disabled={ llmsTxtSelectionMode === "auto" }
 														>
 															<TrashIcon className="yst-h-5 yst-w-5" />
 														</Button>
@@ -229,7 +291,12 @@ const LlmTxt = () => {
 												</Transition>
 											) ) }
 											{ /* eslint-disable-next-line react/jsx-no-bind */ }
-											<Button id="button-add-page" variant="secondary" onClick={ ()=>handleAddPage( pageArrayHelpers ) }>
+											<Button
+												id="button-add-page"
+												variant="secondary"
+												onClick={ ()=>handleAddPage( pageArrayHelpers ) }
+												disabled={ llmsTxtSelectionMode === "auto" }
+											>
 												<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />
 												{ __( "Add page", "wordpress-seo" ) }
 											</Button>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -242,7 +242,7 @@ const LlmTxt = () => {
 														// eslint-disable-next-line react/jsx-no-bind
 														onClick={ arrayHelpers.remove.bind( null, index ) }
 														className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
-														// translators: %1$s expands to array index + 2.
+														// translators: %1$s expands to array index + 1.
 														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
 														disabled={ ! activeManualSelection }
 													>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -1,6 +1,5 @@
-import { Transition } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/solid";
-import { Fragment, useCallback, useEffect, useMemo } from "@wordpress/element";
+import { useCallback, useEffect, useMemo } from "@wordpress/element";
 import { ExternalLinkIcon, TrashIcon } from "@heroicons/react/outline";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { __, sprintf } from "@wordpress/i18n";
@@ -226,40 +225,30 @@ const LlmTxt = () => {
 									<>
 										<div className="yst-space-y-4">
 											{ otherIncludedPages.map( ( _, index ) => (
-												<Transition
+												<div
+													className="yst-w-full yst-flex yst-items-start yst-gap-2 yst-mt-2"
 													key={ `wpseo_llmstxt.other_included_pages.${ index }` }
-													as={ Fragment }
-													appear={ true }
-													show={ true }
-													enter="yst-transition yst-ease-out yst-duration-300"
-													enterFrom="yst-transform yst-opacity-0"
-													enterTo="yst-transform yst-opacity-100"
-													leave="yst-transition yst-ease-out yst-duration-300"
-													leaveFrom="yst-transform yst-opacity-100"
-													leaveTo="yst-transform yst-opacity-0"
 												>
-													<div className="yst-w-full yst-flex yst-items-start yst-gap-2 yst-mt-2">
-														<FormikIndexablePageSelectField
-															name={ `wpseo_llmstxt.other_included_pages.${ index }` }
-															id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
-															// translators: %1$s expands to array index + 2.
-															label={ `${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }` }
-															className="yst-max-w-sm yst-flex-grow"
-															disabled={ ! activeManualSelection }
-														/>
-														<Button
-															variant="secondary"
-															// eslint-disable-next-line react/jsx-no-bind
-															onClick={ arrayHelpers.remove.bind( null, index ) }
-															className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
-															// translators: %1$s expands to array index + 2.
-															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
-															disabled={ ! activeManualSelection }
-														>
-															<TrashIcon className="yst-h-5 yst-w-5" />
-														</Button>
-													</div>
-												</Transition>
+													<FormikIndexablePageSelectField
+														name={ `wpseo_llmstxt.other_included_pages.${ index }` }
+														id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
+														// translators: %1$s expands to array index + 2.
+														label={ `${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }` }
+														className="yst-max-w-sm yst-flex-grow"
+														disabled={ ! activeManualSelection }
+													/>
+													<Button
+														variant="secondary"
+														// eslint-disable-next-line react/jsx-no-bind
+														onClick={ arrayHelpers.remove.bind( null, index ) }
+														className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
+														// translators: %1$s expands to array index + 2.
+														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
+														disabled={ ! activeManualSelection }
+													>
+														<TrashIcon className="yst-h-5 yst-w-5" />
+													</Button>
+												</div>
 											) ) }
 											<Button
 												id="button-add-page"

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -184,89 +184,88 @@ const LlmTxt = () => {
 									id={ `input-wpseo_llmstxt-about_us_page` }
 									label={ __( "About us page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
-									disabled={ llmsTxtSelectionMode === "auto" }
+									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 								/>
 								<FormikIndexablePageSelectField
 									name={ `wpseo_llmstxt.contact_page` }
 									id={ `input-wpseo_llmstxt-contact_page` }
 									label={ __( "Contact page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
-									disabled={ llmsTxtSelectionMode === "auto" }
+									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 								/>
 								<FormikIndexablePageSelectField
 									name={ `wpseo_llmstxt.terms_page` }
 									id={ `input-wpseo_llmstxt-terms_page` }
 									label={ __( "Terms page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
-									disabled={ llmsTxtSelectionMode === "auto" }
+									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 								/>
 								<FormikIndexablePageSelectField
 									name={ `wpseo_llmstxt.privacy_policy_page` }
 									id={ `input-wpseo_llmstxt-privacy_policy_page` }
-									label={ __( "Privacy Policy", "wordpress-seo" ) }
+									label={ __( "Privacy policy", "wordpress-seo" ) }
 									className="yst-max-w-sm"
-									disabled={ llmsTxtSelectionMode === "auto" }
+									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 								/>
 								<FormikIndexablePageSelectField
 									name={ `wpseo_llmstxt.shop_page` }
 									id={ `input-wpseo_llmstxt-shop_page` }
 									label={ __( "Shop page", "wordpress-seo" ) }
 									className="yst-max-w-sm"
-									disabled={ llmsTxtSelectionMode === "auto" }
+									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 								/>
 								<hr class="yst-my-8 yst-max-w-md" />
 								<FieldArray name="wpseo_llmstxt.other_included_pages">
 									{ arrayHelpers => (
 										<>
-											<h4 className="yst-text-lg yst-font-semibold yst-mb-4">
-												{ __( "Content pages", "wordpress-seo" ) }
-											</h4>
-											{ otherIncludedPages.map( ( _, index ) => (
-												<Transition
-													key={ `wpseo_llmstxt.other_included_pages.${ index }` }
-													as={ Fragment }
-													appear={ true }
-													show={ true }
-													enter="yst-transition yst-ease-out yst-duration-300"
-													enterFrom="yst-transform yst-opacity-0"
-													enterTo="yst-transform yst-opacity-100"
-													leave="yst-transition yst-ease-out yst-duration-300"
-													leaveFrom="yst-transform yst-opacity-100"
-													leaveTo="yst-transform yst-opacity-0"
+											<div class="yst-space-y-4">
+												{ otherIncludedPages.map( ( _, index ) => (
+													<Transition
+														key={ `wpseo_llmstxt.other_included_pages.${ index }` }
+														as={ Fragment }
+														appear={ true }
+														show={ true }
+														enter="yst-transition yst-ease-out yst-duration-300"
+														enterFrom="yst-transform yst-opacity-0"
+														enterTo="yst-transform yst-opacity-100"
+														leave="yst-transition yst-ease-out yst-duration-300"
+														leaveFrom="yst-transform yst-opacity-100"
+														leaveTo="yst-transform yst-opacity-0"
+													>
+														<div className="yst-w-full yst-flex yst-items-start yst-gap-2 yst-mt-2">
+															<FormikIndexablePageSelectField
+																name={ `wpseo_llmstxt.other_included_pages.${ index }` }
+																id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
+																// translators: %1$s expands to array index + 2.
+																label={`${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }`}
+																className="yst-max-w-sm yst-flex-grow"
+																disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
+															/>
+															<Button
+																variant="secondary"
+																// eslint-disable-next-line react/jsx-no-bind
+																onClick={ arrayHelpers.remove.bind( null, index ) }
+																className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
+																// translators: %1$s expands to array index + 2.
+																aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
+																disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
+															>
+																<TrashIcon className="yst-h-5 yst-w-5" />
+															</Button>
+														</div>
+													</Transition>
+												) ) }
+												{ /* eslint-disable-next-line react/jsx-no-bind */ }
+												<Button
+													id="button-add-page"
+													variant="secondary"
+													onClick={ ()=>handleAddPage( arrayHelpers ) }
+													disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
 												>
-													<div className="yst-w-full yst-flex yst-items-start yst-gap-2">
-														<FormikIndexablePageSelectField
-															name={ `wpseo_llmstxt.other_included_pages.${ index }` }
-															id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
-															// translators: %1$s expands to array index + 2.
-															label={ sprintf( __( "Content Page %1$s", "wordpress-seo" ), index + 1 ) }
-															className="yst-max-w-sm yst-flex-grow"
-															disabled={ llmsTxtSelectionMode === "auto" }
-														/>
-														<Button
-															variant="secondary"
-															// eslint-disable-next-line react/jsx-no-bind
-															onClick={ arrayHelpers.remove.bind( null, index ) }
-															className="yst-mt-7 yst-p-2.5"
-															// translators: %1$s expands to array index + 2.
-															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
-															disabled={ llmsTxtSelectionMode === "auto" }
-														>
-															<TrashIcon className="yst-h-5 yst-w-5" />
-														</Button>
-													</div>
-												</Transition>
-											) ) }
-											{ /* eslint-disable-next-line react/jsx-no-bind */ }
-											<Button
-												id="button-add-page"
-												variant="secondary"
-												onClick={ ()=>handleAddPage( arrayHelpers ) }
-												disabled={ llmsTxtSelectionMode === "auto" }
-											>
-												<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />
-												{ __( "Add page", "wordpress-seo" ) }
-											</Button>
+													<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />
+													{ __( "Add page", "wordpress-seo" ) }
+												</Button>
+											</div>
 										</>
 									) }
 								</FieldArray>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -1,9 +1,7 @@
 import { Transition } from "@headlessui/react";
-import { TrashIcon } from "@heroicons/react/outline";
 import { PlusIcon } from "@heroicons/react/solid";
-import { Fragment, useCallback } from "@wordpress/element";
-import { ExternalLinkIcon } from "@heroicons/react/outline";
-import { useEffect, useMemo } from "@wordpress/element";
+import { Fragment, useCallback, useEffect, useMemo } from "@wordpress/element";
+import { ExternalLinkIcon, TrashIcon } from "@heroicons/react/outline";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button, Radio, RadioGroup, ToggleField } from "@yoast/ui-library";
@@ -33,15 +31,15 @@ const LlmTxt = () => {
 	const { values, initialValues } = useFormikContext();
 	const { other_included_pages: otherIncludedPages } = values.wpseo_llmstxt;
 	const {
-		enable_llms_txt: isLlmsTxtEnabled
+		enable_llms_txt: isLlmsTxtEnabled,
 	} = values.wpseo;
 
 	const {
-		enable_llms_txt: initialIsLlmsTxtEnabled
+		enable_llms_txt: initialIsLlmsTxtEnabled,
 	} = initialValues.wpseo;
 
 	const {
-		llms_txt_selection_mode: llmsTxtSelectionMode
+		llms_txt_selection_mode: llmsTxtSelectionMode,
 	} = values.wpseo_llmstxt;
 
 	// eslint-disable-next-line no-console
@@ -54,6 +52,10 @@ const LlmTxt = () => {
 	const activeTxtButton = useMemo( () => (
 		initialIsLlmsTxtEnabled && isLlmsTxtEnabled
 	), [ initialIsLlmsTxtEnabled, isLlmsTxtEnabled ] );
+
+	const activeManualSelection = useMemo( () => (
+		isLlmsTxtEnabled && llmsTxtSelectionMode === "manual"
+	), [ isLlmsTxtEnabled, llmsTxtSelectionMode ] );
 
 	const featureDescription = useMemo( () => safeCreateInterpolateElement(
 		sprintf(
@@ -178,99 +180,99 @@ const LlmTxt = () => {
 						title={ __( "Manual page selection", "wordpress-seo" ) }
 						description={ __( "Select the pages that you want to include in the llms.txt file.", "wordpress-seo" ) }
 					>
-							<>
-								<FormikIndexablePageSelectField
-									name={ `wpseo_llmstxt.about_us_page` }
-									id={ `input-wpseo_llmstxt-about_us_page` }
-									label={ __( "About us page", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-								/>
-								<FormikIndexablePageSelectField
-									name={ `wpseo_llmstxt.contact_page` }
-									id={ `input-wpseo_llmstxt-contact_page` }
-									label={ __( "Contact page", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-								/>
-								<FormikIndexablePageSelectField
-									name={ `wpseo_llmstxt.terms_page` }
-									id={ `input-wpseo_llmstxt-terms_page` }
-									label={ __( "Terms page", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-								/>
-								<FormikIndexablePageSelectField
-									name={ `wpseo_llmstxt.privacy_policy_page` }
-									id={ `input-wpseo_llmstxt-privacy_policy_page` }
-									label={ __( "Privacy policy", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-								/>
-								<FormikIndexablePageSelectField
-									name={ `wpseo_llmstxt.shop_page` }
-									id={ `input-wpseo_llmstxt-shop_page` }
-									label={ __( "Shop page", "wordpress-seo" ) }
-									className="yst-max-w-sm"
-									disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-								/>
-								<hr class="yst-my-8 yst-max-w-md" />
-								<FieldArray name="wpseo_llmstxt.other_included_pages">
-									{ arrayHelpers => (
-										<>
-											<div class="yst-space-y-4">
-												{ otherIncludedPages.map( ( _, index ) => (
-													<Transition
-														key={ `wpseo_llmstxt.other_included_pages.${ index }` }
-														as={ Fragment }
-														appear={ true }
-														show={ true }
-														enter="yst-transition yst-ease-out yst-duration-300"
-														enterFrom="yst-transform yst-opacity-0"
-														enterTo="yst-transform yst-opacity-100"
-														leave="yst-transition yst-ease-out yst-duration-300"
-														leaveFrom="yst-transform yst-opacity-100"
-														leaveTo="yst-transform yst-opacity-0"
-													>
-														<div className="yst-w-full yst-flex yst-items-start yst-gap-2 yst-mt-2">
-															<FormikIndexablePageSelectField
-																name={ `wpseo_llmstxt.other_included_pages.${ index }` }
-																id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
-																// translators: %1$s expands to array index + 2.
-																label={`${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }`}
-																className="yst-max-w-sm yst-flex-grow"
-																disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-															/>
-															<Button
-																variant="secondary"
-																// eslint-disable-next-line react/jsx-no-bind
-																onClick={ arrayHelpers.remove.bind( null, index ) }
-																className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
-																// translators: %1$s expands to array index + 2.
-																aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
-																disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
-															>
-																<TrashIcon className="yst-h-5 yst-w-5" />
-															</Button>
-														</div>
-													</Transition>
-												) ) }
-												{ /* eslint-disable-next-line react/jsx-no-bind */ }
-												<Button
-													id="button-add-page"
-													variant="secondary"
-													onClick={ ()=>handleAddPage( arrayHelpers ) }
-													disabled={ ! isLlmsTxtEnabled || llmsTxtSelectionMode === "auto" }
+						<>
+							<FormikIndexablePageSelectField
+								name="wpseo_llmstxt.about_us_page"
+								id="input-wpseo_llmstxt-about_us_page"
+								label={ __( "About us page", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+								disabled={ ! activeManualSelection }
+							/>
+							<FormikIndexablePageSelectField
+								name="wpseo_llmstxt.contact_page"
+								id="input-wpseo_llmstxt-contact_page"
+								label={ __( "Contact page", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+								disabled={ ! activeManualSelection }
+							/>
+							<FormikIndexablePageSelectField
+								name="wpseo_llmstxt.terms_page"
+								id="input-wpseo_llmstxt-terms_page"
+								label={ __( "Terms page", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+								disabled={ ! activeManualSelection }
+							/>
+							<FormikIndexablePageSelectField
+								name="wpseo_llmstxt.privacy_policy_page"
+								id="input-wpseo_llmstxt-privacy_policy_page"
+								label={ __( "Privacy policy", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+								disabled={ ! activeManualSelection }
+							/>
+							<FormikIndexablePageSelectField
+								name="wpseo_llmstxt.shop_page"
+								id="input-wpseo_llmstxt-shop_page"
+								label={ __( "Shop page", "wordpress-seo" ) }
+								className="yst-max-w-sm"
+								disabled={ ! activeManualSelection }
+							/>
+							<hr className="yst-my-8 yst-max-w-md" />
+							<FieldArray name="wpseo_llmstxt.other_included_pages">
+								{ arrayHelpers => (
+									<>
+										<div className="yst-space-y-4">
+											{ otherIncludedPages.map( ( _, index ) => (
+												<Transition
+													key={ `wpseo_llmstxt.other_included_pages.${ index }` }
+													as={ Fragment }
+													appear={ true }
+													show={ true }
+													enter="yst-transition yst-ease-out yst-duration-300"
+													enterFrom="yst-transform yst-opacity-0"
+													enterTo="yst-transform yst-opacity-100"
+													leave="yst-transition yst-ease-out yst-duration-300"
+													leaveFrom="yst-transform yst-opacity-100"
+													leaveTo="yst-transform yst-opacity-0"
 												>
-													<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />
-													{ __( "Add page", "wordpress-seo" ) }
-												</Button>
-											</div>
-										</>
-									) }
-								</FieldArray>
-							</>
-					</FieldsetLayout>					
+													<div className="yst-w-full yst-flex yst-items-start yst-gap-2 yst-mt-2">
+														<FormikIndexablePageSelectField
+															name={ `wpseo_llmstxt.other_included_pages.${ index }` }
+															id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
+															// translators: %1$s expands to array index + 2.
+															label={ `${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }` }
+															className="yst-max-w-sm yst-flex-grow"
+															disabled={ ! activeManualSelection }
+														/>
+														<Button
+															variant="secondary"
+															// eslint-disable-next-line react/jsx-no-bind
+															onClick={ arrayHelpers.remove.bind( null, index ) }
+															className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
+															// translators: %1$s expands to array index + 2.
+															aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
+															disabled={ ! activeManualSelection }
+														>
+															<TrashIcon className="yst-h-5 yst-w-5" />
+														</Button>
+													</div>
+												</Transition>
+											) ) }
+											<Button
+												id="button-add-page"
+												variant="secondary"
+												/* eslint-disable-next-line react/jsx-no-bind */
+												onClick={ ()=>handleAddPage( arrayHelpers ) }
+												disabled={ ! activeManualSelection }
+											>
+												<PlusIcon className="yst--ms-1 yst-me-1 yst-h-5 yst-w-5 yst-text-slate-400" />
+												{ __( "Add page", "wordpress-seo" ) }
+											</Button>
+										</div>
+									</>
+								) }
+							</FieldArray>
+						</>
+					</FieldsetLayout>
 				</div>
 			</FormLayout>
 		</RouteLayout>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -233,8 +233,7 @@ const LlmTxt = () => {
 													<FormikIndexablePageSelectField
 														name={ `wpseo_llmstxt.other_included_pages.${ index }` }
 														id={ `input-wpseo_llmstxt-other_included_pages-${ index }` }
-														// translators: %1$s expands to array index + 2.
-														label={ `${ ( index === 0 ) ? __( "Content pages", "wordpress-seo" ) : "" }` }
+														label={ index === 0 ? __( "Content pages", "wordpress-seo" ) : "" }
 														className="yst-max-w-sm yst-flex-grow"
 														disabled={ ! activeManualSelection }
 													/>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -46,8 +46,6 @@ const LlmTxt = () => {
 	console.log( "hasGenerationFailed", hasGenerationFailed );
 	// eslint-disable-next-line no-console
 	console.log( "generationFailureReason", generationFailureReason );
-	// eslint-disable-next-line no-console
-	console.log( "otherIncludedPages", otherIncludedPages );
 
 	const activeTxtButton = useMemo( () => (
 		initialIsLlmsTxtEnabled && isLlmsTxtEnabled
@@ -59,9 +57,10 @@ const LlmTxt = () => {
 
 	const featureDescription = useMemo( () => safeCreateInterpolateElement(
 		sprintf(
-			/* translators: %1$s and %2$s are replaced by opening and closing <a> tags. */
-			__( "Future-proof your website for visibility in AI tools like ChatGPT and Google Gemini. This helps them provide better, more accurate information about your site. %1$sLearn more about the llms.txt file%2$s.", "wordpress-seo" ),
+			/* translators: %1$s and %3$s are replaced by opening and closing <a> tags, %2$s is replaced by "llms.txt". */
+			__( "Future-proof your website for visibility in AI tools like ChatGPT and Google Gemini. This helps them provide better, more accurate information about your site. %1$sLearn more about the %2$s file%3$s.", "wordpress-seo" ),
 			"<a>",
+			label,
 			"</a>"
 		), {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
@@ -71,10 +70,11 @@ const LlmTxt = () => {
 
 	const selectionDescription = useMemo( () => safeCreateInterpolateElement(
 		sprintf(
-			/* translators: %1$s and %2$s are replaced by opening and closing <a> tags. */
-			__( "Generate an automatic selection based on %1$sYoast SEO’s best practices%2$s, or manually choose the content to include in your llms.txt file.", "wordpress-seo" ),
+			/* translators: %1$s and %2$s are replaced by opening and closing <a> tags, %3$s is replaced by "llms.txt".. */
+			__( "Generate an automatic page selection based on %1$sYoast SEO’s best practices%2$s, or manually choose the pages to be included in your %3$s file.", "wordpress-seo" ),
 			"<a>",
-			"</a>"
+			"</a>",
+			label
 		), {
 			// eslint-disable-next-line jsx-a11y/anchor-has-content
 			a: <a id="llms-best-practices" href={ bestPracticesLink } target="_blank" rel="noopener noreferrer" />,
@@ -112,7 +112,7 @@ const LlmTxt = () => {
 							description={ sprintf(
 								// translators: %1$s expands to "llms.txt".
 								__(
-									"By enabling this feature an %1$s file is automatically generated that lists a selection of your site's content.",
+									"Enabling this feature generates and updates an %1$s file weekly that lists a selection of your site's content.",
 									"wordpress-seo"
 								),
 								label
@@ -160,7 +160,7 @@ const LlmTxt = () => {
 								type="radio"
 								name="wpseo_llmstxt.llms_txt_selection_mode"
 								id="input-wpseo_llmstxt-llms_txt_selection_mode-auto"
-								label={ __( "Automatic selection", "wordpress-seo" ) }
+								label={ __( "Automatic page selection", "wordpress-seo" ) }
 								value="auto"
 								disabled={ ! isLlmsTxtEnabled }
 							/>
@@ -169,7 +169,7 @@ const LlmTxt = () => {
 								type="radio"
 								name="wpseo_llmstxt.llms_txt_selection_mode"
 								id="input-wpseo_llmstxt-llms_txt_selection_mode-manual"
-								label={ __( "Manual selection", "wordpress-seo" ) }
+								label={ __( "Manual page selection", "wordpress-seo" ) }
 								value="manual"
 								disabled={ ! isLlmsTxtEnabled }
 							/>
@@ -178,7 +178,11 @@ const LlmTxt = () => {
 					<hr className="yst-my-8" />
 					<FieldsetLayout
 						title={ __( "Manual page selection", "wordpress-seo" ) }
-						description={ __( "Select the pages that you want to include in the llms.txt file.", "wordpress-seo" ) }
+						description={ sprintf(
+							// translators: %1$s expands to "llms.txt".
+							__( "Select the pages that you want to include in the %1$s file", "wordpress-seo" ),
+							label
+						) }
 					>
 						<>
 							<FormikIndexablePageSelectField

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -4,6 +4,7 @@ import { ExternalLinkIcon, TrashIcon } from "@heroicons/react/outline";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button, Radio, RadioGroup, ToggleField } from "@yoast/ui-library";
+import classNames from "classnames";
 import { FieldArray, Field, useFormikContext } from "formik";
 import {
 	FieldsetLayout,
@@ -241,7 +242,7 @@ const LlmTxt = () => {
 														variant="secondary"
 														// eslint-disable-next-line react/jsx-no-bind
 														onClick={ arrayHelpers.remove.bind( null, index ) }
-														className={ `yst-p-2.5${ ( index === 0 ) ? " yst-mt-7" : "" }` }
+														className={ classNames( "yst-p-2.5", index === 0 && "yst-mt-7" ) }
 														// translators: %1$s expands to array index + 1.
 														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
 														disabled={ ! activeManualSelection }

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -81,6 +81,7 @@ const LlmTxt = () => {
 	) );
 
 	const handleAddPage = useCallback( async( arrayHelpers ) => {
+		// Async/await is needed to ensure the new field is rendered before clicking it.
 		await arrayHelpers.push( 0 );
 		document.querySelector( `[data-id="input-wpseo_llmstxt-other_included_pages-${ otherIncludedPages.length }"]` )?.click();
 	}, [ otherIncludedPages ] );

--- a/packages/js/src/settings/store/index.js
+++ b/packages/js/src/settings/store/index.js
@@ -21,6 +21,7 @@ import defaultSettingValues, {
 	defaultSettingValuesActions,
 	defaultSettingValuesSelectors,
 } from "./default-setting-values";
+import indexablePages, { createInitialIndexablePagesState, indexablePagesActions, indexablePagesControls, indexablePagesSelectors } from "./indexable-pages";
 import fallbacks, { createInitialFallbacksState, fallbacksActions, fallbacksSelectors } from "./fallbacks";
 import llmsTxt, { createInitialLlmsTxtState, llmsTxtActions, llmsTxtSelectors } from "./llms-txt";
 import media, { createInitialMediaState, mediaActions, mediaControls, mediaSelectors } from "./media";
@@ -52,6 +53,7 @@ const createStore = ( { initialState } ) => {
 		actions: {
 			...defaultSettingValuesActions,
 			...fallbacksActions,
+			...indexablePagesActions,
 			...linkParamsActions,
 			...llmsTxtActions,
 			...mediaActions,
@@ -70,6 +72,7 @@ const createStore = ( { initialState } ) => {
 			...breadcrumbsSelectors,
 			...defaultSettingValuesSelectors,
 			...fallbacksSelectors,
+			...indexablePagesSelectors,
 			...linkParamsSelectors,
 			...llmsTxtSelectors,
 			...mediaSelectors,
@@ -89,6 +92,7 @@ const createStore = ( { initialState } ) => {
 			{
 				defaultSettingValues: createInitialDefaultSettingValuesState(),
 				fallbacks: createInitialFallbacksState(),
+				indexablePages: createInitialIndexablePagesState(),
 				[ LINK_PARAMS_NAME ]: getInitialLinkParamsState(),
 				llmsTxt: createInitialLlmsTxtState(),
 				media: createInitialMediaState(),
@@ -108,6 +112,7 @@ const createStore = ( { initialState } ) => {
 		reducer: combineReducers( {
 			defaultSettingValues,
 			fallbacks,
+			indexablePages,
 			llmsTxt,
 			[ LINK_PARAMS_NAME ]: linkParamsReducer,
 			media,
@@ -128,6 +133,7 @@ const createStore = ( { initialState } ) => {
 			...postTypeControls,
 			...taxonomyControls,
 			...pageControls,
+			...indexablePagesControls,
 		},
 	} );
 };

--- a/packages/js/src/settings/store/indexable-pages.js
+++ b/packages/js/src/settings/store/indexable-pages.js
@@ -1,9 +1,9 @@
 /* eslint-disable complexity */
-import { createEntityAdapter, createSelector, createSlice } from "@reduxjs/toolkit";
+import { createEntityAdapter, createSlice } from "@reduxjs/toolkit";
 import apiFetch from "@wordpress/api-fetch";
 import { decodeEntities } from "@wordpress/html-entities";
 import { buildQueryString } from "@wordpress/url";
-import { map, trim, pickBy } from "lodash";
+import { map, trim } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 
 const indexablePagesAdapter = createEntityAdapter();
@@ -87,23 +87,6 @@ export const indexablePagesSelectors = {
 	selectIndexablePageById: indexablePageAdapterSelectors.selectById,
 	selectIndexablePages: indexablePageAdapterSelectors.selectEntities,
 };
-indexablePagesSelectors.selectIndexablePagesWith = createSelector(
-	[
-		indexablePagesSelectors.selectIndexablePages,
-		( state, additionalIndexablePage = {} ) => additionalIndexablePage,
-	],
-	( indexablePages, additionalIndexablePage ) => {
-		const additionalIndexablePages = {};
-		additionalIndexablePage.forEach( indexablePage => {
-			if ( indexablePage?.id && ! indexablePages[ indexablePage.id ] ) {
-				// Add the additional page.
-				additionalIndexablePages[ indexablePage.id ] = { ...indexablePage };
-			}
-		} );
-		const cleanIndexablePages = pickBy( indexablePages, ( value ) => ! value.protected );
-		return { ...additionalIndexablePages, ...cleanIndexablePages };
-	}
-);
 
 export const indexablePagesActions = {
 	...indexablePagesSlice.actions,

--- a/packages/js/src/settings/store/indexable-pages.js
+++ b/packages/js/src/settings/store/indexable-pages.js
@@ -1,0 +1,126 @@
+/* eslint-disable complexity */
+import { createEntityAdapter, createSelector, createSlice } from "@reduxjs/toolkit";
+import apiFetch from "@wordpress/api-fetch";
+import { decodeEntities } from "@wordpress/html-entities";
+import { buildQueryString } from "@wordpress/url";
+import { map, trim, pickBy } from "lodash";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+
+const indexablePagesAdapter = createEntityAdapter();
+
+export const FETCH_INDEXABLE_PAGES_ACTION_NAME = "fetchIndexablePages";
+export const INDEXABLE_PAGE_NAME = "indexablePages";
+// Global abort controller for this reducer to abort requests made by multiple selects.
+let abortController;
+
+/**
+ * @param {Object} queryData The query data.
+ * @returns {Object} Success or error action object.
+ */
+export function* fetchIndexablePages( queryData ) {
+	yield{ type: `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }` };
+	try {
+		// Trigger the fetch indexable pages control flow.
+		const indexablePages = yield{
+			type: FETCH_INDEXABLE_PAGES_ACTION_NAME,
+			payload: { ...queryData },
+		};
+		return { type: `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, payload: indexablePages };
+	} catch ( error ) {
+		return { type: `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, payload: error };
+	}
+}
+
+/**
+ * @returns {Object} The initial state.
+ */
+export const createInitialIndexablePagesState = () => indexablePagesAdapter.getInitialState( {
+	status: ASYNC_ACTION_STATUS.idle,
+	error: "",
+} );
+
+/**
+ * @param {Object} indexablePage The indexable page.
+ * @returns {Object} The prepared and predictable indexable page.
+ */
+const prepareIndexablePage = indexablePage => (
+	{
+		id: indexablePage?.id,
+		// Fallbacks for page title, because we always need something to show.
+		name: decodeEntities( trim( indexablePage?.title.rendered ) ) || indexablePage?.slug || indexablePage.id,
+		slug: indexablePage?.slug,
+		"protected": indexablePage?.content?.protected,
+	} );
+
+const indexablePagesSlice = createSlice( {
+	name: "indexablePages",
+	initialState: createInitialIndexablePagesState(),
+	reducers: {
+		addOneIndexablePage: {
+			reducer: indexablePagesAdapter.addOne,
+			prepare: indexablePage => ( { payload: prepareIndexablePage( indexablePage ) } ),
+		},
+		addManyIndexablePages: {
+			reducer: indexablePagesAdapter.addMany,
+			prepare: indexablePages => ( { payload: map( indexablePages, prepareIndexablePage ) } ),
+		},
+	},
+	extraReducers: ( builder ) => {
+		builder.addCase( `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.loading;
+		} );
+		builder.addCase( `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, action ) => {
+			state.status = ASYNC_ACTION_STATUS.success;
+			indexablePagesAdapter.addMany( state, map( action.payload, prepareIndexablePage ) );
+		} );
+		builder.addCase( `${ FETCH_INDEXABLE_PAGES_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state, action ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
+			state.error = action.payload;
+		} );
+	},
+} );
+
+// Prefix selectors
+const indexablePageAdapterSelectors = indexablePagesAdapter.getSelectors( state => state.indexablePages );
+export const indexablePagesSelectors = {
+	selectIndexablePageIds: indexablePageAdapterSelectors.selectIds,
+	selectIndexablePageById: indexablePageAdapterSelectors.selectById,
+	selectIndexablePages: indexablePageAdapterSelectors.selectEntities,
+};
+indexablePagesSelectors.selectIndexablePagesWith = createSelector(
+	[
+		indexablePagesSelectors.selectIndexablePages,
+		( state, additionalIndexablePage = {} ) => additionalIndexablePage,
+	],
+	( indexablePages, additionalIndexablePage ) => {
+		const additionalIndexablePages = {};
+		additionalIndexablePage.forEach( indexablePage => {
+			if ( indexablePage?.id && ! indexablePages[ indexablePage.id ] ) {
+				// Add the additional page.
+				additionalIndexablePages[ indexablePage.id ] = { ...indexablePage };
+			}
+		} );
+		const cleanIndexablePages = pickBy( indexablePages, ( value ) => ! value.protected );
+		return { ...additionalIndexablePages, ...cleanIndexablePages };
+	}
+);
+
+export const indexablePagesActions = {
+	...indexablePagesSlice.actions,
+	fetchIndexablePages,
+};
+
+export const indexablePagesControls = {
+	[ FETCH_INDEXABLE_PAGES_ACTION_NAME ]: async( { payload } ) => {
+		abortController?.abort();
+
+
+		abortController = new AbortController();
+		return apiFetch( {
+			path: `/wp/v2/pages?${ buildQueryString( payload ) }`,
+			signal: abortController.signal,
+		} );
+	},
+};
+
+export default indexablePagesSlice.reducer;

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -637,7 +637,7 @@ class Settings_Integration implements Integration_Interface {
 
 				$page['name'] = $post->post_title;
 
-				$llms_txt_pages[ $key ] = $page;
+				$llms_txt_pages['other_included_pages'][] = $page;
 
 			}
 		}

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -49,7 +49,7 @@ class Settings_Integration implements Integration_Interface {
 	 *
 	 * @var array
 	 */
-	public const ALLOWED_OPTION_GROUPS = [ 'wpseo', 'wpseo_titles', 'wpseo_social' ];
+	public const ALLOWED_OPTION_GROUPS = [ 'wpseo', 'wpseo_titles', 'wpseo_social', 'wpseo_llmstxt' ];
 
 	/**
 	 * Holds the disallowed settings, per option group.
@@ -529,6 +529,7 @@ class Settings_Integration implements Integration_Interface {
 			'upsellSettings'                => $this->get_upsell_settings(),
 			'siteRepresentsPerson'          => $this->get_site_represents_person( $settings ),
 			'siteBasicsPolicies'            => $this->get_site_basics_policies( $settings ),
+			'llmTxtPages'                   => $this->get_site_llms_txt_pages( $settings ),
 		];
 	}
 
@@ -537,7 +538,7 @@ class Settings_Integration implements Integration_Interface {
 	 *
 	 * @param array $settings The settings.
 	 *
-	 * @return array The currently represented person's ID and name.
+	 * @return array The currently represented person.
 	 */
 	protected function get_site_represents_person( $settings ) {
 		$person = [
@@ -566,46 +567,83 @@ class Settings_Integration implements Integration_Interface {
 	private function get_site_basics_policies( $settings ) {
 		$policies = [];
 
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['publishing_principles_id'], 'publishing_principles_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['ownership_funding_info_id'], 'ownership_funding_info_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['actionable_feedback_policy_id'], 'actionable_feedback_policy_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['corrections_policy_id'], 'corrections_policy_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['ethics_policy_id'], 'ethics_policy_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['diversity_policy_id'], 'diversity_policy_id' );
-		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['diversity_staffing_report_id'], 'diversity_staffing_report_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['publishing_principles_id'], 'publishing_principles_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['ownership_funding_info_id'], 'ownership_funding_info_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['actionable_feedback_policy_id'], 'actionable_feedback_policy_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['corrections_policy_id'], 'corrections_policy_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['ethics_policy_id'], 'ethics_policy_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['diversity_policy_id'], 'diversity_policy_id' );
+		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['diversity_staffing_report_id'], 'diversity_staffing_report_id' );
 
 		return $policies;
 	}
 
 	/**
-	 * Adds policy data if it is present.
+	 * Adds page if it is present.
 	 *
-	 * @param array  $policies The existing policy data.
-	 * @param int    $policy   The policy id to check.
-	 * @param string $key      The option key name.
+	 * @param array  $pages The existing pages.
+	 * @param int    $page  The page id to check.
+	 * @param string $key   The option key name.
 	 *
 	 * @return array<int, string> The policy data.
 	 */
-	private function maybe_add_policy( $policies, $policy, $key ) {
-		$policy_array = [
+	private function maybe_add_page( $pages, $page, $key ) {
+		$page_array = [
 			'id'   => 0,
 			'name' => \__( 'None', 'wordpress-seo' ),
 		];
 
-		if ( isset( $policy ) && \is_int( $policy ) ) {
-			$policy_array['id'] = $policy;
-			$post               = \get_post( $policy );
+		if ( isset( $page ) && \is_int( $page ) && $page !== 0 ) {
+			$page_array['id'] = $page;
+			$post             = \get_post( $page );
 			if ( $post instanceof WP_Post ) {
 				if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
-					return $policies;
+					return $pages;
 				}
-				$policy_array['name'] = $post->post_title;
+				$page_array['name'] = $post->post_title;
 			}
 		}
 
-		$policies[ $key ] = $policy_array;
+		$pages[ $key ] = $page_array;
 
-		return $policies;
+		return $pages;
+	}
+
+	/**
+	 * Get site llms.txt pages.
+	 *
+	 * @param array $settings The settings.
+	 *
+	 * @return array The llms.txt pages.
+	 */
+	private function get_site_llms_txt_pages( $settings ) {
+		$llms_txt_pages = [];
+
+		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['about_us_page'], 'about_us_page' );
+		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['contact_page'], 'contact_page' );
+		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['terms_page'], 'terms_page' );
+		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['privacy_policy_page'], 'privacy_policy_page' );
+		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['shop_page'], 'shop_page' );
+		
+		if ( isset( $settings['wpseo_llmstxt']['other_included_pages']  ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
+			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $id ) {
+				$page = [];
+
+				$page['id'] = $id;
+				$post       = \get_post( $id );
+				if ( ! ( $post instanceof WP_Post ) || ( $post->post_status !== 'publish' || $post->post_password !== '' ) ) {
+					continue;
+				}
+
+				$page['name'] = $post->post_title;
+
+				$llms_txt_pages[ $key ] = $page;
+
+			}
+		}
+
+		return $llms_txt_pages;
+
 	}
 
 	/**

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -809,6 +809,11 @@ class Settings_Integration implements Integration_Interface {
 			'UTF-8'
 		);
 
+		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
+			// Add an empty social URL.
+			$settings['wpseo_llmstxt']['other_included_pages'][] = 0;
+		}
+
 		return $settings;
 	}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -810,7 +810,7 @@ class Settings_Integration implements Integration_Interface {
 		);
 
 		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
-			// Add an empty social URL.
+			// Append an empty page to the other included pages, so that we manage to show an empty field in the UI.
 			$settings['wpseo_llmstxt']['other_included_pages'][] = 0;
 		}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -588,23 +588,21 @@ class Settings_Integration implements Integration_Interface {
 	 * @return array<int, string> The policy data.
 	 */
 	private function maybe_add_page( $pages, $page, $key ) {
-		$page_array = [
-			'id'   => 0,
-			'name' => \__( 'None', 'wordpress-seo' ),
-		];
-
 		if ( isset( $page ) && \is_int( $page ) && $page !== 0 ) {
-			$page_array['id'] = $page;
-			$post             = \get_post( $page );
+			$page_array = [
+				'id'   => $page,
+				'name' => \__( 'None', 'wordpress-seo' ),
+			];
+			$post       = \get_post( $page );
 			if ( $post instanceof WP_Post ) {
 				if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
 					return $pages;
 				}
 				$page_array['name'] = $post->post_title;
 			}
-		}
 
-		$pages[ $key ] = $page_array;
+			$pages[ $key ] = $page_array;
+		}
 
 		return $pages;
 	}
@@ -626,7 +624,8 @@ class Settings_Integration implements Integration_Interface {
 		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['shop_page'], 'shop_page' );
 
 		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
-			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $id ) {
+			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $id ) {
+				// @TODO: This needs to be using the indexables table. The next PR should fix this, that's why we are duplicating some code here.
 				$page = [];
 
 				$page['id'] = $id;
@@ -637,7 +636,7 @@ class Settings_Integration implements Integration_Interface {
 
 				$page['name'] = $post->post_title;
 
-				$llms_txt_pages['other_included_pages'][] = $page;
+				$llms_txt_pages[ 'other_included_pages-' . $key ] = $page;
 			}
 		}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -614,7 +614,7 @@ class Settings_Integration implements Integration_Interface {
 	 *
 	 * @param array $settings The settings.
 	 *
-	 * @return array The llms.txt pages.
+	 * @return array<string, array<string, int|string>> The llms.txt pages.
 	 */
 	private function get_site_llms_txt_pages( $settings ) {
 		$llms_txt_pages = [];
@@ -624,9 +624,9 @@ class Settings_Integration implements Integration_Interface {
 		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['terms_page'], 'terms_page' );
 		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['privacy_policy_page'], 'privacy_policy_page' );
 		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['shop_page'], 'shop_page' );
-		
-		if ( isset( $settings['wpseo_llmstxt']['other_included_pages']  ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
-			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $id ) {
+
+		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
+			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $id ) {
 				$page = [];
 
 				$page['id'] = $id;
@@ -638,12 +638,10 @@ class Settings_Integration implements Integration_Interface {
 				$page['name'] = $post->post_title;
 
 				$llms_txt_pages['other_included_pages'][] = $page;
-
 			}
 		}
 
 		return $llms_txt_pages;
-
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds multiple dropdowns for the manual selection of pages in the llms.txt file.

## Relevant technical choices:

Known limitations of this first iteration:
* The UX around the page selection dropdowns is weird. Examples
  * When first going into the page and while the `/page` request is still going, clicking an empty dropdown to add a page, doesn't give you a list of pages to choose from or a loading state. And as soon as the `/page` request is done, then suddenly you get a list of pages to choose from. Basically, **a lack of loading state when the initial `/page request is still going**.
  * While you are searching for a page and you are typing the letters slowly, you are greeted with a `page not found` message while it searches, until you finish typing. When you finish typing, after a while you're greeted with the list of pages that are satisfying the search term.
  * When the `/page` request fails, there's no errored UX and the user is left guessing
* The pages that are stored in the db as manual page selections can later be deleted/made private/etc. We will take care not displaying them in the .txt file in [the backend](https://github.com/Yoast/reserved-tasks/issues/644). As far as the frontend is concerned, when the user visits again the llms.txt settings page, we will show them an active `None` option in the dropdown where they had selected a now-deleted page.
* The user can select a page multiple times in the manual page selection dropdowns. This will be taken care of [here](https://github.com/Yoast/reserved-tasks/issues/655).
* The request that populates the available pages list is looking at WP's REST API's `/page` route. We intend to change that [here](https://github.com/Yoast/reserved-tasks/issues/657).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast settings->llms.txt
* Before enabling the feature, the rest of the settings page is disabled
* Enable the feature and before selecting manual page selection, the relevant section is disabled
* Select manual page selection and the section becomes enabled
* Select pages for the first 5 selections and save and refresh
* Confirm that the pages you had selected are the ones that appear selected in the dropdowns
* Start playing around with the content pages
  * Add a couple of pages and save. Confirm that the selections are persisted after a page load
  * Remove a couple of pages and save. Confirm that the dropdowns for the content pages are the ones that you left, plus an empty one. Find in the DB, the `wpseo_llmstxt` option, run it through https://www.unserialize.com/ and confirm that the `other_included_pages` subsetting is an array that only contains valid page IDs.
  * Add a couple of content pages but empty ones and save. Confirm after a page load, that you only get a single empty dropdown. Find in the DB, the `wpseo_llmstxt` option, run it through https://www.unserialize.com/ and confirm that the `other_included_pages` subsetting is an array that only contains valid page IDs.
  * Add a couple of content pages with selected pages. Then clear the selections by clicking the `X` at the right of the dropdown. Then save. Confirm after a page load, that you only get a single empty dropdown. Find in the DB, the `wpseo_llmstxt` option, run it through https://www.unserialize.com/ and confirm that the `other_included_pages` subsetting is an array that only contains valid page IDs.
* Select auto page selection, save and refresh. Confirm that the selections you had in the pages are still there, albeit looking disabled.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* https://github.com/Yoast/wordpress-seo/pull/20349

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [χ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [χ] I have written this PR in accordance with my team's definition of done.
* [χ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
