### PR TITLE
Activate Site Kit feature flag when Site Kit is enabled

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -91,6 +91,7 @@ class WPSEO_Upgrade {
 			'20.7-RC0'   => 'upgrade_207',
 			'20.8-RC0'   => 'upgrade_208',
 			'22.6-RC0'   => 'upgrade_226',
+			'26.0-RC0'   => 'upgrade_260',
 		];
 
 		array_walk( $routines, [ $this, 'run_upgrade_routine' ], $version );
@@ -1153,6 +1154,18 @@ class WPSEO_Upgrade {
 		if ( get_option( Cleanup_Integration::CURRENT_TASK_OPTION ) === false ) {
 			$cleanup_integration = YoastSEO()->classes->get( Cleanup_Integration::class );
 			$cleanup_integration->start_cron_job( 'clean_selected_empty_usermeta', DAY_IN_SECONDS );
+		}
+	}
+
+	/**
+	 * Performs the 26.0 upgrade routine.
+	 * Enables the Site Kit integration feature flag if Site Kit is active.
+	 *
+	 * @return void
+	 */
+	private function upgrade_260() {
+		if ( is_plugin_active( 'google-site-kit/google-site-kit.php' ) ) {
+			WPSEO_Options::set( 'google_site_kit_feature_enabled', true, 'wpseo' );
 		}
 	}
 

--- a/src/dashboard/user-interface/enable-site-kit-feature-flag-on-activation.php
+++ b/src/dashboard/user-interface/enable-site-kit-feature-flag-on-activation.php
@@ -1,0 +1,65 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+namespace Yoast\WP\SEO\Dashboard\User_Interface;
+
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\Third_Party\Site_Kit_Conditional;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+
+/**
+ * Enables the Site Kit integration feature flag on plugin activation, if Site Kit is active.
+ */
+class Enable_Site_Kit_Feature_Flag_On_Activation implements Integration_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The Site Kit conditional.
+	 *
+	 * @var Site_Kit_Conditional $site_kit_conditional
+	 */
+	private $site_kit_conditional;
+
+	/**
+	 * The options helper.
+	 *
+	 * @var Options_Helper $options_helper
+	 */
+	private $options_helper;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Site_Kit_Conditional $site_kit_conditional The Site Kit conditional.
+	 * @param Options_Helper       $options_helper       The options helper.
+	 */
+	public function __construct(
+		Site_Kit_Conditional $site_kit_conditional,
+		Options_Helper $options_helper
+	) {
+		$this->site_kit_conditional = $site_kit_conditional;
+		$this->options_helper       = $options_helper;
+	}
+
+	/**
+	 * Registers the enabling of the Site Kit feature flag.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'wpseo_activate', [ $this, 'enable_site_kit_feature_flag' ] );
+	}
+
+	/**
+	 * Enables the Site Kit integration feature flag on plugin activation, if Site Kit is active.
+	 *
+	 * @return void
+	 */
+	public function enable_site_kit_feature_flag() {
+		if ( $this->site_kit_conditional->is_met() ) {
+			$this->options_helper->set( 'google_site_kit_feature_enabled', true );
+		}
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Activates the Site Kit feature flag when Site Kit is enabled

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

In three separate sites (make sure you don't have the Site Kit feature flag enabled):
1. With Yoast production version installed and Site Kit active, do an upgrade to this current RC/PR
2. With Yoast not installed and Site Kit active, install Yoast
3. With this RC/PR installed but Site Kit not active, install and activate Site Kit

* In all cases, visit the Yoast Dashboard and check that the Site Kit feature flag got enabled
* After resetting your settings (confirm that the feature flag got disabled), repeat the 2 first tests but with Site Kit not active. Confirm in the Yoast Dashboard that the feature flag didn't get enabled.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
