### PR TITLE
2421 major on a toast for product unlock with woo seo should be displayed

### DIFF
--- a/packages/js/src/ai-generator/components/feature-error.js
+++ b/packages/js/src/ai-generator/components/feature-error.js
@@ -16,13 +16,15 @@ import { UsageCountError } from "./usage-count-error";
  */
 export const FeatureError = ( { currentSubscriptions, isSeoAnalysisActive = true } ) => {
 	const { postType } = useTypeContext();
-	const { isPremium, isWooCommerceActive, usageCountStatus, usageCountError } = useSelect( ( select ) => {
+	const { isPremium, isWooCommerceActive, usageCountStatus, usageCountError, isProductEntity, isWooSeoActive } = useSelect( ( select ) => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
 			isPremium: editorSelect.getIsPremium(),
 			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
 			usageCountStatus: select( STORE_NAME_AI ).selectUsageCountStatus(),
 			usageCountError: select( STORE_NAME_AI ).selectUsageCountError(),
+			isProductEntity: editorSelect.getIsProductEntity(),
+			isWooSeoActive: editorSelect.getIsWooSeoActive(),
 		};
 	}, [] );
 	const missingWooSeo = useMemo( () => {
@@ -30,20 +32,18 @@ export const FeatureError = ( { currentSubscriptions, isSeoAnalysisActive = true
 	}, [ isWooCommerceActive, postType, currentSubscriptions.wooCommerceSubscription ] );
 
 	const invalidSubscriptions = useMemo( () => {
-		if ( ! isPremium ) {
-			return [];
-		}
 		const subscriptions = [];
-		if ( ! currentSubscriptions.premiumSubscription ) {
+
+		if ( isPremium && ! currentSubscriptions.premiumSubscription && ! isProductEntity ) {
 			subscriptions.push( "Yoast SEO Premium" );
 		}
 
-		if ( missingWooSeo ) {
+		if ( missingWooSeo && isWooSeoActive ) {
 			subscriptions.push( "Yoast WooCommerce SEO" );
 		}
 
 		return subscriptions;
-	}, [ isPremium, currentSubscriptions.premiumSubscription, missingWooSeo, currentSubscriptions.wooCommerceSubscription ] );
+	}, [ isPremium, currentSubscriptions.premiumSubscription, missingWooSeo, isWooSeoActive, isProductEntity ] );
 
 	if ( invalidSubscriptions.length > 0 ) {
 		return <SubscriptionError invalidSubscriptions={ invalidSubscriptions } />;

--- a/packages/js/src/ai-generator/components/sparks-limit-notification.js
+++ b/packages/js/src/ai-generator/components/sparks-limit-notification.js
@@ -91,7 +91,15 @@ const SparksLimitUpsellContent = ( {
  * @returns {JSX.Element} The element.
  */
 export const SparksLimitNotification = ( { className = "" } ) => {
-	const { isUsageCountLimitReached, usageCount, usageCountLimit, isPremium, upsellLink } = useSelect( ( select ) => {
+	const {
+		isUsageCountLimitReached,
+		usageCount,
+		usageCountLimit,
+		isPremium,
+		premiumUpsellLink,
+		wooUpsellLink,
+		isProductEntity,
+	} = useSelect( ( select ) => {
 		const aiSelect = select( STORE_NAME_AI );
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return ( {
@@ -99,7 +107,9 @@ export const SparksLimitNotification = ( { className = "" } ) => {
 			usageCount: aiSelect.selectUsageCount(),
 			usageCountLimit: aiSelect.selectUsageCountLimit(),
 			isPremium: editorSelect.getIsPremium(),
-			upsellLink: editorSelect.selectLink( "https://yoa.st/ai-toast-out-of-free-sparks" ),
+			premiumUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-toast-out-of-free-sparks" ),
+			wooUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-toast-out-of-free-sparks-woo" ),
+			isProductEntity: editorSelect.getIsProductEntity(),
 		} );
 	}, [] );
 	const [ showNotification, , setShowNotification, , hideNotification ] = useToggleState( usageCount === usageCountLimit );
@@ -109,6 +119,13 @@ export const SparksLimitNotification = ( { className = "" } ) => {
 		const showNotificationFree = ! isPremium && isUsageCountLimitReached;
 		setShowNotification( showNotificationPremium || showNotificationFree );
 	}, [ usageCount, usageCountLimit ] );
+
+	const upsellLink = isProductEntity ? wooUpsellLink : premiumUpsellLink;
+	const upsellLabel = sprintf(
+		/* translators: %1$s expands to Yoast SEO Premium. */
+		__( "Unlock with %1$s", "wordpress-seo" ),
+		isProductEntity ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
+	);
 
 	return showNotification && (
 		<Notifications.Notification
@@ -133,7 +150,7 @@ export const SparksLimitNotification = ( { className = "" } ) => {
 		>
 			{ isPremium
 				? <SparksLimitContent onClose={ hideNotification } />
-				: <SparksLimitUpsellContent onClose={ hideNotification } upsellLink={ upsellLink } />
+				: <SparksLimitUpsellContent onClose={ hideNotification } upsellLink={ upsellLink } upsellLabel={ upsellLabel } />
 			}
 		</Notifications.Notification>
 	);

--- a/packages/js/src/ai-generator/components/sparks-limit-notification.js
+++ b/packages/js/src/ai-generator/components/sparks-limit-notification.js
@@ -46,7 +46,7 @@ const SparksLimitUpsellContent = ( {
 		<>
 			<p className={ CLASSNAMES.paragraph }>
 				{ sprintf(
-					/* translators: %s expands to Yoast SEO Premium. */
+					/* translators: %s expands to Yoast SEO Premium or Yoast WooCommerce SEO. */
 					__( "Keep the momentum going, unlock unlimited sparks with %s!", "wordpress-seo" ),
 					isProductEntity ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 				) }
@@ -67,7 +67,7 @@ const SparksLimitUpsellContent = ( {
 				>
 					<LockOpenIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-me-2 yst-shrink-0" { ...svgAriaProps } />
 					{ sprintf(
-						/* translators: %1$s expands to Yoast SEO Premium. */
+						/* translators: %1$s expands to Yoast SEO Premium or Yoast WooCommerce SEO. */
 						__( "Unlock with %1$s", "wordpress-seo" ),
 						isProductEntity ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 					) }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the Spark limit notification upsell message and button label on a WooCommerce product.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install woocommerce and create a product.
* Edit a product and use the ai generator ( You can use this patch on local environment [notification-spark-limit.patch](https://github.com/user-attachments/files/21311436/notification-spark-limit.patch)).
* Once you reach the limit, check you see the limit notification with the message and upsell button for Yoast Woocommerce SEO.
<img width="473" height="315" alt="Screenshot 2025-07-18 at 09 58 29" src="https://github.com/user-attachments/assets/f6b54fdb-a9f6-4b26-aa23-86e5c63e1e6d" />

* Repeat the steps for regular post and check you see the Premium message and button upsell.


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [[Major] On a toast for product Unlock with Woo SEO should be displayed](https://github.com/Yoast/plugins-automated-testing/issues/2421)
