### PR TITLE
GH Actions/deploy: avoid cache poisoning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,13 +68,14 @@ jobs:
         env:
           fail-fast: true
 
-      # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node
-      - name: Set up node and enable caching of dependencies
+      - name: Set up node and disable caching of dependencies
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version-file: './.nvmrc'
-          cache: 'yarn'
+          # Explicitly NOT using the cache functionality to prevent cache poisoning for deployments.
+          cache: ''
+          package-manager-cache: false
 
       - name: "Debug info: show tooling versions"
         run: |
@@ -85,17 +86,9 @@ jobs:
           grunt --version
           git --version
 
-      # Install dependencies and handle caching in one go.
-      # The Grunt artifact creation will run `composer install` multiple times (both no-dev as well as dev),
-      # however, Composer packages downloaded are not cached via Grunt.
-      # Running `composer install` ahead of time will ensure that the cache is warmed up
-      # and available across runs of the same workflow.
-      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
-      - name: Install Composer dependencies and run the prefixing script
-        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
-        with:
-          # Bust the cache at least once a week - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+      # The Grunt artifact creation will run `composer install` twice (first: no-dev, then dev).
+      # Explicitly NOT using the cache functionality via the `ramsey/composer-install`
+      # action runner to prevent cache poisoning for deployments.
 
       - name: "Debug info: show directory layout"
         run: tree -dC .


### PR DESCRIPTION

## Context

* Improve CI security

## Summary


This PR can be summarized in the following changelog entry:

* Improve CI security

## Relevant technical choices:

> Caching and restoring build state is a process eased by utilities provided by GitHub, in particular actions/cache and its "save" and "restore" sub-actions. In addition, many of the setup-like actions provided by GitHub come with built-in caching functionality, like actions/setup-node, actions/setup-java and others.
>
> This vulnerability happens when release workflows leverage build state cached from previous workflow executions, in general on top of the aforementioned actions or similar ones. The publication of artifacts usually happens driven by trigger events like release or events with path filters like push (e.g. for tags).
>
> In such scenarios, an attacker with access to a valid GITHUB_TOKEN can use it to poison the repository's GitHub Actions caches. That compounds with the default behavior of actions/toolkit during cache restorations, allowing an attacker to retrieve payloads from poisoned cache entries, hence achieving code execution at Workflow runtime, potentially compromising ready-to-publish artifacts.

This commit removes the use of cached build states from the `deploy` workflow.

Refs:
* https://docs.zizmor.sh/audits/#cache-poisoning
* https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/
* https://adnanthekhan.com/2024/12/21/cacheract-the-monster-in-your-build-cache/


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_