### PR TITLE
Fixes RTL supportl for newsletter signup  alert

### DIFF
--- a/packages/js/src/general/components/alert-items/ping-other-admins-alert-item.js
+++ b/packages/js/src/general/components/alert-items/ping-other-admins-alert-item.js
@@ -7,7 +7,7 @@ import { select, useDispatch } from "@wordpress/data";
 import { useState, useCallback, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { isEmail } from "@wordpress/url";
-import { Button, TextField } from "@yoast/ui-library";
+import { Button, TextField, useRootContext } from "@yoast/ui-library";
 import { STORE_NAME } from "../../constants";
 import { useSelectGeneralPage } from "../../hooks";
 import { safeCreateInterpolateElement } from "../../../helpers/i18n";
@@ -83,6 +83,7 @@ export const PingOtherAdminsAlertItem = ( { id, dismissed, message, resolveNonce
 	const isPremium = useSelectGeneralPage( "selectPreference", [], "isPremium" );
 	const addonsStatus = useSelectGeneralPage( "selectPreference", [], "addonsStatus" );
 	const inputRef = useRef();
+	const { isRtl } = useRootContext();
 
 	const clearError = useCallback( () => {
 		setError( "" );
@@ -148,6 +149,7 @@ export const PingOtherAdminsAlertItem = ( { id, dismissed, message, resolveNonce
 					onInput={ clearError }
 					ref={ inputRef }
 					onChange={ noop }
+					style={ { direction: isRtl ? "rtl" : "ltr" } }
 				/>
 				<Button
 					variant="primary"
@@ -157,8 +159,8 @@ export const PingOtherAdminsAlertItem = ( { id, dismissed, message, resolveNonce
 					disabled={ isLoading || dismissed }
 				>
 					{ __( "Send", "wordpress-seo" ) }
-					<div className="yst-ml-2 yst-w-4">
-						<ArrowNarrowRightIcon className="yst-w-4 yst-text-white" />
+					<div className="yst-ms-2 yst-w-4">
+						<ArrowNarrowRightIcon className="yst-w-4 yst-text-white rtl:yst-rotate-180" />
 					</div>
 				</Button>
 			</div>


### PR DESCRIPTION
* Fixes the input placeholder
* Fixes the the button arrow

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the alert for signing up to the newsletter didn't support rtl direction for buttons and inputs in RTL languages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO for the first time in your site (or deactivate Yoast on your existing site and then manually delete from the db all wpseo options and then activate the plugin)
* Log in with a different user and confirm that you see the topbar and sidebar notifying that you have a new notification
* Go to the alert center and confirm that you see this alert:
<img width="723" height="228" alt="image" src="https://github.com/user-attachments/assets/ed7859a4-b211-453b-aa59-72f6c7461d48" />

* Switch language to RTL language like Hebrew or Arabic
* Go back to Yoas SEO -> General -> Alert center
* Check the arrow is in the right direction and the placeholder is in RTL direction:

<img width="591" height="246" alt="Screenshot 2025-12-29 at 16 47 58" src="https://github.com/user-attachments/assets/c5ec1db8-64fc-4379-9575-60dfa80c7e43" />


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Fix admin sign up to newsletter alert on RTL](https://github.com/Yoast/reserved-tasks/issues/968)
