### PR TITLE
658 adjust feature card to point to the new settings page

### DIFF
--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -691,10 +691,14 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			keywords: [],
 		},
 		enable_llms_txt: {
-			route: "/site-features",
-			routeLabel: __( "Site features", "wordpress-seo" ),
-			fieldId: "card-wpseo-enable_llms_txt",
-			fieldLabel: __( "llms.txt", "wordpress-seo" ),
+			route: "/llms-txt",
+			routeLabel: __( "llm.txt", "wordpress-seo" ),
+			fieldId: "input-wpseo.enable_llms_txt",
+			fieldLabel: sprintf(
+				// translators: %1$s expands to "llms.txt".
+				__( "Enable %1$s file feature", "wordpress-seo" ),
+				"llms.txt"
+			),
 			keywords: [],
 		},
 	},

--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -692,7 +692,7 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 		},
 		enable_llms_txt: {
 			route: "/llms-txt",
-			routeLabel: __( "llm.txt", "wordpress-seo" ),
+			routeLabel: __( "llms.txt", "wordpress-seo" ),
 			fieldId: "input-wpseo.enable_llms_txt",
 			fieldLabel: sprintf(
 				// translators: %1$s expands to "llms.txt".

--- a/packages/js/src/settings/routes/site-features.js
+++ b/packages/js/src/settings/routes/site-features.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import { ArrowNarrowRightIcon, ExternalLinkIcon, LockOpenIcon } from "@heroicons/react/outline";
-import { useMemo } from "@wordpress/element";
+import { useMemo, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, Card, Link, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
@@ -9,6 +9,7 @@ import { get } from "lodash";
 import PropTypes from "prop-types";
 import { FormikValueChangeField, FormLayout, RouteLayout } from "../components";
 import { useDisabledMessage, useSelectSettings } from "../hooks";
+import { useNavigate } from "react-router-dom";
 
 /**
  * @param {string} name The field name.
@@ -174,6 +175,10 @@ const SiteFeatures = () => {
 	const { values, initialValues } = useFormikContext();
 	const { enable_xml_sitemap: enableXmlSitemap } = values.wpseo;
 	const { enable_xml_sitemap: initialEnableXmlSitemap } = initialValues.wpseo;
+	const navigate = useNavigate();
+	const handleLlmsTxtNavigate = useCallback( () => {
+		navigate( "/llms-txt" );
+	}, [] );
 
 	// grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 	// yst-grid yst-grid-cols-1 yst-gap-6 sm:yst-grid-cols-2 md:yst-grid-cols-2 lg:yst-grid-cols-3 xl:yst-grid-cols-4
@@ -420,6 +425,27 @@ const SiteFeatures = () => {
 							>
 								<p>{ __( "Automatically ping search engines like Bing and Yandex whenever you publish, update or delete a post.", "wordpress-seo" ) }</p>
 								<LearnMoreLink id="link-index-now" link="https://yoa.st/index-now-feature" ariaLabel={ __( "IndexNow", "wordpress-seo" ) } />
+							</FeatureCard>
+							<FeatureCard
+								name="wpseo.enable_llms_txt"
+								cardId="card-wpseo-enable_llms_txt"
+								inputId="input-wpseo-enable_llms_txt"
+								imageSrc="/images/llms.png"
+								title={ __( "llms.txt", "wordpress-seo" ) }
+							>
+								<p>{ __( "Generate a file that points to your website's most relevant content. Designed to help AI Assistants understand your website better.", "wordpress-seo" ) }</p>
+								<Button
+									onClick={ handleLlmsTxtNavigate }
+									id="link-llms"
+									variant="secondary"
+									target="_blank"
+									rel="noopener"
+									className="yst-self-start"
+								>
+									{ __( "Customize llms.txt file", "wordpress-seo" ) }
+									<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-5 yst-w-5 yst-text-slate-400 rtl:yst-rotate-[270deg]" />
+								</Button>
+								<LearnMoreLink id="link-llms-txt" link="https://yoa.st/site-features-llmstxt-learn-more" ariaLabel={ __( "llms.txt", "wordpress-seo" ) } />
 							</FeatureCard>
 						</div>
 					</fieldset>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Restores llms.txt feature card that was removed in [Create the llms.txt settings page with some first elements](https://github.com/Yoast/wordpress-seo/pull/22345/files#top) and updates the button to redirect to the llms.txt settings page. 
* Updates the search value target route for llms.txt to the new llms.txt settings page.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO -> Settings -> Site features
* Check the last feature is the llm.txt and is has a button with the label: "Customize llm.txt file"
![Screenshot 2025-07-04 at 12 48 49](https://github.com/user-attachments/assets/9bb9c0c6-613c-48de-af91-c7d4b03cd544)
* Click on the button and check you are redirected to the llm.txt settings page
* Go back to the Sites features tab and disable the llm.txt feature, refresh and check it is save, enable and check it is enable.
* Click on the Search field in the sidebar and search for `llms.txt`
* Click on the result and check you are redirected to the llm.txt settings page.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/658
