### PR TITLE
Use remote feature flag from Site Kit

### DIFF
--- a/src/conditionals/google-site-kit-feature-conditional.php
+++ b/src/conditionals/google-site-kit-feature-conditional.php
@@ -31,6 +31,6 @@ class Google_Site_Kit_Feature_Conditional implements Conditional {
 	 * @return bool `true` when the Site Kit feature is enabled.
 	 */
 	public function is_met() {
-		return $this->options->get( 'google_site_kit_feature_enabled' ) === true || \apply_filters( 'googlesitekit_is_feature_enabled', false, 'yoast_integration' );
+		return $this->options->get( 'google_site_kit_feature_enabled' ) === true || \apply_filters( 'googlesitekit_is_feature_enabled', false, 'yoastIntegration' );
 	}
 }

--- a/src/conditionals/google-site-kit-feature-conditional.php
+++ b/src/conditionals/google-site-kit-feature-conditional.php
@@ -31,6 +31,6 @@ class Google_Site_Kit_Feature_Conditional implements Conditional {
 	 * @return bool `true` when the Site Kit feature is enabled.
 	 */
 	public function is_met() {
-		return $this->options->get( 'google_site_kit_feature_enabled' ) === true;
+		return $this->options->get( 'google_site_kit_feature_enabled' ) === true || \apply_filters( 'googlesitekit_is_feature_enabled', false, 'yoast_integration' );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The implementation adheres to what has been talked about [here](https://yoast.slack.com/archives/C08LLAMGF1C/p1756904080250839?thread_ts=1756715427.809609&cid=C08LLAMGF1C).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Allows Site Kit to control the Site Kit feature flag remotely.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Since we don't have a way to use Site Kit's services related to remote feature flag, we will edit the relevant DB option to do the same thing. We could have waited to get the test plugin (mentioned [here](https://yoast.slack.com/archives/C08LLAMGF1C/p1756908187825479?thread_ts=1756715427.809609&cid=C08LLAMGF1C)) from Site Kit, but for velocity purposes, we'll do the below until we get it.
* Make sure you don't have the Site Kit integration's feature flag enabled - go to the Yoast dashboard and confirm you see nothing Site Kit related there.
* Search in your DB for the `googlesitekitpersistent_remote_features` option
  * If there's no such option, add it with the `a:2:{s:16:"yoastIntegration";a:1:{s:7:"enabled";b:1;}s:15:"last_updated_at";i:1756890270;}` value
  * If there's such an option, copy its value, add the yoastIntegration array in the existing value. You can do so like this:
    * Use unserialize.com to unserialize the value, using the `var_export` setting and copy the results somewhere.
    * Go to onlinephp.io/serialize and paste the unserialized value, but before serializing it again, add the `'yoastIntegration' => array ( 'enabled' => true, ),` sub-array before the `'last_updated_at' => 1756890270,` pair
    * Serialize the new value and update the `googlesitekitpersistent_remote_features` option with that
* Our DB edit essentially mimics how the Site Kit services will enable our integration remotely
* Refresh the Yoast Dashboard and confirm that the Site Kit integration is now active.
* Use [the modified Test helper](https://yoast.slack.com/archives/C03KU0EHCNQ/p1745911970355829) to enable our own feature flag too and refresh the Yoast dashboard
* Confirm you again see the Site Kit integration.
* If your DB didnt have the `googlesitekitpersistent_remote_features` option before your edits, delete it again
* If your DB did have the `googlesitekitpersistent_remote_features` option before your edits, paste the old value again
* In both cases, confirm that the Site Kit integration in Yoast Dashboard is still visible.
* Now use the Test Helper again to disable our own feature flag too
* Now confirm that the Site Kit integration in Yoast Dashboard is now invisible

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
