### PR TITLE
Update styling for the black friday ads.

### DIFF
--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -59,6 +59,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		$arguments = $this->get_arguments( $is_woocommerce_active );
 
+		$header_class   = ( $is_woocommerce_active ) ? 'woo-header' : '';
 		$arguments_html = implode( '', array_map( [ $this, 'get_argument_html' ], $arguments ) );
 
 		$class = $this->get_html_class();
@@ -80,14 +81,14 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$bf_label   = esc_html__( 'BLACK FRIDAY', 'wordpress-seo' );
-			$sale_label = esc_html__( '30% OFF', 'wordpress-seo' );
+			$sale_label = esc_html__( '30% OFF WordPress SEO', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
 			echo "<div class='black-friday-container'><span>$sale_label</span> <span style='margin-left: auto;'>$bf_label</span> </div>";
 		}
 
 		echo '<div class="' . esc_attr( $class . '--container' ) . '">';
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Correctly escaped in get_header() method.
-		echo '<h2 class="' . esc_attr( $class . '--header' ) . '">' . $header_text . $header_icon . '</h2>';
+		echo '<h2 class="' . esc_attr( $class . '--header' ) . ' ' . esc_attr( $header_class ) . ' ">' . $header_text . $header_icon . '</h2>';
 
 		echo '<span class="' . esc_attr( $class . '--subheader' ) . '">'
 			. esc_html__( 'Now includes Local, News & Video SEO + 1 Google Docs seat!', 'wordpress-seo' )
@@ -198,7 +199,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 	 */
 	private function get_button_text( bool $is_woocommerce_active ): string {
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-			return esc_html__( 'Upgrade now', 'wordpress-seo' );
+			return esc_html__( 'Get 30% off now!', 'wordpress-seo' );
 		}
 		else {
 			// phpcs:disable Squiz.ControlStructures.InlineIfDeclaration.NotSingleLine -- needed to add translators comments.

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -78,7 +78,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		echo '<div class="' . esc_attr( $class ) . '">';
 
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$bf_label   = esc_html__( 'BLACK FRIDAY', 'wordpress-seo' );
 			$sale_label = esc_html__( '30% OFF', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
@@ -197,7 +197,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 	 * @return string The button text.
 	 */
 	private function get_button_text( bool $is_woocommerce_active ): string {
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			return esc_html__( 'Upgrade now', 'wordpress-seo' );
 		}
 		else {

--- a/admin/class-premium-upsell-admin-block.php
+++ b/admin/class-premium-upsell-admin-block.php
@@ -81,7 +81,7 @@ class WPSEO_Premium_Upsell_Admin_Block {
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$bf_label   = esc_html__( 'BLACK FRIDAY', 'wordpress-seo' );
-			$sale_label = esc_html__( '30% OFF WordPress SEO', 'wordpress-seo' );
+			$sale_label = esc_html__( '30% OFF', 'wordpress-seo' );
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped above.
 			echo "<div class='black-friday-container'><span>$sale_label</span> <span style='margin-left: auto;'>$bf_label</span> </div>";
 		}

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -260,7 +260,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 			$title = __( 'Upgrades', 'wordpress-seo' );
 		}
 
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
 			$title = __( 'Upgrades', 'wordpress-seo' ) . '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';
 		}
 

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -860,7 +860,7 @@ body.folded .wpseo-admin-submit-fixed {
 	color: #dba617;
 }
 
-#black-friday-2024-promotion-sidebar.notice-yoast {
+#black-friday-promotion-sidebar.notice-yoast {
 	border-color: #fcd34d;
 	border-width: 2px;
 	border-radius: 8px;
@@ -873,12 +873,12 @@ body.folded .wpseo-admin-submit-fixed {
 	margin-top: 20px;
 }
 
-#black-friday-2024-promotion-sidebar .notice-yoast__header {
+#black-friday-promotion-sidebar .notice-yoast__header {
 	margin-bottom: 2px;
     padding-right: 20px;
 }
 
-#black-friday-2024-promotion-metabox.notice-yoast {
+#black-friday-promotion-metabox.notice-yoast {
 	border-color: #fcd34d;
 	border-width: 2px;
 	border-radius: 8px;
@@ -887,23 +887,23 @@ body.folded .wpseo-admin-submit-fixed {
 	margin: 20px;
 }
 
