### PR TITLE
Re-introduce the other-admins alert, this time with an input field so that they can be subscribed to our newsletter

### DIFF
--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -59,6 +59,7 @@ class Yoast_Notification {
 	 * -     capabilities: Capabilities that a user must have for this Notification to show.
 	 * - capability_check: How to check capability pass: all or any.
 	 * -  wpseo_page_only: Only display on wpseo page or on every page.
+	 * -      input_field: An optional input field to include in the notification.
 	 *
 	 * @var array
 	 */
@@ -80,6 +81,7 @@ class Yoast_Notification {
 		'capabilities'     => [],
 		'capability_check' => self::MATCH_ALL,
 		'yoast_branding'   => false,
+		'input_field'      => null,
 	];
 
 	/**
@@ -175,6 +177,19 @@ class Yoast_Notification {
 	 */
 	public function get_priority() {
 		return $this->options['priority'];
+	}
+
+	/**
+	 * Get the input field of the notification.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_input_field() {
+		if ( ! is_a( $this->options['input_field'], 'Yoast\WP\SEO\Alerts\Domain\Input_Field' ) ) {
+			return null;
+		}
+
+		return $this->options['input_field']->to_array();
 	}
 
 	/**

--- a/packages/js/src/general/components/alerts-list.js
+++ b/packages/js/src/general/components/alerts-list.js
@@ -2,11 +2,12 @@
 import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
 import { useDispatch } from "@wordpress/data";
 import { useCallback, useContext } from "@wordpress/element";
-import { Button } from "@yoast/ui-library";
+import { Button, TextField } from "@yoast/ui-library";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { STORE_NAME } from "../constants";
 import { AlertsContext } from "../contexts/alerts-context";
+import { noop } from "lodash";
 
 /**
  * The alert item object.
@@ -15,10 +16,11 @@ import { AlertsContext } from "../contexts/alerts-context";
  * @param {string} [nonce=""] The alert nonce.
  * @param {boolean} [dismissed=false] Whether the alert is dismissed or not.
  * @param {string} [message=""] The alert message.
+ * @param {Object|null} [inputField=null] The alert input field.
  *
  * @returns {JSX.Element} The alert item component.
  */
-const AlertItem = ( { id = "", nonce = "", dismissed = false, message = "" } ) => {
+const AlertItem = ( { id = "", nonce = "", dismissed = false, message = "", inputField = null } ) => {
 	const { bulletClass = "" } = useContext( AlertsContext );
 	const { toggleAlertStatus } = useDispatch( STORE_NAME );
 	const Eye = dismissed ? EyeIcon : EyeOffIcon;
@@ -41,8 +43,39 @@ const AlertItem = ( { id = "", nonce = "", dismissed = false, message = "" } ) =
 				className={ classNames(
 					"yst-text-sm yst-text-slate-600 yst-grow",
 					dismissed && "yst-opacity-50" ) }
-				dangerouslySetInnerHTML={ { __html: message } }
-			/>
+			>
+				<div
+					dangerouslySetInnerHTML={ { __html: message } }
+				/>
+				{ inputField &&
+					<div className="yst-flex yst-items-end yst-gap-2 yst-mt-2">
+						<TextField
+							type="text"
+							name={ id + "-input-field" }
+							id={ id + "-input-field" }
+							label={ inputField.label }
+							onChange={ noop }
+							placeholder={ inputField.placeholder }
+							className="yst-flex-1"
+						/>
+						<Button
+							variant="primary"
+							size="large"
+						>
+							{ inputField.button_text }
+							<div
+								className="yst-ml-2 yst-w-4"
+								dangerouslySetInnerHTML={ { __html: inputField.button_icon } }
+							/>
+						</Button>
+					</div>
+				}
+				{ inputField?.footer_text && <p
+					className="yst-text-slate-600 yst-text-xxs yst-leading-4 yst-mt-1"
+					dangerouslySetInnerHTML={ { __html: inputField.footer_text } }
+				/>
+				}
+			</div>
 
 			<Button variant="secondary" size="small" className="yst-self-center yst-h-8" onClick={ toggleAlert }>
 				<Eye className="yst-w-4 yst-h-4 yst-text-neutral-700" />
@@ -78,6 +111,7 @@ export const AlertsList = ( { className = "", items = [] } ) => {
 					nonce={ item.nonce }
 					dismissed={ item.dismissed }
 					message={ item.message }
+					inputField={ item.input_field }
 				/>
 			) ) }
 		</ul>
@@ -91,5 +125,6 @@ AlertsList.propTypes = {
 		id: PropTypes.string,
 		nonce: PropTypes.string,
 		dismissed: PropTypes.bool,
+		inputField: PropTypes.object,
 	} ) ),
 };

