### PR TITLE
Fix enhancers to work on single schema pieces

### DIFF
--- a/src/schema-aggregator/application/enhancement/article-schema-enhancer.php
+++ b/src/schema-aggregator/application/enhancement/article-schema-enhancer.php
@@ -42,32 +42,29 @@ class Article_Schema_Enhancer extends Abstract_Schema_Enhancer implements Schema
 	 * @return Schema_Piece The enhanced schema piece.
 	 */
 	public function enhance( Schema_Piece $schema_piece, Indexable $indexable ): Schema_Piece {
-
-		$data = $schema_piece->get_data();
-		foreach ( $data as $key => $schema_data ) {
-			if ( ! isset( $schema_data['@type'] ) ) {
-				continue;
-			}
-			if (
-				\in_array(
-					$schema_data['@type'],
-					[
-						'Article',
-						'NewsArticle',
-						'BlogPosting',
-					],
-					true
-				) ) {
-				$data[ $key ] = $this->enhance_schema_piece( $schema_data, $indexable );
-			}
-
-			if (
-				\is_array( $schema_data['@type'] ) && \in_array( 'Article', $schema_data['@type'], true ) ) {
-				$data[ $key ] = $this->enhance_schema_piece( $schema_data, $indexable );
-			}
+		$schema_data = $schema_piece->get_data();
+		if ( ! isset( $schema_data['@type'] ) ) {
+			return $schema_piece;
+		}
+		if (
+			\in_array(
+				$schema_data['@type'],
+				[
+					'Article',
+					'NewsArticle',
+					'BlogPosting',
+				],
+				true
+			) ) {
+			$schema_data = $this->enhance_schema_piece( $schema_data, $indexable );
 		}
 
-		return new Schema_Piece( $data, $schema_piece->get_type() );
+		if (
+				\is_array( $schema_data['@type'] ) && \in_array( 'Article', $schema_data['@type'], true ) ) {
+			$schema_data = $this->enhance_schema_piece( $schema_data, $indexable );
+		}
+
+		return new Schema_Piece( $schema_data, $schema_piece->get_type() );
 	}
 
 	/**
@@ -78,7 +75,7 @@ class Article_Schema_Enhancer extends Abstract_Schema_Enhancer implements Schema
 	 *
 	 * @return array<string> The enhanced schema data.
 	 */
-	private function enhance_schema_piece( $schema_data, $indexable ) {
+	private function enhance_schema_piece( array $schema_data, Indexable $indexable ): array {
 		try {
 			$has_excerpt = false;
 

--- a/src/schema-aggregator/application/enhancement/person-schema-enhancer.php
+++ b/src/schema-aggregator/application/enhancement/person-schema-enhancer.php
@@ -40,14 +40,12 @@ class Person_Schema_Enhancer extends Abstract_Schema_Enhancer implements Schema_
 	 * @return Schema_Piece The enhanced schema piece.
 	 */
 	public function enhance( Schema_Piece $schema_piece, Indexable $indexable ): Schema_Piece {
-		$data = $schema_piece->get_data();
-		foreach ( $data as $key => $schema_data ) {
-			if ( isset( $schema_data['@type'] ) && $schema_data['@type'] === 'Person' ) {
-				$data[ $key ] = $this->enhance_schema_piece( $schema_data, $indexable );
-			}
+		$schema_data = $schema_piece->get_data();
+		if ( isset( $schema_data['@type'] ) && $schema_data['@type'] === 'Person' ) {
+			$schema_data = $this->enhance_schema_piece( $schema_data, $indexable );
 		}
 
-		return new Schema_Piece( $data, $schema_piece->get_type() );
+		return new Schema_Piece( $schema_data, $schema_piece->get_type() );
 	}
 
 	/**
@@ -58,7 +56,7 @@ class Person_Schema_Enhancer extends Abstract_Schema_Enhancer implements Schema_
 	 *
 	 * @return array<string> The enhanced schema data.
 	 */
-	private function enhance_schema_piece( $schema_data, $indexable ) {
+	private function enhance_schema_piece( array $schema_data, Indexable $indexable ): array {
 		try {
 			// Add jobTitle if enabled and not already present.
 			if ( $this->config->is_enhancement_enabled( 'person_job_title' ) && ! isset( $entity['jobTitle'] ) ) {


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a wrong enhancers behaviour caused by breaking changes introduced in #22801.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where schema piece enhancers were never applied.

## Relevant technical choices:

* In #22801 we switched from a JSON-LD schema representation to a JSON-L one. This also means we now process single schema pieces instead of the full schema. 
* The enhancers, however, preserved their full-schema-processing logic, even though we changed the input parameter from `array<Schema_Piece>` to `Schema_Piece`. 
* This leads to enhancers not being applied because the guard condition `if ( isset( $schema_data['@type'] ) )` is always false ( being `$schema_data` a property value now), leading to the enhancer returning the unchanged schema piece. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Follow the test instructions in #22685
* Verify that without this PR the enhancers are not applied

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
