### PR TITLE
Fix google docs introduction react warnings & adjust modals titles + copies

### DIFF
--- a/packages/js/src/introductions/components/content.js
+++ b/packages/js/src/introductions/components/content.js
@@ -12,6 +12,8 @@ import { get } from "lodash";
 export const Content = () => {
 	const imageLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectImageLink( "google-docs-addon-thumbnail.png" ), [] );
 	const isPremium = useMemo( () => Boolean( get( window, "wpseoIntroductions.isPremium", false ) ), [] );
+	const upsellLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/google-docs-add-on-introduction-upsell/" ), [] );
+	const premiumLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/google-docs-add-on-introduction-get-started/" ), [] );
 
 	const thumbnail = useMemo( () => ( {
 		src: imageLink,
@@ -32,18 +34,10 @@ export const Content = () => {
 	}
 	, [ isPremium ] );
 
-	const buttonLink = useMemo( () => {
-		if ( isPremium ) {
-			return useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/google-docs-add-on-introduction-get-started/" ), [] );
-		}
-
-		return useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/google-docs-add-on-introduction-upsell/" ), [] );
-	}, [ isPremium ] );
-
 	return (
 		<Modal>
 			<GoogleDocsAddonUpsell
-				buttonLink={ buttonLink }
+				buttonLink={ isPremium ? premiumLink : upsellLink }
 				thumbnail={ thumbnail }
 				buttonLabel={ buttonLabel }
 				isPremium={ isPremium }

--- a/packages/js/src/introductions/components/google-docs-addon-upsell.js
+++ b/packages/js/src/introductions/components/google-docs-addon-upsell.js
@@ -48,9 +48,9 @@ export const GoogleDocsAddonUpsell = ( {
 					<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
 						{
 							sprintf(
-								/* translators: %s: Yoast SEO Google Docs Add-On" */
-								__( "%s - incl. in Premium", "wordpress-seo" ),
-								"Yoast SEO Google Docs Add-On"
+								/* translators: %s: Google Docs Add-On" */
+								__( "Get one seat for the new %s", "wordpress-seo" ),
+								"Google Docs Add-On"
 							)
 						}
 					</h3>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  We want to fix the React warnings from the dev console that where introduced by the Google Docs Add-On introduction, and adjust the title in the modals as per indicated in this [issue](https://github.com/Yoast/wordpress-seo-premium/issues/4603) (indicated right under the images).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the Google Docs Add-on would introduce React render warnings. 
* Adjusts the text and the title of the Google Docs Add-on introduction modals. 

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:
 
### React warnings + modal title
* Have Free and Premium activated. 
* In `trunk` go to the` wp-config.php` file of your test site (as explained in the [DoD](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2464809024/CR+Acceptance+testing+DoD)) and add the following PHP constant to the file: 
`if ( ! defined( 'SCRIPT_DEBUG' ) ) {
    define( 'SCRIPT_DEBUG', true );
}` 
* Build the plugin. 
* Open the database for your test site in any sql editor or use wp db query wp-cli command and remove _yoast_wpseo_introductions meta_key from wp_usermeta table:
DELETE FROM `wp_usermeta` WHERE `meta_key` = '_yoast_wpseo_introductions'

![image](https://github.com/user-attachments/assets/3039830a-ca4f-4354-a74c-96b284283ccb)

* In the WP backend, go to the Yoast SEO admin tab. with the dev. tools console open. 
* Confirm that you see the Google Docs add-on introduction modal. 
* Check the console and confirm that there are several React warning errors from that refer to calling Hooks inside a useEffect(). 
![image](https://github.com/user-attachments/assets/4d242de2-163b-4993-9759-dffb86c0bd69)
* Confirm also that the modal title is still _**Yoast SEO Google Docs Add-On - incl. in Premium**_
* Check out to this branch `583-fix-google-docs-introduction-react-warnings-adjust-urls-modals-title` in the terminal and build the plugin. 
* Remove _yoast_wpseo_introductions meta_key row from the wp_usermeta table once more. 
* Refresh the Yoast SEO admin page in WP 
* Confirm that the React warnings about the calling Hooks inside the useEffect() are gone, and that the title of the modal now says _**Get one seat for the new Google Docs Add-On**_
![image](https://github.com/user-attachments/assets/914bad00-5ba4-46da-a92a-4110bcc8392a)
* Deactivate the Premium plugin. 
* Remove _yoast_wpseo_introductions meta_key row from the wp_usermeta table once again. 
* Go to the Yoast SEO admin page.
* Confirm that the title of the upsell modal in Free is also _**Get one seat for the new Google Docs Add-On**_
![SCR-20250707-ownr](https://github.com/user-attachments/assets/8edfa830-8603-4735-bf21-c9246376ca55)


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [X] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #583
