### PR TITLE
Also add the plans page when on the frontend

### DIFF
--- a/src/plans/user-interface/plans-page-integration.php
+++ b/src/plans/user-interface/plans-page-integration.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Plans\User_Interface;
 
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
@@ -14,6 +15,8 @@ use Yoast\WP\SEO\Plans\Application\Add_Ons_Collector;
  * Adds the plans page to the Yoast admin menu.
  */
 class Plans_Page_Integration implements Integration_Interface {
+
+	use No_Conditionals;
 
 	/**
 	 * The page name.
@@ -54,32 +57,33 @@ class Plans_Page_Integration implements Integration_Interface {
 	private $short_link_helper;
 
 	/**
+	 * Holds the Admin_Conditional.
+	 *
+	 * @var Admin_Conditional
+	 */
+	private $admin_conditional;
+
+	/**
 	 * Constructs the instance.
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager       The WPSEO_Admin_Asset_Manager.
 	 * @param Add_Ons_Collector         $add_ons_collector   The Add_Ons_Collector.
 	 * @param Current_Page_Helper       $current_page_helper The Current_Page_Helper.
 	 * @param Short_Link_Helper         $short_link_helper   The Short_Link_Helper.
+	 * @param Admin_Conditional         $admin_conditional   The Admin_Conditional.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Add_Ons_Collector $add_ons_collector,
 		Current_Page_Helper $current_page_helper,
-		Short_Link_Helper $short_link_helper
+		Short_Link_Helper $short_link_helper,
+		Admin_Conditional $admin_conditional
 	) {
 		$this->asset_manager       = $asset_manager;
 		$this->add_ons_collector   = $add_ons_collector;
 		$this->current_page_helper = $current_page_helper;
 		$this->short_link_helper   = $short_link_helper;
-	}
-
-	/**
-	 * Returns the conditionals based on which this loadable should be active.
-	 *
-	 * @return array<string>
-	 */
-	public static function get_conditionals() {
-		return [ Admin_Conditional::class ];
+		$this->admin_conditional   = $admin_conditional;
 	}
 
 	/**
@@ -95,7 +99,7 @@ class Plans_Page_Integration implements Integration_Interface {
 		\add_filter( 'wpseo_network_submenu_pages', [ $this, 'add_page' ], 7 );
 
 		// Are we on our page?
-		if ( $this->current_page_helper->get_current_yoast_seo_page() === self::PAGE ) {
+		if ( $this->admin_conditional->is_met() && $this->current_page_helper->get_current_yoast_seo_page() === self::PAGE ) {
 			\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 			\add_action( 'in_admin_header', [ $this, 'remove_notices' ], \PHP_INT_MAX );
 		}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Plans page would not have a link in the Yoast menu on the frontend.

## Relevant technical choices:

* No conditionals is fine?

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Crucial fix:
* [x] Verify `Plans` is present in the WP admin bar menu (under SEO Settings) while on the frontend
* [x] Verify `Plans` is present in the WP admin bar menu (under SEO Settings) while on the frontend of a multisite site

Can't hurt to check (again):
* [x] Verify `Plans` is present in the WP admin bar menu (under SEO Settings)
* [x] Verify `Plans` is present in the WP admin bar menu (under SEO Settings) of a multisite
* [x] Verify `Plans` is present in the WP admin bar menu (under SEO Settings) on the network admin of a multisite
* [x] Verify `Plans` is present in the Yoast admin menu
* [x] Verify `Plans` is present in the Yoast admin menu on a multisite
* [x] Verify `Plans` is present in the Yoast admin menu on the network admin of a multisite

Extra safety test:
Due to the no conditionals, always running, it makes sense to me to verify there is no issue in other requests like AJAX.
* Visiting our dashboard triggers a AJAX GET for the scores, you could even search for a term to trigger more
* Changing something in our first time configuration does a AJAX POST to save

Smoke test to be very safe:
Follow the other instructions from https://github.com/Yoast/wordpress-seo/pull/22374

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No conditionals, 

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
