### PR TITLE
fix woo ads on products only

### DIFF
--- a/packages/js/src/components/contentAnalysis/PremiumSeoAnalysisUpsellAd.js
+++ b/packages/js/src/components/contentAnalysis/PremiumSeoAnalysisUpsellAd.js
@@ -30,7 +30,7 @@ export const getLocationKey = ( location, isElementorEditor ) => {
  * @returns {JSX.Element} The PremiumSEOAnalysisUpsellAd component.
  */
 export const PremiumSeoAnalysisUpsellAd = ( { location } ) => {
-	const { metaboxUrl, sidebarUrl, elementorUrl, isElementorEditor, isWooCommerceActive } = useSelect( ( select ) => {
+	const { metaboxUrl, sidebarUrl, elementorUrl, isElementorEditor, isWooCommerceActive, isProductEntity } = useSelect( ( select ) => {
 		const { selectLink } = select( STORE_NAME_EDITOR );
 		return {
 			metaboxUrl: selectLink( "https://yoa.st/premium-seo-analysis-metabox" ),
@@ -38,10 +38,11 @@ export const PremiumSeoAnalysisUpsellAd = ( { location } ) => {
 			elementorUrl: selectLink( "https://yoa.st/premium-seo-analysis-elementor" ),
 			isElementorEditor: select( STORE_NAME_EDITOR ).getIsElementorEditor(),
 			isWooCommerceActive: select( STORE_NAME_EDITOR ).getIsWooCommerceActive(),
+			isProductEntity: select( STORE_NAME_EDITOR ).getIsProductEntity(),
 		};
 	}, [] );
 
-	if ( isWooCommerceActive ) {
+	if ( isWooCommerceActive && isProductEntity ) {
 		return <WooSeoAnalysisUpsellAd location={ location } />;
 	}
 

--- a/packages/js/src/components/contentAnalysis/WooSeoAnalysisUpsellAd.js
+++ b/packages/js/src/components/contentAnalysis/WooSeoAnalysisUpsellAd.js
@@ -23,13 +23,14 @@ export const WooSeoAnalysisUpsellAd = ( { location } ) => {
 		{ icon: IdentificationIcon, text: __( "SKUs", "wordpress-seo" ) },
 	];
 
-	const { metaboxUrl, sidebarUrl, elementorUrl, isElementorEditor } = useSelect( ( select ) => {
+	const { metaboxUrl, sidebarUrl, elementorUrl, isElementorEditor, isWooSEOActive } = useSelect( ( select ) => {
 		const { selectLink } = select( STORE_NAME_EDITOR );
 		return {
 			metaboxUrl: selectLink( "https://yoa.st/seo-analysis-metabox-woocommerce" ),
 			sidebarUrl: selectLink( "https://yoa.st/seo-analysis-sidebar-woocommerce" ),
 			elementorUrl: selectLink( "https://yoa.st/seo-analysis-woocommerce-elementor" ),
 			isElementorEditor: select( STORE_NAME_EDITOR ).getIsElementorEditor(),
+			isWooSEOActive: select( STORE_NAME_EDITOR ).getIsWooSeoActive(),
 		};
 	}, [] );
 
@@ -76,7 +77,7 @@ export const WooSeoAnalysisUpsellAd = ( { location } ) => {
 					data-ctb-id="f6a84663-465f-4cb5-8ba5-f7a6d72224b2"
 				>
 					<LockOpenIcon className="yst-w-4 yst-me-1.5" { ...svgAriaProps } />
-					{ sprintf(
+					{ isWooSEOActive ? __( "Unlock with Premium", "wordpress-seo" )  : sprintf(
 						/* translators: WooCommerce SEO */
 						__( "Get %s", "wordpress-seo" ),
 						"WooCommerce SEO"

--- a/packages/js/src/components/modals/UpsellModal.js
+++ b/packages/js/src/components/modals/UpsellModal.js
@@ -1,11 +1,12 @@
 /* eslint-disable complexity */
 import { Button, Modal, Title } from "@yoast/ui-library";
 import { ReactComponent as YoastLogo } from "../../../images/Yoast_icon_kader.svg";
-import { select } from "@wordpress/data";
+import { useSelect } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { LockOpenIcon, CheckIcon } from "@heroicons/react/outline";
 import { ShoppingCartIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
+import { useMemo } from "@wordpress/element";
 
 /**
  * The Redux store name of the editor.
@@ -40,8 +41,16 @@ export const UpsellModal = ( {
 	ctbId = "",
 	modalTitle,
 } ) => {
-	const isBlackFriday = select( STORE_NAME_EDITOR ).isPromotionActive( "black-friday-promotion" );
-	const isWooCommerceActive = select( STORE_NAME_EDITOR ).getIsWooCommerceActive();
+	const { isBlackFriday, isWooCommerceActive, isProductEntity } = useSelect( ( select ) => {
+		const editorStore = select( STORE_NAME_EDITOR );
+		return {
+			isProductEntity: editorStore.getIsProductEntity(),
+			isWooCommerceActive: editorStore.getIsWooCommerceActive(),
+			isBlackFriday: editorStore.isPromotionActive( "black-friday-promotion" ),
+		};
+	}, [] );
+
+	const isWooAd = useMemo( () => isWooCommerceActive && isProductEntity, [ isWooCommerceActive, isProductEntity ] );
 	return <Modal
 		isOpen={ isOpen }
 		onClose={ onClose }
@@ -50,12 +59,12 @@ export const UpsellModal = ( {
 		<Modal.Panel className="yst-max-w-[26.25rem] yst-p-0" hasCloseButton={ false }>
 			<Modal.Container>
 				<Modal.Container.Header className="yst-p-6 yst-border-b-slate-200 yst-border-b yst-flex yst-justify-start yst-gap-4 yst-items-center">
-					{ isWooCommerceActive ? <ShoppingCartIcon className="yst-text-woo-light yst-w-6 yst-h-6 yst-scale-x-[-1]" />
+					{ isWooAd ? <ShoppingCartIcon className="yst-text-woo-light yst-w-6 yst-h-6 yst-scale-x-[-1]" />
 						: <YoastLogo className="yst-fill-primary-500 yst-w-5 yst-h-5" /> }
 					<Modal.Title
 						as="h3" className={
 							classNames(
-								isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500",
+								isWooAd ? "yst-text-woo-light" : "yst-text-primary-500",
 								"yst-text-xl"
 							) }
 					>
@@ -94,7 +103,7 @@ export const UpsellModal = ( {
 								{ sprintf(
 									/* translators: %s expands to 'Yoast SEO Premium' or 'Yoast Woocommerce SEO'. */
 									__( "Explore %s", "wordpress-seo" ),
-									isWooCommerceActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
+									isWooAd ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 								) }
 								<span className="yst-sr-only">{ __( "Opens in a new tab", "wordpress-seo" ) }</span>
 							</Button>

--- a/packages/js/src/components/modals/UpsellModal.js
+++ b/packages/js/src/components/modals/UpsellModal.js
@@ -41,12 +41,13 @@ export const UpsellModal = ( {
 	ctbId = "",
 	modalTitle,
 } ) => {
-	const { isBlackFriday, isWooCommerceActive, isProductEntity } = useSelect( ( select ) => {
+	const { isBlackFriday, isWooCommerceActive, isProductEntity, isWooSEOActive } = useSelect( ( select ) => {
 		const editorStore = select( STORE_NAME_EDITOR );
 		return {
 			isProductEntity: editorStore.getIsProductEntity(),
 			isWooCommerceActive: editorStore.getIsWooCommerceActive(),
 			isBlackFriday: editorStore.isPromotionActive( "black-friday-promotion" ),
+			isWooSEOActive: editorStore.getIsWooSeoActive(),
 		};
 	}, [] );
 
@@ -103,7 +104,7 @@ export const UpsellModal = ( {
 								{ sprintf(
 									/* translators: %s expands to 'Yoast SEO Premium' or 'Yoast Woocommerce SEO'. */
 									__( "Explore %s", "wordpress-seo" ),
-									isWooAd ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
+									isWooAd && ! isWooSEOActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 								) }
 								<span className="yst-sr-only">{ __( "Opens in a new tab", "wordpress-seo" ) }</span>
 							</Button>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where WooCommerce SEO ad would be visible when not on a product page. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate WooCommerce
* Edit a post and click on the SEO analysis tab
* Check you see the Premium ad: 
* <img width="611" height="208" alt="Screenshot 2025-09-26 at 16 00 29" src="https://github.com/user-attachments/assets/f44e4f4c-5e7d-4dca-b743-d6b1a1965225" />
* Edit a product and click on the SEO analysis tab
* Check you see the woocommerce seo ad
<img width="626" height="228" alt="Screenshot 2025-09-26 at 16 23 58" src="https://github.com/user-attachments/assets/f235c622-f89f-4e9d-aeb9-777f88a27bab" />

* Activate Woo SEO analysis and check you see the woocommerce SEO ad has the premium labeled button (Unlock with Premium).

### Test the upsell modals.
* Check the upsell modals theme is blue with a cart only on a product, there are 3 modal to test, you can trigger them by:
   * Click on the toggle " + Add related keyphrase".
   * Click on the toggle "Internal linking suggestions".
   * Edit a post in elementor. Click on the toggle "Readability" and then on the eye icon with the lock. Make sure your content has consecutive sentences or passive voice. (only for premium)
<img width="351" height="457" alt="Screenshot 2025-09-29 at 12 39 48" src="https://github.com/user-attachments/assets/202ba21e-0dec-44c9-bfac-5a184b6e325c" />

* Enable woo seo nd check the upsell button label is for Premium.
* Repeat the tests for Black Friday from https://github.com/Yoast/wordpress-seo/pull/22523

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [X] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2609
