### PR TITLE
Fix error for task list opt in

### DIFF
--- a/packages/js/src/general/components/opt-in-container.js
+++ b/packages/js/src/general/components/opt-in-container.js
@@ -2,9 +2,6 @@ import { TaskListOptInNotification } from "./task-list-opt-in-notification";
 import { useSelectGeneralPage } from "../hooks";
 import { useLocation } from "react-router-dom";
 import { ROUTES } from "../routes";
-import { useDispatch } from "@wordpress/data";
-import { STORE_NAME } from "../constants";
-import { useEffect } from "@wordpress/element";
 
 /**
  * The container for the opt-in notification.
@@ -14,15 +11,7 @@ import { useEffect } from "@wordpress/element";
  */
 export const OptInContainer = () => {
 	const taskListOptInNotificationSeen = useSelectGeneralPage( "selectIsOptInNotificationSeen", [], "task_list" );
-	const { setOptInNotificationSeen, hideOptInNotification } = useDispatch( STORE_NAME );
 	const { pathname } = useLocation();
-
-	useEffect( () => {
-		if ( pathname === ROUTES.taskList && ! taskListOptInNotificationSeen ) {
-			setOptInNotificationSeen( "task_list" );
-			hideOptInNotification( "task_list" );
-		}
-	}, [ pathname, taskListOptInNotificationSeen, setOptInNotificationSeen, hideOptInNotification ] );
 
 	if ( pathname === ROUTES.firstTimeConfiguration || taskListOptInNotificationSeen || pathname === ROUTES.taskList ) {
 		return null;


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where console error would appear when navigating to task list tab while the task list opt-in is rendered.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If it's not new site, reset task list opt-in by deleteing the user meta `_yoast_wpseo_task_list_opt_in_notification_seen`
* Go to general page dashboard.
* Open the devtools console.
* Check you see the task list opt in.
* Do not dismiss it and navigate to the Task list tab
* Check you see no error.
* Reset the opt in
* Refresh the page when you are on the task list tab
* Check you don't see the opt-in
* Navigate to dashboard tab. 
* Check you see the opt in (in contrast to the test instructions in https://github.com/Yoast/wordpress-seo/pull/22836)

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2817
