### PR TITLE
Implement AIOptimizeButton state management

### DIFF
--- a/packages/js/src/ai-optimizer/components/ai-optimize-button.js
+++ b/packages/js/src/ai-optimizer/components/ai-optimize-button.js
@@ -132,6 +132,16 @@ const AIOptimizeButton = ( { id, isPremium = false } ) => {
 				ariaLabel: disabledAIButtons[ aiOptimizeId ],
 			};
 		}
+
+		// Disable this button if another AI button is active (in preview mode).
+		const currentActiveAIButton = select( "yoast-seo/editor" ).getActiveAIFixesButton();
+		if ( currentActiveAIButton && currentActiveAIButton !== aiOptimizeId ) {
+			return {
+				isEnabled: false,
+				ariaLabel: __( "Please apply or discard the current AI suggestion.", "wordpress-seo" ),
+			};
+		}
+
 		// Fallback for when all conditions above pass and the button is enabled.
 		return {
 			isEnabled: true,

--- a/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
+++ b/packages/js/tests/ai-optimizer/components/ai-optimize-button.test.js
@@ -253,5 +253,24 @@ describe( "AIOptimizeButton", () => {
 		expect( button ).toBeEnabled();
 		expect( button ).toHaveAttribute( "aria-label", "Optimize with AI" );
 	} );
+
+	test( "should be disabled when another AI button is active (in preview mode)", () => {
+		// Another button (introductionKeywordAIFixes) is active, so keyphraseDensity button should be disabled.
+		mockSelect( "introductionKeywordAIFixes" );
+		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
+		const button = screen.getByRole( "button" );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toBeDisabled();
+		expect( button ).toHaveAttribute( "aria-label", "Please apply or discard the current AI suggestion." );
+	} );
+
+	test( "should be enabled when no other AI button is active", () => {
+		mockSelect( null );
+		render( <AIOptimizeButton id="keyphraseDensity" isPremium={ true } /> );
+		const button = screen.getByRole( "button" );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toBeEnabled();
+		expect( button ).toHaveAttribute( "aria-label", "Optimize with AI" );
+	} );
 } );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes a bug where the Yoast AI Optimize buttons remained active after another button in the group had already been pressed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the AI Optimize buttons remained active even when another button had been pressed. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

In an environment with access to the Yoast AI features. 
* Create a post in Block editor/Classic editor.
* Set your focus keyphrase.
* In your post, add some blocks from the following types: Paragraph, Heading, List, Details, and Table block.
* Add text of less than 1000 words/2000 tokens.
* Make sure to NOT add the keyphrase to the text.
* Go to the SEO analysis in the metabox/sidebar.
* You should see that the AI button for Keyphrase in introduction, density and keyphrase distribution are enabled.
* Click on the AI button for one of the Keyphrase assessments.
* When the AI Optimize dialog and the AI suggestions are en preview mode, check the status of the other AI Optimize buttons for the other assessments.
* Confirm that they are disabled.
* Hover over them and confirm that they show a tooltip with the label '_Please apply or discard the current AI suggestion._'
<img width="415" height="537" alt="image" src="https://github.com/user-attachments/assets/7eb4aa83-8f8a-4d6f-9d8d-9f1eefc364c7" />

* Confirm that clicking on them doesn't change the toast title or triggers any errors in the console.
* Dismiss the AI notification and confirm that they are again enabled with tooltip _'Optimize with AI'_ on hover. 
* Smoke test the same behavior for the AI Optimize buttons in the Readability analysis (also if the button pressed is a button for the SEO assessments, the AI buttons for the Readability assessments should be disabled and, vice versa). 

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#4847](github.com/Yoast/wordpress-seo-premium/issues/4847)