--- a/src/alerts/application/ping-other-admins/ping-other-admins-alert.php
+++ b/src/alerts/application/ping-other-admins/ping-other-admins-alert.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Alerts\Application\Ping_Other_Admins;
 
+use Yoast\WP\SEO\Alerts\Domain\Input_Field;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
@@ -91,8 +92,7 @@ class Ping_Other_Admins_Alert implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		// @phpcs:ignore Squiz.PHP.CommentedOutCode.Found, Squiz.Commenting.InlineComment.InvalidEndChar -- we're gonna postpone this notification until we're actually ready for it.
-		// \add_action( 'admin_init', [ $this, 'add_notifications' ] );
+		\add_action( 'admin_init', [ $this, 'add_notifications' ] );
 	}
 
 	/**
@@ -150,7 +150,20 @@ class Ping_Other_Admins_Alert implements Integration_Interface {
 	 * @return Yoast_Notification The ping-other-admins notification.
 	 */
 	private function get_ping_other_admins_notification(): Yoast_Notification {
-		$message = $this->get_message();
+		$message     = $this->get_message();
+		$input_field = new Input_Field(
+			'',
+			'',
+			\__( 'E.g. example@email.com', 'wordpress-seo' ),
+			\__( 'Send', 'wordpress-seo' ),
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%"> <path fill-rule="evenodd" d="M2 8c0 .414.336.75.75.75h8.69l-1.22 1.22a.75.75 0 1 0 1.06 1.06l2.5-2.5a.75.75 0 0 0 0-1.06l-2.5-2.5a.75.75 0 1 0-1.06 1.06l1.22 1.22H2.75A.75.75 0 0 0 2 8Z" clip-rule="evenodd" /> </svg>',
+			\sprintf(
+				/* translators: 1: opening anchor tag, 2: closing anchor tag. */
+				\__( 'Yoast respects your privacy. Read %1$sour privacy policy%2$s on how we handle your personal information.', 'wordpress-seo' ),
+				'<a href="' . \esc_url( $this->short_link_helper->get( 'https://yoa.st/gdpr-config-workout' ) ) . '" target="_blank" rel="noopener noreferrer">',
+				'</a>'
+			)
+		);
 
 		return new Yoast_Notification(
 			$message,
@@ -159,6 +172,7 @@ class Ping_Other_Admins_Alert implements Integration_Interface {
 				'type'         => Yoast_Notification::WARNING,
 				'capabilities' => [ 'wpseo_manage_options' ],
 				'priority'     => 20,
+				'input_field'  => $input_field,
 			]
 		);
 	}
