### PR TITLE
Add upgrade buttons

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -625,6 +625,7 @@ class WPSEO_Admin_Asset_Manager {
 			[
 				'name' => 'admin-global',
 				'src'  => 'admin-global-' . $flat_version,
+				'deps' => [ self::PREFIX . 'tailwind' ],
 			],
 			[
 				'name' => 'filter-explanation',

--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -16,10 +16,7 @@
   margin-bottom: 5px;
 }
 
-#wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-get-premium a {
-	font-weight: bold !important;
-	color: #fff !important;
-}
+
 
 #wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-get-premium span {
 	color: rgb(252, 211, 77);
@@ -150,4 +147,51 @@
   }
 }
 
+/** A lot of CSS for this stolen from the UI libary but slightly modified since the site bar css is very aggressive */
+#wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-get-premium .ab-empty-item{
+	@apply
+	yst-inline-flex
+	yst-items-center
+	yst-justify-center
+	yst-h-4
+	yst-mt-2
+	yst-mx-auto
+	yst-text-xs
+	yst-leading-4
+	yst-px-2.5
+	yst-py-1.5
+	yst-ring-inset
+	yst-ring-1
+	yst-ring-transparent
+	yst-shadow-sm
+	yst-no-underline
+	yst-cursor-pointer
+	yst-rounded-md
+	yst-font-medium
+	yst-text-center
+
+	focus:yst-outline
+	focus:yst-outline-2
+	focus:yst-outline-offset-2
+	yst-bg-amber-300
+	yst-border-transparent
+	hover:yst-text-amber-900
+	hover:yst-bg-amber-400
+	focus:yst-text-amber-900
+	focus:yst-outline-amber-400
+	visited:yst-text-amber-900
+	visited:hover:yst-text-amber-900;
+
+}
+#wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-get-premium {
+ @apply yst-flex;
+}
+#wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-get-premium .ab-empty-item a{
+	@apply
+	yst-text-amber-900;
+}
+
+#wpadminbar .quicklinks #wp-admin-bar-wpseo-menu #wp-admin-bar-wpseo-menu-default li#wp-admin-bar-wpseo-upgrade-sidebar {
+	@apply yst-hidden;
+}
 /*# sourceMappingURL=adminbar.css.map */

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -5,6 +5,7 @@
  * @package WPSEO
  */
 
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Score_Icon_Helper;
 use Yoast\WP\SEO\Integrations\Support_Integration;
