### PR TITLE
Fix console warnings

### DIFF
--- a/packages/js/src/redirects/routes/redirects.js
+++ b/packages/js/src/redirects/routes/redirects.js
@@ -8,6 +8,7 @@ import { useSelectRedirects } from "../hooks";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { FieldsetLayout } from "../../shared-admin/components";
 import { ChevronDownIcon } from "@heroicons/react/solid";
+import { noop } from "lodash";
 
 /**
  * Redirects component.
@@ -72,8 +73,10 @@ export const Redirects = () => {
 								id="yst-input-type-redirect"
 								label={ __( "Redirect Type", "wordpress-seo" ) }
 								className="yst-max-w-sm"
-								options={ [ { value: 301, label: __( "301 Moved Permatently", "wordpress-seo" ) } ] }
+								options={ [ { value: 301, label: __( "301 Moved Permanently", "wordpress-seo" ) } ] }
 								disabled={ true }
+								value={ false }
+								onChange={ noop }
 							/>
 							<div className="yst-text-field__description">
 								{ redirectTypeDescription }
@@ -86,6 +89,7 @@ export const Redirects = () => {
 							id="yst-input-origin-redirect"
 							label={ __( "Old URL", "wordpress-seo" ) }
 							disabled={ true }
+							onChange={ noop }
 						/>
 						<TextField
 							type="text"
@@ -93,6 +97,7 @@ export const Redirects = () => {
 							id="yst-input-target-redirect"
 							label={ __( "New URL", "wordpress-seo" ) }
 							disabled={ true }
+							onChange={ noop }
 						/>
 					</div>
 					<Button
@@ -119,6 +124,8 @@ export const Redirects = () => {
 								className="yst-w-full"
 								label={ __( "Filter Redirect type", "wordpress-seo" ) }
 								disabled={ true }
+								value={ false }
+								onChange={ noop }
 							/>
 						</div>
 					</div>
@@ -127,8 +134,11 @@ export const Redirects = () => {
 							<Table.Row>
 								<Table.Header className="yst-w-4">
 									<Checkbox
+										id="yst-select-all-redirects"
+										name="selectAllRedirects"
 										aria-label={ __( "Select all", "wordpress-seo" ) }
 										disabled={ true }
+										value="dummy-value"
 									/>
 								</Table.Header>
 								<Table.Header className="yst-w-32">
@@ -147,10 +157,10 @@ export const Redirects = () => {
 
 						<Table.Body>
 							<Table.Row>
-								<Table.Cell />
-								<Table.Cell />
+								<Table.Cell><></></Table.Cell>
+								<Table.Cell><></></Table.Cell>
 								<Table.Cell className="yst-text-center">{ __( "No items found", "wordpress-seo" ) }</Table.Cell>
-								<Table.Cell />
+								<Table.Cell><></></Table.Cell>
 							</Table.Row>
 						</Table.Body>
 					</Table>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes console warnings related to missing required components props.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you don't have Yoast SEO Premium enabled
* Go to `Yoast SEO` -> `Redirects`
  * Verify there are no warnings in the console about missing required props 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#718](https://github.com/Yoast/reserved-tasks/issues/718)
