### PR TITLE
Move task list logic to the store

### DIFF
--- a/packages/dashboard-frontend/src/store/task-list.js
+++ b/packages/dashboard-frontend/src/store/task-list.js
@@ -1,9 +1,10 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { get, keys } from "lodash";
+import { get, keys, sortBy, values, size } from "lodash";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../constants";
 
 export const TASK_LIST_NAME = "taskList";
 const COMPLETE_TASK = "completeTask";
+const FETCH_TASK = "fetchTasks";
 
 /**
  * @typedef {Object} CallToAction
@@ -38,6 +39,8 @@ const COMPLETE_TASK = "completeTask";
  * @property {Object.<string, Task>} tasks
  * @property {Endpoints} endpoints
  * @property {string} nonce
+ * @property {string} status
+ * @property {string|null} error
  */
 
 /** @type {TaskListState} */
@@ -49,7 +52,36 @@ const initialState = {
 		getTasks: "",
 	},
 	nonce: "",
+	status: ASYNC_ACTION_STATUS.idle,
+	error: null,
 };
+
+/**
+ * Sort tasks whenever they change.
+ * Sorting order:
+ * 1. Incomplete tasks first.
+ * 2. Higher priority tasks first (high, medium, low).
+  * 3. If tasks have the same completion status and priority, sort by duration (shorter duration first).
+ * 4. If tasks have the same completion status, priority, and duration, sort alphabetically by title.
+ *
+ * @param {Object.<string, Task>} tasks The tasks to sort.
+ *
+ * @returns {Object.<string, Task>} The sorted tasks.
+ */
+function sortTasks( tasks ) {
+	const priorityOrder = { high: 1, medium: 2, low: 3 };
+	const sortedTasksArray = sortBy( values( tasks ), [
+		( task ) => task.isCompleted,
+		( task ) => priorityOrder[ task.priority ],
+		( task ) => task.duration,
+		( task ) => task.title.toLowerCase(),
+	] );
+	// Return an object with the same structure, but sorted.
+	return sortedTasksArray.reduce( ( acc, task ) => {
+		acc[ task.id ] = task;
+		return acc;
+	}, {} );
+}
 
 /**
  * Completes a task by its ID.
@@ -73,6 +105,29 @@ function* completeTask( id, endpoint, nonce ) {
 		return { type: `${ COMPLETE_TASK }/${ ASYNC_ACTION_NAMES.success }`, payload: { id } };
 	} catch ( error ) {
 		return { type: `${ COMPLETE_TASK }/${ ASYNC_ACTION_NAMES.error }`, payload: { error, id } };
+	}
+}
+
+/**
+ * Fetches tasks from the given endpoint.
+ *
+ * @param {string} endpoint The get tasks endpoint.
+ * @param {string} nonce The WP nonce.
+ * @returns {Object} Success or error action object.
+ */
+function* fetchTasks( endpoint, nonce ) {
+	yield{ type: `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.request }` };
+	try {
+		const response = yield{
+			type: FETCH_TASK,
+			payload: { nonce, endpoint },
+		};
+		if ( response.success !== true ) {
+			throw new Error( response.error );
+		}
+		return { type: `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.success }`, payload: { tasks: response.tasks } };
+	} catch ( error ) {
+		return { type: `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.error }`, payload: { error } };
 	}
 }
 
@@ -114,6 +169,19 @@ const slice = createSlice( {
 			state.tasks[ id ].status = ASYNC_ACTION_STATUS.error;
 			state.tasks[ id ].error = error.message;
 		} );
