### PR TITLE
Add new column in indexables of post count for terms

### DIFF
--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -133,6 +133,8 @@ class Indexable_Term_Builder {
 
 		$indexable->version = $this->version;
 
+		$indexable->post_count = $term->count;
+
 		return $indexable;
 	}
 

--- a/src/config/migrations/20250812133129_AddNumberOfPostsInTerms.php
+++ b/src/config/migrations/20250812133129_AddNumberOfPostsInTerms.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Yoast SEO Plugin File.
+ *
+ * @package Yoast\WP\SEO\Config\Migrations
+ */
+
+namespace Yoast\WP\SEO\Config\Migrations;
+
+use Yoast\WP\Lib\Migrations\Migration;
+use Yoast\WP\Lib\Model;
+
+/**
+ * AddNumberOfPostsInTerms class.
+ */
+class AddNumberOfPostsInTerms extends Migration {
+
+	/**
+	 * The plugin this migration belongs to.
+	 *
+	 * @var string
+	 */
+	public static $plugin = 'free';
+
+	/**
+	 * Migration up.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		$this->add_column(
+			$this->get_table_name(),
+			'post_count',
+			'integer',
+			[
+				'null'     => true,
+				'default'  => null,
+			]
+		);
+	}
+
+	/**
+	 * Migration down.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		$this->remove_column(
+			$this->get_table_name(),
+			'post_count'
+		);
+	}
+
+	/**
+	 * Retrieves the table name to use for storing indexables.
+	 *
+	 * @return string The table name to use.
+	 */
+	protected function get_table_name() {
+		return Model::get_table_name( 'Indexable' );
+	}
+}

--- a/src/models/indexable.php
+++ b/src/models/indexable.php
@@ -81,6 +81,8 @@ use Yoast\WP\Lib\Model;
  * @property string $object_last_modified
  * @property string $object_published_at
  *
+ * @property int    $post_count
+ *
  * @property int    $version
  */
 class Indexable extends Model {

--- a/src/values/indexables/indexable-builder-versions.php
+++ b/src/values/indexables/indexable-builder-versions.php
@@ -22,7 +22,7 @@ class Indexable_Builder_Versions {
 		'home-page'         => 2,
 		'post'              => 2,
 		'post-type-archive' => 2,
-		'term'              => 2,
+		'term'              => 3,
 		'user'              => 2,
 		'system-page'       => self::DEFAULT_INDEXABLE_BUILDER_VERSION,
 	];


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

*

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a site with multiple terms and complete indexables
* In order to trigger the migration (aka, the update of the indexable table to get the new column), find the `yoast_migrations_free` entry in wp_options and lower the version there to one below the current one
  * If you're QA, you dont need to do that, you just need to either install the RC to a new site or upgrade from the production version
* Check the indexable table and confirm you get the new `post_count` column
* All term indexables with `2` in the `version` column, should have `NULL` in the new `post_count` column
* Visit a term in the frontend
* Confirm that its indexable got updated:
  * It has `3` in the `version` column and `X` in the new `post_count` column, where X is the number of posts assigned to that term (you can check that in the term overview)
* Refresh that term in the frontend and confirm that the `updated_at` column stayed the same (which means we didnt retrigger an update of the indexable
* 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