-#black-friday-2024-promotion-metabox h2.notice-yoast__header-heading {
+#black-friday-promotion-metabox h2.notice-yoast__header-heading {
 	padding: 0px;
 }
 
-#black-friday-2024-promotion-metabox .notice-yoast__container {
+#black-friday-promotion-metabox .notice-yoast__container {
 	padding-bottom: 0px;
 }
 
-#black-friday-2024-promotion-metabox .notice-yoast__container p {
+#black-friday-promotion-metabox .notice-yoast__container p {
 	display: inline;
 }
 
-#black-friday-2024-promotion-metabox .notice-yoast__header {
+#black-friday-promotion-metabox .notice-yoast__header {
 	margin-bottom: 8px;
 }
 
-#black-friday-2024-promotion-metabox .notice-yoast__header a {
+#black-friday-promotion-metabox .notice-yoast__header a {
 	font-weight: 400;
 	margin-left: 13px;
 }

--- a/css/src/black-friday-banner.css
+++ b/css/src/black-friday-banner.css
@@ -3,10 +3,9 @@
     width: calc(100% + 60px);
     line-height: 30px;
     margin-left: -30px;
-    transform: rotate(-5deg);
     letter-spacing: 0.5px;
     box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
-    @apply yst-text-lg yst-font-bold yst-bg-black yst-mt-5 yst-text-center yst-mb-[10px] yst-px-0 yst-py-1;
+    @apply yst-text-lg yst-font-bold yst-bg-black yst-mt-10 yst-text-center yst-mb-[10px] yst-px-0 yst-py-1;
 }
 
 .sidebar__sale_banner_container .sidebar__sale_banner .banner_text {

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -607,13 +607,14 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 .yoast-sidebar__product .yoast-price-micro-copy {
 	font-weight: 300;
 	font-size: 12px;
+	font-style: italic;
 	text-align: center;
 	line-height: 20px;
 	margin-bottom: 16px;
 }
 
 .yoast-sidebar__product .yoast-button-upsell {
-	@apply yst-bg-amber-300;
+	@apply yst-bg-amber-300 yst-text-amber-900;
 
 }
 
@@ -639,7 +640,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	width: 100%;
 	padding-top: 0;
 	padding-bottom: 0;
-	@apply yst-bg-amber-300;
+	@apply yst-bg-amber-300 yst-text-amber-900;
 
 }
 
