### PR TITLE
Remove bundle related props from a upsell

### DIFF
--- a/packages/js/src/ai-generator/components/upsell-modal-content.js
+++ b/packages/js/src/ai-generator/components/upsell-modal-content.js
@@ -19,7 +19,6 @@ import classNames from "classnames";
 export const UpsellModalContent = ( { onActivateFreeSparks } ) => {
 	const {
 		premiumUpsellLink,
-		bundleUpsellLink,
 		wooUpsellLink,
 		isWooCommerceActive,
 		isProductPost,
@@ -34,7 +33,6 @@ export const UpsellModalContent = ( { onActivateFreeSparks } ) => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
 			premiumUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell" ),
-			bundleUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell-woo-seo-premium-bundle" ),
 			wooUpsellLink: editorSelect.selectLink( "https://yoa.st/ai-generator-upsell-woo-seo" ),
 			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
 			isProductPost: editorSelect.getIsProduct(),
@@ -53,9 +51,8 @@ export const UpsellModalContent = ( { onActivateFreeSparks } ) => {
 		upsellLabel,
 		upsellLink,
 		ctbId,
-		bundleNote,
 		newToText,
-	} = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink, bundle: bundleUpsellLink } );
+	} = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink } );
 	const isProductCopy = useMemo( () => isWooCommerceActive && isProductPost,
 		[ isWooCommerceActive, isProductPost ] );
 
@@ -178,7 +175,6 @@ export const UpsellModalContent = ( { onActivateFreeSparks } ) => {
 					{ __( "Try for free", "wordpress-seo" ) }
 				</GradientButton> }
 			</div>
-			{ bundleNote }
 			<Button
 				as="a"
 				className="yst-mt-4"

--- a/packages/js/src/ai-generator/hooks/use-upsell-props.js
+++ b/packages/js/src/ai-generator/hooks/use-upsell-props.js
@@ -9,7 +9,6 @@ import { STORE_NAME_EDITOR } from "../constants";
  * @property {string} upsellLink The URL for the upsell.
  * @property {string} [upsellLabel] The label for the upsell.
  * @property {string} [newToText] The "new to" text for the upsell.
- * @property {React.ReactNode} [bundleNote] A note about the bundle upsell.
  * @property {string} [ctbId] The CTB ID for the upsell.
  */
 
@@ -18,15 +17,12 @@ import { STORE_NAME_EDITOR } from "../constants";
  * @param {Object} upsellLinks An object containing the upsell links and their associated data.
  * @param {string} upsellLinks.premium The Yoast SEO Premium upsell link .
  * @param {string} upsellLinks.woo The Yoast WooCommerce SEO upsell link.
