### PR TITLE
Revert "Check addons subscription only if any addon is activated"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2381",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2385",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=251",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -73,7 +73,7 @@ class WPSEO_Addon_Manager {
 	/**
 	 * The expected addon data.
 	 *
-	 * @var array<string, string>
+	 * @var array
 	 */
 	protected static $addons = [
 		'wp-seo-premium.php'    => self::PREMIUM_SLUG,
@@ -86,7 +86,7 @@ class WPSEO_Addon_Manager {
 	/**
 	 * The addon data for the shortlinks.
 	 *
-	 * @var array<string, array<string, string>>
+	 * @var array
 	 */
 	private $addon_details = [
 		self::PREMIUM_SLUG     => [
@@ -211,7 +211,7 @@ class WPSEO_Addon_Manager {
 	/**
 	 * Retrieves a list of (subscription) slugs by the active addons.
 	 *
-	 * @return array<string, stdClass> The slugs.
+	 * @return array The slugs.
 	 */
 	public function get_subscriptions_for_active_addons() {
 		$active_addons      = array_keys( $this->get_active_addons() );
@@ -227,7 +227,7 @@ class WPSEO_Addon_Manager {
 	/**
 	 * Retrieves a list of versions for each addon.
 	 *
-	 * @return array<string, string> The addon versions.
+	 * @return array The addon versions.
 	 */
 	public function get_installed_addons_versions() {
 		$addon_versions = [];
@@ -488,17 +488,6 @@ class WPSEO_Addon_Manager {
 
 			$notification_center->remove_notification( $notification );
 		}
-	}
-
-	/**
-	 * Checks if the user has any active addons.
-	 *
-	 * @return bool Whether there are active addons.
-	 */
-	public function has_active_addons() {
-		$active_addons = $this->get_active_addons();
-
-		return ! empty( $active_addons );
 	}
 
 	/**

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -474,12 +474,12 @@ class HelpScout_Beacon implements Integration_Interface {
 	 */
 	private function get_beacon_id() {
 		// Case where the user has a Yoast WooCommerce SEO plan subscription (highest priority).
-		if ( $this->addon_manager->has_active_addons() && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
+		if ( $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ) ) {
 			return $this->beacon_id_woocommerce;
 		}
 
 		// Case where the user has a Yoast SEO Premium plan subscription.
-		if ( $this->addon_manager->has_active_addons() && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
+		if ( $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ) ) {
 			return $this->beacon_id_premium;
 		}
 

--- a/src/integrations/support-integration.php
+++ b/src/integrations/support-integration.php
@@ -181,8 +181,8 @@ class Support_Integration implements Integration_Interface {
 	public function get_script_data() {
 		return [
 			'preferences'       => [
-				'hasPremiumSubscription' => $this->addon_manager->has_active_addons() && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ),
-				'hasWooSeoSubscription'  => $this->addon_manager->has_active_addons() && $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ),
+				'hasPremiumSubscription' => $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::PREMIUM_SLUG ),
+				'hasWooSeoSubscription'  => $this->addon_manager->has_valid_subscription( WPSEO_Addon_Manager::WOOCOMMERCE_SLUG ),
 				'isRtl'                  => \is_rtl(),
 				'pluginUrl'              => \plugins_url( '', \WPSEO_FILE ),
 				'upsellSettings'         => [

--- a/tests/Unit/Integrations/Support_Integration_Test.php
+++ b/tests/Unit/Integrations/Support_Integration_Test.php
@@ -362,11 +362,6 @@ final class Support_Integration_Test extends TestCase {
 		];
 
 		$this->addon_manager
-			->expects( 'has_active_addons' )
-			->times( 2 )
-			->andReturn( true );
-
-		$this->addon_manager
 			->expects( 'has_valid_subscription' )
 			->once()
 			->with( WPSEO_Addon_Manager::PREMIUM_SLUG )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Reverts #22634.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
