### PR TITLE
Add post launch introduction

### DIFF
--- a/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
+++ b/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
@@ -24,14 +24,14 @@ const AiBrandInsightsPostLaunchContent = ( {
 	isPremium,
 	buttonLabel = __( "Discover Brand Insights now", "wordpress-seo" ),
 	productName = sprintf(
-		/* translators: %1$s expands to Yoast AI brand insights. */
-		__( "Available now - %1$s", "wordpress-seo" ),
-		"Yoast AI brand insights"
+		/* translators: %1$s expands to Yoast SEO AI+. */
+		__( "New - Upgrade to %1$s", "wordpress-seo" ),
+		"Yoast SEO AI+"
 	),
 } ) => {
 	const { onClose, initialFocus } = useModalContext();
 
-	const premiumDescription = 					safeCreateInterpolateElement(
+	const premiumDescription = safeCreateInterpolateElement(
 		sprintf(
 			// translators: %1$s and %2$s expand to <span> and </span> respectively.
 			__(
@@ -45,7 +45,7 @@ const AiBrandInsightsPostLaunchContent = ( {
 			span: <span className="yst-font-bold yst-text-slate-600" />,
 		}
 	);
-	const	description =  isPremium
+	const description =  isPremium
 		?  premiumDescription
 		: __( "Track visibility, control perception, and stay ahead - tools to manage your AI presence are now live!", "wordpress-seo" );
 

--- a/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
+++ b/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
@@ -114,7 +114,7 @@ const AiBrandInsightsPostLaunchContent = ( {
  */
 export const AiBrandInsightsPostLaunch = () => {
 	const imageLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectImageLink( "ai-brand-insights-pre-launch.png" ), [] );
-	const joinWishlistLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/ai-brand-insights-introduction-pre-launch/" ), [] );
+	const joinWishlistLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/ai-brand-insights-introduction-post-launch/" ), [] );
 	const isPremium = get( window, "wpseoIntroductions.isPremium", false );
 	const thumbnail = useMemo( () => ( {
 		src: imageLink,

--- a/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
+++ b/packages/js/src/introductions/components/modals/ai-brand-insights-post-launch.js
@@ -1,0 +1,134 @@
+import { useSelect } from "@wordpress/data";
+import { useMemo } from "@wordpress/element";
+import { __, sprintf } from "@wordpress/i18n";
+import { Button, useModalContext } from "@yoast/ui-library";
+import { SparklesIcon } from "@heroicons/react/outline";
+import { get } from "lodash";
+import { safeCreateInterpolateElement } from "../../../helpers/i18n";
+import { STORE_NAME_INTRODUCTIONS } from "../../constants";
+import { Modal } from "../modal";
+
+/**
+ * @param {Object} thumbnail The thumbnail: img props.
+ * @param {string} buttonLink The button link.
+ * @param {boolean} isPremium Whether the user has Premium activated.
+ * @param {string} buttonLabel The button label.
+ * @param {string} productName The product name.
+ * @param {string} description The description for the introduction
+ * @param {string} ctbId The click to buy to register for this upsell instance.
+ * @returns {JSX.Element} The element.
+ */
+const AiBrandInsightsPostLaunchContent = ( {
+	thumbnail,
+	buttonLink,
+	isPremium,
+	buttonLabel = __( "Discover Brand Insights now", "wordpress-seo" ),
+	productName = sprintf(
+		/* translators: %1$s expands to Yoast AI brand insights. */
+		__( "Available now - %1$s", "wordpress-seo" ),
+		"Yoast AI brand insights"
+	),
+} ) => {
+	const { onClose, initialFocus } = useModalContext();
+
+	const premiumDescription = 					safeCreateInterpolateElement(
+		sprintf(
+			// translators: %1$s and %2$s expand to <span> and </span> respectively.
+			__(
+				"Track visibility, control perception, and stay ahead - tools to manage your AI presence are now live. %1$sTry it for free, on us!%2$s",
+				"wordpress-seo-premium"
+			),
+			"<span>",
+			"</span>"
+		),
+		{
+			span: <span className="yst-font-bold yst-text-slate-600" />,
+		}
+	);
+	const	description =  isPremium
+		?  premiumDescription
+		: __( "Track visibility, control perception, and stay ahead - tools to manage your AI presence are now live!", "wordpress-seo" );
+
+	return (
+		<>
+			<div className="yst-px-10 yst-pt-10 yst-introduction-gradient yst-text-center">
+				<img
+					className="yst-w-full yst-h-auto yst-rounded-md yst-drop-shadow-md"
+					alt={ __( "Web chart showing aspects of brand visibility in AI responses", "wordpress-seo" ) }
+					loading="lazy"
+					decoding="async"
+					{ ...thumbnail }
+				/>
+				<div className="yst-mt-6 yst-text-xs yst-font-medium yst-flex yst-flex-col yst-items-center">
+					<span className="yst-introduction-modal-uppercase yst-flex yst-gap-2 yst-items-center">
+						<span className="yst-ai-insights-icon" />
+						{ productName }
+					</span>
+				</div>
+			</div>
+			<div className="yst-px-10 yst-pb-4 yst-flex yst-flex-col yst-items-center">
+				<div className="yst-mt-4 yst-mx-1.5 yst-text-center">
+					<h3 className="yst-text-slate-900 yst-text-lg yst-font-medium">
+						{
+							__( "How does your brand show up in AI responses?", "wordpress-seo" )
+						}
+					</h3>
+					<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
+						<p>{ description }</p>
+					</div>
+				</div>
+				<div className="yst-w-full yst-flex yst-mt-6">
+					<Button
+						as="a"
+						className="yst-grow yst-border-slate-200 yst-ai-insights-waitlist-button"
+						size="extra-large"
+						variant="upsell"
+						href={ buttonLink }
+						target="_blank"
+						ref={ initialFocus }
+					>
+						<SparklesIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5 yst-text-white" />
+						{ buttonLabel }
+						<span className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "(Opens in a new browser tab)", "wordpress-seo" )
+							}
+						</span>
+					</Button>
+				</div>
+				<Button
+					className="yst-mt-2"
+					variant="tertiary"
+					onClick={ onClose }
+				>
+					{ __( "Close", "wordpress-seo" ) }
+				</Button>
+			</div>
+		</>
+	);
+};
+
+/**
+ * @returns {JSX.Element} The element.
+ */
+export const AiBrandInsightsPostLaunch = () => {
+	const imageLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectImageLink( "ai-brand-insights-pre-launch.png" ), [] );
+	const joinWishlistLink = useSelect( select => select( STORE_NAME_INTRODUCTIONS ).selectLink( "https://yoa.st/ai-brand-insights-introduction-pre-launch/" ), [] );
+	const isPremium = get( window, "wpseoIntroductions.isPremium", false );
+	const thumbnail = useMemo( () => ( {
+		src: imageLink,
+		width: "432",
+		height: "243",
+	} ), [ imageLink ] );
+
+	return (
+		<Modal>
+			<AiBrandInsightsPostLaunchContent
+				buttonLink={ joinWishlistLink }
+				thumbnail={ thumbnail }
+				isPremium={ isPremium }
+			/>
+		</Modal>
+	);
+};

--- a/packages/js/src/introductions/initialize.js
+++ b/packages/js/src/introductions/initialize.js
@@ -7,7 +7,7 @@ import { Root } from "@yoast/ui-library";
 import { get, isEmpty, find } from "lodash";
 import { LINK_PARAMS_NAME, PLUGIN_URL_NAME, WISTIA_EMBED_PERMISSION_NAME } from "../shared-admin/store";
 import { Introduction, IntroductionProvider } from "./components";
-import { AiBrandInsightsPreLaunch } from "./components/modals/ai-brand-insights-pre-launch";
+import { AiBrandInsightsPostLaunch } from "./components/modals/ai-brand-insights-post-launch";
 import { BlackFridayAnnouncement } from "./components/modals/black-friday-announcement";
 import { DelayedPremiumUpsell } from "./components/modals/delayed-premium-upsell";
 import { STORE_NAME_INTRODUCTIONS } from "./constants";
@@ -22,7 +22,7 @@ domReady( () => {
 	}
 
 	const initialComponents = {
-		"ai-brand-insights-pre-launch": AiBrandInsightsPreLaunch,
+		"ai-brand-insights-post-launch": AiBrandInsightsPostLaunch,
 		"black-friday-announcement": BlackFridayAnnouncement,
 		"delayed-premium-upsell": DelayedPremiumUpsell,
 	};

--- a/src/introductions/application/ai-brand-insights-post-launch.php
+++ b/src/introductions/application/ai-brand-insights-post-launch.php
@@ -1,0 +1,71 @@
+<?php
+
+
+namespace Yoast\WP\SEO\Introductions\Application;
+
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Introductions\Domain\Introduction_Interface;
+
+/**
+ * Represents the introduction for the AI Brand Insights post-launch.
+ */
+class AI_Brand_Insights_Post_Launch implements Introduction_Interface {
+
+	use User_Allowed_Trait;
+
+	public const ID = 'ai-brand-insights-post-launch';
+
+	/**
+	 * Holds the current page helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
+
+	/**
+	 * Constructs the introduction.
+	 *
+	 * @param Current_Page_Helper $current_page_helper The current page helper.
+	 */
+	public function __construct( Current_Page_Helper $current_page_helper ) {
+		$this->current_page_helper = $current_page_helper;
+	}
+
+	/**
+	 * Returns the ID.
+	 *
+	 * @return string The ID.
+	 */
+	public function get_id() {
+		return self::ID;
+	}
+
+	/**
+	 * Returns the name of the introduction.
+	 *
+	 * @return string The name.
+	 */
+	public function get_name() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO Premium 21.6', 'Please use get_id() instead' );
+
+		return self::ID;
+	}
+
+	/**
+	 * Returns the requested pagination priority. Lower means earlier.
+	 *
+	 * @return int The priority.
+	 */
+	public function get_priority() {
+		return 20;
+	}
+
+	/**
+	 * Returns whether this introduction should show.
+	 *
+	 * @return bool Whether this introduction should show.
+	 */
+	public function should_show() {
+		return $this->current_page_helper->is_yoast_seo_page();
+	}
+}

--- a/src/introductions/application/ai-brand-insights-pre-launch.php
+++ b/src/introductions/application/ai-brand-insights-pre-launch.php
@@ -66,6 +66,6 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 	 * @return bool Whether this introduction should show.
 	 */
 	public function should_show() {
-		return $this->current_page_helper->is_yoast_seo_page();
+		return false;
 	}
 }

--- a/src/introductions/application/ai-brand-insights-pre-launch.php
+++ b/src/introductions/application/ai-brand-insights-pre-launch.php
@@ -25,6 +25,8 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 	/**
 	 * Constructs the introduction.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @param Current_Page_Helper $current_page_helper The current page helper.
 	 */
 	public function __construct( Current_Page_Helper $current_page_helper ) {
@@ -34,6 +36,8 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 	/**
 	 * Returns the ID.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return string The ID.
 	 */
 	public function get_id() {
@@ -42,6 +46,8 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 
 	/**
 	 * Returns the name of the introduction.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @return string The name.
 	 */
@@ -54,6 +60,8 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 	/**
 	 * Returns the requested pagination priority. Lower means earlier.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @return int The priority.
 	 */
 	public function get_priority() {
@@ -62,6 +70,8 @@ class AI_Brand_Insights_Pre_Launch implements Introduction_Interface {
 
 	/**
 	 * Returns whether this introduction should show.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool Whether this introduction should show.
 	 */

--- a/tests/Unit/Introductions/Application/AI_Brand_Insights_Post_Launch_Test.php
+++ b/tests/Unit/Introductions/Application/AI_Brand_Insights_Post_Launch_Test.php
@@ -4,24 +4,24 @@ namespace Yoast\WP\SEO\Tests\Unit\Introductions\Application;
 
 use Mockery;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
-use Yoast\WP\SEO\Introductions\Application\AI_Brand_Insights_Pre_Launch;
+use Yoast\WP\SEO\Introductions\Application\AI_Brand_Insights_Post_Launch;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
- * Tests the AI Brand Insights pre-launch.
+ * Tests the AI Brand Insights post-launch.
  *
  * @group introductions
  *
- * @coversDefaultClass \Yoast\WP\SEO\Introductions\Application\AI_Brand_Insights_Pre_Launch
+ * @coversDefaultClass \Yoast\WP\SEO\Introductions\Application\AI_Brand_Insights_Post_Launch
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-final class AI_Brand_Insights_Pre_Launch_Test extends TestCase {
+final class AI_Brand_Insights_Post_Launch_Test extends TestCase {
 
 	/**
 	 * Holds the instance.
 	 *
-	 * @var AI_Brand_Insights_Pre_Launch
+	 * @var AI_Brand_Insights_Post_Launch
 	 */
 	private $instance;
 
@@ -42,7 +42,7 @@ final class AI_Brand_Insights_Pre_Launch_Test extends TestCase {
 
 		$this->current_page_helper = Mockery::mock( Current_Page_Helper::class );
 
-		$this->instance = new AI_Brand_Insights_Pre_Launch( $this->current_page_helper );
+		$this->instance = new AI_Brand_Insights_Post_Launch( $this->current_page_helper );
 	}
 
 	/**
@@ -67,7 +67,7 @@ final class AI_Brand_Insights_Pre_Launch_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_name() {
-		$this->assertSame( 'ai-brand-insights-pre-launch', $this->instance->get_id() );
+		$this->assertSame( 'ai-brand-insights-post-launch', $this->instance->get_id() );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* N/A

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the post-launch introduction about Yoast AI Brand Insights and removes the pre-launch one. 

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use [this](https://www.figma.com/design/OHKjiKm5cSAS7mzI4hK8dd/Introduction?node-id=1-2331&t=MQ5EbyIPwDdC5W5N-4) Figma design as reference
* Start with just Yoast SEO activated
* With a MySQL client locate the `wp_usermeta` table
  * Find the row where `meta_key` = `_yoast_wpseo_introductions` and delete the content of the `meta_value` column: this would **reset all the introductions** you have previously seen
* Visit a Yoast SEO page
  * Confirm you see the introduction as in the design for Free
  * Confirm you don't see the pre-launch introduction ( Figma design [here](https://www.figma.com/design/
OHKjiKm5cSAS7mzI4hK8dd/Introduction?node-id=1-2329&t=MQ5EbyIPwDdC5W5N-4))
  * Confirm the `Discover Brand Insights now` button points to `https://yoa.st/ai-brand-insights-introduction-post-launch/`
* Refresh and verify you don't get the introduction
* Activate Yoast SEO Premium
* Visit a Yoast SEO page and confirm you see the introduction as in the design for Premium
* Reset the introductions again
* Activate WooCommerce
* Confirm you see the same introduction as with Premium

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#770](https://github.com/Yoast/reserved-tasks/issues/770)
