### PR TITLE
Fix case when multiple introductions are prevented to be seen in the FTC

### DIFF
--- a/packages/js/src/introductions/initialize.js
+++ b/packages/js/src/introductions/initialize.js
@@ -29,7 +29,7 @@ domReady( () => {
 
 	if ( location.href.indexOf( "page=wpseo_dashboard#/first-time-configuration" ) !== -1 ) {
 		// When on the FTC, we should abort displaying introductions and to mark them as not seen.
-		window.YoastSEO._registerIntroductionComponent = ( id ) => {
+		window.YoastSEO._registerIntroductionComponent = async( id ) => {
 			const introduction = find( initialIntroductions, { id } );
 			if ( ! introduction ) {
 				return;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Prevent race conditions in API requests in the FTC, by making sure each request (and the later action) is fired only after the previous request finishes, by properly using `async/await`.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the introduction with the highest priority will never be seen, if the user reaches the FTC without reaching any other Yoast page and there are multiple introductions to be displayed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a fresh site (or with the `_yoast_wpseo_introductions` usermeta deleted), install the RC but dont go to any Yoast page
* To easily see multiple introductions, enable the Black Friday one 
  * You can do that by edit `src\promotions\domain\black-friday-promotion.php`: `new Time_Interval( \gmmktime( 10, 00, 00, 11, 28, 2024 ), \gmmktime( 10, 00, 00, 12, 3, 2026 ) )`
* Before visiting any Yoast page, go straight to the FTC
* Visit any other Yoast page now

**Without this fix**:
*  You will get the BF modal and after you refresh you will never see the AI insight one

**With this fix**:
* You will first see the BF. If you refresh, now you will see the AI insight one.

Test for Premium introductions:
* Activate Free and Premium in a fresh site (or with the introduction usermeta deleted)
* Because we currently do have an introduction modal that's set to be seen in a Yoast page, let's edit the `ai-optimize-classic` that's set to be displayed in the classic post editor
  * In `src\introductions\application\ai-optimize-classic-introduction.php` make `should_show()` return true early.
* Go to the FTC without going through any other Yoast page
* Revert your change in `ai-optimize-classic-introduction.php`
* Go to a Yoast page

**Without this fix**:
*  You wouldnt get the AI Insights upsell

**With this fix**:
* You would get the AI Insights upsell
* If you now go to a classic post editor, you will also get the AI optimize classic introduction, as per the instructions [here](https://github.com/Yoast/wordpress-seo-premium/pull/4639).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
