### PR TITLE
Fix Semrush request limit warning in related keyphrases

### DIFF
--- a/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
+++ b/packages/js/src/components/SEMrushRelatedKeyphrasesModalContent.js
@@ -34,7 +34,7 @@ export function hasMaximumRelatedKeyphrases( relatedKeyphrases ) {
  *
  * @param {object} props The props to use within the content.
  *
- * @returns {string} The user message variant.
+ * @returns {?string} The user message variant, or null if no message is needed.
  */
 export function getUserMessage( props ) {
 	const {
@@ -60,6 +60,8 @@ export function getUserMessage( props ) {
 	if ( hasMaximumRelatedKeyphrases( relatedKeyphrases ) ) {
 		return "maxRelatedKeyphrases";
 	}
+
+	return null;
 }
 
 /**

--- a/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
+++ b/packages/js/tests/components/SEMrushRelatedKeyphrasesModalContent.test.js
@@ -166,6 +166,17 @@ describe( "SEMrushRelatedKeyphrasesModalContent", () => {
 
 			expect( actual ).toEqual( "requestEmpty" );
 		} );
+
+		it( "returns null when none of the messages apply", () => {
+			props = {
+				...props,
+				requestHasData: true,
+			};
+
+			const actual = getUserMessage( props );
+
+			expect( actual ).toBeNull();
+		} );
 	} );
 
 	describe( "hasMaximumRelatedKeyphrases", () => {

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/index.js
@@ -5,13 +5,13 @@ import { MaxRelatedKeyphrases, RequestEmpty, RequestFailed, RequestLimitReached 
 /**
  * Displays the user message following a request or action.
  *
- * @param {string} [variant="requestLimitReached"] The type of message to display.
+ * @param {?string} [variant=null] The type of message to display.
  * @param {string} [upsellLink=""] The link to the upsell page.
  * @param {string} [className=""] The class name for the button.
  *
  * @returns {JSX.Element} The user message.
  */
-export const UserMessage = ( { variant = "requestLimitReached", upsellLink = "", className = "" } ) => {
+export const UserMessage = ( { variant = null, upsellLink = "", className = "" } ) => {
 	switch ( variant ) {
 		case "requestLimitReached":
 			return <RequestLimitReached upsellLink={ upsellLink } className={ className } />;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Fixes a refactor mistake from https://github.com/Yoast/wordpress-seo/commit/9a029fca862c3627623453dc337ca40660cafa1b -- not realizing the actual current default was `undefined`.


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a request limit warning would be shown, in the Semrush related keyphrases, when no warnings would be applicable.
* [@yoast/related-keyphrase-suggestions 0.0.1 bugfix] Fixes a bug where the UserMessage would always result in a message, while the usages did were not made for that.

## Relevant technical choices:

Now changing the default to documented `null` both in the UserMessage and the `getUserMessage` that supplies the variant.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post after integrating the Semrush account
* Be sure you have a focus keyphrase
* Click on the "Get related keyphrases" within the post
* Verify there is no request limit warning
* Verify the Semrush report for the related keyphrase is showing

Now lets test some warnings do show up by changing the php file https://github.com/Yoast/wordpress-seo/blob/6a203be31488434137b361b440582314273f9bbc/src/routes/semrush-route.php#L219
Here are the possible warnings/messages:

#####  Sorry, there's no data available for that keyphrase/country combination.
![image](https://github.com/user-attachments/assets/04b037f9-5000-4dd8-b5bd-9febb80bf94e)
Code path/variant: `requestEmpty`
```php
		$data = [
			'results' => [
				'rows' => [],
			],
			'status'  => 200,
		];
```

#####  You've reached your request limit for today. Check back tomorrow or upgrade your plan over at Semrush.
![image](https://github.com/user-attachments/assets/3bc6199d-342c-452b-b650-2f1a4fa9e861)
Code path/variant: `requestLimitReached`
```php
		$data = [
			'error'  => 'TOTAL LIMIT EXCEEDED',
			'status' => 400,
		];
```

##### We've encountered a problem trying to get related keyphrases. Please try again later.
![image](https://github.com/user-attachments/assets/24be59c3-805a-4789-9af6-00df1ab74dff)
Code path/variant: `requestFailed`
```php
		$data = [
			'error'  => 'Some other error',
			'status' => 400,
		];
```

##### You've reached the maximum amount of 4 related keyphrases. You can change or remove related keyphrases in the Yoast SEO metabox or sidebar.
![image](https://github.com/user-attachments/assets/2e9eee70-d2ff-4b6f-a5d3-361d46cecd28)
Code path/variant: `maxRelatedKeyphrases`
* Reset the PHP code back to the way it was
* Ensure you have Premium activated
* Add the maximum amount of related keyphrases
* Opening the modal should show this message

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/22403