@@ -691,32 +692,31 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 }
 
 .yoast-sidebar__product .sidebar__sale_banner_container .sidebar__sale_banner {
-	background: #000;
-	@apply yst-text-amber-300;
+	color: #fcd34d;
 	width: calc(100% + 60px);
 	line-height: 30px;
 	margin-left: -30px;
-	font-size: 20px;
-	font-weight: 500;
 	letter-spacing: 0.5px;
-	text-align: center;
-	z-index: 1;
-	margin-top: 20px;
-	margin-bottom: 20px;
 	box-shadow: 0 -1px 4px 0 #fcd34d, 0 1px 4px 0 #fcd34d, 0 -1px 0 0 #fcd34d, 0 1px 0 0 #fcd34d;
-	padding: 7px 0;
+	margin-top: 2.5rem;
+	margin-bottom: 10px;
+	--tw-bg-opacity: 1;
+	background-color: rgb(0 0 0 / var(--tw-bg-opacity, 1));
+	padding: 0.25rem 0;
+	text-align: center;
+	font-size: 1.125rem;
+	font-weight: 700;
 }
 
 .yoast-sidebar__product .sidebar__sale_banner_container .sidebar__sale_banner .banner_text {
+	margin: 0 35px;
 	display: inline-block;
-	margin: 0 40px;
 }
 
 .yoast-sidebar__product .sidebar__sale_text {
 	text-align: center;
 	border-top: solid 1px #ffffff;
 	font-style: italic;
-
 }
 
 .yoast-sidebar__product .sidebar__sale_text p {
@@ -808,7 +808,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 .black-friday-container span {
 	@apply yst-text-amber-300;
 	font-size: 1.2rem;
-	font-weight: 600;
+	font-weight: 500;
 }
 
 .yoast_premium_upsell--header {
@@ -817,6 +817,9 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	font-weight: 500;
 	line-height: 25px;
 	margin: 0;
+}
+.yoast_premium_upsell--header.woo-header {
+	color: #0075B3;
 }
 
 .yoast_premium_upsell--subheader {

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -696,7 +696,6 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	width: calc(100% + 60px);
 	line-height: 30px;
 	margin-left: -30px;
-	transform: rotate(-5deg);
 	font-size: 20px;
 	font-weight: 500;
 	letter-spacing: 0.5px;

--- a/css/src/yst_plugin_tools.css
+++ b/css/src/yst_plugin_tools.css
@@ -819,7 +819,7 @@ body.toplevel_page_wpseo_dashboard .wp-badge {
 	margin: 0;
 }
 .yoast_premium_upsell--header.woo-header {
-	color: #0075B3;
+	@apply yst-text-woo-light;
 }
 
 .yoast_premium_upsell--subheader {

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -591,7 +591,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 */
 	protected function add_premium_link( WP_Admin_Bar $wp_admin_bar ) {
 		$sale_percentage = '';
-		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$sale_percentage = sprintf(
 				'<span class="admin-bar-premium-promotion">%1$s</span>',
 				esc_html__( '30% OFF', 'wordpress-seo' )

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -42,9 +42,9 @@ export const BlackFridayPromotion = ( {
 		);
 	return isPremium ? null : (
 		<TimeConstrainedNotification
-			id={ `black-friday-2024-promotion-${ location }` }
-			promoId="black-friday-2024-promotion"
-			alertKey="black-friday-2024-promotion"
+			id={ `black-friday-promotion-${ location }` }
+			promoId="black-friday-promotion"
+			alertKey="black-friday-promotion"
 			store={ store }
 			title={ title }
 			{ ...props }

--- a/packages/js/src/components/UpsellBox.js
+++ b/packages/js/src/components/UpsellBox.js
@@ -106,7 +106,7 @@ class UpsellBox extends Component {
 	 * @returns {wp.Element} The rendered UpsellBox component.
 	 */
 	render() {
-		const isBlackFriday = select( "yoast-seo/editor" ).isPromotionActive( "black-friday-2024-promotion" );
+		const isBlackFriday = select( "yoast-seo/editor" ).isPromotionActive( "black-friday-promotion" );
 		return (
 			<Fragment>
 				{ isBlackFriday &&

--- a/packages/js/src/helpers/shouldShowWebinarPromotionNotification.js
+++ b/packages/js/src/helpers/shouldShowWebinarPromotionNotification.js
@@ -26,8 +26,8 @@ const shouldShowWebinarPromotionNotificationInDashboard = ( store = "yoast-seo/e
 	 * @returns {boolean} Whether the Webinar promotion should be shown.
 	 */
 const shouldShowWebinarPromotionNotificationInSidebar = ( store = "yoast-seo/editor" ) => {
-	const isBlackFridayPromotionActive = select( store ).isPromotionActive( "black-friday-2024-promotion" );
-	const isBlackFridayPromotionAlertDismissed = select( store ).isAlertDismissed( "black-friday-2024-promotion" );
+	const isBlackFridayPromotionActive = select( store ).isPromotionActive( "black-friday-promotion" );
+	const isBlackFridayPromotionAlertDismissed = select( store ).isAlertDismissed( "black-friday-promotion" );
 
 	if ( isBlackFridayPromotionActive ) {
 		return isBlackFridayPromotionAlertDismissed;

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -27,6 +27,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 		? getWooSeoBenefits
 		: getPremiumBenefits;
 	let info = useMemo( () => __( "Now with Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ), [] );
+	let upsellButtonText = __( "Buy now", "wordpress-seo" );
 	let upsellTitle = isWooCommerceActive
 		? safeCreateInterpolateElement(
 			sprintf(
@@ -52,24 +53,10 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 				nowrap: <span className="yst-whitespace-nowrap" />,
 			}
 		);
-	const isBlackFriday = isPromotionActive( "black-friday-2024-promotion" );
+	const isBlackFriday = isPromotionActive( "black-friday-promotion" );
 
 	if ( isBlackFriday ) {
-		info = useMemo( () => __( "If you were thinking about upgrading, now's the time! 30% OFF ends 3rd Dec 11am (CET)", "wordpress-seo" ), [] );
-
-		upsellTitle = safeCreateInterpolateElement(
-			sprintf(
-				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$sBuy%2$s %3$s", "wordpress-seo" ),
-				"<nowrap>",
-				"</nowrap>",
-				"Yoast SEO Premium"
-
-			),
-			{
-				nowrap: <span className="yst-whitespace-nowrap" />,
-			}
-		);
+		upsellButtonText = __( "Buy now for 30% off", "wordpress-seo" );
 	}
 	return (
 		<div
@@ -87,7 +74,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 			</figure>
 			{ isBlackFriday && <div className="sidebar__sale_banner_container">
 				<div className="sidebar__sale_banner">
-					<span className="banner_text">{ __( "30% OFF - BLACK FRIDAY", "wordpress-seo" ) }</span>
+					<span className="banner_text">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</span>
 				</div>
 			</div> }
 			<Title as="h2" className="yst-mt-6 yst-text-base yst-font-extrabold yst-text-white">
@@ -111,10 +98,10 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
 				{ ...linkProps }
 			>
-				<span>{ __( "Buy now", "wordpress-seo" ) }</span>
+				<span>{ upsellButtonText }</span>
 				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 			</Button>
-			<p className="yst-text-center yst-text-xs yst-mx-2 yst-font-light yst-leading-5 yst-mt-2">
+			<p className="yst-text-center yst-text-xs yst-mx-2 yst-font-light yst-leading-5 yst-italic yst-mt-2">
 				{ __( "30-day money back guarantee", "wordpress-seo" ) }
 			</p>
 			<hr className="yst-border-t yst-border-primary-300 yst-my-4" />

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -66,7 +66,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 	return (
 		<div
 			className={ classNames( "yst-p-6 yst-rounded-lg yst-text-white  yst-shadow",
-				isWooCommerceActive ? "yst-bg-[#0e1e65]" : "yst-bg-primary-500"
+				isWooCommerceActive ? "yst-bg-woo-dark" : "yst-bg-primary-500"
 			) }
 		>
 			<figure

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -26,7 +26,12 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 	const getBenefits = isWooCommerceActive
 		? getWooSeoBenefits
 		: getPremiumBenefits;
-	let info = useMemo( () => __( "Now with Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ), [] );
+	let info = useMemo( () => {
+		if(isWooCommerceActive) {
+		return	__( "SEO that scales with your product catalog.", "wordpress-seo" )
+		}
+		return __( "Now with Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" );
+	}, [isWooCommerceActive] );
 	let upsellButtonText = __( "Buy now", "wordpress-seo" );
 	let upsellTitle = isWooCommerceActive
 		? safeCreateInterpolateElement(

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -26,14 +26,14 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 	const getBenefits = isWooCommerceActive
 		? getWooSeoBenefits
 		: getPremiumBenefits;
-	let info = useMemo( () => {
-		if(isWooCommerceActive) {
-		return	__( "SEO that scales with your product catalog.", "wordpress-seo" )
+	const info = useMemo( () => {
+		if ( isWooCommerceActive ) {
+			return	__( "SEO that scales with your product catalog.", "wordpress-seo" );
 		}
 		return __( "Now with Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" );
-	}, [isWooCommerceActive] );
+	}, [ isWooCommerceActive ] );
 	let upsellButtonText = __( "Buy now", "wordpress-seo" );
-	let upsellTitle = isWooCommerceActive
+	const upsellTitle = isWooCommerceActive
 		? safeCreateInterpolateElement(
 			sprintf(
 			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -15,28 +15,43 @@ import { ReactComponent as TrolleyIcon } from "../../../images/icon-trolley.svg"
  * @returns {JSX.Element} The premium upsell card.
  */
 export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromotionActive, isWooCommerceActive } ) => {
-	const isBlackFriday = isPromotionActive( "black-friday-2024-promotion" );
+	const isBlackFriday = isPromotionActive( "black-friday-promotion" );
 	const getBenefits = isWooCommerceActive
 		? getWooSeoBenefits
 		: getPremiumBenefits;
 
+	let upsellTitle = isWooCommerceActive
+		? sprintf(
+			/* translators: %s expands to "Yoast WooCommerce SEO" */
+			__( "Explore %s now!", "wordpress-seo" ),
+			"Yoast WooCommerce SEO",
+		)
+		: sprintf(
+			/* translators: %s expands to "Yoast SEO" Premium */
+			__( "Explore %s now!", "wordpress-seo" ),
+			"Yoast SEO Premium",
+		);
+
+	if(isBlackFriday){
+		upsellTitle = __( " Get 30% off now!", "wordpress-seo" );
+	}
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
 			{ isBlackFriday && <div
 				className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold"
 			>
-				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
+				<div>{ __( "30% OFF WORDPRESS SEO", "wordpress-seo" ) }</div>
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 			</div> }
 			<div className="yst-p-6 yst-flex yst-flex-col">
 				<div className="yst-flex yst-items-center">
-					{	isWooCommerceActive
+					{ isWooCommerceActive
 						? <>
 							<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast WooCommerce SEO"
+									"Yoast WooCommerce SEO",
 								) }
 							</Title>
 							<TrolleyIcon className="yst-ml-2 yst-w-4 yst-h-3" />
@@ -44,16 +59,17 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 						: <>
 							<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
 								{ sprintf(
-								/* translators: %s expands to "Yoast SEO" Premium */
+									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast SEO Premium"
+									"Yoast SEO Premium",
 								) }
 							</Title>
 							<CrownIcon className="yst-ml-2 yst-w-4 yst-h-3" />
 						</>
 					}
 				</div>
-				<span className="yst-font-medium yst-text-slate-500 yst-text-xs yst-leading-5 yst-uppercase yst-mt-2">{ __( "Now includes Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ) }</span>
+				<span
+					className="yst-font-medium yst-text-slate-500 yst-text-xs yst-leading-5 yst-uppercase yst-mt-2">{ __( "Now includes Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ) }</span>
 				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-none yst-list-outside yst-text-slate-600 yst-mt-6">
 					{ getBenefits().map( ( benefit, index ) => (
 						<li key={ `upsell-benefit-${ index }` }><span className="yst-mx-2">•</span>{ benefit }</li>
@@ -69,18 +85,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 					rel="noopener"
 					{ ...premiumUpsellConfig }
 				>
-					{ isWooCommerceActive
-						? sprintf(
-							/* translators: %s expands to "Yoast WooCommerce SEO" */
-							__( "Explore %s now!", "wordpress-seo" ),
-							"Yoast WooCommerce SEO"
-						)
-						: sprintf(
-							/* translators: %s expands to "Yoast SEO" Premium */
-							__( "Explore %s now!", "wordpress-seo" ),
-							"Yoast SEO Premium"
-						)
-					}
+					{ upsellTitle }
 					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
 				</Button>
 			</div>

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Paper, Title } from "@yoast/ui-library";
@@ -24,16 +25,16 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 		? sprintf(
 			/* translators: %s expands to "Yoast WooCommerce SEO" */
 			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast WooCommerce SEO",
+			"Yoast WooCommerce SEO"
 		)
 		: sprintf(
 			/* translators: %s expands to "Yoast SEO" Premium */
 			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast SEO Premium",
+			"Yoast SEO Premium"
 		);
 
-	if(isBlackFriday){
-		upsellTitle = __( " Get 30% off now!", "wordpress-seo" );
+	if ( isBlackFriday ) {
+		upsellTitle = __( "Get 30% off now!", "wordpress-seo" );
 	}
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
@@ -47,21 +48,21 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 				<div className="yst-flex yst-items-center">
 					{ isWooCommerceActive
 						? <>
-							<Title as="h2" size="4" className={`yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }`}>
+							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }` }>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast WooCommerce SEO",
+									"Yoast WooCommerce SEO"
 								) }
 							</Title>
 							<TrolleyIcon className="yst-ml-2 yst-w-4 yst-h-3" />
 						</>
 						: <>
-							<Title as="h2" size="4" className={`yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }`}>
+							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }` }>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast SEO Premium",
+									"Yoast SEO Premium"
 								) }
 							</Title>
 							<CrownIcon className="yst-ml-2 yst-w-4 yst-h-3" />
@@ -69,7 +70,8 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 					}
 				</div>
 				<span
-					className="yst-font-medium yst-text-slate-500 yst-text-xs yst-leading-5 yst-uppercase yst-mt-2">{ __( "Now includes Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ) }</span>
+					className="yst-font-medium yst-text-slate-500 yst-text-xs yst-leading-5 yst-uppercase yst-mt-2"
+				>{ __( "Now includes Local, News & Video SEO + 1 Google Docs seat!", "wordpress-seo" ) }</span>
 				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-list-none yst-list-outside yst-text-slate-600 yst-mt-6">
 					{ getBenefits().map( ( benefit, index ) => (
 						<li key={ `upsell-benefit-${ index }` }><span className="yst-mx-2">•</span>{ benefit }</li>

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -38,7 +38,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 	return (
 		<Paper as="div" className="xl:yst-max-w-3xl">
 			{ isBlackFriday && <div
-				className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-semibold"
+				className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-medium"
 			>
 				<div>{ __( "30% OFF WORDPRESS SEO", "wordpress-seo" ) }</div>
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
@@ -47,7 +47,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 				<div className="yst-flex yst-items-center">
 					{ isWooCommerceActive
 						? <>
-							<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
+							<Title as="h2" size="4" className={`yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }`}>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
@@ -57,7 +57,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 							<TrolleyIcon className="yst-ml-2 yst-w-4 yst-h-3" />
 						</>
 						: <>
-							<Title as="h2" size="4" className="yst-text-xl yst-text-primary-500">
+							<Title as="h2" size="4" className={`yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }`}>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -41,7 +41,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 			{ isBlackFriday && <div
 				className="yst-rounded-t-lg yst-h-9 yst-flex yst-justify-between yst-items-center yst-bg-black yst-text-amber-300 yst-px-4 yst-text-lg yst-border-b yst-border-amber-300 yst-border-solid yst-font-medium"
 			>
-				<div>{ __( "30% OFF WORDPRESS SEO", "wordpress-seo" ) }</div>
+				<div>{ __( "30% OFF", "wordpress-seo" ) }</div>
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 			</div> }
 			<div className="yst-p-6 yst-flex yst-flex-col">

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -48,7 +48,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 				<div className="yst-flex yst-items-center">
 					{ isWooCommerceActive
 						? <>
-							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }` }>
+							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),
@@ -58,7 +58,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig, isPromoti
 							<TrolleyIcon className="yst-ml-2 yst-w-4 yst-h-3" />
 						</>
 						: <>
-							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-[#0075B3]" : "yst-text-primary-500 " }` }>
+							<Title as="h2" size="4" className={ `yst-text-xl ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
 								{ sprintf(
 									/* translators: %s expands to "Yoast SEO" Premium */
 									__( "Upgrade to %s", "wordpress-seo" ),

--- a/packages/tailwindcss-preset/index.js
+++ b/packages/tailwindcss-preset/index.js
@@ -37,6 +37,10 @@ module.exports = {
 					bad: "#dc3232",
 					na: "#cbd5e1",
 				},
+				woo: {
+					dark: "#0e1e65",
+					light: "#0075B3"
+				}
 			},
 			strokeWidth: {
 				3: "3px",

--- a/src/general/user-interface/general-page-integration.php
+++ b/src/general/user-interface/general-page-integration.php
@@ -219,7 +219,7 @@ class General_Page_Integration implements Integration_Interface {
 		\wp_enqueue_media();
 		$this->asset_manager->enqueue_script( 'general-page' );
 		$this->asset_manager->enqueue_style( 'general-page' );
-		if ( $this->promotion_manager->is( 'black-friday-2024-promotion' ) ) {
+		if ( $this->promotion_manager->is( 'black-friday-promotion' ) ) {
 			$this->asset_manager->enqueue_style( 'black-friday-banner' );
 		}
 		$this->asset_manager->localize_script( 'general-page', 'wpseoScriptData', $this->get_script_data() );

--- a/src/integrations/alerts/black-friday-promotion-notification.php
+++ b/src/integrations/alerts/black-friday-promotion-notification.php
@@ -12,5 +12,5 @@ class Black_Friday_Promotion_Notification extends Abstract_Dismissable_Alert {
 	 *
 	 * @var string
 	 */
-	protected $alert_identifier = 'black-friday-2024-promotion';
+	protected $alert_identifier = 'black-friday-promotion';
 }

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -401,7 +401,7 @@ class Settings_Integration implements Integration_Interface {
 		\wp_enqueue_media();
 		$this->asset_manager->enqueue_script( 'new-settings' );
 		$this->asset_manager->enqueue_style( 'new-settings' );
-		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$this->asset_manager->enqueue_style( 'black-friday-banner' );
 		}
 		$this->asset_manager->localize_script( 'new-settings', 'wpseoScriptData', $this->get_script_data() );

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -144,7 +144,7 @@ class Support_Integration implements Integration_Interface {
 		\remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
 		$this->asset_manager->enqueue_script( 'support' );
 		$this->asset_manager->enqueue_style( 'support' );
-		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+		if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$this->asset_manager->enqueue_style( 'black-friday-banner' );
 		}
 		$this->asset_manager->localize_script( 'support', 'wpseoScriptData', $this->get_script_data() );

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -18,7 +18,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 	 * @return string The sidebar HTML.
 	 */
 	public function present() {
-		$title = \__( '30% OFF - BLACK FRIDAY', 'wordpress-seo' );
+		$title = \__( 'BLACK FRIDAY | 30% OFF', 'wordpress-seo' );
 
 		$assets_uri            = \trailingslashit( \plugin_dir_url( \WPSEO_FILE ) );
 		$is_woocommerce_active = ( new WooCommerce_Conditional() )->is_met();
@@ -63,26 +63,13 @@ class Sidebar_Presenter extends Abstract_Presenter {
 					<?php endif; ?>
 					<h2 class="yoast-get-premium-title">
 						<?php
-						if (
-							\YoastSEO()->classes->get( Promotion_Manager::class )
-								->is( 'black-friday-promotion' ) ) {
-							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-							\printf( \esc_html__( '%1$sBuy%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
-						}
-						else {
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
 							echo ( $is_woocommerce_active ) ? \sprintf( \esc_html__( '%1$s%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast WooCommerce SEO' ) : \sprintf( \esc_html__( '%1$s%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
-						}
 						?>
 					</h2>
-					<span> <?php echo \esc_html__( 'Now with Local, News & Video SEO + 1 Google Docs seat!', 'wordpress-seo' ); ?></span>
+					<span> 
 					<?php
-					if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-						echo '<p>';
-						echo \esc_html__( 'If you were thinking about upgrading, now\'s the time! 30% OFF ends 3rd Dec 11am (CET)', 'wordpress-seo' );
-						echo '</p>';
-					}
-					else {
+						echo ( $is_woocommerce_active ) ? \esc_html__( 'SEO that scales with your product catalog.', 'wordpress-seo' ) : \esc_html__( 'Now with Local, News & Video SEO + 1 Google Docs seat!', 'wordpress-seo' );
 						echo '<ul>';
 						echo '<li>' . \esc_html__( 'AI tools included', 'wordpress-seo' ) . '</li>';
 						echo '<li>';
@@ -91,7 +78,6 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						echo '</li>';
 						echo '<li>' . \esc_html__( '24/7 support', 'wordpress-seo' ) . '</li>';
 						echo '</ul>';
-					}
 					?>
 					<p class="plugin-buy-button">
 						<a class="yoast-button-upsell" data-action="load-nfd-ctb"
@@ -101,7 +87,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							if (
 								\YoastSEO()->classes->get( Promotion_Manager::class )
 									->is( 'black-friday-promotion' ) ) {
-								echo \esc_html__( 'Buy now', 'wordpress-seo' );
+								echo \esc_html__( 'Buy now for 30% off', 'wordpress-seo' );
 							}
 							else {
 								echo \esc_html__( 'Buy now', 'wordpress-seo' );
@@ -111,9 +97,8 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						</a>
 					</p>
 					<p class="yoast-price-micro-copy">
-
 						<?php
-						echo \esc_html__( '30-day money back guarantee.', 'wordpress-seo' );
+							echo \esc_html__( '30-day money back guarantee.', 'wordpress-seo' );
 						?>
 					</p>
 					<hr class="yoast-upsell-hr" aria-hidden="true">

--- a/src/presenters/admin/sidebar-presenter.php
+++ b/src/presenters/admin/sidebar-presenter.php
@@ -53,7 +53,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 					<?php
 					if (
 						\YoastSEO()->classes->get( Promotion_Manager::class )
-							->is( 'black-friday-2024-promotion' ) ) :
+							->is( 'black-friday-promotion' ) ) :
 						?>
 						<div class="sidebar__sale_banner_container">
 							<div class="sidebar__sale_banner">
@@ -65,7 +65,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 						<?php
 						if (
 							\YoastSEO()->classes->get( Promotion_Manager::class )
-								->is( 'black-friday-2024-promotion' ) ) {
+								->is( 'black-friday-promotion' ) ) {
 							/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
 							\printf( \esc_html__( '%1$sBuy%2$s %3$s', 'wordpress-seo' ), '<span>', '</span>', 'Yoast SEO Premium' );
 						}
@@ -77,7 +77,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 					</h2>
 					<span> <?php echo \esc_html__( 'Now with Local, News & Video SEO + 1 Google Docs seat!', 'wordpress-seo' ); ?></span>
 					<?php
-					if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
+					if ( \YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 						echo '<p>';
 						echo \esc_html__( 'If you were thinking about upgrading, now\'s the time! 30% OFF ends 3rd Dec 11am (CET)', 'wordpress-seo' );
 						echo '</p>';
@@ -100,7 +100,7 @@ class Sidebar_Presenter extends Abstract_Presenter {
 							<?php
 							if (
 								\YoastSEO()->classes->get( Promotion_Manager::class )
-									->is( 'black-friday-2024-promotion' ) ) {
+									->is( 'black-friday-promotion' ) ) {
 								echo \esc_html__( 'Buy now', 'wordpress-seo' );
 							}
 							else {

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -12,8 +12,8 @@ class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Int
 	 */
 	public function __construct() {
 		parent::__construct(
-			'black-friday-2024-promotion',
-			new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2024 ) )
+			'black-friday-promotion',
+			new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2025 ) )
 		);
 	}
 }

--- a/src/promotions/domain/black-friday-promotion.php
+++ b/src/promotions/domain/black-friday-promotion.php
@@ -13,7 +13,7 @@ class Black_Friday_Promotion extends Abstract_Promotion implements Promotion_Int
 	public function __construct() {
 		parent::__construct(
 			'black-friday-promotion',
-			new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2025 ) )
+			new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2024 ) )
 		);
 	}
 }

--- a/tests/Unit/General/User_Interface/General_Page_Integration_Test.php
+++ b/tests/Unit/General/User_Interface/General_Page_Integration_Test.php
@@ -315,7 +315,7 @@ final class General_Page_Integration_Test extends TestCase {
 		$this->promotion_manager
 			->expects( 'is' )
 			->once()
-			->with( 'black-friday-2024-promotion' )
+			->with( 'black-friday-promotion' )
 			->andReturn( true );
 
 		$this->asset_manager

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -298,7 +298,7 @@ final class Support_Integration_Test extends TestCase {
 
 		// In enqueue_assets method.
 		$this->promotion_manager->expects( 'is' )
-			->with( 'black-friday-2024-promotion' )
+			->with( 'black-friday-promotion' )
 			->once()
 			->andReturn( $is_black_friday );
 
@@ -398,7 +398,7 @@ final class Support_Integration_Test extends TestCase {
 				'isWooCommerceActive' => false,
 			],
 			'linkParams'        => $link_params,
-			'currentPromotions' => [ 'black-friday-2024-promotion' ],
+			'currentPromotions' => [ 'black-friday-promotion' ],
 		];
 
 		$this->assertSame( $expected, $this->instance->get_script_data() );
@@ -412,7 +412,7 @@ final class Support_Integration_Test extends TestCase {
 	protected function assert_promotions() {
 		$this->promotion_manager->expects( 'get_current_promotions' )
 			->once()
-			->andReturn( [ 'black-friday-2024-promotion' ] );
+			->andReturn( [ 'black-friday-promotion' ] );
 
 		Monkey\Functions\expect( 'YoastSEO' )
 			->andReturn( (object) [ 'classes' => $this->create_classes_surface( $this->container ) ] );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update the styling for our ads.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates black friday ad styling.

## Relevant technical choices:

* Just like in https://github.com/Yoast/wordpress-seo/pull/22488 there are tiny differences between the tools page and the other pages.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Make sure you don't have Premium nor WooCommerce installed
* Go to /src/promotions/domain/black-friday-promotion.php and make sure the bf promotion is active by changing line 16 to:
`new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2026 ) )`
* Visit the following pages:
  * `General`
  * `Settings`
  * `Tools`
  * `Support` ( sidebar ad only) 
  and verify the footer and sidebar ads are about Yoast SEO Premium and follow the designs [here](https://github.com/Yoast/ux/issues/276)
* Now install and activate WooCommerce
  * Visit the aforementioned pages and verify:
    * the footer and sidebar ads are about Yoast WooCommerce SEO and follow the designs [here](https://github.com/Yoast/ux/issues/276)
* Install and activate Yoast SEO Premium
  * Verify you don't get any ads.



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
