### PR TITLE
Show focus keyphrase error message without ai consent

### DIFF
--- a/packages/js/src/ai-generator/initialize/filter-focus-keyphrase-errors.js
+++ b/packages/js/src/ai-generator/initialize/filter-focus-keyphrase-errors.js
@@ -1,6 +1,4 @@
 import { isConsideredEmpty } from "../helpers";
-import { select as wpSelect } from "@wordpress/data";
-import { STORE_NAME_AI } from "../constants";
 import { __ } from "@wordpress/i18n";
 
 let hasInteractedWithFeature = false;
@@ -24,8 +22,8 @@ export const updateInteractedWithFeature = () => {
  * @returns {string[]} The errors.
  */
 export const filterFocusKeyphraseErrors = ( errors, focusKeyphrase ) => {
-	if ( ! hasInteractedWithFeature || ! wpSelect( STORE_NAME_AI ).selectHasAiGeneratorConsent() ) {
-		// No interaction or consent: don't adjust the errors.
+	if ( ! hasInteractedWithFeature ) {
+		// No interaction: don't adjust the errors.
 		return errors;
 	}
 


### PR DESCRIPTION
We want to check the error message before asking for consent.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Show error message for the missing focus keyphrase before giving consent for the ai feature. 

## Relevant technical choices:

* We decided to do that before consent because we have the upsell before the consent and we want to reduce steps between the upsell modal appears and the ai generator modal.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you revoked consent or didn't grant it for the ai feature.
* Edit a post without focus keyphrase.
* Click on "Use AI" button.
* Check you the focus is on the focus keyphrase field and there is an error message:
<img width="687" height="183" alt="Screenshot 2025-07-18 at 11 33 02" src="https://github.com/user-attachments/assets/f64fa738-738e-48cd-9251-f7dbb6ecfef8" />


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [[Major]25.6: Validation msg for keyphrase is not displayed on Use AI](https://github.com/Yoast/plugins-automated-testing/issues/2420)