@@ -169,21 +183,13 @@ class Ping_Other_Admins_Alert implements Integration_Interface {
 	 * @return string The HTML string representation of the notification.
 	 */
 	private function get_message() {
-		$shortlink = $this->short_link_helper->get( 'https://yoa.st/new-admin-newsletter-sign-up/' );
-
 		$message = \sprintf(
-			/* translators: %1$s and %3$s expands to "Yoast SEO" , %2$s expands to an opening link tag, %4$s expands to a closing link tag. */
-			\esc_html__( 'Looks like you’re new here. %1$s makes it easy to optimize your website for search engines. Want to keep your site healthy and easier to find? %2$sSign up for the %3$s newsletter for short, practical weekly tips%4$s.', 'wordpress-seo' ),
-			'Yoast SEO',
-			'<a href="' . \esc_url( $shortlink ) . '" target="_blank">',
-			'Yoast SEO',
-			'</a>'
+			/* translators: %1$s expands to "Yoast SEO". */
+			\esc_html__( 'Looks like you’re new here. %1$s makes it easy to optimize your website for search engines. Want to keep your site healthy and easier to find? Sign up below to receive practical emails to get you started!', 'wordpress-seo' ),
+			'Yoast SEO'
 		);
 
-		$notification_text  = '<p>' . $message . '</p>';
-		$notification_text .= '<a class="button wpseo-resolve-alert" href="#" data-alert-id="' . \esc_attr( self::NOTIFICATION_ID ) . '" data-nonce="' . \esc_attr( \wp_create_nonce( 'wpseo-resolve-alert-nonce' ) ) . '">';
-		$notification_text .= \esc_html__( 'Dismiss', 'wordpress-seo' );
-		$notification_text .= '</a>';
+		$notification_text = '<p>' . $message . '</p>';
 
 		return $notification_text;
 	}

--- a/src/alerts/domain/input-field.php
+++ b/src/alerts/domain/input-field.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Yoast\WP\SEO\Alerts\Domain;
+
+/**
+ * Class Input_Field
+ *
+ * Represents an input field for alerts.
+ */
+class Input_Field {
+
+	/**
+	 * The input field label.
+	 *
+	 * @var string
+	 */
+	private $label;
+
+	/**
+	 * The input field value.
+	 *
+	 * @var string
+	 */
+	private $value;
+
+	/**
+	 * The placeholder text.
+	 *
+	 * @var string
+	 */
+	private $placeholder;
+
+	/**
+	 * The button text.
+	 *
+	 * @var string
+	 */
+	private $button_text;
+
+	/**
+	 * The button icon
+	 *
+	 * @var string
+	 */
+	private $button_icon;
+
+	/**
+	 * The footer text.
+	 *
+	 * @var string
+	 */
+	private $footer_text;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string $label       The input field label.
+	 * @param string $value       The input field value.
+	 * @param string $placeholder The input field placeholder.
+	 * @param string $button_text The input field button text.
+	 * @param string $button_icon The input field button icon.
+	 * @param string $footer_text The input field footer text.
+	 */
+	public function __construct( string $label, string $value, string $placeholder, string $button_text, string $button_icon, string $footer_text ) {
+		$this->label       = $label;
+		$this->value       = $value;
+		$this->placeholder = $placeholder;
+		$this->button_text = $button_text;
+		$this->button_icon = $button_icon;
+		$this->footer_text = $footer_text;
+	}
+
+	/**
+	 * Returns the input field label.
+	 *
+	 * @return string
+	 */
+	public function get_label(): string {
+		return $this->label;
+	}
+
+	/**
+	 * Returns the input field value.
+	 *
+	 * @return string
+	 */
+	public function get_value(): string {
+		return $this->value;
+	}
+
+	/**
+	 * Returns the input field placeholder.
+	 *
+	 * @return string
+	 */
+	public function get_placeholder(): string {
+		return $this->placeholder;
+	}
+
+	/**
+	 * Returns the input field button text.
+	 *
+	 * @return string
+	 */
+	public function get_button_text(): string {
+		return $this->button_text;
+	}
+
+	/**
+	 * Returns the input field button icon.
+	 *
+	 * @return string
+	 */
+	public function get_button_icon(): string {
+		return $this->button_icon;
+	}
+
+	/**
+	 * Returns the input field footer text.
+	 *
+	 * @return string
+	 */
+	public function get_footer_text(): string {
+		return $this->footer_text;
+	}
+
+	/**
+	 * Parse the input field into an array.
+	 *
+	 * @return array<string, string>
+	 */
+	public function to_array(): array {
+		return [
+			'label'       => $this->label,
+			'value'       => $this->value,
+			'placeholder' => $this->placeholder,
+			'button_text' => $this->button_text,
+			'button_icon' => $this->button_icon,
+			'footer_text' => $this->footer_text,
+		];
+	}
+}

--- a/src/helpers/notification-helper.php
+++ b/src/helpers/notification-helper.php
@@ -53,7 +53,7 @@ class Notification_Helper {
 	/**
 	 * Parses all the notifications to an array with just id, message, nonce, type and dismissed.
 	 *
-	 * @return array<string, string|bool>
+	 * @return array<string, string|bool|array<string, string>>
 	 */
 	public function get_alerts(): array {
 		$all_notifications = $this->get_sorted_notifications();
@@ -61,11 +61,12 @@ class Notification_Helper {
 		return \array_map(
 			function ( $notification ) {
 				return [
-					'id'        => $notification->get_id(),
-					'message'   => $notification->get_message(),
-					'nonce'     => $notification->get_nonce(),
-					'type'      => $notification->get_type(),
-					'dismissed' => $this->is_notification_dismissed( $notification ),
+					'id'          => $notification->get_id(),
+					'message'     => $notification->get_message(),
+					'nonce'       => $notification->get_nonce(),
+					'type'        => $notification->get_type(),
+					'dismissed'   => $this->is_notification_dismissed( $notification ),
+					'input_field' => $notification->get_input_field(),
 				];
 			},
 			$all_notifications


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Basically re-imagines the since-reverted https://github.com/Yoast/wordpress-seo/pull/22644 one, with a twist. We're now gonna have an input field in the alert itself, allowing them to subscribe to the newsletter much easier.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Re-introduces the other-admins alert, this time with an input field so that they can be subscribed to our newsletter.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

*

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