- * @param {string} upsellLinks.bundle The bundle upsell link.
  * @returns {UpsellProps} The upsell props.
  */
 export const useUpsellProps = ( upsellLinks ) => {
-	const { isPremiumActive, isWooSeoActive, isWooCommerceActive, isProductEntity, isProductPost } = useSelect( select => {
+	const { isWooCommerceActive, isProductEntity, isProductPost } = useSelect( select => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
-			isPremiumActive: editorSelect.getIsPremium(),
-			isWooSeoActive: editorSelect.getIsWooSeoActive(),
 			isWooCommerceActive: editorSelect.getIsWooCommerceActive(),
 			isProductEntity: editorSelect.getIsProductEntity(),
 			isProductPost: editorSelect.getIsProduct(),
@@ -42,58 +38,36 @@ export const useUpsellProps = ( upsellLinks ) => {
 				"Yoast SEO Premium"
 			),
 			newToText: "Yoast SEO Premium",
-			bundleNote: "",
 			ctbId: "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 			title: __( "Use AI to generate your titles & descriptions!", "wordpress-seo" ),
 		};
 
 		// Use specific copy for product posts and terms, otherwise revert to the defaults.
 		if ( isWooCommerceActive && isProductEntity ) {
-			const upsellPremiumWooLabel = sprintf(
-				/* translators: %1$s expands to Yoast SEO Premium, %2$s expands to Yoast WooCommerce SEO. */
-				__( "%1$s + %2$s", "wordpress-seo" ),
-				"Yoast SEO Premium",
-				"Yoast WooCommerce SEO"
-			);
 			if ( isProductPost ) {
 				upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
 			}
 			upsellProps.newToText = sprintf(
 				/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
 				__( "New in %1$s", "wordpress-seo" ),
-				upsellPremiumWooLabel
+				"Yoast WooCommerce SEO"
 			);
 
-			if ( isPremiumActive ) {
-				upsellProps.upsellLabel = sprintf(
-					/* translators: %1$s expands to Yoast WooCommerce SEO. */
-					__( "Unlock with %1$s", "wordpress-seo" ),
-					"Yoast WooCommerce SEO"
-				);
-				upsellProps.upsellLink = upsellLinks.woo;
-				upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
-			} else if ( ! isWooSeoActive ) {
-				upsellProps.upsellLabel = `${ sprintf(
-					/* translators: %1$s expands to Woo Premium bundle. */
-					__( "Unlock with the %1$s", "wordpress-seo" ),
-					"Woo Premium bundle"
-				) }*`;
-				upsellProps.bundleNote = <div className="yst-text-xs yst-text-slate-500 yst-mt-2">
-					{ `*${ upsellPremiumWooLabel }` }
-				</div>;
-				upsellProps.upsellLink = upsellLinks.bundle;
-				upsellProps.ctbId = "c7e7baa1-2020-420c-a427-89701700b607";
-			}
+			upsellProps.upsellLabel = sprintf(
+				/* translators: %1$s expands to Yoast WooCommerce SEO. */
+				__( "Unlock with %1$s", "wordpress-seo" ),
+				"Yoast WooCommerce SEO"
+			);
+			upsellProps.upsellLink = upsellLinks.woo;
+			upsellProps.ctbId = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
 		}
 
 		return upsellProps;
 	}, [
-		isPremiumActive,
-		isWooSeoActive,
 		isWooCommerceActive,
 		isProductEntity,
+		isProductPost,
 		upsellLinks.premium,
 		upsellLinks.woo,
-		upsellLinks.bundle,
 	] );
 };

