### PR TITLE
Free: Replace `interpolate-components` dependency

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "@wordpress/a11y": "^1.1.3",
     "@wordpress/i18n": "^1.2.3",
+    "@wordpress/element": "^6.8.1",
     "@yoast/helpers": "^0.17.0-alpha.1",
     "@yoast/style-guide": "^0.14.0-alpha.0",
-    "interpolate-components": "^1.1.1",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^18.2.0",

--- a/packages/components/src/LanguageNotice.js
+++ b/packages/components/src/LanguageNotice.js
@@ -1,12 +1,9 @@
-/* External dependencies */
-import React, { PureComponent } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
-import interpolateComponents from "interpolate-components";
-
-/* Internal dependencies */
 import { makeOutboundLink } from "@yoast/helpers";
+import PropTypes from "prop-types";
+import React, { PureComponent } from "react";
+import styled from "styled-components";
+import { safeCreateInterpolateElement } from "./safeCreateInterpolateElement";
 
 const YoastLanguageNotice = styled.p`
 	margin: 1em 0;
@@ -50,22 +47,19 @@ export default class LanguageNotice extends PureComponent {
 		let text = sprintf(
 			/* Translators: %s expands to the actual language. */
 			__( "Your site language is set to %s.", "wordpress-seo" ),
-			`{{strong}}${ language }{{/strong}}`
+			`<strong>${ language }</strong>`
 		);
 
 		if ( ! canChangeLanguage ) {
 			text = sprintf(
 				/* Translators: %s expands to the actual language. */
 				__( "Your site language is set to %s. If this is not correct, contact your site administrator.", "wordpress-seo" ),
-				`{{strong}}${ language }{{/strong}}`
+				`<strong>${ language }</strong>`
 			);
 		}
 
 		// Replace the strong marking with an actual ReactComponent.
-		text = interpolateComponents( {
-			mixedString: text,
-			components: { strong: <strong /> },
-		} );
+		text = safeCreateInterpolateElement( text, { strong: <strong /> } );
 
 		return (
 			<YoastLanguageNotice>

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -1,8 +1,8 @@
 // External dependencies.
 import React from "react";
 import PropTypes from "prop-types";
-import interpolateComponents from "interpolate-components";
 import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "./safeCreateInterpolateElement";
 
 // Yoast dependencies.
 import WordOccurrences from "./WordOccurrences";
@@ -25,16 +25,13 @@ const getKeywordResearchArticleLink = ( url ) => {
 			"Read our %1$sultimate guide to keyword research%2$s to learn more about keyword research and keyword strategy.",
 			"wordpress-seo"
 		),
-		"{{a}}",
-		"{{/a}}"
+		"<a>",
+		"</a>"
 	);
 
-	return interpolateComponents( {
-		mixedString: keywordsResearchLinkTranslation,
-		components: {
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			a: <a href={ url } target="_blank" rel="noreferrer" />,
-		},
+	return safeCreateInterpolateElement( keywordsResearchLinkTranslation, {
+		// eslint-disable-next-line jsx-a11y/anchor-has-content
+		a: <a href={ url } target="_blank" rel="noreferrer" />,
 	} );
 };
 

--- a/packages/components/src/safeCreateInterpolateElement.js
+++ b/packages/components/src/safeCreateInterpolateElement.js
@@ -1,0 +1,17 @@
+import { createInterpolateElement } from "@wordpress/element";
+
+/**
+ * Wrapper function for `createInterpolateElement` to catch errors.
+ *
+ * @param {string} interpolatedString The interpolated string.
+ * @param {Object<string, JSX.Element>} conversionMap The conversion map object.
+ * @returns {JSX.Element|string} The interpolated element or string if it failed.
+ */
+export const safeCreateInterpolateElement = ( interpolatedString, conversionMap ) => {
+	try {
+		return createInterpolateElement( interpolatedString, conversionMap );
+	} catch ( error ) {
+		console.error( "Error in translation for:", interpolatedString, error );
+		return interpolatedString;
+	}
+};

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -51,7 +51,6 @@
     "draft-js": "^0.11.7",
     "find-with-regex": "~1.0.2",
     "formik": "^2.2.9",
-    "interpolate-components": "^1.1.0",
     "jed": "^1.1.1",
     "lodash": "^4.17.21",
     "marked": "^0.7.0",

--- a/packages/js/src/components/SchemaTab.js
+++ b/packages/js/src/components/SchemaTab.js
@@ -2,9 +2,9 @@ import { createPortal, Fragment, useCallback, useEffect, useState } from "@wordp
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, FieldGroup, Select } from "@yoast/components";
 import { makeOutboundLink, join } from "@yoast/helpers";
-import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import styled from "styled-components";
+import { safeCreateInterpolateElement } from "../helpers/i18n";
 import WooCommerceUpsell from "./WooCommerceUpsell";
 import { useSelect } from "@wordpress/data";
 
@@ -97,8 +97,8 @@ const footerText = ( postTypeName ) => sprintf(
 	/* translators: %1$s expands to the plural name of the current post type, %2$s and %3$s expand to a link to the Settings page */
 	__( "You can change the default type for %1$s under Content types in the %2$sSettings%3$s.", "wordpress-seo" ),
 	postTypeName,
-	"{{link}}",
-	"{{/link}}"
+	"<link>",
+	"</link>"
 );
 
 /**
@@ -109,12 +109,10 @@ const footerText = ( postTypeName ) => sprintf(
  *
  * @returns {string} A link to the Search Appearance settings.
  */
-const footerWithLink = ( postTypeName, href ) => interpolateComponents(
-	{
-		mixedString: footerText( postTypeName ),
-		// eslint-disable-next-line jsx-a11y/anchor-has-content
-		components: { link: <a href={ href } target="_blank" rel="noreferrer" /> },
-	}
+const footerWithLink = ( postTypeName, href ) => safeCreateInterpolateElement(
+	footerText( postTypeName ),
+	// eslint-disable-next-line jsx-a11y/anchor-has-content
+	{ link: <a href={ href } target="_blank" rel="noreferrer" /> }
 );
 
 /**

--- a/packages/js/src/components/WincherPerformanceReport.js
+++ b/packages/js/src/components/WincherPerformanceReport.js
@@ -6,11 +6,11 @@ import styled from "styled-components";
 import { __, sprintf } from "@wordpress/i18n";
 import { Fragment } from "@wordpress/element";
 import { isEmpty, map } from "lodash";
-import interpolateComponents from "interpolate-components";
 
 /* Yoast dependencies */
 import { makeOutboundLink } from "@yoast/helpers";
 import { Alert, NewButton } from "@yoast/components";
+import { safeCreateInterpolateElement } from "../helpers/i18n";
 
 /* Internal dependencies */
 import WincherNoTrackedKeyphrasesAlert from "./modals/WincherNoTrackedKeyphrasesAlert";
@@ -319,33 +319,30 @@ const TableExplanation = ( { isLoggedIn } ) => {
 	const loggedInMessage = sprintf(
 		/* translators: %s expands to a link to Wincher login */
 		__( "This overview only shows you keyphrases added to Yoast SEO. There may be other keyphrases added to your %s.", "wordpress-seo" ),
-		"{{wincherAccountLink/}}"
+		"<wincherAccountLink/>"
 	);
 
 	const notLoggedInMessage = sprintf(
 		/* translators: %s expands to a link to Wincher login */
 		__( "This overview will show you your top performing keyphrases in Google. Connect with %s to get started.", "wordpress-seo" ),
-		"{{wincherLink/}}"
+		"<wincherLink/>"
 	);
 
 	const message = isLoggedIn ? loggedInMessage : notLoggedInMessage;
 
 	return <p>
 		{
-			interpolateComponents( {
-				mixedString: message,
-				components: {
-					wincherAccountLink: <WincherAccountLink href={ wpseoAdminGlobalL10n[ "links.wincher.login" ] }>
-						{
-							sprintf(
-								/* translators: %s : Expands to "Wincher". */
-								__( "%s account", "wordpress-seo" ),
-								"Wincher"
-							)
-						}
-					</WincherAccountLink>,
-					wincherLink: <WincherLink href={ wpseoAdminGlobalL10n[ "links.wincher.about" ] }>Wincher</WincherLink>,
-				},
+			safeCreateInterpolateElement( message, {
+				wincherAccountLink: <WincherAccountLink href={ wpseoAdminGlobalL10n[ "links.wincher.login" ] }>
+					{
+						sprintf(
+							/* translators: %s : Expands to "Wincher". */
+							__( "%s account", "wordpress-seo" ),
+							"Wincher"
+						)
+					}
+				</WincherAccountLink>,
+				wincherLink: <WincherLink href={ wpseoAdminGlobalL10n[ "links.wincher.about" ] }>Wincher</WincherLink>,
 			} )
 		}
 	</p>;

--- a/packages/js/src/components/modals/WincherExplanation.js
+++ b/packages/js/src/components/modals/WincherExplanation.js
@@ -2,8 +2,8 @@
 
 /* External dependencies */
 import { __, sprintf } from "@wordpress/i18n";
-import interpolateComponents from "interpolate-components";
 import { makeOutboundLink } from "@yoast/helpers";
+import { safeCreateInterpolateElement } from "../../helpers/i18n";
 
 /* Yoast dependencies */
 const WincherLink = makeOutboundLink();
@@ -21,23 +21,20 @@ const WincherExplanation = () => {
 			"With %1$s you can track the ranking position of your page in the search results based on your keyphrase(s). %2$s",
 			"wordpress-seo"
 		),
-		"{{wincherLink/}}",
-		"{{wincherReadMoreLink/}}"
+		"<wincherLink/>",
+		"<wincherReadMoreLink/>"
 	);
 
 	return (
 		<p>
 			{
-				interpolateComponents( {
-					mixedString: message,
-					components: {
-						wincherLink: <WincherLink href={ wpseoAdminGlobalL10n[ "links.wincher.website" ] }>
-							Wincher
-						</WincherLink>,
-						wincherReadMoreLink: <WincherReadMoreLink href={ wpseoAdminL10n[ "shortlinks.wincher.seo_performance" ] }>
-							{ __( "Read more about keyphrase tracking with Wincher", "wordpress-seo" ) }
-						</WincherReadMoreLink>,
-					},
+				safeCreateInterpolateElement( message, {
+					wincherLink: <WincherLink href={ wpseoAdminGlobalL10n[ "links.wincher.website" ] }>
+						Wincher
+					</WincherLink>,
+					wincherReadMoreLink: <WincherReadMoreLink href={ wpseoAdminL10n[ "shortlinks.wincher.seo_performance" ] }>
+						{ __( "Read more about keyphrase tracking with Wincher", "wordpress-seo" ) }
+					</WincherReadMoreLink>,
 				} )
 			}
 		</p>

--- a/packages/js/src/components/modals/WincherLimitReached.js
+++ b/packages/js/src/components/modals/WincherLimitReached.js
@@ -6,8 +6,8 @@ import { __, sprintf } from "@wordpress/i18n";
 /* Yoast dependencies */
 import { makeOutboundLink } from "@yoast/helpers";
 import { Alert } from "@yoast/components";
-import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
+import { safeCreateInterpolateElement } from "../../helpers/i18n";
 
 const UpdateWincherPlanLink = makeOutboundLink();
 
@@ -26,25 +26,22 @@ const WincherLimitReached = ( props ) => {
 			"wordpress-seo"
 		),
 		props.limit,
-		"{{updateWincherPlanLink/}}"
+		"<updateWincherPlanLink/>"
 	);
 
 	return (
 		<Alert type="error">
 			{
-				interpolateComponents( {
-					mixedString: message,
-					components: {
-						updateWincherPlanLink: <UpdateWincherPlanLink href={ wpseoAdminGlobalL10n[ "links.wincher.pricing" ] }>
-							{
-								sprintf(
-									/* translators: %s : Expands to "Wincher". */
-									__( "upgrade your %s plan", "wordpress-seo" ),
-									"Wincher"
-								)
-							}
-						</UpdateWincherPlanLink>,
-					},
+				safeCreateInterpolateElement( message, {
+					updateWincherPlanLink: <UpdateWincherPlanLink href={ wpseoAdminGlobalL10n[ "links.wincher.pricing" ] }>
+						{
+							sprintf(
+								/* translators: %s : Expands to "Wincher". */
+								__( "upgrade your %s plan", "wordpress-seo" ),
+								"Wincher"
+							)
+						}
+					</UpdateWincherPlanLink>,
 				} )
 			}
 		</Alert>

--- a/packages/js/src/components/modals/WincherReconnectAlert.js
+++ b/packages/js/src/components/modals/WincherReconnectAlert.js
@@ -1,10 +1,10 @@
 /* External dependencies */
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
-import interpolateComponents from "interpolate-components";
 
 /* Yoast dependencies */
 import { Alert } from "@yoast/components";
+import { safeCreateInterpolateElement } from "../../helpers/i18n";
 
 /**
  * Creates the content for the Wincher reconnect alert.
@@ -20,32 +20,29 @@ const WincherReconnectAlert = ( props ) => {
 			"It seems like something went wrong when retrieving your website's data. Please %s and try again.",
 			"wordpress-seo"
 		),
-		"{{reconnectToWincher/}}",
+		"<reconnectToWincher/>",
 		"Wincher"
 	);
 
 	return (
 		<Alert type="error" className={ props.className }>
 			{
-				interpolateComponents( {
-					mixedString: message,
-					components: {
-						// eslint-disable-next-line jsx-a11y/anchor-is-valid
-						reconnectToWincher: <a
-							href="#" onClick={ e => { // eslint-disable-line react/jsx-no-bind
-								e.preventDefault();
-								props.onReconnect();
-							} }
-						>
-							{
-								sprintf(
-									/* translators: %s : Expands to "Wincher". */
-									__( "reconnect to %s", "wordpress-seo" ),
-									"Wincher"
-								)
-							}
-						</a>,
-					},
+				safeCreateInterpolateElement( message, {
+					// eslint-disable-next-line jsx-a11y/anchor-is-valid
+					reconnectToWincher: <a
+						href="#" onClick={ e => { // eslint-disable-line react/jsx-no-bind
+							e.preventDefault();
+							props.onReconnect();
+						} }
+					>
+						{
+							sprintf(
+								/* translators: %s : Expands to "Wincher". */
+								__( "reconnect to %s", "wordpress-seo" ),
+								"Wincher"
+							)
+						}
+					</a>,
 				} )
 			}
 		</Alert>

--- a/packages/js/src/components/modals/WincherUpgradeCallout.js
+++ b/packages/js/src/components/modals/WincherUpgradeCallout.js
@@ -2,7 +2,6 @@
 
 /* External dependencies */
 import styled from "styled-components";
-import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
 import { useEffect, useState } from "@wordpress/element";
@@ -11,6 +10,7 @@ import { useEffect, useState } from "@wordpress/element";
 import { SvgIcon } from "@yoast/components";
 import { colors } from "@yoast/style-guide";
 import { makeOutboundLink } from "@yoast/helpers";
+import { safeCreateInterpolateElement } from "../../helpers/i18n";
 
 /* Internal dependencies */
 import { checkLimit, getUpgradeCampaign } from "../../helpers/wincherEndpoints";
@@ -197,20 +197,13 @@ const WincherUpgradeCalloutDescription = ( { discount, months } ) => {
 			"%1$s and get an exclusive %2$s discount for %3$s month(s).",
 			"wordpress-seo"
 		),
-		"{{wincherAccountUpgradeLink/}}",
+		"<wincherAccountUpgradeLink/>",
 		discountPercentage + "%",
 		months
 	);
 
 	return <DescriptionContainer>
-		{
-			interpolateComponents( {
-				mixedString: description,
-				components: {
-					wincherAccountUpgradeLink,
-				},
-			} )
-		}
+		{ safeCreateInterpolateElement( description, { wincherAccountUpgradeLink } ) }
 	</DescriptionContainer>;
 };
 

--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -25,11 +25,11 @@
   "dependencies": {
     "@wordpress/a11y": "^1.0.7",
     "@wordpress/i18n": "^1.1.0",
+    "@wordpress/element": "^6.8.1",
     "@yoast/components": "^3.0.0-alpha.2",
     "@yoast/helpers": "^0.17.0-alpha.1",
     "@yoast/replacement-variable-editor": "^2.0.0-alpha.0",
     "@yoast/style-guide": "^0.14.0-alpha.0",
-    "interpolate-components": "^1.1.1",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
     "react": "^18.2.0",

--- a/packages/search-metadata-previews/src/helpers/safeCreateInterpolateElement.js
+++ b/packages/search-metadata-previews/src/helpers/safeCreateInterpolateElement.js
@@ -1,0 +1,17 @@
+import { createInterpolateElement } from "@wordpress/element";
+
+/**
+ * Wrapper function for `createInterpolateElement` to catch errors.
+ *
+ * @param {string} interpolatedString The interpolated string.
+ * @param {Object<string, JSX.Element>} conversionMap The conversion map object.
+ * @returns {JSX.Element|string} The interpolated element or string if it failed.
+ */
+export const safeCreateInterpolateElement = ( interpolatedString, conversionMap ) => {
+	try {
+		return createInterpolateElement( interpolatedString, conversionMap );
+	} catch ( error ) {
+		console.error( "Error in translation for:", interpolatedString, error );
+		return interpolatedString;
+	}
+};

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -1,7 +1,6 @@
 // External dependencies.
 import React, { PureComponent } from "react";
 import styled from "styled-components";
-import interpolateComponents from "interpolate-components";
 import PropTypes from "prop-types";
 import truncate from "lodash/truncate";
 import { __ } from "@wordpress/i18n";
@@ -19,6 +18,7 @@ const {
 } = languageProcessing;
 
 // Internal dependencies.
+import { safeCreateInterpolateElement } from "../helpers/safeCreateInterpolateElement";
 import FixedWidthContainer from "./FixedWidthContainer";
 import ProductDataDesktop from "./ProductDataDesktop";
 import ProductDataMobile from "./ProductDataMobile";
@@ -383,13 +383,10 @@ function highlightWords( locale, wordsToHighlight, text, cleanText ) {
 	const keywordFormsMatcher = createRegexFromArray( wordsToHighlightCleaned, false, "", false );
 
 	textToUse = textToUse.replace( keywordFormsMatcher, function( matchedKeyword ) {
-		return `{{strong}}${ matchedKeyword }{{/strong}}`;
+		return `<strong>${ matchedKeyword }</strong>`;
 	} );
 
-	return interpolateComponents( {
-		mixedString: textToUse,
-		components: { strong: <strong /> },
-	} );
+	return safeCreateInterpolateElement( textToUse, { strong: <strong /> } );
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -9062,6 +9062,20 @@
     react "^18.3.0"
     react-dom "^18.3.0"
 
+"@wordpress/element@^6.8.1":
+  version "6.27.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/element/-/element-6.27.0.tgz#e1256de0c8645867cc1ec75aebdd2d513274715e"
+  integrity sha512-gHk4B0J0f7bEsDoUBdTm22vPQwmEWLZxyaojgRyx1ncE2IyktfmubD/q2NIcMEKh7p+Jq3ZUwzPcpchpvkH2mA==
+  dependencies:
+    "@babel/runtime" "7.25.7"
+    "@types/react" "^18.2.79"
+    "@types/react-dom" "^18.2.25"
+    "@wordpress/escape-html" "^3.27.0"
+    change-case "^4.1.2"
+    is-plain-object "^5.0.0"
+    react "^18.3.0"
+    react-dom "^18.3.0"
+
 "@wordpress/escape-html@^1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-1.12.2.tgz#dcc92178bacc69952cde9bb8fb1cbbea9deb2cc3"
@@ -9108,6 +9122,13 @@
   version "3.23.0"
   resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-3.23.0.tgz#16c21ccc31be6c567fa0d52416feb368a6d44251"
   integrity sha512-Qd+7Rb+4oO1On7VfR9SVpnETvdGf7A/NOlLEF52EVyC71I353005W/cjAAm+k3E5lrlIOoPSvPmHOLnJuuISgQ==
+  dependencies:
+    "@babel/runtime" "7.25.7"
+
+"@wordpress/escape-html@^3.27.0":
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/@wordpress/escape-html/-/escape-html-3.27.0.tgz#091a1c3899b640c7ec5d8e26bd2d91568c074fd0"
+  integrity sha512-1LBB/xOFBUySSmVpd2nFwIZ8fVnP8dLNFl0wLprHVLtW6ZcdykO2ITY9bkaHu2lZ9HLRgHL7A/3R7MsJ1azYkg==
   dependencies:
     "@babel/runtime" "7.25.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13466,11 +13466,6 @@ core-js-pure@^3.30.2:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.35.0.tgz#4660033304a050215ae82e476bd2513a419fbb34"
   integrity sha512-f+eRYmkou59uh7BPcyJ8MC76DiGhspj1KMxVIcF24tzP8NA9HVa1uC7BTW2tgx7E1QVCzDzsgp7kArrzhlz8Ew==
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7, core-js@^2.6.12:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
@@ -15343,7 +15338,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11, encoding@^0.1.12:
+encoding@^0.1.12:
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
   integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
@@ -17235,19 +17230,6 @@ fbjs-css-vars@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
   integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
-fbjs@^0.8.4:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  integrity sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
 
 fbjs@^2.0.0:
   version "2.0.0"
@@ -19975,15 +19957,6 @@ internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
-interpolate-components@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/interpolate-components/-/interpolate-components-1.1.1.tgz#699fff45d1525e98c7ce7b7159591d992b5dd6df"
-  integrity sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=
-  dependencies:
-    react "^0.14.3 || ^15.1.0 || ^16.0.0"
-    react-addons-create-fragment "^0.14.3 || ^15.1.0"
-    react-dom "^0.14.3 || ^15.1.0 || ^16.0.0"
-
 interpret@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-3.1.1.tgz#5be0ceed67ca79c6c4bc5cf0d7ee843dcea110c4"
@@ -20646,7 +20619,7 @@ is-ssh@^1.4.0:
   dependencies:
     protocols "^2.0.1"
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -20815,14 +20788,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -22791,7 +22756,7 @@ lookup-closest-locale@6.2.0:
   resolved "https://registry.yarnpkg.com/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz#57f665e604fd26f77142d48152015402b607bcf3"
   integrity sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -23860,14 +23825,6 @@ node-fetch@2.6.7, node-fetch@^2.6.7:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-fetch@^2.0.0, node-fetch@^2.6.12:
   version "2.7.0"
@@ -27239,15 +27196,6 @@ re-resizable@^6.4.0:
   resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.9.tgz#99e8b31c67a62115dc9c5394b7e55892265be216"
   integrity sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==
 
-"react-addons-create-fragment@^0.14.3 || ^15.1.0":
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz#a394de7c2c7becd6b5475ba1b97ac472ce7c74f8"
-  integrity sha1-o5TefCx77Na1R1uhuXrEcs58dPg=
-  dependencies:
-    fbjs "^0.8.4"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.0"
-
 react-addons-shallow-compare@^15.6.2:
   version "15.6.3"
   resolved "https://registry.yarnpkg.com/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz#28a94b0dfee71530852c66a69053d59a1baf04cb"
@@ -27339,7 +27287,7 @@ react-docgen@^7.0.0:
     resolve "^1.22.1"
     strip-indent "^4.0.0"
 
-"react-dom@^0.14.3 || ^15.1.0 || ^16.0.0", react-dom@^16.13.1, react-dom@^16.9.0:
+react-dom@^16.13.1, react-dom@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -27730,7 +27678,7 @@ react-with-styles@^3.2.0:
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
 
-"react@^0.14.3 || ^15.1.0 || ^16.0.0", react@^16.13.1, react@^16.9.0:
+react@^16.13.1, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -31435,11 +31383,6 @@ ua-parser-js@^0.7.18:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.25.tgz#67689fa263a87a52dabbc251ede89891f59156ce"
   integrity sha512-8NFExdfI24Ny8R3Vc6+uUytP/I7dpqk3JERlvxPWlrtx5YboqCgxAXYKPAifbPLV2zKbgmmPL53ufW7mUC/VOQ==
 
-ua-parser-js@^0.7.9:
-  version "0.7.18"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
-  integrity sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA==
-
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
@@ -32338,11 +32281,6 @@ whatwg-fetch@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
   integrity sha1-rDydOfMgxtzlM5lp0FTvQ90zMxk=
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19975,7 +19975,7 @@ internal-slot@^1.0.7:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
-interpolate-components@^1.1.0, interpolate-components@^1.1.1:
+interpolate-components@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/interpolate-components/-/interpolate-components-1.1.1.tgz#699fff45d1525e98c7ce7b7159591d992b5dd6df"
   integrity sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Replace unmaintained package

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Replaces the unmaintained `interpolate-components` package with the `createInterpolateElement` from `@wordpress/element`.
* [@yoast/components 0.1.0 other] Replaces the unmaintained `interpolate-components` package with the `createInterpolateElement` from `@wordpress/element`.
* [@yoast/search-metadata-previews 0.1.0 other] Replaces the unmaintained `interpolate-components` package with the `createInterpolateElement` from `@wordpress/element`.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### `@yoast/components`
We don't seem to use the `LanguageNotice` or the `WordOccurrenceInsights` anywhere in our plugins.
So the following is **devs only**:
I tested by adding the components to some random JS page and checking for errors.
Either use this [components.patch](https://github.com/user-attachments/files/21666930/components.patch) and check the schema tab in the metabox, or follow the details yourself:

<details><summary>Details</summary>
<p>

Copied and adjusted from our components app:
```js
import { languageProcessing } from "yoastseo";