@@ -590,6 +591,12 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function add_premium_link( WP_Admin_Bar $wp_admin_bar ) {
+		$has_woocommerce = ( new Woocommerce_Conditional() )->is_met();
+		$link            = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium' );
+		if ( $has_woocommerce ) {
+			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium-woocommerce' );
+		}
+
 		$sale_percentage = '';
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-2024-promotion' ) ) {
 			$sale_percentage = sprintf(
@@ -603,9 +610,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'id'     => 'wpseo-get-premium',
 				// Circumvent an issue in the WP admin bar API in order to pass `data` attributes. See https://core.trac.wordpress.org/ticket/38636.
 				'title'  => sprintf(
-					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2" style="padding:0;">%2$s &raquo; %3$s</a>',
-					esc_url( $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium' ) ),
-					esc_html__( 'Get Yoast SEO Premium', 'wordpress-seo' ),
+					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s %3$s</a>',
+					esc_url( $link ),
+					esc_html__( 'Upgrade', 'wordpress-seo' ),
 					$sale_percentage
 				),
 				'meta'   => [

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -107,7 +107,7 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-woocommerce' );
 		}
 
-		\wp_safe_redirect( $link );
+		\wp_redirect( $link );//phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect -- Safe redirect is used here.
 		exit;
 	}
 }

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -23,18 +23,24 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 
 	/**
 	 * The WooCommerce conditional.
+	 *
+	 * @var WooCommerce_Conditional
 	 */
-	private WooCommerce_Conditional $woocommerce_conditional;
+	private $woocommerce_conditional;
 
 	/**
 	 * The shortlinker.
+	 *
+	 * @var WPSEO_Shortlinker
 	 */
-	private WPSEO_Shortlinker $shortlinker;
+	private $shortlinker;
 
 	/**
 	 * The product helper.
+	 *
+	 * @var Product_Helper
 	 */
-	private Product_Helper $product_helper;
+	private $product_helper;
 
 	/**
 	 * Constructor.

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Yoast\WP\SEO\Plans\User_Interface;
+
+use WPSEO_Shortlinker;
+use Yoast\WP\SEO\Conditionals\Traits\Admin_Conditional_Trait;
+use Yoast\WP\SEO\Conditionals\WooCommerce_Conditional;
+use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Adds the plans page to the Yoast admin menu.
+ */
+class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
+
+	use Admin_Conditional_Trait;
+
+	/**
+	 * The page name.
+	 */
+	public const PAGE = 'wpseo_upgrade_sidebar';
+
+	/**
+	 * The WooCommerce conditional.
+	 */
+	private WooCommerce_Conditional $woocommerce_conditional;
+
+	/**
+	 * The shortlinker.
+	 */
+	private WPSEO_Shortlinker $shortlinker;
+
+	/**
+	 * The product helper.
+	 */
+	private Product_Helper $product_helper;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WooCommerce_Conditional $woocommerce_conditional The WooCommerce conditional.
+	 * @param WPSEO_Shortlinker       $shortlinker             The shortlinker.
+	 * @param Product_Helper          $product_helper          The product helper.
+	 */
+	public function __construct(
+		WooCommerce_Conditional $woocommerce_conditional,
+		WPSEO_Shortlinker $shortlinker,
+		Product_Helper $product_helper
+	) {
+		$this->woocommerce_conditional = $woocommerce_conditional;
+		$this->shortlinker             = $shortlinker;
+		$this->product_helper          = $product_helper;
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		// Add page with PHP_INT_MAX so its always the last item.
+		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_page' ], \PHP_INT_MAX );
+		\add_filter( 'wpseo_network_submenu_pages', [ $this, 'add_page' ], \PHP_INT_MAX );
+	}
+
+	/**
+	 * Adds the page to the (currently) last position in the array.
+	 *
+	 * @param array<string, array<string, array<static|string>>> $pages The pages.
+	 *
+	 * @return array<string, array<string, array<static|string>>> The pages.
+	 */
+	public function add_page( $pages ) {
+
+		if ( ! $this->product_helper->is_premium() ) {
+			$pages[] = [
+				General_Page_Integration::PAGE,
+				'',
+				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . \__( 'Upgrade', 'wordpress-seo' ) . ' </span></span>',
+				'wpseo_manage_options',
+				self::PAGE,
+				[ $this, 'do_redirect' ],
+			];
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Redirects to the yoast.com.
+	 *
+	 * @return void
+	 */
+	public function do_redirect() {
+
+		$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-premium' );
+		if ( $this->woocommerce_conditional->is_met() ) {
+			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-woocommerce' );
+		}
+
+		\wp_safe_redirect( $link );
+		exit;
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add an upgrade button to the sidebar and the admin menu.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an `upgrade` button to the sidebar and admin menu.

## Relevant technical choices:

* The sidebar button works with a link to a `page` and the page is just a redirect to the correct yoa.st link.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you only have free enabled and not `WooCommerce`(woo) and `Yoast SEO premium`(premium)
* Make sure the sidebar and top bar buttons looks like the ones in the design. For the top bar one make sure the url is:
`admin-bar-get-premium` and for the sidebar one turn on `preserve log` in the dev tools from chrome and make sure the redirect url is: `https://yoa.st/wordpress-menu-upgrade-premium`
* Enable woo and make sure the links change to `wordpress-menu-upgrade-woocommerce` and `wordpress-menu-upgrade-premium`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
