### PR TITLE
Add more checks before deeming the hello world task as open

### DIFF
--- a/src/task-list/application/tasks/delete-hello-world.php
+++ b/src/task-list/application/tasks/delete-hello-world.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Task_List\Application\Tasks;
 
+use WP_Comment;
 use WP_Post;
 use Yoast\WP\SEO\Task_List\Domain\Components\Call_To_Action_Entry;
 use Yoast\WP\SEO\Task_List\Domain\Components\Copy_Set;
@@ -45,6 +46,20 @@ class Delete_Hello_World extends Abstract_Completeable_Task {
 			return true;
 		}
 
+		// Check if this is the actual Hello World post by checking the first comment.
+		$comments = \get_comments(
+			[
+				'post_id' => 1,
+				'number'  => 1,
+				'order'   => 'ASC',
+			]
+		);
+
+		if ( empty( $comments ) || \is_a( $comments[0], WP_Comment::class ) === false || $comments[0]->comment_author_email !== 'wapuu@wordpress.example' ) {
+			// Not the Hello World post, so consider task completed.
+			return true;
+		}
+
 		return $post->post_date !== $post->post_modified;
 	}
 
@@ -68,7 +83,7 @@ class Delete_Hello_World extends Abstract_Completeable_Task {
 		$post = \get_post( 1 );
 
 		if ( $post instanceof WP_Post ) {
-			$result = \wp_delete_post( $post->ID, true );
+			$result = \wp_delete_post( $post->ID );
 
 			if ( ! $result ) {
 				throw new Complete_Hello_World_Task_Exception();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* As per [this thread](https://yoast.slack.com/archives/C09P39054FQ/p1765534614794309), there might be cases in the wild where the post with ID equal to 1 might not be the Hello World, but rather a legit post
* In order to safe guard this, we have added another check before prompting users to delete the post with ID equal to 1 and that is checking that that post has also its first comment coming from the author with the email `wapuu@wordpress.example` and only if that's the case, we make that task as open
* We also make it so that the `Delete for me` button in that task will place the Hello World post into the trash, and will not force delete it completely.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog items is meant for the changelog of a javascript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the `Delete the Hello World post` task might make users delete legit tasks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In a fresh installation with the Hello World post intact, go to the task list and confirm that the `Remove the “Hello World” post` task is incomplete
* Go to the Hello World post as a visitor and add a new comment, with your own email 
* Run `wp transient delete --all`, revisit the task list and confirm that the `Remove the “Hello World” post` task is incomplete
* Visit the `Comments` page in WP admin and edit the first comment to NOT have the `wapuu@wordpress.example` email
* Run `wp transient delete --all`, revisit the task list and confirm that the `Remove the “Hello World” post` task is now complete
* Revert the email of the first comment to the `wapuu@wordpress.example` email
* Run `wp transient delete --all`, revisit the task list and confirm that the `Remove the “Hello World” post` task is incomplete
* Delete all comments
* Run `wp transient delete --all`, revisit the task list and confirm that the `Remove the “Hello World” post` task is complete
* In a new site the Hello World post intact, edit the Hello World post
* Go to the task list and confirm that the `Remove the “Hello World” post` task is complete
* In a new site the Hello World post intact, don't edit the Hello World post
* Go to the task list and confirm that the `Remove the “Hello World” post` task is incomplete and click on the `Delete for me` button
  * Confirm that now the Hello World post goes to the trash instead of being completely deleted.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have ran `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