const ProminentWord = languageProcessing.values.ProminentWord;

const words = [
	new ProminentWord( "davids", "david", 2 ),
	new ProminentWord( "goliaths", "goliath", 6 ),
	new ProminentWord( "word", "word", 3 ),
	new ProminentWord( "yoast", "yoast", 8 ),
	new ProminentWord( "test", "test", 10 ),
	new ProminentWord( "apps", "app", 6 ),
	new ProminentWord( "teletubbies", "teletubby", 11 ),
	new ProminentWord( "strange", "stange", 4 ),
	new ProminentWord( "improvisation", "improvisation", 4 ),
	new ProminentWord( "ranking", "rank", 5 ),
	new ProminentWord( "google", "google", 5 ),
	new ProminentWord( "terms", "term", 8 ),
	new ProminentWord( "wordpress", "wordpress", 9 ),
	new ProminentWord( "inspiration", "inspiration", 2 ),
	new ProminentWord( "internal", "internal", 2 ),
	new ProminentWord( "linking", "link", 2 ),
	new ProminentWord( "suggestions", "suggestion", 3 ),
	new ProminentWord( "keyword", "keyword", 3 ),
	new ProminentWord( "analysis", "analysis", 4 ),
	new ProminentWord( "linguïns", "linguïn", 5 ),
];
```

Then you can use those `words` as prop and render like so:

```jsx
<WordOccurrenceInsights words={ words } researchArticleLink="https://yoast.com/" />
```

The `LanguageNotice` is covered in the tests by rendering:
```jsx
<LanguageNotice
	changeLanguageLink="http://www.example.com"
	canChangeLanguage={ true }
	language="English"
	showLanguageNotice={ true }
/>
```

</p>
</details> 

#### `@yoast/search-metadata-previews`




#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/725
