### PR TITLE
Excludes empty sentences from the analysis of consecutive sentences assessment

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/getSentenceBeginningsSpec.js
@@ -152,6 +152,15 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings( mockPaper, researcher )[ 2 ].count ).toBe( 1 );
 	} );
 
+	it( "excludes sentences that contains only shortcodes", function() {
+		mockPaper = new Paper( "[shortcode]. [shortcode]. [shortcode]. First sentence.", { shortcodes: [ "shortcode" ] } );
+		researcher = new EnglishResearcher( mockPaper );
+		buildTree( mockPaper, researcher );
+		const sentenceBeginnings = getSentenceBeginnings( mockPaper, researcher );
+		expect( sentenceBeginnings ).toHaveLength( 1 );
+		expect( getSentenceBeginnings( mockPaper, researcher )[ 0 ].word ).toBe( "first" );
+	} );
+
 	it( "returns an object with English sentence beginnings with paragraph tags - it should match over paragraphs", function() {
 		mockPaper = new Paper( "<p>Sentence 1. Sentence 2.</p><p>Sentence 3.</p>" );
 		researcher = new EnglishResearcher( mockPaper );

--- a/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
+++ b/packages/yoastseo/src/languageProcessing/researches/getSentenceBeginnings.js
@@ -97,8 +97,9 @@ export default ( paper, researcher ) => {
 	let tree = cloneDeep( paper.getTree() );
 	tree = filterTree( tree, additionalFilters );
 
-	// Get all sentences from the tree, and find their sentence beginnings.
-	const sentences = getSentencesFromTree( tree );
+	// Get all sentences from the tree that contain tokens.
+	const sentences = getSentencesFromTree( tree ).filter( sentence => sentence.tokens.length > 0 );
+	// Get the sentence beginnings.
 	const sentenceBeginnings = sentences.map( sentence => getSentenceBeginning( sentence, firstWordExceptions, secondWordExceptions ) );
 
 	// Turn the sentence beginnings into an array that combines sentences beginning with the same word(s).


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [wordpress-seo-local] Fixes a bug where adding Local SEO shortcodes to the content in Classic Editor would break the _consecutive sentences_ assessment.
* [yoastseo enhancement] Excludes empty sentences from the analysis of _consecutive sentences_ assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Install and activate Local SEO
* Install and activate Classic editor.
* Set up multiple locations
* Create a post or location in Classic Editor
* Add some text. Make sure that no sentences start with the same beginning.
* At the beginning of the content, add at least three Local SEO shortcodes and add them consecutively
* Confirm that you don't see the following error in the console anymore: `RangeError: positionEnd should be larger than 0.`
* Go to the Readability analysis
* Confirm that you don't see the following message: `An error occurred in the 'sentenceBeginnings' assessment`
* Confirm that the _Consecutive sentences_  assessment returns the following feedback: `There are no repetitive sentence beginnings. That's great!`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-local/issues/2604
