### PR TITLE
fix(files): Remove misleading text about .htaccess editing

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -200,7 +200,7 @@ if ( ! WPSEO_Utils::is_nginx() ) {
 			echo '<p><em>';
 			printf(
 				/* translators: %s expands to ".htaccess". */
-				esc_html__( 'If your %s were writable, you could edit it from here.', 'wordpress-seo' ),
+				esc_html__( 'Editing the %s file is not supported via the Yoast SEO file editor.', 'wordpress-seo' ),
 				'.htaccess'
 			);
 			echo '</em></p>';
@@ -232,7 +232,7 @@ if ( ! WPSEO_Utils::is_nginx() ) {
 		echo '<p>';
 		printf(
 			/* translators: %s expands to ".htaccess". */
-			esc_html__( 'If you had a %s file and it was editable, you could edit it from here.', 'wordpress-seo' ),
+			esc_html__( 'Editing the %s file is not supported via the Yoast SEO file editor.', 'wordpress-seo' ),
 			'.htaccess'
 		);
 		echo '</p>';

--- a/inc/class-wpseo-utils.php
+++ b/inc/class-wpseo-utils.php
@@ -41,7 +41,7 @@ class WPSEO_Utils {
 
 		/**
 		 * Filter: 'wpseo_allow_system_file_edit' - Allow developers to change whether the editing of
-		 * .htaccess and robots.txt is allowed.
+		 * robots.txt is allowed.
 		 *
 		 * @param bool $allowed Whether file editing is allowed.
 		 */


### PR DESCRIPTION
## Context
This PR fixes a bug where the File Editor tool misleadingly suggests that editing the `.htaccess` file is a supported feature. This text is confusing to users, as this functionality is not supported. This PR removes the misleading text and also corrects a related internal code comment to prevent future confusion.

## Summary

This PR can be summarized in the following changelog entry:

* `changelog: bugfix`
* Fixes a bug where the File Editor would misleadingly suggest that editing the .htaccess file is supported.

## Relevant technical choices:

* Modified `admin/views/tool-file-editor.php` to change the two user-facing strings that incorrectly implied `.htaccess` editing was possible.
* Modified `inc/class-wpseo-utils.php` to correct an internal code comment that also incorrectly stated `.htaccess` editing was allowed.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1.  In your WordPress admin, go to **Yoast SEO > Tools**.
2.  Click on the "**File editor**" link.
3.  Scroll down to the **`.htaccess file`** section.
4.  **Verify:** The text should now read: `Editing the .htaccess file is not supported via the Yoast SEO file editor.`
5.  (This single check covers both scenarios for the bug: when the file doesn't exist and when it exists but isn't writable).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* This is a low-impact text change on the **File editor** tool page (`admin.php?page=wpseo_tools&tool=file-editor`).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other. (Updated code comments).

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #12065.
```
