### PR TITLE
Fixes the scroll issue of Yoast Search and Social appearance modals

### DIFF
--- a/css/src/modal.css
+++ b/css/src/modal.css
@@ -417,6 +417,12 @@
 	margin-top: auto;
 }
 
+/**
+ * As of WordPress 7.0, the div children of .components-modal__content have a class name.
+ * However, to maintain backward compatibility with older WordPress versions, we also need to target the
+ * divs without a class name.
+ * We can remove the :not selectors when we drop support for WordPress versions older than 7.0.
+ */
 .yoast-post-settings-modal .components-modal__content > div.components-modal__children-container,
 .yoast-post-settings-modal .components-modal__content > div:not([class]):not([class=""]) {
 	overflow: hidden;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* There was a compatibility issue when Yoast SEO was used in WordPress 6.9 and Gutenberg `22.3.0` was also activated. The issue found in the Search and Social appearance modals.
* This is because we use `import { Modal as WpModal } from "@wordpress/components";` for the modals. And previously, the child `div` that contains the modal content was rendered without a classname.
* We applied the following style for that element:
   ```
    .yoast-post-settings-modal .components-modal__content > div:not([class]):not([class=""]) {
	overflow: hidden;
        display: flex;
        flex-direction: column;
    }
   ```
* However, with the newest Gutenberg (`22.3.0`), the child is now rendered with `.components-modal__children-container` classname. Hence the style above won't be applied.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Search and Social appearance modals looked off on WordPress 7.0 or with Gutenberg 22.3.0.

## Relevant technical choices:

* The solution is to extend the following style also when the `div` has `.components-modal__children-container` classname:
 ```
    .yoast-post-settings-modal .components-modal__content > div:not([class]):not([class=""]) {
	overflow: hidden;
        display: flex;
        flex-direction: column;
    }
   ```
   to
   ```
   .yoast-post-settings-modal .components-modal__content > div.components-modal__children-container,    
   .yoast-post-settings-modal .components-modal__content > div:not([class]):not([class=""]) {
	overflow: hidden;
        display: flex;
        flex-direction: column;
    }
   ```
* Gutenberg `22.3.0` will be part of WordPress 7.0. Hence, once WP 7.2 is out and we don't support WP version older than 7.0, we can simplify the above style where we can remove ` .yoast-post-settings-modal .components-modal__content > div:not([class]):not([class=""])` selector. Issue: https://github.com/Yoast/reserved-tasks/issues/1004

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure to use WordPress version 6.9
* Install and activate Yoast SEO
* Create a post/page
* Navigate to Social appearance tab in the Yoast sidebar and click
* Confirm that the notice container doesn't turn transparrant that you can see the modal content when you scroll
<img width="905" height="750" alt="Screenshot 2026-01-07 at 15 29 56" src="https://github.com/user-attachments/assets/4bc29716-85e6-49a5-989f-1888781d7353" />

* Navigate to Search appearance tab in the Yoast sidebar and click
* Confirm that you don't see any issue with the modal when you scroll the content
   * Tips: zoom in you screen so that the modal appears larger. This way, the scroll will be visible
* Install and activate Gutenberg `22.3.0`
* Run the same steps as above
* Confirm that you get the same result

* Upgrade to WP 7.0 nightly (via e.g. the WordPress Beta Tester plugin)
* deactivate Gutenberg
* Run the same steps as above
* Confirm that you get the same result


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/22863
