### PR TITLE
Change helpscout beacon behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2395",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2385",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=251",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -36,7 +36,10 @@ const openHelpScoutBeacon = () => {
  * @returns {JSX.Element} The app component.
  */
 export const App = () => {
-	const isPremium = useSelectSupport( "selectPreference", [], "isPremium", false );
+	const hasPremiumSubscription = useSelectSupport( "selectPreference", [], "hasPremiumSubscription", false );
+	const hasWooSeoSubscription = useSelectSupport( "selectPreference", [], "hasWooSeoSubscription", false );
+	const isWooCommerceActive = useSelectSupport( "selectPreference", [], "isWooCommerceActive", false );
+	const hasAnyAddon = hasPremiumSubscription || hasWooSeoSubscription;
 	const premiumUpsellConfig = useSelectSupport( "selectUpsellSettingsAsProps" );
 	const pluginUrl = useSelectSupport( "selectPreference", [], "pluginUrl", "" );
 	const linkParams = useSelectSupport( "selectLinkParams" );
@@ -48,7 +51,6 @@ export const App = () => {
 	const githubLink = useSelectSupport( "selectLink", [], "https://yoa.st/github-repository-support-card" );
 	const contactSupportLink = useSelectSupport( "selectLink", [], "https://yoa.st/contact-support-to-unlock-premium-support-section" );
 	const { isPromotionActive } = useSelect( STORE_NAME );
-	const isWooCommerceActive = useSelectSupport( "selectPreference", [], "isWooCommerceActive" );
 
 	const faq = useMemo( () => ( [
 		{
@@ -87,7 +89,7 @@ export const App = () => {
 
 	return (
 		<div className="yst-p-4 min-[783px]:yst-p-8">
-			<div className={ classNames( "yst-flex yst-flex-grow yst-flex-wrap", ! isPremium && "xl:yst-pe-[17.5rem]" ) }>
+			<div className={ classNames( "yst-flex yst-flex-grow yst-flex-wrap", ! hasAnyAddon && "xl:yst-pe-[17.5rem]" ) }>
 				<Paper as="main" className="yst-max-w-page yst-flex-grow yst-mb-8 xl:yst-mb-0">
 					<Paper.Header>
 						<div className="yst-max-w-screen-sm">
@@ -182,7 +184,7 @@ export const App = () => {
 								title={ (
 									<div className="yst-flex yst-items-center yst-gap-1.5">
 										<span>{ __( "Contact our support team", "wordpress-seo" ) }</span>
-										{ isPremium && <Badge variant="upsell">Premium</Badge> }
+										{ hasAnyAddon && <Badge variant="upsell">Premium</Badge> }
 									</div>
 								) }
 								description={ (
@@ -203,7 +205,7 @@ export const App = () => {
 								) }
 							>
 								<FeatureUpsell
-									shouldUpsell={ ! isPremium }
+									shouldUpsell={ ! hasAnyAddon }
 									variant="card"
 									cardLink={ contactSupportLink }
 									cardText={ sprintf(
@@ -213,7 +215,7 @@ export const App = () => {
 									) }
 									{ ...premiumUpsellConfig }
 								>
-									<div className={ classNames( "yst-flex", ! isPremium && "yst-opacity-50" ) }>
+									<div className={ classNames( "yst-flex", ! hasAnyAddon && "yst-opacity-50" ) }>
 										<div className="yst-me-6">
 											<p>{ __( "Our support team is here to answer any questions you may have. Fill out the (pop-up) contact form, and we'll get back to you as soon as possible!", "wordpress-seo" ) }</p>
 											<Button
@@ -239,7 +241,7 @@ export const App = () => {
 						</div>
 					</Paper.Content>
 				</Paper>
-				{ ! isPremium &&
+				{ ! hasAnyAddon &&
 					<div className="xl:yst-max-w-3xl xl:yst-fixed xl:yst-end-8 xl:yst-w-[16rem]">
 						<SidebarRecommendations
 							premiumLink={ isWooCommerceActive ? wooLink :  premiumLink }

--- a/packages/js/src/support/app.js
+++ b/packages/js/src/support/app.js
@@ -32,8 +32,11 @@ const openHelpScoutBeacon = () => {
 	}
 };
 
+/* eslint-disable complexity */
+
 /**
  * @returns {JSX.Element} The app component.
+ *
  */
 export const App = () => {
 	const hasPremiumSubscription = useSelectSupport( "selectPreference", [], "hasPremiumSubscription", false );

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -35,9 +35,23 @@ class HelpScout_Beacon implements Integration_Interface {
 	protected $beacon_id_tracking_users = '6b8e74c5-aa81-4295-b97b-c2a62a13ea7f';
 
 	/**
+	 * The id for the beacon for Premium users.
+	 *
+	 * @var string
+	 */
+	protected $beacon_id_premium = '1ae02e91-5865-4f13-b220-7daed946ba25';
+
+	/**
+	 * The id for the beacon for WooCommerce SEO users.
+	 *
+	 * @var string
+	 */
+	protected $beacon_id_woocommerce = '8535d745-4e80-48b9-b211-087880aa857d';
+
+	/**
 	 * The products the beacon is loaded for.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected $products = [];
 
@@ -56,16 +70,23 @@ class HelpScout_Beacon implements Integration_Interface {
 	protected $options;
 
 	/**
+	 * The addon manager.
+	 *
+	 * @var WPSEO_Addon_Manager
+	 */
+	protected $addon_manager;
+
+	/**
 	 * The array of pages we need to show the beacon on with their respective beacon IDs.
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	protected $pages_ids;
 
 	/**
 	 * The array of pages we need to show the beacon on.
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
 	protected $base_pages = [
 		'wpseo_dashboard',
@@ -106,10 +127,12 @@ class HelpScout_Beacon implements Integration_Interface {
 	 * @param Options_Helper            $options          The options helper.
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager    The asset manager.
 	 * @param Migration_Status          $migration_status The migrations status.
+	 * @param WPSEO_Addon_Manager       $addon_manager    The addon manager.
 	 */
-	public function __construct( Options_Helper $options, WPSEO_Admin_Asset_Manager $asset_manager, Migration_Status $migration_status ) {
+	public function __construct( Options_Helper $options, WPSEO_Admin_Asset_Manager $asset_manager, Migration_Status $migration_status, WPSEO_Addon_Manager $addon_manager ) {
 		$this->options       = $options;
 		$this->asset_manager = $asset_manager;
+		$this->addon_manager = $addon_manager;
 		$this->ask_consent   = ! $this->options->get( 'tracking' );
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reason: We are not processing form information.
 		if ( isset( $_GET['page'] ) && \is_string( $_GET['page'] ) ) {
@@ -121,19 +144,16 @@ class HelpScout_Beacon implements Integration_Interface {
 		}
 		$this->migration_status = $migration_status;
 
+		$beacon_id = $this->get_beacon_id();
 		foreach ( $this->base_pages as $page ) {
-			if ( $this->ask_consent ) {
-				// We want to be able to show surveys to people who have tracking on, so we give them a different beacon.
-				$this->pages_ids[ $page ] = $this->beacon_id_tracking_users;
-			}
-			else {
-				$this->pages_ids[ $page ] = $this->beacon_id;
-			}
+			$this->pages_ids[ $page ] = $beacon_id;
 		}
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @return void
 	 */
 	public function register_hooks() {
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_help_scout_script' ] );
@@ -247,7 +267,7 @@ class HelpScout_Beacon implements Integration_Interface {
 	/**
 	 * Returns basic info about the server software.
 	 *
-	 * @return array
+	 * @return array<string, string>
 	 */
 	private function get_server_info() {
 		$server_tracking_data = new WPSEO_Tracking_Server_Data();
@@ -441,10 +461,35 @@ class HelpScout_Beacon implements Integration_Interface {
 	/**
 	 * Returns the conditionals based on which this integration should be active.
 	 *
-	 * @return array The array of conditionals.
+	 * @return array<string> The array of conditionals.
 	 */
 	public static function get_conditionals() {
 		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Get the beacon id to use based on the user's subscription and tracking settings.
+	 *
+	 * @return string The beacon id to use.
+	 */
+	private function get_beacon_id() {
+		// Case where the user has a Yoast WooCommerce SEO plan subscription (highest priority).
+		if ( $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
+			return $this->beacon_id_woocommerce;
+		}
+
+		// Case where the user has a Yoast SEO Premium plan subscription.
+		if ( $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+			return $this->beacon_id_premium;
+		}
+
+		// Case where the user has no plan active and tracking enabled.
+		if ( $this->ask_consent ) {
+			return $this->beacon_id_tracking_users;
+		}
+
+		// Case where the user has no plan active and tracking disabled.
+		return $this->beacon_id;
 	}
 
 	/**
@@ -464,8 +509,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		 * @param string $beacon_settings The HelpScout beacon settings.
 		 */
 		$helpscout_settings = \apply_filters( 'wpseo_helpscout_beacon_settings', $filterable_helpscout_setting );
-
-		$this->products  = $helpscout_settings['products'];
-		$this->pages_ids = $helpscout_settings['pages_ids'];
+		$this->products     = $helpscout_settings['products'];
+		$this->pages_ids    = $helpscout_settings['pages_ids'];
 	}
 }

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -2,6 +2,7 @@
 
 namespace Yoast\WP\SEO\Integrations;
 
+use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
@@ -56,6 +57,13 @@ class Support_Integration implements Integration_Interface {
 	private $woocommerce_conditional;
 
 	/**
+	 * Holds the WPSEO_Addon_Manager.
+	 *
+	 * @var WPSEO_Addon_Manager
+	 */
+	private $addon_manager;
+
+	/**
 	 * Constructs Support_Integration.
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager           The WPSEO_Admin_Asset_Manager.
@@ -63,25 +71,28 @@ class Support_Integration implements Integration_Interface {
 	 * @param Product_Helper            $product_helper          The Product_Helper.
 	 * @param Short_Link_Helper         $shortlink_helper        The Short_Link_Helper.
 	 * @param WooCommerce_Conditional   $woocommerce_conditional The WooCommerce_Conditional.
+	 * @param WPSEO_Addon_Manager       $addon_manager           The WPSEO_Addon_Manager.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Current_Page_Helper $current_page_helper,
 		Product_Helper $product_helper,
 		Short_Link_Helper $shortlink_helper,
-		WooCommerce_Conditional $woocommerce_conditional
+		WooCommerce_Conditional $woocommerce_conditional,
+		WPSEO_Addon_Manager $addon_manager
 	) {
 		$this->asset_manager           = $asset_manager;
 		$this->current_page_helper     = $current_page_helper;
 		$this->product_helper          = $product_helper;
 		$this->shortlink_helper        = $shortlink_helper;
 		$this->woocommerce_conditional = $woocommerce_conditional;
+		$this->addon_manager           = $addon_manager;
 	}
 
 	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public static function get_conditionals() {
 		return [ Admin_Conditional::class, User_Can_Manage_Wpseo_Options_Conditional::class ];
@@ -108,11 +119,11 @@ class Support_Integration implements Integration_Interface {
 	/**
 	 * Adds the page.
 	 *
-	 * @param array $pages The pages.
+	 * @param array<array<string|callable>> $pages The pages.
 	 *
-	 * @return array The pages.
+	 * @return array<array<string|callable>> The pages.
 	 */
-	public function add_page( $pages ) {
+	public function add_page( array $pages ) {
 		$pages[] = [
 			'wpseo_dashboard',
 			'',
@@ -165,19 +176,20 @@ class Support_Integration implements Integration_Interface {
 	/**
 	 * Creates the script data.
 	 *
-	 * @return array The script data.
+	 * @return array<string, array<array<string, bool|string|array<string>>, bool, string>> The script data.
 	 */
 	public function get_script_data() {
 		return [
 			'preferences'       => [
-				'isPremium'           => $this->product_helper->is_premium(),
-				'isRtl'               => \is_rtl(),
-				'pluginUrl'           => \plugins_url( '', \WPSEO_FILE ),
-				'upsellSettings'      => [
+				'hasPremiumSubscription' => $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ),
+				'hasWooSeoSubscription'  => $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ),
+				'isRtl'                  => \is_rtl(),
+				'pluginUrl'              => \plugins_url( '', \WPSEO_FILE ),
+				'upsellSettings'         => [
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
-				'isWooCommerceActive' => $this->woocommerce_conditional->is_met(),
+				'isWooCommerceActive'    => $this->woocommerce_conditional->is_met(),
 			],
 			'linkParams'        => $this->shortlink_helper->get_query_params(),
 			'currentPromotions' => \YoastSEO()->classes->get( Promotion_Manager::class )->get_current_promotions(),

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations;
 
 use Brain\Monkey;
 use Mockery;
+use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
@@ -60,6 +61,13 @@ final class Support_Integration_Test extends TestCase {
 	private $promotion_manager;
 
 	/**
+	 * Holds the WPSEO_Addon_Manager.
+	 *
+	 * @var WPSEO_Addon_Manager
+	 */
+	private $addon_manager;
+
+	/**
 	 * Holds the container.
 	 *
 	 * @var Mockery\MockInterface|Container
@@ -93,6 +101,7 @@ final class Support_Integration_Test extends TestCase {
 		$this->product_helper          = Mockery::mock( Product_Helper::class );
 		$this->shortlink_helper        = Mockery::mock( Short_Link_Helper::class );
 		$this->promotion_manager       = Mockery::mock( Promotion_Manager::class );
+		$this->addon_manager           = Mockery::mock( WPSEO_Addon_Manager::class );
 		$this->container               = $this->create_container_with( [ Promotion_Manager::class => $this->promotion_manager ] );
 		$this->woocommerce_conditional = Mockery::mock( WooCommerce_Conditional::class );
 
@@ -102,6 +111,7 @@ final class Support_Integration_Test extends TestCase {
 			$this->product_helper,
 			$this->shortlink_helper,
 			$this->woocommerce_conditional,
+			$this->addon_manager,
 		);
 	}
 
@@ -121,6 +131,7 @@ final class Support_Integration_Test extends TestCase {
 				$this->product_helper,
 				$this->shortlink_helper,
 				$this->woocommerce_conditional,
+				$this->addon_manager
 			)
 		);
 	}
@@ -350,9 +361,16 @@ final class Support_Integration_Test extends TestCase {
 			'user_language'    => 'en_US',
 		];
 
-		$this->product_helper
-			->expects( 'is_premium' )
+		$this->addon_manager
+			->expects( 'has_valid_subscription' )
 			->once()
+			->with( WPSEO_Addon_Manager::PREMIUM_SLUG )
+			->andReturn( true );
+
+		$this->addon_manager
+			->expects( 'has_valid_subscription' )
+			->once()
+			->with( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG )
 			->andReturn( false );
 
 		Monkey\Functions\expect( 'is_rtl' )->once()->andReturn( false );
@@ -388,14 +406,15 @@ final class Support_Integration_Test extends TestCase {
 
 		$expected = [
 			'preferences'       => [
-				'isPremium'           => false,
-				'isRtl'               => false,
-				'pluginUrl'           => 'http://basic.wordpress.test/wp-content/worspress-seo',
-				'upsellSettings'      => [
+				'hasPremiumSubscription' => true,
+				'hasWooSeoSubscription'  => false,
+				'isRtl'                  => false,
+				'pluginUrl'              => 'http://basic.wordpress.test/wp-content/worspress-seo',
+				'upsellSettings'         => [
 					'actionId'     => 'load-nfd-ctb',
 					'premiumCtbId' => 'f6a84663-465f-4cb5-8ba5-f7a6d72224b2',
 				],
-				'isWooCommerceActive' => false,
+				'isWooCommerceActive'    => false,
 			],
 			'linkParams'        => $link_params,
 			'currentPromotions' => [ 'black-friday-promotion' ],

--- a/tests/Unit/Main_Test.php
+++ b/tests/Unit/Main_Test.php
@@ -7,6 +7,7 @@ use Exception;
 use Mockery;
 use wpdb;
 use Yoast\WP\SEO\Exceptions\Forbidden_Property_Mutation_Exception;
+use Yoast\WP\SEO\Integrations\Admin\HelpScout_Beacon;
 use Yoast\WP\SEO\Integrations\Third_Party\Elementor;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Category_Permalink_Watcher;
 use Yoast\WP\SEO\Integrations\Watchers\Indexable_Permalink_Watcher;
@@ -44,6 +45,7 @@ final class Main_Test extends TestCase {
 		Indexable_Category_Permalink_Watcher::class,
 		Indexable_Permalink_Watcher::class,
 		Elementor::class,
+		HelpScout_Beacon::class,
 	];
 
 	/**


### PR DESCRIPTION
## Context

We want to adapt the behavior of the `Contact our support team` button in the `Support` page to our new Premium and WooCommerce SEO subscription plans.
Currently, only users who have Yoast SEO Premium **installed** can access the Helpscout Beacon through the button, which would have a specific `beacon_id` for Premium.
In light of our switch to plan subscription, we want to:
1. activate the button when the user has one of the two subscription plans active
2. set the `beacon_id` value according to the user's plan: in case the Premium plan is active, we are going to use the Premium `beacon_id`. Coversely, if the WooCommerce SEO plan is active, we will use the WooCommerce SEO `beacon_id`

⚠️ This PR must be tested together with its relative [Premium one ](https://github.com/Yoast/wordpress-seo-premium/pull/4797)⚠️ 

## Summary

This PR can be summarized in the following changelog entry:

* Adapts the behavior of the `Contact our support team` button in the `Support` page to our new Premium and WooCommerce SEO subscription plans.

## Relevant technical choices:

* The checks whether the `Contact our support team` button is active or not have been changed from checking if Premium is installed to checking the user's subscription plan (i.e. if the user has a Premium or WooCommerce SEO valid license).

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

<details>

<summary>Scenario 1: User with no active subscription plans (Free user)</summary>

* Make sure you don't have Premium nor WooCommerce SEO license active
* Go to `Yoast SEO` -> `Support` and verify:
  * There's no `Premium` badge aside the `Contact our support team` section title 
  * The `Contact our support team` button is deactivated and shows an upsell
  * The HelpScout beacon says "Need help?"
  * Clicking on the  HelpScout beacon opens an `Instant answers` section
* Go to another page where the HelpScout beacon is available
  * Verify its behaviour is the same as above 

</details>

<details>

<summary>Scenario 2: User with Premium subscription only</summary>

* Make sure you have a Premium license active but not a WooCommerce SEO one
* Do not activate the Premium plugin
* Go to `Yoast SEO` -> `Support` and verify:
  * There's a `Premium` badge aside the `Contact our support team` section title 
  * The `Contact our support team` button is active
  * The HelpScout beacon says "Chat with us"
  * Clicking on the  `Contact our support team` opens a section with two available tabs: `Ask` and `Answers`
  * Inspect the page source code
    * Search for `window.wpseoHelpScoutBeacon`
    * Verify the following directive is found: `window.wpseoHelpScoutBeacon('1ae02e91-5865-4f13-b220-7daed946ba25', (...)`   
* Go to another page where the HelpScout beacon is available
  * Verify its behaviour is the same as above 
  * Verify the same directive is present in the page source code
* Go to `Yoast SEO` -> `Redirects`
  * Verify the page shows an upsell
* Activate the Premium plugin 
* Go back to `Yoast SEO` -> `Redirects`
  * Verify the page functionalities are active
  * Verify you have the `Chat with us` HelpScout beacon
  * Verify the same directive as above is present in the page source code

</details>

<details>

<summary>Scenario 2: User with WooCommerce subscription only</summary>

* Make sure you have a WooCommerce SEO license active but not a Premium one
* Do not activate the Premium plugin nor the WooCommerce SEO one
* Go to `Yoast SEO` -> `Support` and verify:
  * There's a `Premium` badge aside the `Contact our support team` section title 
  * The `Contact our support team` button is active
  * The HelpScout beacon says "Chat with us"
  * Clicking on the  `Contact our support team` opens a section with two available tabs: `Ask` and `Answers`
  * Inspect the page source code
    * Search for `window.wpseoHelpScoutBeacon`
    * Verify the following directive is found: `window.wpseoHelpScoutBeacon('8535d745-4e80-48b9-b211-087880aa857d', (...)`   
* Go to another page where the HelpScout beacon is available
  * Verify its behaviour is the same as above 
  * Verify the same directive is present in the page source code
* Go to `Yoast SEO` -> `Redirects`
  * Verify the page shows an upsell
* Activate the WooCommerce SEO plugin
* Go to `Yoast SEO` -> `WooCommerce SEO`
  * Verify you have the `Chat with us` HelpScout beacon
  * Verify the same directive as above is present in the page source code
* Activate the Premium plugin
* Go to `Yoast SEO` -> `Redirects`
  * Inspect the source code  
  * Search for `window.wpseoHelpScoutBeacon`
     * Verify the following directive is found: `window.wpseoHelpScoutBeacon('1ae02e91-5865-4f13-b220-7daed946ba25', (...)`   

</details>

<details>

<summary>Scenario 4: User with both Premium and WooCommerce SEO subscriptions</summary>

* Make sure you have both WooCommerce SEO and Premium licenses active
* Perform the same tests as `Scenario 4` and verify nothing changes

</details>

<details>

<summary>Scenario 5: Test the add-ons pages HelpScout Beacon</summary>

* Make sure you have at least one subscription active ( Premium or WooCommerce SEO)
* Activate Yoast News SEO
* Go to `Yoast SEO` -> `News SEO`
 * Verify you have the `Chat with us` HelpScout beacon
 * Inspect the source code  
  * Search for `window.wpseoHelpScoutBeacon`
     * Verify the following directive is found: `window.wpseoHelpScoutBeacon('1161a6b32-9360-4613-bd04-d8098b283a0f', (...)`   
 * Perform the same checks for `Local SEO` and `Video SEO`
   * Verify you get the same behaviour
   * Verify in the respective plugin source page you have the following directives:
     * Local SEO `window.wpseoHelpScoutBeacon('84c1df2c-435a-45ac-8708-f5e3a00843c5', (...)`
     * Video SEO `window.wpseoHelpScoutBeacon('4e7489db-f907-41b3-9e86-93a01b4df9b0', (...)`  
</details>

<details>

<summary>Scenario 6: Test this PR with an old version of Premium</summary>

* Make sure you have the WooCommerce SEO plan active
* Install and activate an old version of Premium
* Go to `Yoast SEO` -> `Support` and verify
   * There's a `Premium` badge aside the `Contact our support team` section title 
  * The `Contact our support team` button is active
  * The HelpScout beacon says "Chat with us"
  * Clicking on the  `Contact our support team` opens a section with two available tabs: `Ask` and `Answers`
* Visit any other page (other than any add-on page) that has an active HelpScout Beacon (e.g. `Academy`)
  * Inspect the page source code
    * Search for `window.wpseoHelpScoutBeacon`
    * Verify the following directive is found: `window.wpseoHelpScoutBeacon('1ae02e91-5865-4f13-b220-7daed946ba25', (...)`     

</details>

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The browser console should be open to inspect the HelpScout beacon script and verify the correct beacon ID is being used based on subscription status.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #4004