### PR TITLE
Fix styling of wishlist button

### DIFF
--- a/css/src/introductions.css
+++ b/css/src/introductions.css
@@ -40,7 +40,6 @@
 
 	.yst-ai-insights-waitlist-button {
 		background-image: linear-gradient(97deg, #A61E69 0%, #6366F1 100%) !important;
-		font-weight: 400 !important;
 		color: white !important;
 
 		&:hover {

--- a/images/ai-sparkle.svg
+++ b/images/ai-sparkle.svg
@@ -1,1 +1,0 @@
-<svg width="14" height="14" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true" focusable="false"><path d="M2.333 1v2.667M1 2.333h2.666m-.666 8V13m-1.334-1.333h2.667M7.666 1L9.19 5.57 13 7 9.19 8.429l-1.524 4.57-1.524-4.57-3.81-1.43 3.81-1.428L7.666 1z" stroke="#fff" stroke-width="1.333" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/js/src/introductions/components/ai-brand-insights-pre-launch.js
+++ b/packages/js/src/introductions/components/ai-brand-insights-pre-launch.js
@@ -1,7 +1,7 @@
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, useModalContext } from "@yoast/ui-library";
 import PropTypes from "prop-types";
-import { ReactComponent as AiSparkleIcon } from "../../../../../images/ai-sparkle.svg";
+import { SparklesIcon } from "@heroicons/react/outline";
 
 /**
  * @param {Object} thumbnail The thumbnail: img props.
@@ -56,14 +56,14 @@ export const AiBrandInsightsPreLaunch = ( {
 				<div className="yst-w-full yst-flex yst-mt-6">
 					<Button
 						as="a"
-						className="yst-grow yst-gap-2 yst-border-slate-200 yst-ai-insights-waitlist-button"
+						className="yst-grow yst-border-slate-200 yst-ai-insights-waitlist-button"
 						size="extra-large"
 						variant="upsell"
 						href={ buttonLink }
 						target="_blank"
 						ref={ initialFocus }
 					>
-						<AiSparkleIcon className="yst-mt-[1px]" />
+						<SparklesIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5 yst-text-white" />
 						{ buttonLabel }
 						<span className="yst-sr-only">
 							{


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the styling of the wishlist button, in the AI Brand Insights modal.

## Relevant technical choices:

* Used `yst--ms-1 yst-me-2` to replace the `yst-gap-2` of the container, to align with the button of the previous modal (the Google Add-on upsell, that is)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that the styling of the `Join the wishlist`  button is like this:
<img width="660" height="699" alt="image" src="https://github.com/user-attachments/assets/3c6241b4-8747-47f0-8d1a-324cccd728d9" />


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## UI changes

* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