--- a/packages/js/src/ai-generator/hooks/use-upsell-props.js
+++ b/packages/js/src/ai-generator/hooks/use-upsell-props.js
@@ -47,11 +47,7 @@ export const useUpsellProps = ( upsellLinks ) => {
 			if ( isProductPost ) {
 				upsellProps.title = __( "Generate product titles & descriptions with AI!", "wordpress-seo" );
 			}
-			upsellProps.newToText = sprintf(
-				/* translators: %1$s expands to Yoast SEO Premium and Yoast WooCommerce SEO. */
-				__( "New in %1$s", "wordpress-seo" ),
-				"Yoast WooCommerce SEO"
-			);
+			upsellProps.newToText = "Yoast WooCommerce SEO";
 
 			upsellProps.upsellLabel = sprintf(
 				/* translators: %1$s expands to Yoast WooCommerce SEO. */

--- a/packages/js/src/ai-optimizer/components/modal-content.js
+++ b/packages/js/src/ai-optimizer/components/modal-content.js
@@ -10,7 +10,6 @@ import { AIOptimizeUpsell } from "../../shared-admin/components";
 export const ModalContent = () => {
 	const {
 		premiumUpsellLink,
-		bundleUpsellLink,
 		wooUpsellLink,
 		learnMoreLink,
 		imageLink,
@@ -20,7 +19,6 @@ export const ModalContent = () => {
 		const storeSelect = select( STORE_NAME_EDITOR );
 		return {
 			premiumUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell" ),
-			bundleUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo-premium-bundle" ),
 			wooUpsellLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-woo-seo" ),
 			learnMoreLink: storeSelect.selectLink( "https://yoa.st/ai-fix-assessments-upsell-learn-more" ),
 			imageLink: storeSelect.selectImageLink( "ai-fix-assessments-thumbnail.png" ),
@@ -29,7 +27,7 @@ export const ModalContent = () => {
 		};
 	}, [] );
 
-	const upsellProps = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink, bundle: bundleUpsellLink } );
+	const upsellProps = useUpsellProps( { premium: premiumUpsellLink, woo: wooUpsellLink } );
 
 	const thumbnail = useMemo( () => ( {
 		src: imageLink,

--- a/packages/js/src/shared-admin/components/ai-optimize-upsell.js
+++ b/packages/js/src/shared-admin/components/ai-optimize-upsell.js
@@ -13,7 +13,6 @@ import { OutboundLink, VideoFlow } from ".";
  * @param {string} upsellLink The upsell link.
  * @param {string} upsellLabel The upsell label.
  * @param {string} newToText The new to text.
- * @param {string|JSX.Element} bundleNote The bundle note.
  * @param {string} ctbId The click to buy to register for this upsell instance.
  * @returns {JSX.Element} The element.
  */
@@ -24,7 +23,6 @@ export const AIOptimizeUpsell = ( {
 	upsellLink,
 	upsellLabel,
 	newToText,
-	bundleNote,
 	ctbId,
 } ) => {
 	const { onClose, initialFocus } = useModalContext();
@@ -109,7 +107,6 @@ export const AIOptimizeUpsell = ( {
 						</span>
 					</Button>
 				</div>
-				{ bundleNote }
 				<Button
 					as="a"
 					className="yst-mt-4"
@@ -137,10 +134,6 @@ AIOptimizeUpsell.propTypes = {
 	} ).isRequired,
 	upsellLabel: PropTypes.string,
 	newToText: PropTypes.string,
-	bundleNote: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.element,
-	] ),
 	ctbId: PropTypes.string,
 };
 
@@ -151,6 +144,5 @@ AIOptimizeUpsell.defaultProps = {
 		"Yoast SEO Premium"
 	),
 	newToText: "Yoast SEO Premium",
-	bundleNote: "",
 	ctbId: "f6a84663-465f-4cb5-8ba5-f7a6d72224b2",
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the bundle upsell for Yoast SEO premium and Yoast WooCommerce SEO.

## Relevant technical choices:


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have no premium or woo seo activated.
* Make sure you didn't click on the upsell button before and you have no subscriptions active ( you can use this patch on local environment, [9-sparks-no-subscription-unseen-upsell.patch](https://github.com/user-attachments/files/21342595/9-sparks-no-subscription-unseen-upsell.patch)). 
  * Note: if you want to use the actual plugins / licenses you should update the code in this patch and rebuild JS
* Edit a product and click on "Use AI".
* Check you get an upsell for the Yoast WooCommerce SEO only:
  * The upsell button should mention Yoast WooCommerce SEO
  * Check the "New to" in the comment is missing and it says: `Yoast WooCommerce SEO`
* Activate premium and repeat the tests above.
<img width="697" height="834" alt="Screenshot 2025-07-21 at 10 52 52" src="https://github.com/user-attachments/assets/e4771d12-22d2-4146-a644-0ac54043edd2" />

* Deactivate premium
* Edit a post and click on "Use AI"
* Check you get an upsell for the Yoast SEO Premium only:
  * The upsell button should mention Yoast SEO Premium
  * Check the "New to" in the comment is missing and it says: `Yoast SEO Premium`
<img width="703" height="842" alt="Screenshot 2025-07-21 at 10 53 29" src="https://github.com/user-attachments/assets/51baa7b2-62fe-499e-9c38-0cf361368c00" />

* Set a focus keyphrase that is not in the the introduction and click on the spark button in the SEO analysis.
* Check you see an upsell for premium
<img width="540" height="593" alt="image" src="https://github.com/user-attachments/assets/7066a505-a3dd-49f9-9634-51889934a21a" />

Smoke test the ai optimize upsell modal.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* AI optimize upsell modal. Smoke test the ai optmize upsell on a post to make sure it says "Yoast SEO Premium".

## UI changes

* [X] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Remove "bundle" option from ai generator upsell modal](https://github.com/Yoast/reserved-tasks/issues/679)
