### PR TITLE
2630 tooltip stays on after closing upsel modal

### DIFF
--- a/packages/js/src/components/contentBlocks/AddBlockButton.js
+++ b/packages/js/src/components/contentBlocks/AddBlockButton.js
@@ -27,14 +27,13 @@ export const AddBlockButton = ( { showUpsellBadge, blockName, location } ) => {
 	const [ showTooltip, setShowTooltip ] = useState( false );
 	const [ isUpsellModalOpen, , , openUpsellModal, closeUpsellModal ] = useToggleState( false );
 
-	// Helper to manage tooltip and focus logic
+	// Helper to manage the tooltip and focus logic
 	const handleTooltipAndFocus = useCallback( ( event ) => {
-		// Remove focus from the button when clicked to prevent it from staying focused and tooltip showing.
+		// Remove the focus from the button when clicked to prevent it from staying focused and showing the tooltip.
 		event?.currentTarget?.blur();
 		// Hide the tooltip when the button is clicked.
 		setShowTooltip( false );
 	}, [] );
-
 
 	const handleButtonClick = useCallback( ( event ) => {
 		handleTooltipAndFocus( event );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes issue when content block tooltip stays on the + icon even after closing the upsell modal.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the tooltip for the Yoast content blocks would not hide even after closing the modal.

## Relevant technical choices:

* When use click on a button show tooltip is disabled and the button focus removed to not restore displaying tooltip.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install & activate Yoast SEO 26.2 Free only.
* Create new post.
* Scrolldown to Yoast SEO metabox.
* Hover over + button with locker feature (e.g. AI Summerise)
* Make sure that tooltip appears.
* While tooltip is displayed click on the button button.
* Close the upsell modal.
* Tooltip should not be displayed after upsell modal is closed.
* Repeat this scenario wit the Yoast sidebar.
* Repeat tests in other browsers: Safari, Firefox.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Only click functionality is touched so please double check that upsell modal is displayed and add block functionality works as expected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#2630](https://github.com/Yoast/plugins-automated-testing/issues/2630)
