### PR TITLE
664 add error handling to the get usage api

### DIFF
--- a/packages/js/src/ai-generator/store/usage-count.js
+++ b/packages/js/src/ai-generator/store/usage-count.js
@@ -20,6 +20,7 @@ const slice = createSlice( {
 		count: 0,
 		limit: 10,
 		endpoint: "yoast/v1/ai_generator/get_usage",
+		errorCode: null,
 	},
 	reducers: {
 		addUsageCount: ( state, { payload = 1 } ) => {
@@ -38,14 +39,17 @@ const slice = createSlice( {
 	extraReducers: ( builder ) => {
 		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
 			state.status = ASYNC_ACTION_STATUS.loading;
+			state.errorCode = null;
 		} );
 		builder.addCase( FETCH_USAGE_COUNT_SUCCESS_ACTION_NAME, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.success;
 			state.count = payload.count;
 			state.limit = payload.limit;
+			state.errorCode = null;
 		} );
-		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state ) => {
+		builder.addCase( `${ FETCH_USAGE_COUNT_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.error;
+			state.errorCode = payload;
 		} );
 	},
 } );
@@ -57,6 +61,7 @@ export const usageCountSelectors = {
 	selectUsageCount: ( state ) => get( state, [ USAGE_COUNT_NAME, "count" ], slice.getInitialState().count ),
 	selectUsageCountLimit: ( state ) => get( state, [ USAGE_COUNT_NAME, "limit" ], slice.getInitialState().limit ),
 	selectUsageCountEndpoint: ( state ) => get( state, [ USAGE_COUNT_NAME, "endpoint" ], slice.getInitialState().endpoint ),
+	selectUsageCountErrorCode: ( state ) => get( state, [ USAGE_COUNT_NAME, "errorCode" ], slice.getInitialState().errorCode ),
 };
 usageCountSelectors.selectUsageCountRemaining = createSelector(
 	[
@@ -69,9 +74,9 @@ usageCountSelectors.isUsageCountLimitReached = createSelector(
 	[
 		usageCountSelectors.selectUsageCount,
 		usageCountSelectors.selectUsageCountLimit,
+		usageCountSelectors.selectUsageCountErrorCode,
 	],
-	( count, limit ) => count >= limit
-);
+	( count, limit, errorCode ) => errorCode === 429 || count >= limit );
 
 /**
  * Validates the response structure of the usage count.

--- a/src/ai-generator/user-interface/get-usage-route.php
+++ b/src/ai-generator/user-interface/get-usage-route.php
@@ -3,13 +3,13 @@
 namespace Yoast\WP\SEO\AI_Generator\User_Interface;
 
 use WP_REST_Response;
+use WPSEO_Addon_Manager;
 use Yoast\WP\SEO\AI_Authorization\Application\Token_Manager;
 use Yoast\WP\SEO\AI_HTTP_Request\Application\Request_Handler;
 use Yoast\WP\SEO\AI_HTTP_Request\Domain\Exceptions\Remote_Request_Exception;
 use Yoast\WP\SEO\AI_HTTP_Request\Domain\Exceptions\WP_Request_Exception;
 use Yoast\WP\SEO\AI_HTTP_Request\Domain\Request;
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
-use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
 
@@ -53,11 +53,11 @@ class Get_Usage_Route implements Route_Interface {
 	private $request_handler;
 
 	/**
-	 * The product helprer instance.
+	 * Represents the add-on manager.
 	 *
-	 * @var Product_Helper
+	 * @var WPSEO_Addon_Manager
 	 */
-	private $product_helper;
+	private $addon_manager;
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
@@ -71,12 +71,12 @@ class Get_Usage_Route implements Route_Interface {
 	/**
 	 * Class constructor.
 	 *
-	 * @param Token_Manager   $token_manager   The token manager instance.
-	 * @param Request_Handler $request_handler The request handler instance.
-	 * @param Product_Helper  $product_helper  The product helper instance.
+	 * @param Token_Manager       $token_manager   The token manager instance.
+	 * @param Request_Handler     $request_handler The request handler instance.
+	 * @param WPSEO_Addon_Manager $addon_manager   The add-on manager instance.
 	 */
-	public function __construct( Token_Manager $token_manager, Request_Handler $request_handler, Product_Helper $product_helper ) {
-		$this->product_helper  = $product_helper;
+	public function __construct( Token_Manager $token_manager, Request_Handler $request_handler, WPSEO_Addon_Manager $addon_manager ) {
+		$this->addon_manager   = $addon_manager;
 		$this->token_manager   = $token_manager;
 		$this->request_handler = $request_handler;
 	}
@@ -110,17 +110,34 @@ class Get_Usage_Route implements Route_Interface {
 			$request_headers = [
 				'Authorization' => "Bearer $token",
 			];
-			$action_path     = '/usage/' . ( $this->product_helper->is_premium() ? \gmdate( 'Y-m' ) : 'free-usages' );
+			$action_path     = $this->get_action_path();
 			$response        = $this->request_handler->handle( new Request( $action_path, [], $request_headers, false ) );
 			$data            = \json_decode( $response->get_body() );
 
 		}  catch ( Remote_Request_Exception | WP_Request_Exception $e ) {
 			return new WP_REST_Response(
-				'Failed to get usage: ' . $e->getMessage(),
+				$e->getCode(),
 				$e->getCode()
 			);
 		}
 
 		return new WP_REST_Response( $data );
+	}
+
+	/**
+	 * Get action path for the request.
+	 *
+	 * @return string The action path.
+	 */
+	public function get_action_path() {
+		$post_type = \get_post_type();
+		$unlimited = '/usage/' . \gmdate( 'Y-m' );
+		if ( $post_type === 'product' && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
+			return $unlimited;
+		}
+		if ( $post_type !== 'product' && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+			return $unlimited;
+		}
+		return '/usage/free-usages';
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds error handling to the get usage rest api.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* have a site with no premium subscription.
* use the ai generator.
* Check you get the upsell and then you can start generating.
* Refresh, check you can generate without the upsell.
* Once you get to 10 sparks close the modal and reopen
* Check you get the upsell with the blue Alert.
* Enable the subscription but don't install premium
* Use AI generator and check you don't get the upsell.
* Mock 429 error and check you get an alert and not the upsell.
* Repeat those tests for a woo product with and without woo seo.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Add error handling to the get usage api](https://github.com/Yoast/reserved-tasks/issues/664)
