### PR TITLE
Fix case when multiple introductions are prevented to be seen in the FTC

### DIFF
--- a/src/introductions/infrastructure/introductions-seen-repository.php
+++ b/src/introductions/infrastructure/introductions-seen-repository.php
@@ -96,7 +96,56 @@ class Introductions_Seen_Repository {
 	}
 
 	/**
+	 * Sets the introductions as seen.
+	 *
+	 * @param int   $user_id          The user ID.
+	 * @param int[] $introduction_ids The IDs if the introductions to be set.
+	 * @param bool  $are_seen         Whether the introductions are seen.
+	 *
+	 * @return bool False on failure. Not having to update is a success.
+	 *
+	 * @throws Invalid_User_Id_Exception If an invalid user ID is supplied.
+	 */
+	public function set_introductions( int $user_id, array $introduction_ids, bool $are_seen ): bool {
+		$introductions         = $this->get_all_introductions( $user_id );
+		$changed_introductions = false;
+
+		foreach ( $introduction_ids as $introduction_id ) {
+			// Check if the wanted value is already set.
+			if ( \array_key_exists( $introduction_id, $introductions ) ) {
+				if ( \is_array( $introductions[ $introduction_id ] ) ) {
+					// New format with seen_on timestamp.
+					if ( $introductions[ $introduction_id ]['is_seen'] === $are_seen ) {
+						continue;
+					}
+				}
+					// Old format with just a boolean.
+				elseif ( $introductions[ $introduction_id ] === $are_seen ) {
+						continue;
+				}
+			}
+
+			// If not, set it.
+			$introductions[ $introduction_id ] = [
+				'is_seen' => $are_seen,
+				'seen_on' => ( $are_seen === true ) ? \time() : 0,
+			];
+
+			$changed_introductions = true;
+		}
+
+		if ( ! $changed_introductions ) {
+			return true;
+		}
+
+		return $this->set_all_introductions( $user_id, $introductions );
+	}
+
+	/**
 	 * Sets the introduction as seen.
+	 *
+	 * @deprecated 26.1
+	 * @codeCoverageIgnore
 	 *
 	 * @param int    $user_id         The user ID.
 	 * @param string $introduction_id The introduction ID.
@@ -107,6 +156,8 @@ class Introductions_Seen_Repository {
 	 * @throws Invalid_User_Id_Exception If an invalid user ID is supplied.
 	 */
 	public function set_introduction( $user_id, string $introduction_id, bool $is_seen = true ): bool {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 26.1' );
+
 		$introductions = $this->get_all_introductions( $user_id );
 
 		// Check if the wanted value is already set.

--- a/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
@@ -239,22 +239,22 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests setting the introduction.
+	 * Tests setting the introductions.
 	 *
-	 * @covers ::set_introduction
+	 * @covers ::set_introductions
 	 *
-	 * @dataProvider provide_set_introduction_test_data
+	 * @dataProvider provide_set_introductions_test_data
 	 *
-	 * @param string $introduction_id The introduction ID.
-	 * @param bool   $is_seen         Whether the introduction is seen.
-	 * @param mixed  $meta            The get_meta return value.
-	 * @param array  $expected_meta   The expected meta.
+	 * @param int[] $introduction_ids The introduction ID.
+	 * @param bool  $is_seen          Whether the introduction is seen.
+	 * @param mixed $meta             The get_meta return value.
+	 * @param array $expected_meta    The expected meta.
 	 *
 	 * @return void
 	 *
 	 * @throws Invalid_User_Id_Exception Invalid User ID.
 	 */
-	public function test_set_introduction( $introduction_id, $is_seen, $meta, $expected_meta ) {
+	public function test_set_introductions( $introduction_ids, $is_seen, $meta, $expected_meta ) {
 		$user_id = 1;
 		$this->user_helper->expects( 'get_meta' )
 			->once()
@@ -265,44 +265,92 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 			->with( $user_id, Introductions_Seen_Repository::USER_META_KEY, $expected_meta )
 			->andReturnTrue();
 
-		$this->instance->set_introduction( $user_id, $introduction_id, $is_seen, $meta );
+		$this->instance->set_introductions( $user_id, $introduction_ids, $is_seen, $meta );
 	}
 
 	/**
-	 * Provides data for `test_set_introduction()`.
+	 * Provides data for `test_set_introductions()`.
 	 *
 	 * @return array
 	 */
-	public static function provide_set_introduction_test_data() {
+	public static function provide_set_introductions_test_data() {
 		return [
-			'seen'      => [
-				'introduction_id' => 'foo',
-				'is_seen'         => true,
-				'meta'            => [],
-				'expected_meta'   => [ 'foo' => true ],
+			'seen'               => [
+				'introduction_ids' => [ 'foo' ],
+				'is_seen'          => true,
+				'meta'             => [],
+				'expected_meta'    => [ 'foo' => true ],
 			],
-			'not seen'  => [
-				'introduction_id' => 'foo',
-				'is_seen'         => false,
-				'meta'            => [],
-				'expected_meta'   => [
+			'not seen'           => [
+				'introduction_ids' => [ 'foo' ],
+				'is_seen'          => false,
+				'meta'             => [],
+				'expected_meta'    => [
 					'foo' => [
 						'is_seen' => false,
 						'seen_on' => 0,
 					],
 				],
 			],
-			'no change' => [
-				'introduction_id' => 'foo',
-				'is_seen'         => true,
-				'meta'            => [
+			'no change'          => [
+				'introduction_ids' => [ 'foo' ],
+				'is_seen'          => true,
+				'meta'             => [
 					'foo' => [
 						'is_seen' => true,
 						'seen_on' => 12345678,
 					],
 				],
-				'expected_meta'   => [
+				'expected_meta'    => [
 					'foo' => [
+						'is_seen' => true,
+						'seen_on' => 12345678,
+					],
+				],
+			],
+			'multiple seen'      => [
+				'introduction_ids' => [ 'foo', 'bar' ],
+				'is_seen'          => true,
+				'meta'             => [],
+				'expected_meta'    => [
+					'foo' => true,
+					'bar' => true,
+				],
+			],
+			'multiple not seen'  => [
+				'introduction_ids' => [ 'foo', 'bar' ],
+				'is_seen'          => false,
+				'meta'             => [],
+				'expected_meta'    => [
+					'foo' => [
+						'is_seen' => false,
+						'seen_on' => 0,
+					],
+					'bar' => [
+						'is_seen' => false,
+						'seen_on' => 0,
+					],
+				],
+			],
+			'multiple no change' => [
+				'introduction_ids' => [ 'foo', 'bar' ],
+				'is_seen'          => true,
+				'meta'             => [
+					'foo' => [
+						'is_seen' => true,
+						'seen_on' => 12345678,
+					],
+					'bar' => [
+						'is_seen' => true,
+						'seen_on' => 12345678,
+					],
+				],
+				'expected_meta'    => [
+					'foo' => [
+						'is_seen' => true,
+						'seen_on' => 12345678,
+					],
+					'bar' => [
 						'is_seen' => true,
 						'seen_on' => 12345678,
 					],

--- a/tests/Unit/Introductions/User_Interface/Introductions_Seen_Route_Test.php
+++ b/tests/Unit/Introductions/User_Interface/Introductions_Seen_Route_Test.php
@@ -161,9 +161,9 @@ final class Introductions_Seen_Route_Test extends TestCase {
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
 		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
-			->expects( 'set_introduction' )
+			->expects( 'set_introductions' )
 			->once()
-			->with( $user_id, $introduction_id, true )
+			->with( $user_id, [ $introduction_id ], true )
 			->andReturnTrue();
 
 		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
@@ -197,6 +197,54 @@ final class Introductions_Seen_Route_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the set_introduction_seen route's happy path.
+	 *
+	 * @covers ::set_introduction_seen
+	 *
+	 * @return void
+	 */
+	public function test_set_introductions_seen() {
+		$user_id          = 1;
+		$introductions_id = [ 'intro' ];
+		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( 'intro' )->andReturnTrue();
+		$this->introductions_seen_repository
+			->expects( 'set_introductions' )
+			->once()
+			->with( $user_id, $introductions_id, true )
+			->andReturnTrue();
+
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response_mock
+			->expects( '__construct' )
+			->with(
+				[
+					'json' => (object) [
+						'success' => true,
+					],
+				],
+				200
+			)
+			->once();
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_ids' => $introductions_id,
+					'are_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->set_introductions_seen( $wp_rest_request )
+		);
+	}
+
+	/**
 	 * Tests the set_introduction_seen route that failed.
 	 *
 	 * @covers ::set_introduction_seen
@@ -209,9 +257,9 @@ final class Introductions_Seen_Route_Test extends TestCase {
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
 		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
-			->expects( 'set_introduction' )
+			->expects( 'set_introductions' )
 			->once()
-			->with( $user_id, $introduction_id, true )
+			->with( $user_id, [ $introduction_id ], true )
 			->andReturnFalse();
 
 		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
@@ -245,6 +293,56 @@ final class Introductions_Seen_Route_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the set_introduction_seen route that failed.
+	 *
+	 * @covers ::set_introductions_seen
+	 *
+	 * @return void
+	 */
+	public function test_set_introductions_seen_failed() {
+		$user_id          = 1;
+		$introduction_ids = [
+			'intro',
+		];
+		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
+		$this->introductions_collector->expects( 'is_available_introduction' )->with( 'intro' )->andReturnTrue();
+		$this->introductions_seen_repository
+			->expects( 'set_introductions' )
+			->once()
+			->with( $user_id, $introduction_ids, true )
+			->andReturnFalse();
+
+		$wp_rest_response_mock = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response_mock
+			->expects( '__construct' )
+			->with(
+				[
+					'json' => (object) [
+						'success' => false,
+					],
+				],
+				400
+			)
+			->once();
+
+		$wp_rest_request = Mockery::mock( WP_REST_Request::class );
+		$wp_rest_request
+			->expects( 'get_params' )
+			->once()
+			->andReturn(
+				[
+					'introduction_ids' => $introduction_ids,
+					'are_seen'         => true,
+				]
+			);
+
+		$this->assertInstanceOf(
+			'WP_REST_Response',
+			$this->instance->set_introductions_seen( $wp_rest_request )
+		);
+	}
+
+	/**
 	 * Tests the set_introduction_seen route with error.
 	 *
 	 * @covers ::set_introduction_seen
@@ -257,9 +355,9 @@ final class Introductions_Seen_Route_Test extends TestCase {
 		$this->user_helper->expects( 'get_current_user_id' )->andReturn( $user_id );
 		$this->introductions_collector->expects( 'is_available_introduction' )->with( $introduction_id )->andReturnTrue();
 		$this->introductions_seen_repository
-			->expects( 'set_introduction' )
+			->expects( 'set_introductions' )
 			->once()
-			->with( $user_id, $introduction_id, true )
+			->with( $user_id, [ $introduction_id ], true )
 			->andThrow( new Exception( 'Invalid User ID' ) );
 
 		$wp_rest_request = Mockery::mock( WP_REST_Request::class );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the introduction with the highest priority will never be seen, if the user reaches the FTC without reaching any other Yoast page and there are multiple introductions to be displayed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Note: If https://github.com/Yoast/reserved-tasks/issues/770 is also merged, we need to tweak the below steps to use the ID of the new introduction instead.

Test and regression test the endpoint changes:
* To easily see multiple introductions, enable the Black Friday one 
  * You can do that by edit `src\promotions\domain\black-friday-promotion.php`: `new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2026 ) )`
* Make sure you have no `_yoast_wpseo_introductions` usermeta in your fresh site
* Using POSTMAN, do POST requests to the following endpoints, which will set the BF and the AI insight introductions to seen:
  * `http://example.com/wp-json/yoast/v1/introductions/ai-brand-insights-pre-launch/seen?is_seen=true` 
  * `http://example.com/wp-json/yoast/v1/introductions/black-friday-announcement/seen?is_seen=true` 
* Visit a Yoast page and confirm that you don't see any modal there
* Using POSTMAN, do POST requests to the following endpoint, which will set the BF to not seen:
  * `http://example.com/wp-json/yoast/v1/introductions/black-friday-announcement/seen?is_seen=false` 
  * Repeat the POST request, even though the BF modal is already set to not seen
* Visit a Yoast page and confirm that you see the BF modal there. Refresh and confirm you dont see any modals
* Using POSTMAN, do a POST request to the following endpoint, which will set the BF to not seen.
  * `http://example.com/wp-json/yoast/v1/introductions/ai-brand-insights-pre-launch/seen?is_seen=false` 
* Visit a Yoast page and confirm that you see the AI insight modal there.
* Now let's test the new endpoint of setting multiple introductions as seen/not seen. Let's continue from where the last step left us.
* Using POSTMAN, do POST requests to `http://example.com/wp-json/yoast/v1/introductions/set_multiple_seen`. In order to set the BF and the AI insight introductions to not seen, we need to include the following body in the request:
```
{
    "introduction_ids": [
        "black-friday-announcement",
        "ai-brand-insights-pre-launch"
    ],
    "are_seen": false
}
```
* Repeat the POST request even though the introductions are already set to not seen.
* Refresh a Yoast page and confirm you get the BF modal. Refresh again and confirm that you get the AI Insights modal
* Delete the `_yoast_wpseo_introductions` user meta and do POST requests to `http://example.com/wp-json/yoast/v1/introductions/set_multiple_seen`. In order to set the BF and the AI insight introductions to seen, we need to include the following body in the request:
```
{
    "introduction_ids": [
        "black-friday-announcement",
        "ai-brand-insights-pre-launch"
    ],
    "are_seen": true
}
```
* Go to a Yoast page and confirm you see no modals
* Finally, do a POST request to that endpoint using an introduction that doesn't exist. So in the body use:
{
    "introduction_ids": [
        "intro-that-doesnt-exist"
    ],
    "are_seen": true
}
* Confirm that you get a 400 response.

**Test that the FTC bug was fixed**.
* In a fresh site, install the RC but dont go to any Yoast page
* Also, do the above edit to enable the Black Friday ads
* Before visiting any Yoast page, go straight to the FTC
* Visit any other Yoast page now

**Without this fix**:
*  You will get the AI insight modal and you will never see the BF one

**With this fix**:
* You will first see the BF. If you refresh, now you will see the AI insight one.

---

* Let's test the same fix but for AI insights and the delayed Premium upsell.
* In a fresh site, install the RC but dont go to any Yoast page
* In the DB, edit the `first_activated_on` timestamp of the `wpseo` option to be over 2 weeks ago
* Go to the FTC 
* Now go to any other Yoast page
* Confirm you will get the AI Insights modal
* Edit the `_yoast_wpseo_introductions` user meta and make the timestamp of the `ai-brand-insights-pre-launch` modal to something over a week ago
* Refresh the Yoast page and confirm that you get the delayed Premium upsell now


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
