### PR TITLE
Update debug marker presentation to include correct product URLs

### DIFF
--- a/src/presenters/debug/marker-open-presenter.php
+++ b/src/presenters/debug/marker-open-presenter.php
@@ -26,13 +26,9 @@ final class Marker_Open_Presenter extends Abstract_Indexable_Presenter {
 		$product_name = \esc_html( $this->helpers->product->get_name() );
 		$is_premium   = $this->helpers->product->is_premium();
 
-		$version = $is_premium
-			? $this->construct_version_info()
-			: 'v' . \WPSEO_VERSION;
+		$version = ( $is_premium ) ? $this->construct_version_info() : 'v' . \WPSEO_VERSION;
 
-		$url = $is_premium
-			? 'https://yoast.com/product/yoast-seo-premium-wordpress/'
-			: 'https://yoast.com/product/yoast-seo-wordpress/';
+		$url = ( $is_premium ) ? 'https://yoast.com/product/yoast-seo-premium-wordpress/' : 'https://yoast.com/product/yoast-seo-wordpress/';
 
 		return \sprintf(
 			'<!-- This site is optimized with the %1$s %2$s - %3$s -->',

--- a/tests/Unit/Presenters/Debug/Marker_Open_Presenter_Test.php
+++ b/tests/Unit/Presenters/Debug/Marker_Open_Presenter_Test.php
@@ -91,6 +91,7 @@ final class Marker_Open_Presenter_Test extends TestCase {
 	public function test_present_premium() {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Intended use for testing.
 		if ( ! \defined( 'WPSEO_PREMIUM_VERSION' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Testing constant definition.
 			\define( 'WPSEO_PREMIUM_VERSION', '2.0' );
 		}
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the product URL inside the marker presenter for Yoast SEO and Yoast SEO Premium.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test without Premium
* Install and activate Yoast SEO
* Create a Post
* Add some content and publish it
* In the frontend, open the page source
* Confirm that now you see the following (the version will depend on the Yoast SEO version that you are using:
```
<!-- This site is optimized with the Yoast SEO v26.6-RC4 - https://yoast.com/product/yoast-seo-wordpress/ -->
```
* Previously, the URL was: `https://yoast.com/wordpress/plugins/seo/`

#### Test with Premium
* Install and activate Yoast SEO Premium
* Open the post that you created in the previous step
* Confirm that now you see the following (the version will depend on the Yoast SEO version that you are using:
```
<!-- This site is optimized with the Yoast SEO Premium plugin v26.6-RC2 (Yoast SEO v26.6-RC4) - https://yoast.com/product/yoast-seo-premium-wordpress/ -->
```
* Previously, the URL was: `https://yoast.com/wordpress/plugins/seo/`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/22733
