### PR TITLE
Deal with pages that have been selected and then got deleted/private/noindexed etc.

### DIFF
--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -29,6 +29,7 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Llms_Txt\Application\Configuration\Llms_Txt_Configuration;
 use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
+use Yoast\WP\SEO\Llms_Txt\Infrastructure\Content\Manual_Post_Collection;
 
 /**
  * Class Settings_Integration.
@@ -197,6 +198,13 @@ class Settings_Integration implements Integration_Interface {
 	protected $llms_txt_configuration;
 
 	/**
+	 * The manual post collection.
+	 *
+	 * @var Manual_Post_Collection
+	 */
+	private $manual_post_collection;
+
+	/**
 	 * Constructs Settings_Integration.
 	 *
 	 * @param WPSEO_Admin_Asset_Manager                     $asset_manager           The WPSEO_Admin_Asset_Manager.
@@ -213,6 +221,7 @@ class Settings_Integration implements Integration_Interface {
 	 * @param Options_Helper                                $options                 The options helper.
 	 * @param Content_Type_Visibility_Dismiss_Notifications $content_type_visibility The Content_Type_Visibility_Dismiss_Notifications instance.
 	 * @param Llms_Txt_Configuration                        $llms_txt_configuration  The Llms_Txt_Configuration instance.
+	 * @param Manual_Post_Collection                        $manual_post_collection  The manual post collection.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -228,7 +237,8 @@ class Settings_Integration implements Integration_Interface {
 		User_Helper $user_helper,
 		Options_Helper $options,
 		Content_Type_Visibility_Dismiss_Notifications $content_type_visibility,
-		Llms_Txt_Configuration $llms_txt_configuration
+		Llms_Txt_Configuration $llms_txt_configuration,
+		Manual_Post_Collection $manual_post_collection
 	) {
 		$this->asset_manager           = $asset_manager;
 		$this->replace_vars            = $replace_vars;
@@ -244,6 +254,7 @@ class Settings_Integration implements Integration_Interface {
 		$this->options                 = $options;
 		$this->content_type_visibility = $content_type_visibility;
 		$this->llms_txt_configuration  = $llms_txt_configuration;
+		$this->manual_post_collection  = $manual_post_collection;
 	}
 
 	/**
@@ -567,13 +578,44 @@ class Settings_Integration implements Integration_Interface {
 	private function get_site_basics_policies( $settings ) {
 		$policies = [];
 
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['publishing_principles_id'], 'publishing_principles_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['ownership_funding_info_id'], 'ownership_funding_info_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['actionable_feedback_policy_id'], 'actionable_feedback_policy_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['corrections_policy_id'], 'corrections_policy_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['ethics_policy_id'], 'ethics_policy_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['diversity_policy_id'], 'diversity_policy_id' );
-		$policies = $this->maybe_add_page( $policies, $settings['wpseo_titles']['diversity_staffing_report_id'], 'diversity_staffing_report_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['publishing_principles_id'], 'publishing_principles_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['ownership_funding_info_id'], 'ownership_funding_info_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['actionable_feedback_policy_id'], 'actionable_feedback_policy_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['corrections_policy_id'], 'corrections_policy_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['ethics_policy_id'], 'ethics_policy_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['diversity_policy_id'], 'diversity_policy_id' );
+		$policies = $this->maybe_add_policy( $policies, $settings['wpseo_titles']['diversity_staffing_report_id'], 'diversity_staffing_report_id' );
+
+		return $policies;
+	}
+
+	/**
+	 * Adds policy data if it is present.
+	 *
+	 * @param array  $policies The existing policy data.
+	 * @param int    $policy   The policy id to check.
+	 * @param string $key      The option key name.
+	 *
+	 * @return array<int, string> The policy data.
+	 */
+	private function maybe_add_policy( $policies, $policy, $key ) {
+		$policy_array = [
+			'id'   => 0,
+			'name' => \__( 'None', 'wordpress-seo' ),
+		];
+
+		if ( isset( $policy ) && \is_int( $policy ) ) {
+			$policy_array['id'] = $policy;
+			$post               = \get_post( $policy );
+			if ( $post instanceof WP_Post ) {
+				if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
+					return $policies;
+				}
+				$policy_array['name'] = $post->post_title;
+			}
+		}
+
+		$policies[ $key ] = $policy_array;
 
 		return $policies;
 	}
