### PR TITLE
Only run classes that are not deprecated through our systems

### DIFF
--- a/config/dependency-injection/inject-from-registry-pass.php
+++ b/config/dependency-injection/inject-from-registry-pass.php
@@ -45,7 +45,7 @@ class Inject_From_Registry_Pass extends AbstractRecursivePass {
 			$this->process_method_call( $method_call, $value );
 		}
 
-		if ( \is_subclass_of( $class_name, Loadable_Interface::class ) ) {
+		if ( \is_subclass_of( $class_name, Loadable_Interface::class ) && ! $value->isDeprecated() ) {
 			foreach ( $class_name::get_conditionals() as $type ) {
 				$this->add_definition( $type );
 			}

--- a/config/dependency-injection/loader-pass.php
+++ b/config/dependency-injection/loader-pass.php
@@ -92,29 +92,31 @@ class Loader_Pass implements CompilerPassInterface {
 		if ( $this->should_make_public( $definition ) ) {
 			$definition->setPublic( true );
 		}
+		if ( ! $definition->isDeprecated() ) {
+			if ( \is_subclass_of( $class, Conditional::class ) ) {
+				$definition->setPublic( true );
+			}
 
-		if ( \is_subclass_of( $class, Conditional::class ) ) {
-			$definition->setPublic( true );
-		}
+			if ( \is_subclass_of( $class, Initializer_Interface::class ) ) {
 
-		if ( \is_subclass_of( $class, Initializer_Interface::class ) ) {
-			$loader_definition->addMethodCall( 'register_initializer', [ $class ] );
-			$definition->setPublic( true );
-		}
+				$loader_definition->addMethodCall( 'register_initializer', [ $class ] );
+				$definition->setPublic( true );
+			}
 
-		if ( \is_subclass_of( $class, Integration_Interface::class ) ) {
-			$loader_definition->addMethodCall( 'register_integration', [ $class ] );
-			$definition->setPublic( true );
-		}
+			if ( \is_subclass_of( $class, Integration_Interface::class ) ) {
+				$loader_definition->addMethodCall( 'register_integration', [ $class ] );
+				$definition->setPublic( true );
+			}
 
-		if ( \is_subclass_of( $class, Route_Interface::class ) ) {
-			$loader_definition->addMethodCall( 'register_route', [ $class ] );
-			$definition->setPublic( true );
-		}
+			if ( \is_subclass_of( $class, Route_Interface::class ) ) {
+				$loader_definition->addMethodCall( 'register_route', [ $class ] );
+				$definition->setPublic( true );
+			}
 
-		if ( \is_subclass_of( $class, Command_Interface::class ) ) {
-			$loader_definition->addMethodCall( 'register_command', [ $class ] );
-			$definition->setPublic( true );
+			if ( \is_subclass_of( $class, Command_Interface::class ) ) {
+				$loader_definition->addMethodCall( 'register_command', [ $class ] );
+				$definition->setPublic( true );
+			}
 		}
 
 		if ( \is_subclass_of( $class, Migration::class ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We don't want to run the `register_hooks` and `get_conditionals` when a class is deprecated.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes sure deprecated classes are not called when they are not supposed to.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Clear your debug.log and click through your site and make sure nothing about deprecated classes show up.
* Make sure you have this enabled:
```
if ( ! defined( 'WP_DEBUG' ) ) {
	define( 'WP_DEBUG', true );
}
if ( ! defined( 'WP_DEBUG_LOG' ) ) {
	define( 'WP_DEBUG_LOG', true );
}
```

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
