### PR TITLE
Set the minimum supported WordPress version to 6.7

### DIFF
--- a/.github/workflows/finish-coveralls.yml
+++ b/.github/workflows/finish-coveralls.yml
@@ -105,5 +105,5 @@ jobs:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
-          carryforward: "unit-php-7.4,unit-php-8.3,php-7.4-wp-6.6-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
+          carryforward: "unit-php-7.4,unit-php-8.3,php-7.4-wp-6.7-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
           parallel-finished: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
       matrix:
         include:
           - php_version: "7.4"
-            wp_version: "6.6"
+            wp_version: "6.7"
             multisite: true
             coverage: true
 
@@ -153,17 +153,17 @@ jobs:
             coverage: false
 
           - php_version: "8.0"
-            wp_version: "6.6"
+            wp_version: "6.7"
             multisite: false
             coverage: false
 
           - php_version: '8.1'
-            wp_version: '6.6'
+            wp_version: '6.7'
             multisite: true
             coverage: false
 
           - php_version: '8.2'
-            wp_version: '6.6'
+            wp_version: '6.7'
             multisite: true
             coverage: false
 

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -583,7 +583,7 @@ final class Addon_Manager_Test extends TestCase {
 
 		// Now check that the Premium plugin won't show updates, if the requirement for the WP version coming from Yoast free, is not met.
 		if ( isset( $addons['wp-seo-premium.php'] ) ) {
-			$wp_version = '6.5';
+			$wp_version = '6.6';
 			$updates    = $this->instance->check_for_updates( $data );
 
 			$this->assertTrue( isset( $updates->no_update['wp-seo-premium.php'] ) );

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -41,7 +41,7 @@ if ( ! \defined( 'WPSEO_BASENAME' ) ) {
 
 \define( 'YOAST_SEO_PHP_REQUIRED', '7.4' );
 \define( 'YOAST_SEO_WP_TESTED', '6.8.2' );
-\define( 'YOAST_SEO_WP_REQUIRED', '6.6' );
+\define( 'YOAST_SEO_WP_REQUIRED', '6.7' );
 
 if ( ! \defined( 'WPSEO_NAMESPACES' ) ) {
 	\define( 'WPSEO_NAMESPACES', true );

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -36,7 +36,7 @@ define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 define( 'YOAST_SEO_PHP_REQUIRED', '7.4' );
 define( 'YOAST_SEO_WP_TESTED', '6.8.2' );
-define( 'YOAST_SEO_WP_REQUIRED', '6.6' );
+define( 'YOAST_SEO_WP_REQUIRED', '6.7' );
 
 if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
 	define( 'WPSEO_NAMESPACES', true );

--- a/wp-seo.php
+++ b/wp-seo.php
@@ -16,7 +16,7 @@
  * Text Domain: wordpress-seo
  * Domain Path: /languages/
  * License:     GPL v3
- * Requires at least: 6.6
+ * Requires at least: 6.7
  * Requires PHP: 7.4
  *
  * WC requires at least: 7.1


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Template PR: https://github.com/Yoast/wordpress-seo/pull/22035

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the minimum supported WordPress version to 6.7.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/698
