### PR TITLE
25.5-Google docs introduction model has react warnings in the console #2395

### DIFF
--- a/packages/js/src/introductions/components/provider.js
+++ b/packages/js/src/introductions/components/provider.js
@@ -27,8 +27,6 @@ export const IntroductionProvider = ( { children, initialComponents } ) => {
 	const registerComponent = useCallback( ( id, Component ) => {
 		const introduction = find( introductions, { id } );
 		if ( ! introduction ) {
-			// Bail when unknown.
-			console.error( "Warning: Introductions received a registration for an unknown key:", id );
 			return;
 		}
 		setComponents( currentComponents => ( { ...currentComponents, [ id ]: Component } ) );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fix AI Optimize react warning message in console for upsell modal displayed in Yoast admin.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a console warning message triggered by the introductions in the Yoast admin page.

## Relevant technical choices:

* Remove warning message if introduction is not present in php code but we have it in JS code.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Check that console warning is not displayed
* Have Free and Premium activated. 
* go to the` wp-config.php` file of your test site (as explained in the [DoD](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2464809024/CR+Acceptance+testing+DoD)) and add the following PHP constant to the file: 
`if ( ! defined( 'SCRIPT_DEBUG' ) ) {
    define( 'SCRIPT_DEBUG', true );
}` 
* Open the database for your test site in any sql editor or use wp db query wp-cli command and remove _yoast_wpseo_introductions meta_key from wp_usermeta table:

DELETE FROM `wp_usermeta` WHERE `meta_key` = '_yoast_wpseo_introductions'
![image](https://github.com/user-attachments/assets/3039830a-ca4f-4354-a74c-96b284283ccb)

* Go to the Yoast SEO admin tab. with the dev. tools console open. 
* Confirm that you see an introduction modal. 
* Check the console and confirm warning message is not displayed:

<img width="628" height="45" alt="image" src="https://github.com/user-attachments/assets/1cb59928-f73e-4544-9a0a-2c24dd39728b" />

#### Check that AI Optimize introduction modal is displayed
* Have Free and Premium activated. 
* go to the` wp-config.php` file of your test site (as explained in the [DoD](https://yoast.atlassian.net/wiki/spaces/LIN/pages/2464809024/CR+Acceptance+testing+DoD)) and add the following PHP constant to the file: 
`if ( ! defined( 'SCRIPT_DEBUG' ) ) {
    define( 'SCRIPT_DEBUG', true );
}` 
* Open the database for your test site in any sql editor or use wp db query wp-cli command and remove _yoast_wpseo_introductions meta_key from wp_usermeta table:

DELETE FROM `wp_usermeta` WHERE `meta_key` = '_yoast_wpseo_introductions'
![image](https://github.com/user-attachments/assets/3039830a-ca4f-4354-a74c-96b284283ccb)

* Create any post
* Confirm that you see an AI Optimize introduction modal:
<img width="388" height="137" alt="image" src="https://github.com/user-attachments/assets/ccabda3b-a6b5-47fb-8b7a-43163027648b" />

* Check the console and confirm warning message **Warning: Introductions received a registration for an unknown key: ai-optimize-classic** is not displayed. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Should not impact any other place

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#2395](https://github.com/Yoast/plugins-automated-testing/issues/2395)