+		builder.addCase( `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload: { tasks } } ) => {
+			slice.caseReducers.setTasks( state, { payload: sortTasks( tasks ) } );
+			state.status = ASYNC_ACTION_STATUS.idle;
+			state.error = null;
+		} );
+		builder.addCase( `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
+			state.status = ASYNC_ACTION_STATUS.loading;
+			state.error = null;
+		} );
+		builder.addCase( `${ FETCH_TASK }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload: { error } } ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
+			state.error = error.message;
+		} );
 	},
 } );
 
@@ -130,11 +198,28 @@ export const taskListSelectors = {
 	selectTasksEndpoints: ( state ) => get( state, [ TASK_LIST_NAME, "endpoints" ], {} ),
 	selectNonce: ( state ) => get( state, [ TASK_LIST_NAME, "nonce" ], "" ),
 	selectIsTaskCompleted: ( state, id ) => get( state, [ TASK_LIST_NAME, "tasks", id, "isCompleted" ], null ),
+	selectTasksStatus: ( state ) => get( state, [ TASK_LIST_NAME, "status" ], ASYNC_ACTION_STATUS.idle ),
+	selectTasksError: ( state ) => get( state, [ TASK_LIST_NAME, "error" ], null ),
+	selectSortedTasks: ( state ) => {
+		const tasks = get( state, [ TASK_LIST_NAME, "tasks" ], {} );
+		return sortTasks( tasks );
+	},
+	selectTotalTasksCount: ( state ) => {
+		const tasks = get( state, [ TASK_LIST_NAME, "tasks" ], {} );
+		return size( tasks );
+	},
+	selectCompletedTasksCount: ( state ) => {
+		const tasks = get( state, [ TASK_LIST_NAME, "tasks" ], {} );
+		return size(
+			values( tasks ).filter( task => task.isCompleted )
+		);
+	},
 };
 
 export const taskListActions = {
 	...slice.actions,
 	completeTask,
+	fetchTasks,
 };
 
 export const taskListControls = {
@@ -144,6 +229,20 @@ export const taskListControls = {
 		try {
 			const response = await fetch( url, {
 				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"X-WP-Nonce": payload.nonce,
+				},
+			} );
+			return await response.json();
+		} catch ( error ) {
+			return error;
+		}
+	},
+	[ FETCH_TASK ]: async( { payload } ) => {
+		try {
+			const response = await fetch( payload.endpoint, {
+				method: "GET",
 				headers: {
 					"Content-Type": "application/json",
 					"X-WP-Nonce": payload.nonce,

--- a/packages/dashboard-frontend/tests/store/task-list.test.js
+++ b/packages/dashboard-frontend/tests/store/task-list.test.js
@@ -229,4 +229,118 @@ describe( "taskListSelectors", () => {
 			expect( taskListSelectors.selectIsTaskCompleted( state, "task2" ) ).toBe( false );
 		} );
 	} );
+	describe( "selectTasksStatus", () => {
+		it( "should return 'idle' when task list slice is missing", () => {
+			const state = {};
+			expect( taskListSelectors.selectTasksStatus( state ) ).toBe( "idle" );
+		} );
+
+		it( "should return 'idle' when status property is missing", () => {
+			const state = { taskList: {} };
+			expect( taskListSelectors.selectTasksStatus( state ) ).toBe( "idle" );
+		} );
+
+		it( "should return the tasks status when present", () => {
+			const state = { taskList: { status: "loading" } };
+			expect( taskListSelectors.selectTasksStatus( state ) ).toBe( "loading" );
+		} );
+	} );
+	describe( "selectTasksError", () => {
+		it( "should return null when task list slice is missing", () => {
+			const state = {};
+			expect( taskListSelectors.selectTasksError( state ) ).toBe( null );
+		} );
+
+		it( "should return null when error property is missing", () => {
+			const state = { taskList: {} };
+			expect( taskListSelectors.selectTasksError( state ) ).toBe( null );
+		} );
+
+		it( "should return the tasks error when present", () => {
+			const state = { taskList: { error: "Failed to fetch tasks" } };
+			expect( taskListSelectors.selectTasksError( state ) ).toBe( "Failed to fetch tasks" );
+		} );
+	} );
+	describe( "selectTotalTasksCount", () => {
+		it( "should return 0 when task list slice is missing", () => {
+			const state = {};
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 0 );
+		} );
+
+		it( "should return 0 when tasks property is missing", () => {
+			const state = { taskList: {} };
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 0 );
+		} );
+
+		it( "should return the total number of tasks when present", () => {
+			const state = {
+				taskList: {
+					tasks: {
+						task1: { id: "task1" },
+						task2: { id: "task2" },
+						task3: { id: "task3" },
+					},
+				},
+			};
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 3 );
+		} );
+	} );
+	describe( "selectCompletedTasksCount", () => {
+		it( "should return 0 when task list slice is missing", () => {
+			const state = {};
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 0 );
+		} );
+
+		it( "should return 0 when tasks property is missing", () => {
+			const state = { taskList: {} };
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 0 );
+		} );
+
+		it( "should return the number of completed tasks", () => {
+			const state = {
+				taskList: {
+					tasks: {
+						task1: { id: "task1", isCompleted: true },
+						task2: { id: "task2", isCompleted: false },
+						task3: { id: "task3", isCompleted: true },
+					},
+				},
+			};
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 2 );
+		} );
+	} );
+	describe( "selectSortedTasks", () => {
+		it( "should return an empty array when task list slice is missing", () => {
+			const state = {};
+			expect( taskListSelectors.selectSortedTasks( state ) ).toEqual( {} );
+		} );
+
+		it( "should return an empty array when tasks property is missing", () => {
+			const state = { taskList: {} };
+			expect( taskListSelectors.selectSortedTasks( state ) ).toEqual( {} );
+		} );
+
+		it( "should return sorted tasks based on completion, priority, duration, and title", () => {
+			const state = {
+				taskList: {
+					tasks: {
+						task2: { id: "task2", isCompleted: true, priority: "medium", duration: 5, title: "A Task" },
+						task1: { id: "task1", isCompleted: false, priority: "high", duration: 10, title: "B Task" },
+						task4: { id: "task4", isCompleted: false, priority: "high", duration: 3, title: "D Task" },
+						task3: { id: "task3", isCompleted: true, priority: "low", duration: 8, title: "C Task" },
+						task5: { id: "task5", isCompleted: false, priority: "high", duration: 3, title: "E Task" },
+						task6: { id: "task6", isCompleted: true, priority: "low", duration: 5, title: "F Task" },
+					},
+				},
+			};
+			expect( taskListSelectors.selectSortedTasks( state ) ).toEqual( {
+				task4: { id: "task4", isCompleted: false, priority: "high", duration: 3, title: "D Task" },
+				task5: { id: "task5", isCompleted: false, priority: "high", duration: 3, title: "E Task" },
+				task1: { id: "task1", isCompleted: false, priority: "high", duration: 10, title: "B Task" },
+				task2: { id: "task2", isCompleted: true, priority: "medium", duration: 5, title: "A Task" },
+				task6: { id: "task6", isCompleted: true, priority: "low", duration: 5, title: "F Task" },
+				task3: { id: "task3", isCompleted: true, priority: "low", duration: 8, title: "C Task" },
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
For future reusability in shopify

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Relocates task list logic to the task list store.
* [@yoast/dashboard-frontend 0.0.1] Adds logic to the task list redux slice for fetching tasks, sorting tasks, getting fetch tasks response status and error.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check tasks are sorted in the following order:
  * 1. Incomplete tasks first.
  * 2. Higher priority tasks first (high, medium, low).
  * 3. If tasks have the same completion status and priority, sort by duration (shorter duration first).
  * 4. If tasks have the same completion status, priority, and duration, sort alphabetically by title.
 * Complete the llms.txt task and check it has moved to the bottom of the list.
 * Add the following snippet to create an error when fetching tasks:
 ```php
add_filter( 'wpseo_task_list_tasks', 'custom_task_list_tasks', 10, 3 );

function custom_task_list_tasks( $tasks ) {
    return array_merge( $tasks, [ 'new-task' => [ 'new-task' ] ] );
}
```
* Go to the task list and check you see the error for fetching the tasks.
* Open the console and check you see an error: `Error fetching tasks: Added invalid task.`

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
