### PR TITLE
GH Actions: don't run cron jobs on forks

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   analyze:
+    # Don't run the cron job on forks.
+    if: ${{ github.event_name != 'schedule' || github.event.repository.fork == false }}
+
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Don't run the cronjob in this workflow on forks.
-    if: github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'Yoast')
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
 
     steps:
       - name: Checkout code


### PR DESCRIPTION

## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

While workflows are disabled by default in forks, it is quite common for contributors to enable them to verify CI will pass before submitting a pull request.

When enabling workflow runs in forks, it's "all or nothing". This means that:
* All workflows which are only intended to be run on the canonical repo will also be enabled. These workflows will also often need access to repo-specific secrets and will typically fail when run from a fork.
* Workflows which contain cron jobs will also be enabled. Depending on the type of account the contributor has, this can burn through their "CI minutes".

This commit is based on a review of workflows containing cron jobs and disables running the jobs when a cron job is triggered in a fork.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_