### PR TITLE
GH Actions: fix pre-existing action runner pins

### DIFF
--- a/.github/workflows/browserslist-db.yml
+++ b/.github/workflows/browserslist-db.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update Browserslist database and create PR
-        uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # @v2.5.0 locked to a specific commit to avoid security issues due to a compromised repo.
+        uses: c2corg/browserslist-update-action@a76abb476199caea5399f9e28ff3f16e491ec566 # v2.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: browserslist-update


### PR DESCRIPTION

## Context

* General maintenance

## Summary

This PR can be summarized in the following changelog entry:

* General maintenance

## Relevant technical choices:

For Dependabot to be able to update pinned action runners, there should be a trailing comment with the tag associated with the pinned hash.

These pre-existing comments did not comply with that format.

While it does appear not to be a blocker for Dependabot (see #22854), it is still a good idea to follow best practices in this.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_