@@ -581,27 +623,23 @@ class Settings_Integration implements Integration_Interface {
 	/**
 	 * Adds page if it is present.
 	 *
-	 * @param array  $pages The existing pages.
-	 * @param int    $page  The page id to check.
-	 * @param string $key   The option key name.
+	 * @param array<int, string> $pages   The existing pages.
+	 * @param int                $page_id The page id to check.
+	 * @param string             $key     The option key name.
 	 *
 	 * @return array<int, string> The policy data.
 	 */
-	private function maybe_add_page( $pages, $page, $key ) {
-		if ( isset( $page ) && \is_int( $page ) && $page !== 0 ) {
-			$page_array = [
-				'id'   => $page,
-				'name' => \__( 'None', 'wordpress-seo' ),
-			];
-			$post       = \get_post( $page );
-			if ( $post instanceof WP_Post ) {
-				if ( $post->post_status !== 'publish' || $post->post_password !== '' ) {
-					return $pages;
-				}
-				$page_array['name'] = $post->post_title;
+	private function maybe_add_page( $pages, $page_id, $key ) {
+		if ( isset( $page_id ) && \is_int( $page_id ) && $page_id !== 0 ) {
+			$post = $this->manual_post_collection->get_content_type_entry( $page_id );
+			if ( $post === null ) {
+				return $pages;
 			}
 
-			$pages[ $key ] = $page_array;
+			$pages[ $key ] = [
+				'id'   => $page_id,
+				'name' => ( $post->get_title() ) ? $post->get_title() : $post->get_slug(),
+			];
 		}
 
 		return $pages;
@@ -624,19 +662,8 @@ class Settings_Integration implements Integration_Interface {
 		$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $settings['wpseo_llmstxt']['shop_page'], 'shop_page' );
 
 		if ( isset( $settings['wpseo_llmstxt']['other_included_pages'] ) && \is_array( $settings['wpseo_llmstxt']['other_included_pages'] ) ) {
-			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $id ) {
-				// @TODO: This needs to be using the indexables table. The https://github.com/Yoast/ux/issues/268 task should fix this, that's why we are duplicating some code here.
-				$page = [];
-
-				$page['id'] = $id;
-				$post       = \get_post( $id );
-				if ( ! ( $post instanceof WP_Post ) || ( $post->post_status !== 'publish' || $post->post_password !== '' ) ) {
-					continue;
-				}
-
-				$page['name'] = $post->post_title;
-
-				$llms_txt_pages[ 'other_included_pages-' . $key ] = $page;
+			foreach ( $settings['wpseo_llmstxt']['other_included_pages'] as $key => $page_id ) {
+				$llms_txt_pages = $this->maybe_add_page( $llms_txt_pages, $page_id, 'other_included_pages-' . $key );
 			}
 		}
 

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -28,8 +28,8 @@ use Yoast\WP\SEO\Helpers\Taxonomy_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Llms_Txt\Application\Configuration\Llms_Txt_Configuration;
-use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 use Yoast\WP\SEO\Llms_Txt\Infrastructure\Content\Manual_Post_Collection;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 
 /**
  * Class Settings_Integration.

--- a/src/llms-txt/infrastructure/content/manual-post-collection.php
+++ b/src/llms-txt/infrastructure/content/manual-post-collection.php
@@ -86,10 +86,7 @@ class Manual_Post_Collection implements Post_Collection_Interface {
 				if ( $post !== null ) {
 					$posts[] = $post;
 				}
-				else {
-					// If the post is not found, we log it for debugging purposes.
-					error_log( sprintf( 'Post with ID %d for %s not found or not public.', $page_id, $page ) );
-				}
+				// @TODO: Clean up the DB entries for these pages.
 			}
 		}
 		$other_pages = $this->options_helper->get( 'other_included_pages' );
@@ -100,10 +97,7 @@ class Manual_Post_Collection implements Post_Collection_Interface {
 				if ( $post !== null ) {
 					$posts[] = $post;
 				}
-				else {
-					// If the post is not found, we log it for debugging purposes.
-					error_log( sprintf( 'Post with ID %d for %s not found or not public.', $page_id, $page ) );
-				}
+				// @TODO: Clean up the DB entries for these pages.
 			}
 		}
 

--- a/src/llms-txt/infrastructure/content/manual-post-collection.php
+++ b/src/llms-txt/infrastructure/content/manual-post-collection.php
@@ -81,33 +81,51 @@ class Manual_Post_Collection implements Post_Collection_Interface {
 		foreach ( $pages as $page ) {
 			$page_id = $this->options_helper->get( $page );
 			if ( ! empty( $page_id ) ) {
-				if ( $this->indexable_helper->should_index_indexables() ) {
-					$post = $this->get_content_type_entry_for_indexable( $page_id );
-				}
-				else {
-					$post = $this->get_content_type_entry_wp_query( $page_id );
-				}
+				$post = $this->get_content_type_entry( $page_id );
+
 				if ( $post !== null ) {
 					$posts[] = $post;
+				}
+				else {
+					// If the post is not found, we log it for debugging purposes.
+					error_log( sprintf( 'Post with ID %d for %s not found or not public.', $page_id, $page ) );
 				}
 			}
 		}
 		$other_pages = $this->options_helper->get( 'other_included_pages' );
 		if ( ! empty( $other_pages ) ) {
 			foreach ( $other_pages as $page_id ) {
-				if ( $this->indexable_helper->should_index_indexables() ) {
-					$post = $this->get_content_type_entry_for_indexable( $page_id );
-				}
-				else {
-					$post = $this->get_content_type_entry_wp_query( $page_id );
-				}
+				$post = $this->get_content_type_entry( $page_id );
+
 				if ( $post !== null ) {
 					$posts[] = $post;
+				}
+				else {
+					// If the post is not found, we log it for debugging purposes.
+					error_log( sprintf( 'Post with ID %d for %s not found or not public.', $page_id, $page ) );
 				}
 			}
 		}
 
 		return $posts;
+	}
+
+	/**
+	 * Gets the content entries.
+	 *
+	 * @param int $page_id The id of the page.
+	 *
+	 * @return Content_Type_Entry The content type entry.
+	 */
+	public function get_content_type_entry( int $page_id ): ?Content_Type_Entry {
+		if ( $this->indexable_helper->should_index_indexables() ) {
+			$post = $this->get_content_type_entry_for_indexable( $page_id );
+		}
+		else {
+			$post = $this->get_content_type_entry_wp_query( $page_id );
+		}
+
+		return $post;
 	}
 
 	/**

--- a/tests/Unit/Integrations/Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Settings_Integration_Test.php
@@ -20,6 +20,7 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Helpers\Woocommerce_Helper;
 use Yoast\WP\SEO\Integrations\Settings_Integration;
 use Yoast\WP\SEO\Llms_Txt\Application\Configuration\Llms_Txt_Configuration;
+use Yoast\WP\SEO\Llms_Txt\Infrastructure\Content\Manual_Post_Collection;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Integrations\Settings_Integration_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -75,6 +76,13 @@ final class Settings_Integration_Test extends TestCase {
 	private $llms_txt_configuration;
 
 	/**
+	 * Holds the Manual_Post_Collection instance.
+	 *
+	 * @var Mockery\MockInterface|Manual_Post_Collection
+	 */
+	private $manual_post_collection;
+
+	/**
 	 * Runs the setup to prepare the needed instance
 	 *
 	 * @return void
@@ -94,6 +102,7 @@ final class Settings_Integration_Test extends TestCase {
 		$this->options           = Mockery::mock( Options_Helper::class );
 		$content_type_visibility = Mockery::mock( Content_Type_Visibility_Dismiss_Notifications::class );
 		$llms_txt_configuration  = Mockery::mock( Llms_Txt_Configuration::class );
+		$manual_post_collection  = Mockery::mock( Manual_Post_Collection::class );
 
 		$this->instance = new Settings_Integration(
 			$asset_manager,
@@ -109,7 +118,8 @@ final class Settings_Integration_Test extends TestCase {
 			$user_helper,
 			$this->options,
 			$content_type_visibility,
-			$llms_txt_configuration
+			$llms_txt_configuration,
+			$manual_post_collection
 		);
 
 		$this->instance_double = new Settings_Integration_Double(
@@ -126,7 +136,8 @@ final class Settings_Integration_Test extends TestCase {
 			$user_helper,
 			$this->options,
 			$content_type_visibility,
-			$llms_txt_configuration
+			$llms_txt_configuration,
+			$manual_post_collection
 		);
 	}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Deals with pages that have been selected and then got deleted/private/noindexed etc.

## Relevant technical choices:

* Reverts the registering of the policy pages (via the `get_site_basics_policies()` function) back to what it was before the feature branch). Mainly because we now divert enough from that way for the llms.txt pages so we can reduce the impact of our changes now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Select a couple of pages to be added manually in the llms.txt file
* After saving the settings, do the following to those saved pages (make sure at least one of them are from the contact/about/term/etc pages and one of them from the content pages):
  * Make one private
  * Make one draft
  * Make one scheduled
  * Make one noindexed
  * Make one password-protected
  * Delete one
* Refresh the llms.txt settings page and confirm that you don't see any of those pages as selected. Instead, the respective dropdowns are empty and ready to be selected again
  * Make sure to check both when the `\available_pages` request is not done and after it's done. Should be empty in both
* Dont save and revert one of those pages to the public state it was before
* Refresh the settings page and confirm that the reverted page re-appeared in the settings it was before.
* Make it again private/trashed/etc
* Go to the settings page again and this time, add another page at the end of the selections and save.
* Refresh the settings page and confirm that you see the selections you would expect.
* Now run the scheduled action and confirm that you dont see any pages that are private/draft/etc
  * ~This should have also cleaned up the IDs of the private pages from the db~ In a later PR
  * ~To check that, check the `wpseo_llmstxt` option in the db and confirm that you dont see those IDs in the `about_us_page`, `contact_page`, `terms_page`, `privacy_policy_page`, `shop_page`, and `other_included_pages` attributes.~ In a later PR
* Repeat the above tests, but this time with indexables reset and disabled 
  * The only difference would be that the noindexed pages will be treated as public ones.

Deal with pages with no titles:
* Create a page with no title
* Go to the llms.txt settings and when clicking the dropdown, it should appear as its slug (eg. `123`)
* Select it and save
* Refresh the page and confirm that the dropdown is populated even before the `/available_pages` request is completed
  * you might need to add the first filter from [this PR](https://github.com/Yoast/wordpress-seo/pull/22406), to make sure you delay that request enough for you to check)
 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
