### PR TITLE
fix notification copy and BF badge

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -935,6 +935,17 @@ body.folded .wpseo-admin-submit-fixed {
 	text-wrap: nowrap;
 }
 
+.yoast-update-plugin-bf-sale-badge {
+	margin: auto 8px;
+	border-radius: 16px;
+	background-color: #000;
+	color: #FCD34D;
+	padding: 2px 8px;
+	font-size: 10px;
+	font-weight: 600;
+	line-height: normal;
+}
+
 @media (min-width: 768px) {
 	.wpseo_table_page .tablenav.bottom {
 		margin-bottom: 40px;

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -944,6 +944,8 @@ body.folded .wpseo-admin-submit-fixed {
 	font-size: 10px;
 	font-weight: 600;
 	line-height: normal;
+	display: inline-block;
+	height: 13px;
 }
 
 @media (min-width: 768px) {

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -407,18 +407,19 @@ class WPSEO_Addon_Manager {
 			$addon_link = ( isset( $this->addon_details[ $plugin_data['slug'] ] ) ) ? $this->addon_details[ $plugin_data['slug'] ]['short_link_renewal'] : $this->addon_details[ self::PREMIUM_SLUG ]['short_link_renewal'];
 
 			$sale_copy = '';
-			if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2023-promotion' ) ) {
+			if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 				$sale_copy = sprintf(
-				/* translators: %1$s is a <br> tag. */
-					esc_html__( '%1$s Now with 30%% Black Friday Discount!', 'wordpress-seo' ),
-					'<br>'
+				/* translators: %1$s and %2$s are a <span> opening and closing tag. */
+					esc_html__( '%1$s30%% OFF - Black Friday %2$s', 'wordpress-seo' ),
+					'<span class="yoast-update-plugin-bf-sale-badge">',
+					'</span>'
 				);
 			}
 			echo '<br><br>';
 			echo '<strong><span class="yoast-dashicons-notice warning dashicons dashicons-warning"></span> '
 				. sprintf(
 					/* translators: %1$s is the plugin name, %2$s and %3$s are a link. */
-					esc_html__( '%1$s can\'t be updated because your product subscription is expired. %2$sRenew your product subscription%3$s to get updates again and use all the features of %1$s.', 'wordpress-seo' ),
+					esc_html__( 'Your %1$s plugin cannot be updated as your subscription has expired. %2$sRenew your product subscription%3$s to restore updates and full feature access.', 'wordpress-seo' ),
 					esc_html( $plugin_data['name'] ),
 					'<a href="' . esc_url( WPSEO_Shortlinker::get( $addon_link ) ) . '">',
 					'</a>'


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the copy for updating plugin notification when there is no subscription and adds a badge for the Black Friday campaign.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Got to the plugins page.
* Install Yoast SEO premium with an old version.
* Check the copy of the update notification is:
<img width="1264" height="166" alt="Screenshot 2025-08-19 at 16 17 22" src="https://github.com/user-attachments/assets/2686fb3d-6b91-437d-b0ca-324a70b3f132" />

* Go to /src/promotions/domain/black-friday-promotion.php and make sure the bf promotion is active by changing line 16 to:  `new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2026 ) )`

* Refresh the plugin page and check the notification has the BF badge:
<img width="1716" height="180" alt="Screenshot 2025-08-19 at 16 21 58" src="https://github.com/user-attachments/assets/dcf7e3ea-7ebd-4634-99ab-1d3af0e22208" />

 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Adapt ads for new pricing and packaging - update copy for renewal notification](https://github.com/Yoast/reserved-tasks/issues/747)
