### PR TITLE
Update badges

### DIFF
--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -948,6 +948,21 @@ body.folded .wpseo-admin-submit-fixed {
 	height: 13px;
 }
 
+#wpseo-new-badge-upgrade {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	white-space: nowrap;
+	margin: 0.125rem 0.5rem;
+	width: 2rem;
+	height: 1rem;
+	border-radius: 18px;
+	background-color: #bfdbfe;
+	color: #1e40af;
+	font-size: 0.625rem;
+	font-weight: 600;
+}
+
 @media (min-width: 768px) {
 	.wpseo_table_page .tablenav.bottom {
 		margin-bottom: 40px;

--- a/css/src/admin-global.css
+++ b/css/src/admin-global.css
@@ -954,7 +954,7 @@ body.folded .wpseo-admin-submit-fixed {
 	justify-content: center;
 	white-space: nowrap;
 	margin: 0.125rem 0.5rem;
-	width: 2rem;
+	width: 2.375rem;
 	height: 1rem;
 	border-radius: 18px;
 	background-color: #bfdbfe;

--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -155,7 +155,7 @@
 	yst-justify-center
 	yst-h-4
 	yst-mt-2
-	yst-mx-auto
+	yst-mx-3
 	yst-text-xs
 	yst-leading-4
 	yst-px-2.5

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -596,10 +596,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		$button_label = esc_html__( 'Upgrade', 'wordpress-seo' );
-		$badge        = '<div id="wpseo-new-badge-upgrade">' . __( 'New', 'wordpress-seo' ) . '</div>';
+		$badge        = '';
+		if ( $this->product_helper->is_premium() ) {
+			$badge = '<div id="wpseo-new-badge-upgrade">' . __( 'New', 'wordpress-seo' ) . '</div>';
+		}
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-			$button_label = esc_html__( '30% off - BF Sale', 'wordpress-seo' );
+			$button_label = ( $this->product_helper->is_premium() === true ) ? esc_html__( '30% off', 'wordpress-seo' ) : esc_html__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 		$wp_admin_bar->add_menu(
 			[

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -589,9 +589,13 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return void
 	 */
 	protected function add_premium_link( WP_Admin_Bar $wp_admin_bar ) {
-		$has_woocommerce = ( new Woocommerce_Conditional() )->is_met();
 		$link            = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium' );
-		if ( $has_woocommerce ) {
+		$has_woocommerce = ( new Woocommerce_Conditional() )->is_met();
+
+		if ( $this->product_helper->is_premium() ) {
+			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-ai-insights' );
+		}
+		elseif ( $has_woocommerce ) {
 			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/admin-bar-get-premium-woocommerce' );
 		}
 

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -596,7 +596,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		$button_label = esc_html__( 'Upgrade', 'wordpress-seo' );
-		$badge = '<div id="wpseo-new-badge-upgrade">' . __( "New", "wordpress-seo" ) . '</div>';
+		$badge        = '<div id="wpseo-new-badge-upgrade">' . __( 'New', 'wordpress-seo' ) . '</div>';
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$button_label = esc_html__( '30% off - BF Sale', 'wordpress-seo' );

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -607,9 +607,10 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'id'     => 'wpseo-get-premium',
 				// Circumvent an issue in the WP admin bar API in order to pass `data` attributes. See https://core.trac.wordpress.org/ticket/38636.
 				'title'  => sprintf(
-					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s</a>',
+					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s</a>%3$s',
 					esc_url( $link ),
-					$button_label . $badge,
+					$button_label,
+					$badge,
 				),
 				'meta'   => [
 					'tabindex' => '0',

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -606,7 +606,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-			$button_label = ( $this->product_helper->is_premium() === true ) ? esc_html__( '30% off', 'wordpress-seo' ) : esc_html__( '30% off - BF Sale', 'wordpress-seo' );
+			$button_label =  esc_html__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 		$wp_admin_bar->add_menu(
 			[

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -289,9 +289,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 			$this->add_network_settings_submenu( $wp_admin_bar );
 		}
 
-		if ( ! $this->product_helper->is_premium() ) {
-			$this->add_premium_link( $wp_admin_bar );
-		}
+		$this->add_premium_link( $wp_admin_bar );
 	}
 
 	/**

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -606,7 +606,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
-			$button_label =  esc_html__( '30% off - BF Sale', 'wordpress-seo' );
+			$button_label = esc_html__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 		$wp_admin_bar->add_menu(
 			[

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -598,6 +598,8 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 		}
 
 		$button_label = esc_html__( 'Upgrade', 'wordpress-seo' );
+		$badge = '<div id="wpseo-new-badge-upgrade">' . __( "New", "wordpress-seo" ) . '</div>';
+
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) ) {
 			$button_label = esc_html__( '30% off - BF Sale', 'wordpress-seo' );
 		}
@@ -609,7 +611,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 				'title'  => sprintf(
 					'<a href="%1$s" target="_blank" data-action="load-nfd-ctb" data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2">%2$s</a>',
 					esc_url( $link ),
-					$button_label,
+					$button_label . $badge,
 				),
 				'meta'   => [
 					'tabindex' => '0',

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -139,7 +139,10 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 			return;
 		}
 		$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-premium' );
-		if ( $this->woocommerce_conditional->is_met() ) {
+		if ( $this->product_helper->is_premium() ) {
+			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-ai-insights' );
+		}
+		elseif ( $this->woocommerce_conditional->is_met() ) {
 			$link = $this->shortlinker->build_shortlink( 'https://yoa.st/wordpress-menu-upgrade-woocommerce' );
 		}
 

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -110,19 +110,18 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 			$button_label = \__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 
-		$badge = '<div id="wpseo-new-badge-upgrade">' . __( "New", "wordpress-seo" ) . '</div>';
-		if ( ! $this->product_helper->is_premium() ) {
-			$pages[] = [
-				General_Page_Integration::PAGE,
-				'',
-				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . $badge .' </span></span>',
-				'wpseo_manage_options',
-				self::PAGE,
-				static function () {
-					echo 'redirecting...';
-				},
-			];
-		}
+		$badge = '<div id="wpseo-new-badge-upgrade">' . \__( 'New', 'wordpress-seo' ) . '</div>';
+
+		$pages[] = [
+			General_Page_Integration::PAGE,
+			'',
+			'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . $badge . ' </span></span>',
+			'wpseo_manage_options',
+			self::PAGE,
+			static function () {
+				echo 'redirecting...';
+			},
+		];
 
 		return $pages;
 	}

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -110,11 +110,12 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 			$button_label = \__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 
+		$badge = '<div id="wpseo-new-badge-upgrade">' . __( "New", "wordpress-seo" ) . '</div>';
 		if ( ! $this->product_helper->is_premium() ) {
 			$pages[] = [
 				General_Page_Integration::PAGE,
 				'',
-				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . ' </span></span>',
+				'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . $badge .' </span></span>',
 				'wpseo_manage_options',
 				self::PAGE,
 				static function () {

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -115,7 +115,7 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 		$pages[] = [
 			General_Page_Integration::PAGE,
 			'',
-			'<span class="yst-root"><span class="yst-button yst-w-full yst-button--upsell yst-button--small">' . $button_label . $badge . ' </span></span>',
+			'<span class="yst-root"><span class="yst-button yst-w-full yst-whitespace-nowrap yst-button--upsell yst-button--small">' . $button_label . $badge . ' </span></span>',
 			'wpseo_manage_options',
 			self::PAGE,
 			static function () {

--- a/src/plans/user-interface/upgrade-sidebar-menu-integration.php
+++ b/src/plans/user-interface/upgrade-sidebar-menu-integration.php
@@ -104,18 +104,20 @@ class Upgrade_Sidebar_Menu_Integration implements Integration_Interface {
 	 */
 	public function add_page( $pages ) {
 
-		$button_label = \__( 'Upgrade', 'wordpress-seo' );
+		$button_content = \__( 'Upgrade', 'wordpress-seo' );
 
 		if ( $this->promotion_manager->is( 'black-friday-promotion' ) ) {
-			$button_label = \__( '30% off - BF Sale', 'wordpress-seo' );
+			$button_content = ( $this->product_helper->is_premium() ) ? \__( 'Get 30% off', 'wordpress-seo' ) : \__( '30% off - BF Sale', 'wordpress-seo' );
 		}
 
-		$badge = '<div id="wpseo-new-badge-upgrade">' . \__( 'New', 'wordpress-seo' ) . '</div>';
+		if ( $this->product_helper->is_premium() ) {
+			$button_content .= '<div id="wpseo-new-badge-upgrade">' . \__( 'New', 'wordpress-seo' ) . '</div>';
+		}
 
 		$pages[] = [
 			General_Page_Integration::PAGE,
 			'',
-			'<span class="yst-root"><span class="yst-button yst-w-full yst-whitespace-nowrap yst-button--upsell yst-button--small">' . $button_label . $badge . ' </span></span>',
+			'<span class="yst-root"><span class="yst-button yst-w-full yst-whitespace-nowrap yst-button--upsell yst-button--small">' . $button_content . ' </span></span>',
 			'wpseo_manage_options',
 			self::PAGE,
 			static function () {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* N/A

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the `Upgrade` buttons in WordPress sidebar and admin bar to be shown to all users with a `New` badge.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:


* Use the following Figma designs to check the UI implementation:
  * [Sidebar](https://www.figma.com/design/A8L1q0TQfj7hAfqoezQxjI/Ads---WordPress?node-id=1-1959&t=xgHpsuSUah9GYVfq-4) 
  * [Admin bar ](https://www.figma.com/design/A8L1q0TQfj7hAfqoezQxjI/Ads---WordPress?node-id=23-3459&t=xgHpsuSUah9GYVfq-4)
  The elements in the design are organized in the following order: Free, Free + BF campaing, Premium, Premium + BF Campaing

<details>

<summary> Yoast SEO only </summary>

* Start with only Yoast SEO activated

* In the backend, check that both the `Upgrade` button in the sidebar and in the admin bar is unchanged
* Check the sidebar button redirects to `https://yoast.com/reasons-to-upgrade`
* Check the admin bar one points to `https://yoa.st/admin-bar-get-premium`

</details>

<details>

<summary> Yoast SEO + WooCommerce </summary>

* Activate WooCommerce
  * Check the buttons look same as before
    * Check the sidebar one now redirects you to `https://yoast.com/rtu-woocommerce-seo/`
    * Check the admin bar one points to `https://yoa.st/admin-bar-get-premium-woocommerce`

</details>

<details>

<summary> Yoast SEO only + BF campaign</summary>

* Deactivate Woocommerce
* Edit `src/promotions/domain/black-friday-promotion.php`
  * Change line 16 to `new Time_Interval( \gmmktime( 10, 00, 00, 11, 27, 2023 ), \gmmktime( 10, 00, 00, 12, 2, 2025 ) )`
* In the backend, check the two buttons and make sure they look as in the design

</details>

<details>

<summary> Yoast SEO + WooCommerce + BF campaign </summary>

* Activate WooCommerce
  * Check the buttons look same as before
    * Check the sidebar one now redirects you to `https://yoast.com/rtu-woocommerce-seo/`
    * Check the admin bar one points to `https://yoa.st/admin-bar-get-premium-woocommerce`

</details>

<details>

<summary> Yoast SEO Premium </summary>

* Edit `src/promotions/domain/black-friday-promotion.php`
  * Change line 16 back to `new Time_Interval( \gmmktime( 10, 00, 00, 11, 27, 2025 ), \gmmktime( 10, 00, 00, 12, 2, 2025 ) )`
* Deactivate WooCommerce
* Activate Yoast SEO Premium
* Check the two buttons now look like in the design
* Check the sidebar button redirects to the Yoast homepage (we still don't have the page for this)
* Check the admin bar one points to `https://yoa.st/admin-bar-get-ai-insights`

</details>

<details>

<summary> Yoast SEO Premium + BF campaign </summary>

* Edit `src/promotions/domain/black-friday-promotion.php`
* Change line 16 to `new Time_Interval( \gmmktime( 10, 00, 00, 11, 27, 2023 ), \gmmktime( 10, 00, 00, 12, 2, 2025 ) )`
* Check the two buttons look like in the design
* Check the sidebar button redirects to the Yoast homepage (we still don't have the page for this)
* Check the admin bar one points to `https://yoa.st/admin-bar-get-ai-insights`

</details>

* Repeat the two Premium cases and verify nothing changes if you activate WooCommerce

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#779](https://github.com/Yoast/reserved-tasks/issues/779)
