### PR TITLE
Adds indices to the SEO Links table for the URL field and target_indexable_id_index field.

### DIFF
--- a/src/config/migrations/20260105111111_AddSeoLinksIndex.php
+++ b/src/config/migrations/20260105111111_AddSeoLinksIndex.php
@@ -54,14 +54,14 @@ class AddSeoLinksIndex extends Migration {
 			$table_name,
 			'url',
 			[
-				'name' => 'target_indexable_id_index',
+				'name' => 'url_index',
 			]
 		);
 		$this->remove_index(
 			$table_name,
 			'target_indexable_id',
 			[
-				'name' => 'url_index',
+				'name' => 'target_indexable_id_index',
 			]
 		);
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

This is done to speed up at least two queries where theses fields are used in a single where statement. This way the where can use the index always and speed up the query for very large sites. Small sites should not notice any impact.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves performance in large sites with lots of inbound links by adding appropriate database indices.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open your DB and check that the `SEO_Links` table does not have indexes for the `url` and `target_indexable_id` field.
* Run the following queries and take note of the result:
`explain SELECT target_post_id FROM wp_yoast_seo_links WHERE url = '{an url from your tables content}';`
`explain SELECT COUNT( id ) AS incoming, target_indexable_id FROM wp_yoast_seo_links WHERE target_indexable_id IN ('1', '2', '231755', '3') GROUP BY target_indexable_id;`
* Make sure they are not using a key.
* Go to the yoast helper and click `Reset Indexables tables & migrations`
* Make sure the indices are now there.
* Run the queries again and make sure they use the new index now. Also make sure that they give the same results

Regression tests:
* Find the indexable for a post and take a note of its `incoming_link_count` column
  * Find a different post and add a link to the first post and save
  * Find the initial indexable again and check that the `incoming_link_count` column has now been incremented by one
* Create a post and add an image in the post content and dont add a feature image and publish it
  * Go to the frontend and confirm that the `#primaryimage` node in the schema is as expected.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.
* However, instead of going to the yoast helper and resetting the indexables from there, just upgrade the Yoast plugin with this current RC
  * Which means that you just have to check whether the query uses the new indexes

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
