### PR TITLE
Adapt display to the Wincher API updates

### DIFF
--- a/packages/js/src/components/WincherRankingHistoryChart.js
+++ b/packages/js/src/components/WincherRankingHistoryChart.js
@@ -164,7 +164,7 @@ export default function WincherRankingHistoryChart( { datasets, isChartShown, ke
 							precision: 0,
 							color: "black",
 						},
-						max: 101,
+						max: 31,
 					},
 				},
 			} }

--- a/packages/js/src/components/WincherTableRow.js
+++ b/packages/js/src/components/WincherTableRow.js
@@ -74,7 +74,7 @@ const WincherTableRowElement = styled.tr`
  * @returns {Array} An array of x/y coordinates objects.
  */
 export function transformTrendDataToChartPoints( chartEntry ) {
-	return chartEntry.position.history.map( ( entry, index ) => ( { x: index, y: 101 - entry.value } ) );
+	return chartEntry.position.history.map( ( entry, index ) => ( { x: index, y: 31 - entry.value } ) );
 }
 
 /**
@@ -127,7 +127,7 @@ export function PositionOverTimeChart( { chartData = {} } ) {
 		fillColor="#ade3fc"
 		mapChartDataToTableData={ mapAreaChartDataToTableData }
 		dataTableCaption={
-			__( "Keyphrase position in the last 90 days on a scale from 0 to 100.", "wordpress-seo" )
+			__( "Keyphrase position in the last 90 days on a scale from 0 to 30.", "wordpress-seo" )
 		}
 		dataTableHeaderLabels={ areaChartDataTableHeaderLabels }
 	/>;
@@ -171,8 +171,8 @@ export function renderToggleState( { keyphrase, isEnabled, toggleAction, isLoadi
  * @returns {string} The keyphrase position.
  */
 export function getKeyphrasePosition( keyphrase ) {
-	if ( ! keyphrase || ! keyphrase.position || keyphrase.position.value > 100 ) {
-		return "> 100";
+	if ( ! keyphrase || ! keyphrase.position || keyphrase.position.value > 30 ) {
+		return "> 30";
 	}
 
 	return keyphrase.position.value;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* [Slack thread](https://yoast.slack.com/archives/C01UT1X3DAT/p1758188278608619)
TL;DR: Since late Thu, Sep 18 Wincher has updated their API to get only the top 30 results. We need to adapt our plugin to support it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Ensures compatibility with the recent Wincher API changes.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* edit a post
* add a keyphrase
* click on "Track SEO performance" in the metabox
* connect to Wincher if you are not yet
* check that in the chart `31` is the lowest value
* check that if you have a very low ranking keyphrase you get `> 30` as Position in the table and in the chart the line or the point is at the bottom

Examples:

**Good** (chart shows 31 at the bottom)
<img width="712" height="700" alt="Screenshot 2025-09-19 at 10-27-07 Modifica articolo “Duplicate Post joins Yoast” ‹ blog Lopo it — WordPress" src="https://github.com/user-attachments/assets/3c60e5ab-a437-498b-8b41-c7c71a01c8b0" />

**Good** (chart shows 31 at the bottom, the position is `>30`)
<img width="712" height="682" alt="Screenshot 2025-09-19 at 10-26-53 Modifica articolo “ChatGPT” ‹ blog Lopo it — WordPress" src="https://github.com/user-attachments/assets/7e810791-5e91-48ae-9e1c-985db7a63b4e" />

**Bad** (chart shows 101 at the bottom, the position is `31`)
<img width="712" height="680" alt="Screenshot 2025-09-19 at 10-19-05 Modifica articolo “ChatGPT” ‹ blog Lopo it — WordPress" src="https://github.com/user-attachments/assets/73dfb538-a7c8-4a80-804b-4be5565734c4" />



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
