### PR TITLE
Fix translations for the worker in WordPress 6.9

### DIFF
--- a/packages/js/src/analysis/worker.js
+++ b/packages/js/src/analysis/worker.js
@@ -46,7 +46,12 @@ export function createAnalysisWorker() {
 		const split = text.indexOf( "," );
 		const domain = text.slice( 0, split - 1 );
 		try {
-			const translationData = JSON.parse( text.slice( split + 1, -4 ) );
+			// Since WP 6.9 the translation script has some extra code at the end, we need to find the proper end of the JSON.
+			const endRegex = /}}\s*\);/;
+			const match = endRegex.exec( text );
+			// Find the end index of the JSON data, after the curly braces.
+			const jsonEnd = match.index + 2;
+			const translationData = JSON.parse( text.slice( split + 1, jsonEnd ) );
 			translations.push( [ domain, translationData ] );
 		} catch ( e ) {
 			console.warn( `Failed to parse translation data for ${dependency} to send to the Yoast SEO worker` );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  https://core.trac.wordpress.org/ticket/63887 in WP 6.9 adds `\n//# sourceURL=yoast-seo-analysis-package-js-translations\n` at the end of the `<script>` tags where the translations are added, but that was unexpected for the code in `packages/js/src/analysis/worker.js` trying to parse the content of the script to send the translations to the worker.
We need to adapt the code while keeping backward compatibility

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where translations for the content analysis were not displayed on WordPress 6.9.

## Relevant technical choices:

* I used a regex to catch the case where a different number of spaces (or even no spaces) would follow the double curly braces. 
* I don't expect spaces between the two curly braces because that code should be as compact as possible.
* Not handling the case where no match is found since the catch clause will take care of that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install on a WP 6.8 site
* switch to a language with fairly complete [translations](https://translate.wordpress.org/projects/wp-plugins/wordpress-seo/)
* edit a post and check that the content analysis (also in the readability tab) is translated
  * if it's not fully translated, it's because the translation is not complete in the first place. check on a WP 6.8 site with the previous Yoast SEO version to be sure
* check the JS console, there shouldn't be a warning `Failed to parse translation data for yoast-seo-analysis-package to send to the Yoast SEO worker`
*  upgrade to WP 6.9
* edit a post and check that the content analysis (also in the readability tab) is translated
  * the same strings should be translated, but no need to check one by one, it's either they are all untranslated or some/all are translated
* check the JS console, there shouldn't be a warning `Failed to parse translation data for yoast-seo-analysis-package to send to the Yoast SEO worker`



#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #22792 
