### PR TITLE
Revert "implement new ai frontend gradient button variant"

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -665,10 +665,7 @@ class WPSEO_Admin_Asset_Manager {
 			[
 				'name' => 'new-settings',
 				'src'  => 'new-settings-' . $flat_version,
-				'deps' => [
-					self::PREFIX . 'tailwind',
-					self::PREFIX . 'ai-frontend',
-				],
+				'deps' => [ self::PREFIX . 'tailwind' ],
 			],
 			[
 				'name' => 'redirects',

--- a/css/src/introductions.css
+++ b/css/src/introductions.css
@@ -57,4 +57,16 @@
 		width: 17px;
 		height: 17px;
 	}
+
+	.yst-ai-insights-waitlist-button {
+		background-image: linear-gradient(97deg, #A61E69 0%, #6366F1 100%) !important;
+		color: white !important;
+
+		&:hover {
+			background-image: linear-gradient(97deg, #8F0F57 0%, #4338CA 100%) !important;
+		}
+		&:focus {
+			outline-color: #a61e69 !important;
+		}
+	}
 }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -30,7 +30,7 @@
     "@wordpress/rich-text": "^7.8.4",
     "@wordpress/server-side-render": "^5.8.12",
     "@wordpress/url": "^4.8.1",
-    "@yoast/ai-frontend": "^0.22.0",
+    "@yoast/ai-frontend": "^0.19.0",
     "@yoast/analysis-report": "^2.0.0-alpha.1",
     "@yoast/components": "^3.0.0-alpha.2",
     "@yoast/dashboard-frontend": "^0.1.0",

--- a/packages/js/src/introductions/components/modals/ai-brand-insights-pre-launch.js
+++ b/packages/js/src/introductions/components/modals/ai-brand-insights-pre-launch.js
@@ -2,10 +2,9 @@ import { useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, useModalContext } from "@yoast/ui-library";
+import { SparklesIcon } from "@heroicons/react/outline";
 import { STORE_NAME_INTRODUCTIONS } from "../../constants";
 import { Modal } from "../modal";
-import { GradientButton } from "@yoast/ai-frontend";
-
 
 /**
  * @param {Object} thumbnail The thumbnail: img props.
@@ -57,16 +56,17 @@ const AiBrandInsightsPreLaunchContent = ( {
 						<p>{ description }</p>
 					</div>
 				</div>
-				<div className="yst-w-full yst-mt-6">
-					<GradientButton
+				<div className="yst-w-full yst-flex yst-mt-6">
+					<Button
 						as="a"
-						variant="primary"
+						className="yst-grow yst-border-slate-200 yst-ai-insights-waitlist-button"
 						size="extra-large"
+						variant="upsell"
 						href={ buttonLink }
 						target="_blank"
 						ref={ initialFocus }
-						className="yst-w-full"
 					>
+						<SparklesIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5 yst-text-white" />
 						{ buttonLabel }
 						<span className="yst-sr-only">
 							{
@@ -74,7 +74,7 @@ const AiBrandInsightsPreLaunchContent = ( {
 								__( "(Opens in a new browser tab)", "wordpress-seo" )
 							}
 						</span>
-					</GradientButton>
+					</Button>
 				</div>
 				<Button
 					className="yst-mt-2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9915,10 +9915,10 @@
     js-yaml "^3.10.0"
     tslib "^2.4.0"
 
-"@yoast/ai-frontend@^0.22.0":
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/@yoast/ai-frontend/-/ai-frontend-0.22.0.tgz#f7e3468f4c5c150e60fe6babb94145b7feab33de"
-  integrity sha512-Zp0DcJ21N2ytNEP18yOUNA9T9sKIwUKTeSihhVOINq3HZM+9PtVfQ5j9YUMTN+VaiNHg6/8ZakiYHhNk+EzzIQ==
+"@yoast/ai-frontend@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@yoast/ai-frontend/-/ai-frontend-0.19.0.tgz#22c547b77f00c0933067f44afe7cfb135759af1d"
+  integrity sha512-spXUopJ5peC5sbM7I4LJKRwgBh9EokDm2jDFVqcQZ32LE1hjj7T4v/ih5ahB/zFuJ9V+GhHQdN9121vyfZEQJQ==
   dependencies:
     "@draft-js-plugins/mention" "^5.3.0"
     "@heroicons/react" "^2.1.5"


### PR DESCRIPTION
## Context

* Reverts Yoast/wordpress-seo#22579

## Summary

This PR can be summarized in the following changelog entry:

* Reverts a not needed commit that broke the sidebar menu in the settings page.

## Relevant technical choices:



## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Delete the introductions user meta (yoast_wpseo_introductions) to trigger the insights modal again.
* Go to one of yoast admin pages like the settings page.
* Smoke test the insights introduction modal gradient button.
* Check the the focus is on the gradient button.
* Also confirm that the settings page has its sidebar menu back