### PR TITLE
fix: styles for redirects page

### DIFF
--- a/css/src/redirects.css
+++ b/css/src/redirects.css
@@ -112,6 +112,13 @@ body.seo_page_wpseo_redirects {
 		.yst-dropdown-menu__item--button {
 			@apply yst-text-slate-600 hover:yst-text-slate-900 hover:yst-bg-slate-200 yst-justify-start yst-py-2 yst-px-3;
 		}
+
+		.yst-dropdown-menu__list {
+			z-index: 1100 !important;
+		}
+	}
+	.yst-modal__panel{
+		@apply yst-max-w-lg;
 	}
 
 	/* RTL */

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -99,11 +99,6 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			return;
 		}
 
-		// Don't show on redirects page.
-		if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpseo-redirects' ) {
-			return;
-		}
-
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 		$title    = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();

--- a/src/integrations/admin/first-time-configuration-notice-integration.php
+++ b/src/integrations/admin/first-time-configuration-notice-integration.php
@@ -99,6 +99,11 @@ class First_Time_Configuration_Notice_Integration implements Integration_Interfa
 			return;
 		}
 
+		// Don't show on redirects page.
+		if ( isset( $_GET['page'] ) && $_GET['page'] === 'wpseo-redirects' ) {
+			return;
+		}
+
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
 
 		$title    = $this->first_time_configuration_notice_helper->get_first_time_configuration_title();

--- a/tests/Unit/Integrations/Admin/Redirects_Page_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Redirects_Page_Integration_Test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\Premium_Inactive_Conditional;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Redirects_Page_Integration;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -26,6 +27,13 @@ final class Redirects_Page_Integration_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Represents the current page helper.
+	 *
+	 * @var Current_Page_Helper|Mockery\Mock
+	 */
+	protected $current_page_helper;
+
+	/**
 	 * Set up the fixtures for the tests.
 	 *
 	 * @return void
@@ -33,7 +41,9 @@ final class Redirects_Page_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new Redirects_Page_Integration();
+		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
+
+		$this->instance = new Redirects_Page_Integration( $this->current_page_helper );
 	}
 
 	/**
@@ -61,8 +71,19 @@ final class Redirects_Page_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_register_hooks() {
+		$this->current_page_helper->expects( 'get_current_yoast_seo_page' )
+			->andReturn( Redirects_Page_Integration::PAGE );
 		$this->instance->register_hooks();
-		$this->assertNotFalse( Monkey\Filters\has( 'wpseo_submenu_pages', [ $this->instance, 'add_submenu_page' ] ), 'Does not have expected wpseo_submenu_pages filter' );
+		$this->assertNotFalse(
+			Monkey\Filters\has(
+				'wpseo_submenu_pages',
+				[
+					$this->instance,
+					'add_submenu_page',
+				]
+			),
+			'Does not have expected wpseo_submenu_pages filter'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context
Fixed styles for redirect page

*



## Relevant technical choices:

*


## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
