### PR TITLE
Add modal for unsaved changes in llms.txt

### DIFF
--- a/packages/js/src/settings/components/index.js
+++ b/packages/js/src/settings/components/index.js
@@ -16,3 +16,4 @@ export { default as Search } from "./search";
 export { ErrorFallback } from "./error-fallback";
 export { LlmsTxtAlert } from "./llms-txt-alert";
 export { LlmTxtPopover } from "./llm-txt-popover";
+export { LlmsTxtUnsavedChangesModal } from "./llms-txt-unsaved-changes-modal";

--- a/packages/js/src/settings/components/llms-txt-unsaved-changes-modal.js
+++ b/packages/js/src/settings/components/llms-txt-unsaved-changes-modal.js
@@ -1,0 +1,54 @@
+import { ExclamationIcon } from "@heroicons/react/outline";
+import { Button, Modal, useSvgAria } from "@yoast/ui-library";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+
+/**
+ * The unsaved changes modal.
+ *
+ * @param {boolean} isOpen Whether the modal is open.
+ * @param {function} [onClose] The function to call when the modal is closed.
+ * @param {function} [onDiscard] The function to call when the changes are discarded.
+ * @param {string} title The title of the modal.
+ * @param {string} description The description of the modal.
+ * @param {string} dismissLabel The label for the dismiss button.
+ *
+ * @returns {JSX.Element} The unsaved changes modal.
+ */
+export const LlmsTxtUnsavedChangesModal = ( { isOpen, onClose = noop, onDiscard = noop, title, description, dismissLabel } ) => {
+	const svgAriaProps = useSvgAria();
+
+	return <Modal isOpen={ isOpen } onClose={ onClose }>
+		<Modal.Panel className="yst-max-w-sm">
+			<div className="yst-flex yst-flex-col yst-items-center yst-gap-1">
+				<div
+					className="yst-mx-auto yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-12 yst-w-12 yst-rounded-full yst-bg-red-100"
+				>
+					<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
+				</div>
+				<div className="yst-mt-3 yst-text-center">
+					<Modal.Title className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900 yst-mb-3">
+						{ title }
+					</Modal.Title>
+					<Modal.Description className="yst-text-sm yst-text-slate-500">
+						{ description }
+					</Modal.Description>
+				</div>
+			</div>
+			<div className="yst-flex yst-flex-col sm:yst-flex-row-reverse yst-gap-3 yst-mt-6">
+				<Button type="button" variant="primary" onClick={ onDiscard } className="yst-grow">
+					{ dismissLabel }
+				</Button>
+			</div>
+		</Modal.Panel>
+	</Modal>;
+};
+
+LlmsTxtUnsavedChangesModal.propTypes = {
+	isOpen: PropTypes.bool.isRequired,
+	onClose: PropTypes.func,
+	onDiscard: PropTypes.func,
+	title: PropTypes.string.isRequired,
+	description: PropTypes.string.isRequired,
+	dismissLabel: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the UX of the `llms.txt` settings, by informing the user that they have to save their changes in order for the file to be generated.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a site that has no llms.txt file, go to Yoast settings->llms.txt
* Enable the main toggle to enable the feature but dont save
* Click the **View the llms.txt file** button 
* Confirm that you get the following modal:
<img width="579" height="373" alt="image" src="https://github.com/user-attachments/assets/418a2640-14b8-4d24-9b7c-d1501dba4d25" />

* Discard it either from the close button or from the **Got it** button or from clicking outside of it.
* Save the changes, click the **View the llms.txt file** button and confirm that you're redirected to see the actual file
* Do any other change in the llms.txt settings and repeat the test. You should be getting the modal every time you change something and not save the changes yet.
* Disable the feature and dont save
* Confirm that the **View the llms.txt file** button is disabled now.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
