### PR TITLE
adds the woo upsell to the task list

### DIFF
--- a/packages/js/src/general/components/task-list-upsell-row.js
+++ b/packages/js/src/general/components/task-list-upsell-row.js
@@ -1,8 +1,7 @@
 import { Button, Table, Title } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import { LockClosedIcon, LockOpenIcon } from "@heroicons/react/outline";
-import { select } from "@wordpress/data";
-import { STORE_NAME } from "../constants";
+import { useSelectGeneralPage } from "../hooks";
 
 /**
  * Component rendering an upsell row for the task list.
@@ -10,7 +9,10 @@ import { STORE_NAME } from "../constants";
  * @returns {JSX.Element} The UpsellRow component.
  */
 export const TaskListUpsellRow = () => {
-	const taskListUpsellLink = select( STORE_NAME ).selectLink( "https://yoa.st/task-list-upsell-table-footer" );
+	const premiumUpsellLink = useSelectGeneralPage( "selectLink", [], "https://yoa.st/task-list-upsell-table-footer" );
+	const wooSeoUpsellLink = useSelectGeneralPage( "selectLink", [], "https://yoa.st/task-list-woo-upsell-table-footer" );
+	const isWooCommerceActive = useSelectGeneralPage( "selectPreference", [], "isWooCommerceActive" );
+	const taskListUpsellLink = isWooCommerceActive ? wooSeoUpsellLink : premiumUpsellLink;
 	return (
 		<Table.Row>
 			<Table.Cell className="yst-bg-slate-50" colSpan={ 4 }>
@@ -22,16 +24,16 @@ export const TaskListUpsellRow = () => {
 						<div>
 							<Title size="5" as="h3" className="yst-text-slate-800 yst-leading-5">
 								{ sprintf(
-									/* translators: %1$s expands to Yoast SEO Premium. */
+									/* translators: %1$s expands to Yoast SEO Premium or WooCommerce SEO. */
 									__( "Unlock all %1$s tasks", "wordpress-seo" ),
-									"Yoast SEO Premium"
+									isWooCommerceActive ? "WooCommerce SEO" : "Yoast SEO Premium"
 								) }
 							</Title>
 							<p className="yst-leading-5">{ __( "Get automated technical SEO & optimize content in a breeze", "wordpress-seo" ) }</p>
 						</div>
 					</div>
 					<Button variant="upsell" as="a" href={ taskListUpsellLink } target="_blank" className="yst-flex yst-items-center yst-gap-1.5 yst-pe-2 yst-mt-4 lg:yst-mt-0">
-						{ __( "Unlock with Premium", "wordpress-seo" ) }
+						{ isWooCommerceActive ? __( "Unlock with WooCommerce SEO", "wordpress-seo" ) : __( "Unlock with Premium", "wordpress-seo" ) }
 						<LockOpenIcon className="yst-w-4 yst-h-4 yst-text-amber-900" />
 					</Button>
 				</div>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds Wocommerce SEO upsell to the task list.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable Woocommerce
* Go to Yoast SEO -> General -> Task list
* Check you the upsell line has the following copy, and the button has the Woocommerce SEO label:
<img width="1216" height="189" alt="Screenshot 2025-12-01 at 13 06 02" src="https://github.com/user-attachments/assets/0aa70087-94dc-420b-88bc-53ee79c02e0d" />
* Check the upsell link is `https://yoa.st/task-list-woo-upsell-table-footer` with parameters.
* Disable Woocommerce and check the upsell row has a different copy, and button different label:
<img width="1219" height="118" alt="Screenshot 2025-12-01 at 13 07 48" src="https://github.com/user-attachments/assets/460a4e3f-fee5-4c33-85dd-cc0bde374de4" />
* Check the button link is `https://yoa.st/task-list-upsell-table-footer` with params.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
