### PR TITLE
Re-generates the llms.txt file immediately when there's any change in the selection of the pages to be included

### DIFF
--- a/src/llms-txt/user-interface/enable-llms-txt-option-watcher.php
+++ b/src/llms-txt/user-interface/enable-llms-txt-option-watcher.php
@@ -132,18 +132,6 @@ class Enable_Llms_Txt_Option_Watcher implements Integration_Interface {
 				continue;
 			}
 
-			if ( $option_name === 'other_included_pages' ) {
-				// @TODO: double check the way we compare the arrays both for performance and edge cases.
-				if (
-					\count( $old_value[ $option_name ] ) !== \count( $new_value[ $option_name ] )
-					|| ! empty( \array_diff( $old_value[ $option_name ], $new_value[ $option_name ] ) )
-					|| ! empty( \array_diff( $new_value[ $option_name ], $old_value[ $option_name ] ) )
-				) {
-					$this->populate_file_command_handler->handle();
-					return;
-				}
-			}
-
 			if ( $old_value[ $option_name ] !== $new_value[ $option_name ] ) {
 				$this->populate_file_command_handler->handle();
 				return;

--- a/src/llms-txt/user-interface/enable-llms-txt-option-watcher.php
+++ b/src/llms-txt/user-interface/enable-llms-txt-option-watcher.php
@@ -2,8 +2,8 @@
 
 namespace Yoast\WP\SEO\Llms_Txt\User_Interface;
 
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Conditionals\Traits\Admin_Conditional_Trait;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Populate_File_Command_Handler;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Remove_File_Command_Handler;
@@ -16,6 +16,11 @@ class Enable_Llms_Txt_Option_Watcher implements Integration_Interface {
 
 	use Admin_Conditional_Trait;
 
+	/**
+	 * The option names that should trigger a population of the llms.txt file.
+	 *
+	 * @var string[]
+	 */
 	private $option_names = [
 		'llms_txt_selection_mode',
 		'about_us_page',
@@ -130,9 +135,9 @@ class Enable_Llms_Txt_Option_Watcher implements Integration_Interface {
 			if ( $option_name === 'other_included_pages' ) {
 				// @TODO: double check the way we compare the arrays both for performance and edge cases.
 				if (
-					\count( $old_value[ $option_name ] ) !== \count( $new_value[ $option_name ] ) ||
-					! empty( \array_diff( $old_value[ $option_name ], $new_value[ $option_name ] ) ) ||
-					! empty( \array_diff( $new_value[ $option_name ], $old_value[ $option_name ] ) )
+					\count( $old_value[ $option_name ] ) !== \count( $new_value[ $option_name ] )
+					|| ! empty( \array_diff( $old_value[ $option_name ], $new_value[ $option_name ] ) )
+					|| ! empty( \array_diff( $new_value[ $option_name ], $old_value[ $option_name ] ) )
 				) {
 					$this->populate_file_command_handler->handle();
 					return;

--- a/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Abstract_Enable_Llms_Txt_Option_Watcher_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Abstract_Enable_Llms_Txt_Option_Watcher_Test.php
@@ -4,12 +4,12 @@
 namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\Enable_Llms_Txt_Option_Watcher;
 
 use Mockery;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Populate_File_Command_Handler;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Remove_File_Command_Handler;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Llms_Txt_Cron_Scheduler;
 use Yoast\WP\SEO\Llms_Txt\User_Interface\Cleanup_Llms_Txt_On_Deactivation;
 use Yoast\WP\SEO\Llms_Txt\User_Interface\Enable_Llms_Txt_Option_Watcher;
-use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**

--- a/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Abstract_Enable_Llms_Txt_Option_Watcher_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Abstract_Enable_Llms_Txt_Option_Watcher_Test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Llms_Txt\Application\File\Commands\Remove_File_Command_Handler;
 use Yoast\WP\SEO\Llms_Txt\Application\File\Llms_Txt_Cron_Scheduler;
 use Yoast\WP\SEO\Llms_Txt\User_Interface\Cleanup_Llms_Txt_On_Deactivation;
 use Yoast\WP\SEO\Llms_Txt\User_Interface\Enable_Llms_Txt_Option_Watcher;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -49,6 +50,13 @@ abstract class Abstract_Enable_Llms_Txt_Option_Watcher_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * The options helper mock.
+	 *
+	 * @var Options_Helper|Mockery\MockInterface
+	 */
+	protected $options_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -59,11 +67,13 @@ abstract class Abstract_Enable_Llms_Txt_Option_Watcher_Test extends TestCase {
 		$this->cron_scheduler                = Mockery::mock( Llms_Txt_Cron_Scheduler::class );
 		$this->command_handler               = Mockery::mock( Remove_File_Command_Handler::class );
 		$this->populate_file_command_handler = Mockery::mock( Populate_File_Command_Handler::class );
+		$this->options_helper                = Mockery::mock( Options_Helper::class );
 
 		$this->instance = new Enable_Llms_Txt_Option_Watcher(
 			$this->cron_scheduler,
 			$this->command_handler,
-			$this->populate_file_command_handler
+			$this->populate_file_command_handler,
+			$this->options_helper
 		);
 	}
 }

--- a/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Check_Llms_Txt_Selection_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Check_Llms_Txt_Selection_Test.php
@@ -1,0 +1,141 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\Enable_Llms_Txt_Option_Watcher;
+
+use Generator;
+
+/**
+ * Tests the check_llms_txt_selection.
+ *
+ * @group llms.txt
+ *
+ * @covers Yoast\WP\SEO\Llms_Txt\User_Interface\Enable_Llms_Txt_Option_Watcher::check_llms_txt_selection
+ */
+final class Check_Llms_Txt_Selection_Test extends Abstract_Enable_Llms_Txt_Option_Watcher_Test {
+
+	/**
+	 * Tests that nothing happens when LLMS.txt is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_check_llms_txt_selection_when_disabled() {
+		$this->options_helper->expects( 'get' )
+			->with( 'enable_llms_txt', false )
+			->andReturn( false );
+
+		$this->populate_file_command_handler->expects( 'handle' )->never();
+
+		$old_value = [ 'about_us_page' => '1' ];
+		$new_value = [ 'about_us_page' => '2' ];
+
+		$this->instance->check_llms_txt_selection( $old_value, $new_value );
+	}
+
+	/**
+	 * Tests that populate_file_command_handler is called when an option changes.
+	 *
+	 * @dataProvider option_changes_data_provider
+	 *
+	 * @param array<string,int> $old_value The old value.
+	 * @param array<string,int> $new_value The new value.
+	 *
+	 * @return void
+	 */
+	public function test_check_llms_txt_selection_with_option_changes( $old_value, $new_value ) {
+		$this->options_helper->expects( 'get' )
+			->with( 'enable_llms_txt', false )
+			->andReturn( true );
+
+		$this->populate_file_command_handler->expects( 'handle' )->once();
+
+		$this->instance->check_llms_txt_selection( $old_value, $new_value );
+	}
+
+	/**
+	 * Tests that nothing happens when no relevant options change.
+	 *
+	 * @return void
+	 */
+	public function test_check_llms_txt_selection_with_no_changes() {
+		$this->options_helper->expects( 'get' )
+			->with( 'enable_llms_txt', false )
+			->andReturn( true );
+
+		$this->populate_file_command_handler->expects( 'handle' )->never();
+
+		$old_value = [
+			'about_us_page'        => '1',
+			'contact_page'         => '2',
+			'other_included_pages' => [ 1, 2, 3 ],
+		];
+
+		$new_value = [
+			'about_us_page'           => '1',
+			'contact_page'            => '2',
+			'other_included_pages'    => [ 1, 2, 3 ],
+		];
+
+		$this->instance->check_llms_txt_selection( $old_value, $new_value );
+	}
+
+	/**
+	 * Tests that nothing happens when options are missing.
+	 *
+	 * @return void
+	 */
+	public function test_check_llms_txt_selection_with_missing_options() {
+		$this->options_helper->expects( 'get' )
+			->with( 'enable_llms_txt', false )
+			->andReturn( true );
+
+		$this->populate_file_command_handler->expects( 'handle' )->never();
+
+		$old_value = [];
+		$new_value = [ 'unrelated_option' => 'value' ];
+
+		$this->instance->check_llms_txt_selection( $old_value, $new_value );
+	}
+
+	/**
+	 * Data provider for option changes tests.
+	 *
+	 * @return Generator
+	 */
+	public function option_changes_data_provider() {
+		yield 'about us page change' => [
+			'old_value' => [ 'about_us_page' => '1' ],
+			'new_value' => [ 'about_us_page' => '2' ],
+		];
+
+		yield 'contact page change' => [
+			'old_value' => [ 'contact_page' => '1' ],
+			'new_value' => [ 'contact_page' => '2' ],
+		];
+
+		yield 'terms page change' => [
+			'old_value' => [ 'terms_page' => '1' ],
+			'new_value' => [ 'terms_page' => '2' ],
+		];
+
+		yield 'privacy policy page change' => [
+			'old_value' => [ 'privacy_policy_page' => '1' ],
+			'new_value' => [ 'privacy_policy_page' => '2' ],
+		];
+
+		yield 'shop page change' => [
+			'old_value' => [ 'shop_page' => '1' ],
+			'new_value' => [ 'shop_page' => '2' ],
+		];
+
+		yield 'other included pages count change' => [
+			'old_value' => [ 'other_included_pages' => [ 1, 2 ] ],
+			'new_value' => [ 'other_included_pages' => [ 1, 2, 3 ] ],
+		];
+
+		yield 'other included pages value change' => [
+			'old_value' => [ 'other_included_pages' => [ 1, 2, 3 ] ],
+			'new_value' => [ 'other_included_pages' => [ 1, 2, 4 ] ],
+		];
+	}
+}

--- a/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Check_Toggle_Llms_Txt_Test.php
+++ b/tests/Unit/Llms_Txt/User_Interface/Enable_Llms_Txt_Option_Watcher/Check_Toggle_Llms_Txt_Test.php
@@ -6,7 +6,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\User_Interface\Enable_Llms_Txt_Option
 use Generator;
 
 /**
- * Tests the maybe_remove_llms_file.
+ * Tests the check_toggle_llms_txt.
  *
  * @group llms.txt
  *


### PR DESCRIPTION
> [!NOTE]  
> Even though the PR currently does what's expected, it has not been thoroughly tested or finalized by its author. Consider that, if it's to be resumed.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Re-generates the llms.txt file immediately when there's any change in the selection of the pages to be included.

## Relevant technical choices:

**About the way we detect changes in the llms.txt settings**:
* We're going to check the following sub-settings of the `wpseo_llmstxt` option with a watcher and trigger a re-generation of the file when there's a change in either:
  * `llms_txt_selection_mode`
  * `about_us_page`
  * `contact_page`
  * `terms_page`
  * `privacy_policy_page`
  * `shop_page`
  * `other_included_pages`
* the `other_included_pages` one is an array with maximum 100 elements. this means that with every save of the `wpseo_llmstxt` option, there's going to be a comparison of two arrays with 100 elements each. the current technical conclusion is that we can live with that
* an alternative approach was considered (mostly to avoid comparing two arrays of 100 elements each, every time we save the `wpseo_llmstxt` option), but was rejected. Adding it here for completeness sake
  * have a hidden field in the llms.txt where we would save a timestamp every time an option in that settings page was changed
  * that timestamp would refer to a new sub-setting of the `wpseo_llmstxt` option, so that would be updated every time a llms.txt setting was changed
  * the watcher would then have to only compare that timestamp instead of all the sub-settings above, so a much faster comparison
* reasons the first approach was picked:
  * much cleaner
  * the overhead of comparing two 100-element arrays was deemed insignificant, both because of the size and because it would be triggered only when the `wpseo_llmstxt` option is specifically saved

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have the llms.txt feature enabled
* Change anything in the llms.txt setting page and confirm that the file was immediately regenerated with the new settings
  * that includes changes in the `llms.txt page selection` setting (auto/manual) and changes in any of the pages dropdown below, so please test all
  * for the content pages specifically, check both adding a page, removing a page, or replacing a page with a different page
* Delete the llms.txt file
* Save any setting outside the llms.txt settings page and confirm that the file didnt get re-generated
* Change any llms.txt setting but before saving disable the feature
* Confirm that the file didnt get re-generated

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
