### PR TITLE
Fixes #22244: Handle missing mbstring extension gracefully

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+  "redefinable-internals": [
+    "function_exists"
+  ]
+}

--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -227,7 +227,14 @@ class Article extends Abstract_Schema_Piece {
 			$characters  = \preg_split( '//u', $characters, -1, \PREG_SPLIT_NO_EMPTY );
 			$characters  = \array_unique( $characters );
 			$characters  = \implode( '', $characters );
-			$characters .= \mb_strtoupper( $characters );
+			
+            // Handle mbstring edge case.
+            if ( \function_exists( 'mb_strtoupper' ) ) {
+                $characters .= \mb_strtoupper( $characters );
+            }
+            else {
+                $characters .= \strtoupper( $characters );
+            }
 		}
 
 		// Remove characters from HTML entities.

--- a/tests/Unit/Generators/Schema/Article_Test.php
+++ b/tests/Unit/Generators/Schema/Article_Test.php
@@ -591,4 +591,41 @@ final class Article_Test extends TestCase {
 			],
 		];
 	}
+
+    /**
+     * Tests that word_count() gracefully falls back to strtoupper()
+     * when mbstring is not available.
+     *
+     * @covers ::word_count
+     *
+     * @return void
+     */
+    public function test_word_count_without_mbstring() {
+        // Make function_exists('mb_strtoupper') return false.
+        \Brain\Monkey\Functions\when( 'function_exists' )
+            ->alias( static function( $fn ) {
+                if ( $fn === 'mb_strtoupper' ) {
+                    return false;
+                }
+                return \function_exists( $fn );
+            });
+
+        // Use reflection to access the private method.
+        $reflection = new \ReflectionClass( \Yoast\WP\SEO\Generators\Schema\Article::class );
+        $method     = $reflection->getMethod( 'word_count' );
+        $method->setAccessible( true );
+
+        // Provide Cyrillic content that normally requires mbstring.
+        $content = 'пример'; // "example" in Russian.
+        $title   = '';
+
+        $count = $method->invokeArgs( $this->instance, [ $content, $title ] );
+
+        // Assert that fallback strtoupper() still counts correctly.
+        $this->assertEquals(
+            1,
+            $count,
+            'Fallback strtoupper should correctly count words without mbstring.'
+        );
+    }
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Yoast SEO currently assumes the `mbstring` PHP extension is always available. On servers where `mbstring` is disabled, calling `mb_strtoupper` inside the `word_count` method causes a fatal error.  
* We want `word_count()` to gracefully handle environments without `mbstring` and ensure multibyte content (e.g., Cyrillic) does not break the frontend or schema generation.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `word_count()` could cause a fatal error on servers without the `mbstring` PHP extension. Added a PHPUnit test to verify that `word_count()` gracefully falls back to `strtoupper()` when `mbstring` is unavailable, including multibyte content.

## Relevant technical choices:

* Added a `function_exists( 'mb_strtoupper' )` check before calling `mb_strtoupper` in `word_count()`.
* Falls back to `strtoupper()` when `mb_strtoupper` is unavailable.
* Added a PHPUnit test `test_word_count_without_mbstring()` that verifies the fallback with Cyrillic content.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable the `mbstring` extension on a local PHP setup.
* Install and activate this branch of Yoast SEO.
* Create a new post with Cyrillic content (e.g., Russian: `За здоровье!`).
* Save and publish the post.
* Verify no fatal error occurs on the frontend or during analysis.
* Re-enable `mbstring` and verify `word_count()` works correctly with multibyte content.

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Repeat the steps above with both `mbstring` disabled and enabled.
* Verify that the PHPUnit test passes on CI.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* `word_count` method in `class-yoast-text-statistics.php`.
* Multibyte content handling (Cyrillic, Ukrainian, etc.).
* Frontend schema generation and analysis.

## Labels
Please apply: `changelog: bugfix`

Fixes #22244
