### PR TITLE
Render black friday sale label.

### DIFF
--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -597,12 +597,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium-woocommerce' );
 		}
 
-		$sale_percentage = '';
+		$button_label = esc_html__( 'Upgrade', 'wordpress-seo' );
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-			$sale_percentage = sprintf(
-				'<span class="admin-bar-premium-promotion">%1$s</span>',
-				esc_html__( '30% OFF', 'wordpress-seo' )
-			);
+			$button_label = esc_html__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 		$wp_admin_bar->add_menu(
 			[
@@ -610,10 +607,9 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'id'     => 'wpseo-get-premium',
 				// Circumvent an issue in the WP admin bar API in order to pass `data` attributes. See https://core.trac.wordpress.org/ticket/38636.
 				'title'  => sprintf(
-					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s %3$s</a>',
+					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s</a>',
 					esc_url( $link ),
-					esc_html__( 'Upgrade', 'wordpress-seo' ),
-					$sale_percentage
+					$button_label,
 				),
 				'meta'   => [
 					'tabindex' => '0',

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Promotions\Application\Promotion_Manager;
 
 /**
  * Adds the plans page to the Yoast admin menu.
@@ -51,23 +52,33 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 	private $current_page_helper;
 
 	/**
+	 * The promotion manager.
+	 *
+	 * @var Promotion_Manager
+	 */
+	private $promotion_manager;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WooCommerce_Conditional $woocommerce_conditional The WooCommerce conditional.
 	 * @param WPSEO_Shortlinker       $shortlinker             The shortlinker.
 	 * @param Product_Helper          $product_helper          The product helper.
 	 * @param Current_Page_Helper     $current_page_helper     The current page helper.
+	 * @param Promotion_Manager       $promotion_manager       The promotion manager.
 	 */
 	public function __construct(
 		WooCommerce_Conditional $woocommerce_conditional,
 		WPSEO_Shortlinker $shortlinker,
 		Product_Helper $product_helper,
-		Current_Page_Helper $current_page_helper
+		Current_Page_Helper $current_page_helper,
+		Promotion_Manager $promotion_manager
 	) {
 		$this->woocommerce_conditional = $woocommerce_conditional;
 		$this->shortlinker             = $shortlinker;
 		$this->product_helper          = $product_helper;
 		$this->current_page_helper     = $current_page_helper;
+		$this->promotion_manager       = $promotion_manager;
 	}
 
 	/**
@@ -93,11 +104,17 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 	 */
 	public function add_page( $pages ) {
 
+		$button_label = \__( 'Upgrade', 'wordpress-seo' );
+
+		if ( $this->promotion_manager->is( 'black-friday-promotion' ) ) {
+			$button_label = \__( '30% off - BF Sale', 'wordpress-seo' );
+		}
+
 		if ( ! $this->product_helper->is_premium() ) {
 			$pages[] = [
 				General_Page_Integration::PAGE,
 				'',
-				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . \__( 'Upgrade', 'wordpress-seo' ) . ' </span></span>',
+				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . ' </span></span>',
 				'wpseo_manage_options',
 				self::PAGE,
 				static function () {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to update de button text of the upgrade button for a sale.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the button label when the Black Friday sale is on.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure the black friday sale is not running and you don't have premium enabled. Make sure that in the WP menu sidebar we render a `upgrade` button in our menu
* Make sure that in our topbar we also render a `upgrade` button.
* Enable the sale and make sure the label changes to `30% off - BF Sale` like in the design.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
