### PR TITLE
New filter: `wpseo_schema_main_image_id`

### DIFF
--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -640,9 +640,12 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			return $this->get_main_image_id_for_rest_request();
 		}
 
+		$image_id = null;
+
 		switch ( true ) {
 			case \is_singular():
-				return $this->get_singular_post_image( $this->id );
+				$image_id = $this->get_singular_post_image( $this->id );
+				break;
 			case \is_author():
 			case \is_tax():
 			case \is_tag():
@@ -652,15 +655,21 @@ class Meta_Tags_Context extends Abstract_Presentation {
 			case \is_post_type_archive():
 				if ( ! empty( $GLOBALS['wp_query']->posts ) ) {
 					if ( $GLOBALS['wp_query']->get( 'fields', 'all' ) === 'ids' ) {
-						return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0] );
+						$image_id = $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0] );
+						break;
 					}
 
-					return $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
+					$image_id = $this->get_singular_post_image( $GLOBALS['wp_query']->posts[0]->ID );
 				}
-				return null;
-			default:
-				return null;
+				break;
 		}
+
+		/**
+		 * Filter: 'wpseo_schema_main_image_id' - Allow changing the main image ID.
+		 *
+		 * @param int|array $image_id The image ID.
+		 */
+		return \apply_filters( 'wpseo_schema_main_image_id', $image_id );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Allow changing the main image ID through a filter.
I have a client project which has custom featured images for taxonomies, many other tools, like WooCommerce also do this similarly.
This PR allows me to change the schema output correctly without doing more skechy changes to the full schema output using the `wpseo_schema_webpage` filter.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allow changing the main image ID through a filter `wpseo_schema_main_image_id` props: @JoryHogeveen

## Relevant technical choices:

* I based my changes on other filters already available in this class.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Simply add a filter and change the main image ID to see changed in schema validators.

Filter example for when the `category` taxonomy has a custom image field named `featured_image` that returns the image ID:

```php
add_filter( 'wpseo_schema_main_image_id', function( $image_id ) {
    if ( ! is_category() ) {
        return $image_id;
    }

    $cat_image_id = get_term_meta( get_queried_object_id(), 'featured_image', true );

    return $cat_image_id ?: $image_id;
} );
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

No real relevant test scenarios I can think of other than a single filter change so make sure the results are as expected.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Add f

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

None

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.
* [ ] I have added filter doc comments, similar as done with other filters in this class.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
