### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -64,6 +64,8 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,8 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
+        env:
+          fail-fast: true
 
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Install Composer dependencies and generate vendor_prefixed directory
         uses: ramsey/composer-install@v3
@@ -74,6 +76,7 @@ jobs:
           coverage: none
           tools: cs2pr
         env:
+          fail-fast: true
           update: true
 
       - name: Lint against parse errors

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,8 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Install Composer dependencies, generate vendor_prefixed directory and run dependency injection
         uses: ramsey/composer-install@v3
@@ -91,6 +93,7 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
         env:
+          fail-fast: true
           update: true
 
       # The PHP platform requirement would prevent updating the test utilities to the appropriate versions.
@@ -201,6 +204,8 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
+        env:
+          fail-fast: true
 
       - name: Install Composer dependencies, generate vendor_prefixed directory and run dependency injection
         uses: ramsey/composer-install@v3
@@ -223,6 +228,7 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: ${{ matrix.coverage == true && 'xdebug' || 'none' }}
         env:
+          fail-fast: true
           update: true
 
       # The PHP platform requirement would prevent updating the test utilities to the appropriate versions.


### PR DESCRIPTION

## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

Setup-PHP will normally "gracefully" show a warning and not the build when an extension or tool failed to install.

This is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail the build at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_