### PR TITLE
Create new endpoint for getting available pages to be manually selected for llms.txt

### DIFF
--- a/packages/js/src/settings/store/indexable-pages.js
+++ b/packages/js/src/settings/store/indexable-pages.js
@@ -99,7 +99,7 @@ export const indexablePagesControls = {
 
 		abortController = new AbortController();
 		return apiFetch( {
-			path: `/wp/v2/pages?${ buildQueryString( payload ) }`,
+			path: `/yoast/v1/available_posts?${ buildQueryString( payload ) }`,
 			signal: abortController.signal,
 		} );
 	},

--- a/packages/js/src/settings/store/indexable-pages.js
+++ b/packages/js/src/settings/store/indexable-pages.js
@@ -47,9 +47,8 @@ const prepareIndexablePage = indexablePage => (
 	{
 		id: indexablePage?.id,
 		// Fallbacks for page title, because we always need something to show.
-		name: decodeEntities( trim( indexablePage?.title.rendered ) ) || indexablePage?.slug || indexablePage.id,
+		name: decodeEntities( trim( indexablePage?.title ) ) || indexablePage?.slug || indexablePage.id,
 		slug: indexablePage?.slug,
-		"protected": indexablePage?.content?.protected,
 	} );
 
 const indexablePagesSlice = createSlice( {

--- a/src/conditionals/llms-txt-enabled-conditional.php
+++ b/src/conditionals/llms-txt-enabled-conditional.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+use Yoast\WP\SEO\Helpers\Options_Helper;
+
+/**
+ * Conditional that is only met when the 'llms.txt' feature is enabled.
+ */
+class Llms_Txt_Enabled_Conditional implements Conditional {
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options;
+
+	/**
+	 * Llms_Txt_Enabled_Conditional constructor.
+	 *
+	 * @param Options_Helper $options The options helper.
+	 */
+	public function __construct( Options_Helper $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Returns whether the 'llms.txt' feature has been enabled.
+	 *
+	 * @return bool `true` when the 'llms.txt' feature has been enabled.
+	 */
+	public function is_met() {
+		return $this->options->get( 'enable_llms_txt' );
+	}
+}

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -625,7 +625,7 @@ class Settings_Integration implements Integration_Interface {
 
 		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
 			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $id ) {
-				// @TODO: This needs to be using the indexables table. The next PR should fix this, that's why we are duplicating some code here.
+				// @TODO: This needs to be using the indexables table. The https://github.com/Yoast/ux/issues/268 task should fix this, that's why we are duplicating some code here.
 				$page = [];
 
 				$page['id'] = $id;

--- a/src/llms-txt/application/available-posts/available-posts-repository.php
+++ b/src/llms-txt/application/available-posts/available-posts-repository.php
@@ -6,7 +6,6 @@ use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Available_Posts_D
 use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Available_Posts_Repository_Interface;
 use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Data_Container;
 use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Parameters;
-use Yoast\WP\SEO\Llms_Txt\Domain\Content_Types\Content_Type_Entry;
 use Yoast\WP\SEO\Llms_Txt\Infrastructure\Markdown_Services\Content_Types_Collector;
 
 /**
@@ -33,9 +32,9 @@ class Available_Posts_Repository implements Available_Posts_Repository_Interface
 	}
 
 	/**
-	 * Gets the top queries' data.
+	 * Gets the available posts' data.
 	 *
-	 * @param Parameters $parameters The parameter to use for getting the top queries.
+	 * @param Parameters $parameters The parameters to use for getting the available posts.
 	 *
 	 * @return Data_Container
 	 */
@@ -45,10 +44,6 @@ class Available_Posts_Repository implements Available_Posts_Repository_Interface
 		$available_posts_data_container = new Data_Container();
 
 		foreach ( $available_posts as $available_post ) {
-			if ( ! \is_a( $available_post, Content_Type_Entry::class ) ) {
-				throw new Unexpected_Response_Exception();
-			}
-
 			$available_posts_data_container->add_data( new Available_Posts_Data( $available_post ) );
 		}
 

--- a/src/llms-txt/application/available-posts/available-posts-repository.php
+++ b/src/llms-txt/application/available-posts/available-posts-repository.php
@@ -1,0 +1,57 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Application\Available_Posts;
+
+use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Available_Posts_Data;
+use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Available_Posts_Repository_Interface;
+use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Data_Container;
+use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Parameters;
+use Yoast\WP\SEO\Llms_Txt\Domain\Content_Types\Content_Type_Entry;
+use Yoast\WP\SEO\Llms_Txt\Infrastructure\Markdown_Services\Content_Types_Collector;
+
+/**
+ * The data provider for available posts.
+ */
+class Available_Posts_Repository implements Available_Posts_Repository_Interface {
+
+	/**
+	 * The content type collector.
+	 *
+	 * @var Content_Types_Collector $content_types_collector
+	 */
+	private $content_types_collector;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Content_Types_Collector $content_types_collector The content type collector.
+	 */
+	public function __construct(
+		Content_Types_Collector $content_types_collector
+	) {
+		$this->content_types_collector = $content_types_collector;
+	}
+
+	/**
+	 * Gets the top queries' data.
+	 *
+	 * @param Parameters $parameters The parameter to use for getting the top queries.
+	 *
+	 * @return Data_Container
+	 */
+	public function get_posts( Parameters $parameters ): Data_Container {
+		$available_posts = $this->content_types_collector->get_recent_posts( $parameters->get_post_type(), 10, $parameters->get_search_filter(), true );
+
+		$available_posts_data_container = new Data_Container();
+
+		foreach ( $available_posts as $available_post ) {
+			if ( ! \is_a( $available_post, Content_Type_Entry::class ) ) {
+				throw new Unexpected_Response_Exception();
+			}
+
+			$available_posts_data_container->add_data( new Available_Posts_Data( $available_post ) );
+		}
+
+		return $available_posts_data_container;
+	}
+}

--- a/src/llms-txt/domain/available-posts/data-provider/available-posts-data.php
+++ b/src/llms-txt/domain/available-posts/data-provider/available-posts-data.php
@@ -6,7 +6,7 @@ namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
 use Yoast\WP\SEO\Llms_Txt\Domain\Content_Types\Content_Type_Entry;
 
 /**
- * Domain object that represents a Comparison Search Ranking record.
+ * Domain object that represents a Available Posts data record.
  */
 class Available_Posts_Data implements Data_Interface {
 

--- a/src/llms-txt/domain/available-posts/data-provider/available-posts-data.php
+++ b/src/llms-txt/domain/available-posts/data-provider/available-posts-data.php
@@ -1,0 +1,41 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
+
+use Yoast\WP\SEO\Llms_Txt\Domain\Content_Types\Content_Type_Entry;
+
+/**
+ * Domain object that represents a Comparison Search Ranking record.
+ */
+class Available_Posts_Data implements Data_Interface {
+
+	/**
+	 * The content type entry.
+	 *
+	 * @var Content_Type_Entry
+	 */
+	private $content_type_entry;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Content_Type_Entry $content_type_entry The content type entry.
+	 */
+	public function __construct( Content_Type_Entry $content_type_entry ) {
+		$this->content_type_entry = $content_type_entry;
+	}
+
+	/**
+	 * The array representation of this domain object.
+	 *
+	 * @return array<string|float|int|string[]>
+	 */
+	public function to_array(): array {
+		return [
+			'id'    => $this->content_type_entry->get_id(),
+			'title' => $this->content_type_entry->get_title(),
+			'slug'  => $this->content_type_entry->get_slug(),
+		];
+	}
+}

--- a/src/llms-txt/domain/available-posts/data-provider/available-posts-repository-interface.php
+++ b/src/llms-txt/domain/available-posts/data-provider/available-posts-repository-interface.php
@@ -1,0 +1,19 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
+
+/**
+ * Interface describing the way to get data for a specific data provider.
+ */
+interface Available_Posts_Repository_Interface {
+
+	/**
+	 * Method to get available posts from a provider.
+	 *
+	 * @param Parameters $parameters The parameter to get the dashboard data for.
+	 *
+	 * @return Data_Container
+	 */
+	public function get_posts( Parameters $parameters ): Data_Container;
+}

--- a/src/llms-txt/domain/available-posts/data-provider/available-posts-repository-interface.php
+++ b/src/llms-txt/domain/available-posts/data-provider/available-posts-repository-interface.php
@@ -11,7 +11,7 @@ interface Available_Posts_Repository_Interface {
 	/**
 	 * Method to get available posts from a provider.
 	 *
-	 * @param Parameters $parameters The parameter to get the dashboard data for.
+	 * @param Parameters $parameters The parameter to get the available posts for.
 	 *
 	 * @return Data_Container
 	 */

--- a/src/llms-txt/domain/available-posts/data-provider/data-container.php
+++ b/src/llms-txt/domain/available-posts/data-provider/data-container.php
@@ -1,0 +1,58 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
+
+/**
+ * The data container.
+ */
+class Data_Container {
+
+	/**
+	 * All the data points.
+	 *
+	 * @var array<Data_Interface>
+	 */
+	private $data_container;
+
+	/**
+	 * The constructor
+	 */
+	public function __construct() {
+		$this->data_container = [];
+	}
+
+	/**
+	 * Method to add data.
+	 *
+	 * @param Data_Interface $data The data.
+	 *
+	 * @return void
+	 */
+	public function add_data( Data_Interface $data ) {
+		$this->data_container[] = $data;
+	}
+
+	/**
+	 * Method to get all the data points.
+	 *
+	 * @return Data_Interface[] All the data points.
+	 */
+	public function get_data(): array {
+		return $this->data_container;
+	}
+
+	/**
+	 * Converts the data points into an array.
+	 *
+	 * @return array<string, string> The array of the data points.
+	 */
+	public function to_array(): array {
+		$result = [];
+		foreach ( $this->data_container as $data ) {
+			$result[] = $data->to_array();
+		}
+
+		return $result;
+	}
+}

--- a/src/llms-txt/domain/available-posts/data-provider/data-interface.php
+++ b/src/llms-txt/domain/available-posts/data-provider/data-interface.php
@@ -1,0 +1,17 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
+
+/**
+ * The interface to describe the data domain.
+ */
+interface Data_Interface {
+
+	/**
+	 * A to array method.
+	 *
+	 * @return array<string>
+	 */
+	public function to_array(): array;
+}

--- a/src/llms-txt/domain/available-posts/data-provider/parameters.php
+++ b/src/llms-txt/domain/available-posts/data-provider/parameters.php
@@ -50,26 +50,4 @@ class Parameters {
 	public function get_search_filter(): string {
 		return $this->search_filter;
 	}
-
-	/**
-	 * The post type setter.
-	 *
-	 * @param string $post_type The post type.
-	 *
-	 * @return void
-	 */
-	public function set_post_type( string $post_type ): void {
-		$this->post_type = $post_type;
-	}
-
-	/**
-	 * The search filter setter.
-	 *
-	 * @param string $search_filter The search filter.
-	 *
-	 * @return void
-	 */
-	public function set_search_filter( string $search_filter ): void {
-		$this->search_filter = $search_filter;
-	}
 }

--- a/src/llms-txt/domain/available-posts/data-provider/parameters.php
+++ b/src/llms-txt/domain/available-posts/data-provider/parameters.php
@@ -1,0 +1,75 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider;
+
+/**
+ * Object representation of the request parameters.
+ */
+class Parameters {
+
+	/**
+	 * The post type.
+	 *
+	 * @var string
+	 */
+	private $post_type;
+
+	/**
+	 * The search filter.
+	 *
+	 * @var string
+	 */
+	private $search_filter;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param string $post_type     The post type.
+	 * @param string $search_filter The search filter.
+	 */
+	public function __construct( string $post_type, string $search_filter ) {
+		$this->post_type     = $post_type;
+		$this->search_filter = $search_filter;
+	}
+
+	/**
+	 * Getter for the post type.
+	 *
+	 * @return string
+	 */
+	public function get_post_type(): string {
+		return $this->post_type;
+	}
+
+	/**
+	 * Getter for the search filter.
+	 *
+	 * @return string
+	 */
+	public function get_search_filter(): string {
+		return $this->search_filter;
+	}
+
+	/**
+	 * The post type setter.
+	 *
+	 * @param string $post_type The post type.
+	 *
+	 * @return void
+	 */
+	public function set_post_type( string $post_type ): void {
+		$this->post_type = $post_type;
+	}
+
+	/**
+	 * The search filter setter.
+	 *
+	 * @param string $search_filter The search filter.
+	 *
+	 * @return void
+	 */
+	public function set_search_filter( string $search_filter ): void {
+		$this->search_filter = $search_filter;
+	}
+}

--- a/src/llms-txt/domain/available-posts/invalid-post-type-exception.php
+++ b/src/llms-txt/domain/available-posts/invalid-post-type-exception.php
@@ -1,0 +1,18 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts;
+
+use Exception;
+
+/**
+ * Exception for when the post type asked is invalid.
+ */
+class Invalid_Post_Type_Exception extends Exception {
+
+	/**
+	 * Constructor of the exception.
+	 */
+	public function __construct() {
+		parent::__construct( 'The post type asked is not valid', 400 );
+	}
+}

--- a/src/llms-txt/domain/content-types/content-type-entry.php
+++ b/src/llms-txt/domain/content-types/content-type-entry.php
@@ -36,18 +36,33 @@ class Content_Type_Entry {
 	private $description;
 
 	/**
+	 * The description of the content type entry.
+	 *
+	 * @var string
+	 */
+	private $slug;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param int    $id          The ID of the content type entry.
 	 * @param string $title       The title of the content type entry.
 	 * @param string $url         The URL of the content type entry.
 	 * @param string $description The description of the content type entry.
+	 * @param string $slug        The slug of the content type entry.
 	 */
-	public function __construct( int $id, ?string $title = null, ?string $url = null, ?string $description = null ) {
+	public function __construct(
+		int $id,
+		?string $title = null,
+		?string $url = null,
+		?string $description = null,
+		?string $slug = null
+	) {
 		$this->id          = $id;
 		$this->title       = $title;
 		$this->url         = $url;
 		$this->description = $description;
+		$this->slug        = $slug;
 	}
 
 	/**
@@ -84,5 +99,14 @@ class Content_Type_Entry {
 	 */
 	public function get_description(): string {
 		return $this->description;
+	}
+
+	/**
+	 * Gets the slug of the content type entry.
+	 *
+	 * @return string The slug of the content type entry.
+	 */
+	public function get_slug(): string {
+		return $this->slug;
 	}
 }

--- a/src/llms-txt/domain/content-types/content-type-entry.php
+++ b/src/llms-txt/domain/content-types/content-type-entry.php
@@ -36,7 +36,7 @@ class Content_Type_Entry {
 	private $description;
 
 	/**
-	 * The description of the content type entry.
+	 * The slug of the content type entry.
 	 *
 	 * @var string
 	 */

--- a/src/llms-txt/user-interface/available-posts-route.php
+++ b/src/llms-txt/user-interface/available-posts-route.php
@@ -1,0 +1,141 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Llms_Txt\User_Interface;
+
+use Exception;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\Llms_Txt_Enabled_Conditional;
+use Yoast\WP\SEO\Dashboard\Domain\Time_Based_SEO_Metrics\Repository_Not_Found_Exception;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Llms_Txt\Application\Available_Posts\Available_Posts_Repository;
+use Yoast\WP\SEO\Llms_Txt\Domain\Available_Posts\Data_Provider\Parameters;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Routes\Route_Interface;
+
+/**
+ * Available posts route.
+ */
+class Available_Posts_Route implements Route_Interface {
+
+	/**
+	 * The namespace of the route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_NAMESPACE = Main::API_V1_NAMESPACE;
+
+	/**
+	 * The prefix of the route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_NAME = '/available_posts';
+
+	/**
+	 * Holds the available posts repository.
+	 *
+	 * @var Available_Posts_Repository
+	 */
+	private $available_posts_repository;
+
+	/**
+	 * Holds the capability helper instance.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * Returns the needed conditionals.
+	 *
+	 * @return array<string> The conditionals that must be met to load this.
+	 */
+	public static function get_conditionals(): array {
+		return [ Llms_Txt_Enabled_Conditional::class ];
+	}
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Available_Posts_Repository $available_posts_repository The data provider for the available posts.
+	 * @param Capability_Helper          $capability_helper          The capability helper.
+	 */
+	public function __construct(
+		Available_Posts_Repository $available_posts_repository,
+		Capability_Helper $capability_helper
+	) {
+		$this->available_posts_repository = $available_posts_repository;
+		$this->capability_helper          = $capability_helper;
+	}
+
+	/**
+	 * Registers routes for scores.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			self::ROUTE_NAMESPACE,
+			self::ROUTE_NAME,
+			[
+				[
+					'methods'             => 'GET',
+					'callback'            => [ $this, 'get_available_posts' ],
+					'permission_callback' => [ $this, 'permission_manage_options' ],
+					'args'                => [
+						'search'   => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => '',
+						],
+						'postType' => [
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+							'default'           => 'page',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Gets the time based SEO metrics.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The success or failure response.
+	 *
+	 * @throws Repository_Not_Found_Exception When the given widget name is not implemented yet.
+	 */
+	public function get_available_posts( WP_REST_Request $request ): WP_REST_Response {
+		try {
+			$request_parameters = new Parameters( $request->get_param( 'postType' ), $request->get_param( 'search' ) );
+
+			$available_posts_container = $this->available_posts_repository->get_posts( $request_parameters );
+
+		} catch ( Exception $exception ) {
+			return new WP_REST_Response(
+				[
+					'error' => $exception->getMessage(),
+				],
+				$exception->getCode()
+			);
+		}
+
+		return new WP_REST_Response(
+			$available_posts_container->to_array(),
+			200
+		);
+	}
+
+	/**
+	 * Permission callback.
+	 *
+	 * @return bool True when user has the 'wpseo_manage_options' capability.
+	 */
+	public function permission_manage_options() {
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+}

--- a/src/llms-txt/user-interface/available-posts-route.php
+++ b/src/llms-txt/user-interface/available-posts-route.php
@@ -102,7 +102,7 @@ class Available_Posts_Route implements Route_Interface {
 	}
 
 	/**
-	 * Gets the time based SEO metrics.
+	 * Gets the available posts.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 *

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -466,10 +466,11 @@ class Indexable_Repository {
 	 * @param string $post_type                   The post type.
 	 * @param int    $limit                       The maximum number of posts to return.
 	 * @param bool   $exclude_older_than_one_year Whether to exclude posts older than one year.
+	 * @param string $search_filter               Optional. A search filter to apply to the breadcrumb title.
 	 *
 	 * @return Indexable[] array of indexables.
 	 */
-	public function get_recently_modified_posts( string $post_type, int $limit, bool $exclude_older_than_one_year ) {
+	public function get_recently_modified_posts( string $post_type, int $limit, bool $exclude_older_than_one_year, string $search_filter = '' ) {
 		$query = $this->query()
 			->where( 'object_type', 'post' )
 			->where( 'object_sub_type', $post_type )
@@ -479,6 +480,10 @@ class Indexable_Repository {
 
 		if ( $exclude_older_than_one_year === true ) {
 			$query->where_gte( 'object_published_at', \gmdate( 'Y-m-d H:i:s', \strtotime( '-1 year' ) ) );
+		}
+
+		if ( $search_filter !== '' ) {
+			$query->where_like( 'breadcrumb_title', '%' . $search_filter . '%' );
 		}
 
 		$query->order_by_desc( 'object_last_modified' )

--- a/tests/Unit/Llms_Txt/Infrastructure/Content_Types_Collector/Get_Content_Types_Lists_Test.php
+++ b/tests/Unit/Llms_Txt/Infrastructure/Content_Types_Collector/Get_Content_Types_Lists_Test.php
@@ -120,22 +120,28 @@ final class Get_Content_Types_Lists_Test extends Abstract_Content_Types_Collecto
 		$post1->ID           = 1;
 		$post1->post_title   = 'Post 1';
 		$post1->post_excerpt = 'Excerpt 1';
+		$post1->post_name    = 'post_1';
 		$post2->ID           = 2;
 		$post2->post_title   = 'Post 2';
 		$post2->post_excerpt = 'Excerpt 2';
+		$post2->post_name    = 'post_2';
 		$post3->ID           = 3;
 		$post3->post_title   = 'Post 3';
 		$post3->post_excerpt = 'Excerpt 3';
+		$post3->post_name    = 'post_3';
 
 		$page1->ID           = 1;
 		$page1->post_title   = 'Page 1';
 		$page1->post_excerpt = 'Excerpt 1';
+		$post1->post_name    = 'page_1';
 		$page2->ID           = 2;
 		$page2->post_title   = 'Page 2';
 		$page2->post_excerpt = 'Excerpt 2';
+		$page2->post_name    = 'page_2';
 		$page3->ID           = 3;
 		$page3->post_title   = 'Page 3';
 		$page3->post_excerpt = 'Excerpt 3';
+		$page3->post_name    = 'page_3';
 
 		yield '1 indexable post type with 1 post' => [
 			'indexable_post_type_objects' => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Uses indexables for populating the dropdowns for the manual page selection in llms.txt.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm you have indexables enabled and the SEO optimization completed
* Go to yoast settings->llms.txt
* Click on a dropdown and confirm that you see the 10 most recently modified public pages to select. 
* If you write something in the dropdown, confirm that you see the pages that are properly filtered by what you wrote. The thing you wrote filters page titles.
* Select one page, save, refresh and confirm that it persists
* From the 10 most recently modified public pages that you saw in the previous steps, change some of them likeso:
  * Make one private
  * Make one draft
  * Make one scheduled
  * Make one `noindex`ed
  * Make one password-protected
* Revisit the llms.txt settings page and this time when you click on a dropdown you see again the 10 most recently modified pages, but you won't see the ones you edited in the previous step
* Repeat the above tests, for when you have reset and disabled indexables. (the only difference is that the `noindex`ed page will still appear in the dropdown. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* With indexables both enabled and disabled (and reset), confirm that llms.txt file stays the same both with this RC/PR and without.

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
