### PR TITLE
887 nice to have remove error from task modal when the modal is closed and then re opened

### DIFF
--- a/packages/dashboard-frontend/src/store/task-list.js
+++ b/packages/dashboard-frontend/src/store/task-list.js
@@ -95,7 +95,7 @@ const slice = createSlice( {
 			}
 		},
 		resetTaskError( state, { payload } ) {
-			if ( state.tasks[ payload ] ) {
+			if ( state.tasks[ payload ] && state.tasks[ payload ].status === ASYNC_ACTION_STATUS.error ) {
 				state.tasks[ payload ].error = null;
 				state.tasks[ payload ].status = ASYNC_ACTION_STATUS.idle;
 			}

--- a/packages/js/src/general/components/task.js
+++ b/packages/js/src/general/components/task.js
@@ -44,9 +44,7 @@ export const Task = ( { title, id, how, why, duration, priority, isCompleted, ca
 	};
 
 	const handleOnOpen = useCallback( () => {
-		if ( status === ASYNC_ACTION_STATUS.error ) {
-			resetTaskError( id );
-		}
+		resetTaskError( id );
 		toggleOpen();
 	}, [ toggleOpen ] );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/dashbard-frontend 0.0.1] Adds an action to reset task error for the task list redux slice.
* Resets the task error when reopening the task modal. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Disable the llms.txt feature.
* Add the snippet to generate an error for the llms.txt task:
```php
function custom_update_option_wpseo( $value, $old_value, $option ) {
    return $old_value;
}
add_action( 'pre_update_option_wpseo', 'custom_update_option_wpseo', 10, 3 );
```
* Go to the task list and try to complete the llms.txt task.
* You should get an error alert in the modal.
* Close the modal from the X and the `Close` button
* Reopen the task modal and check the alert is not there.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
