### PR TITLE
remove budle upsell link from the subscription error

### DIFF
--- a/packages/js/src/ai-generator/components/errors/subscription-error.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-error.js
@@ -13,27 +13,16 @@ import { STORE_NAME_EDITOR } from "../../constants";
  * @returns {JSX.Element} The element.
  */
 export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
-	const activatePremiumLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-activate-premium" ),
-		[]
-	);
-	const newPremiumLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-new-premium" ),
-		[] );
-	const activateYoastWooLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-activate-yoast-woocommerce" ),
-		[]
-	);
-	const newYoastWooLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-new-yoast-woocommerce" ),
-		[] );
-	const activatePremiumWooBundleLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-activate-woocommerce-premium-bundle" ),
-		[]
-	);
-	const newPremiumWooBundleLink = useSelect(
-		select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-new-woocommerce-premium-bundle" ),
-		[] );
+	const { newYoastWooLink, activateYoastWooLink, newPremiumLink, activatePremiumLink } = useSelect( ( select ) => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			newYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-yoast-woocommerce" ),
+			activateYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-yoast-woocommerce" ),
+			newPremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-premium" ),
+			activatePremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-premium" ),
+		};
+	}, [] );
+
 	const { onClose } = useModalContext();
 
 	const handleRefresh = useCallback( async() => {
@@ -52,80 +41,46 @@ export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
 	let addonProduct;
 	let activateSubscriptionLink;
 	let newSubscriptionLink;
-	if ( invalidSubscriptions.length === 1 ) {
-		addonProduct = invalidSubscriptions[ 0 ];
-		activateSubscriptionLink = addonProduct === "Yoast SEO Premium"
-			? activatePremiumLink
-			: activateYoastWooLink;
-		newSubscriptionLink = addonProduct === "Yoast SEO Premium"
-			? newPremiumLink
-			: newYoastWooLink;
+	if ( invalidSubscriptions.includes( "Yoast WooCommerce SEO" ) ) {
+		addonProduct = "Yoast WooCommerce SEO";
+		activateSubscriptionLink = activateYoastWooLink;
+		newSubscriptionLink = newYoastWooLink;
+	} else if ( invalidSubscriptions.includes( "Yoast SEO Premium" ) ) {
+		addonProduct = "Yoast SEO Premium";
+		activateSubscriptionLink = activatePremiumLink;
+		newSubscriptionLink = newPremiumLink;
 	}
-
-
-	const errorMessageNoPremiumOrWoo = safeCreateInterpolateElement(
-		sprintf(
-			/**
-			 * translators:
-			 * %1$s expands to Yoast SEO Premium or Yoast WooCommerce SEO.
-			 * %2$s expands to MyYoast.
-			 * %3$s and %4$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
-			 * %5$s and %6$s expand to an opening and closing anchor tag, respectively, to get a new subscription.
-			 **/
-			__(
-				"To access this feature, you need an active %1$s subscription. Please %3$sactivate your subscription in %2$s%4$s or %5$sget a new %1$s subscription%6$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
-				"wordpress-seo"
-			),
-			addonProduct,
-			"MyYoast",
-			"<Activate>",
-			"</Activate>",
-			"<New>",
-			"</New>"
-		),
-		{
-			Activate: <OutboundLink variant="error" href={ activateSubscriptionLink } />,
-			New: <OutboundLink variant="error" href={ newSubscriptionLink } />,
-		}
-	);
-
-	const errorMessageNoPremiumAndWoo = safeCreateInterpolateElement(
-		sprintf(
-			/**
-			 * translators:
-			 * %1$s expands to MyYoast.
-			 * %2$s expands to Yoast SEO Premium.
-			 * %3$s expands to Yoast WooCommerce SEO.
-			 * %4$s expands to Yoast WooCommerce SEO Premium bundle.
-			 * %5$s and %6$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
-			 * %7$s and %8$s expand to an opening and closing anchor tag, respectively, to get a new subscription.
-			 **/
-			__(
-				"To access this feature, you need active %2$s and %3$s subscriptions. Please %5$sactivate your subscriptions in %1$s%6$s or %7$sget a new %4$s%8$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
-				"wordpress-seo"
-			),
-			"MyYoast",
-			"Yoast SEO Premium",
-			"Yoast WooCommerce SEO",
-			"Yoast WooCommerce SEO Premium bundle",
-			"<Activate>",
-			"</Activate>",
-			"<New>",
-			"</New>"
-		),
-		{
-			Activate: <OutboundLink variant="error" href={ activatePremiumWooBundleLink } />,
-			New: <OutboundLink variant="error" href={ newPremiumWooBundleLink } />,
-		}
-	);
 
 	return (
 		<Fragment>
 			<Alert variant="error">
 				<span className="yst-block yst-font-medium">{ __( "Subscription required", "wordpress-seo" ) }</span>
 				<p className="yst-mt-2">
-					{ invalidSubscriptions.length === 1 && errorMessageNoPremiumOrWoo }
-					{ invalidSubscriptions.length > 1 && errorMessageNoPremiumAndWoo }
+					{ safeCreateInterpolateElement(
+						sprintf(
+							/**
+							 * translators:
+							 * %1$s expands to Yoast SEO Premium or Yoast WooCommerce SEO.
+							 * %2$s expands to MyYoast.
+							 * %3$s and %4$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
+							 * %5$s and %6$s expand to an opening and closing anchor tag, respectively, to get a new subscription.
+							 **/
+							__(
+								"To access this feature, you need an active %1$s subscription. Please %3$sactivate your subscription in %2$s%4$s or %5$sget a new %1$s subscription%6$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
+								"wordpress-seo"
+							),
+							addonProduct,
+							"MyYoast",
+							"<Activate>",
+							"</Activate>",
+							"<New>",
+							"</New>"
+						),
+						{
+							Activate: <OutboundLink variant="error" href={ activateSubscriptionLink } />,
+							New: <OutboundLink variant="error" href={ newSubscriptionLink } />,
+						}
+					) }
 				</p>
 			</Alert>
 			<div className="yst-mt-6 yst-mb-1 yst-flex yst-space-x-3 rtl:yst-space-x-reverse yst-place-content-end">
@@ -141,5 +96,5 @@ export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
 };
 
 SubscriptionError.propTypes = {
-	invalidSubscriptions: PropTypes.array,
+	invalidSubscriptions: PropTypes.arrayOf( PropTypes.string ),
 };


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes the Yoast WooCommerce SEO and Premium bundle upsell link from the `AI Generate` subscription error modal.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you don't have premium and woo seo license.
* Install and activate Woocommerce.
* Install and activate Woo seo and premium.
* Edit a product and click on the "Use AI" button. 
* Check you get the error message with an upsell link only for woo SEO.
* Enable subscription for Woo SEO.
* Click on Use AI, and check you are getting an subscription error for Premium.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Remove bundle link from AI subscription error](https://github.com/Yoast/reserved-tasks/issues/686)
