### PR TITLE
Output an article schema piece even if no publisher has been specified

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -20,11 +20,6 @@ class Article extends Abstract_Schema_Piece {
 			return false;
 		}
 
-		// If we cannot output a publisher, we shouldn't output an Article.
-	//	if ( $this->context->site_represents === false ) {
-	//		return false;
-	//	}
-
 		// If we cannot output an author, we shouldn't output an Article.
 		if ( ! $this->helpers->schema->article->is_author_supported( $this->context->indexable->object_sub_type ) ) {
 			return false;

--- a/tests/Unit/Generators/Schema/Article_Test.php
+++ b/tests/Unit/Generators/Schema/Article_Test.php
@@ -186,9 +186,9 @@ final class Article_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_is_needed_no_site_represents() {
-		$this->context_mock->indexable->object_type = 'post';
+		$this->context_mock->indexable->object_type     = 'post';
 		$this->context_mock->indexable->object_sub_type = 'article';
-		$this->context_mock->site_represents        = false;
+		$this->context_mock->site_represents            = false;
 
 		$this->article->expects( 'is_author_supported' )->with( 'article' )->andReturn( true );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to change the Schema output so that `Article` entities are rendered even when the `publisher` property is left empty.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Changes the Schema output to render `Article` entities even when the `publisher` property is left empty.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to `Yoast SEO` -> `Settings` -> `Site representation`
* Make sure either the `Person` or the `Organization` information are empty
* Visit a post in the frontend and check the source
  * Copy-paste the Schema output into a validator (e.g. https://classyschema.org/Visualisation)
  * Verify the output is valid and it contains the `Article` Schema piece
  * Also verify that `Article` has no `publisher` property

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have ~added~ adapted unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#928](https://github.com/Yoast/reserved-tasks/issues/928)
