### PR TITLE
Prevent showing tasks about content SEO if not applicable

### DIFF
--- a/src/task-list/application/tasks/improve-content-seo.php
+++ b/src/task-list/application/tasks/improve-content-seo.php
@@ -2,6 +2,9 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Task_List\Application\Tasks;
 
+use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
+use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Task_List\Application\Tasks\Child_Tasks\Improve_Content_SEO_Child;
 use Yoast\WP\SEO\Task_List\Domain\Components\Call_To_Action_Entry;
 use Yoast\WP\SEO\Task_List\Domain\Components\Copy_Set;
@@ -52,14 +55,34 @@ class Improve_Content_SEO extends Abstract_Post_Type_Parent_Task {
 	private $recent_content_indexable_collector;
 
 	/**
+	 * Holds the indexable helper.
+	 *
+	 * @var Indexable_Helper
+	 */
+	private $indexable_helper;
+
+	/**
+	 * Holds the enabled analysis features repository.
+	 *
+	 * @var Enabled_Analysis_Features_Repository
+	 */
+	private $enabled_analysis_features_repository;
+
+	/**
 	 * Constructs the task.
 	 *
-	 * @param Recent_Content_Indexable_Collector $recent_content_indexable_collector The recent content indexable collector.
+	 * @param Recent_Content_Indexable_Collector   $recent_content_indexable_collector   The recent content indexable collector.
+	 * @param Indexable_Helper                     $indexable_helper                     The indexable helper.
+	 * @param Enabled_Analysis_Features_Repository $enabled_analysis_features_repository The enabled analysis features repository.
 	 */
 	public function __construct(
-		Recent_Content_Indexable_Collector $recent_content_indexable_collector
+		Recent_Content_Indexable_Collector $recent_content_indexable_collector,
+		Indexable_Helper $indexable_helper,
+		Enabled_Analysis_Features_Repository $enabled_analysis_features_repository
 	) {
-		$this->recent_content_indexable_collector = $recent_content_indexable_collector;
+		$this->recent_content_indexable_collector   = $recent_content_indexable_collector;
+		$this->indexable_helper                     = $indexable_helper;
+		$this->enabled_analysis_features_repository = $enabled_analysis_features_repository;
 	}
 
 	/**
@@ -128,11 +151,18 @@ class Improve_Content_SEO extends Abstract_Post_Type_Parent_Task {
 	/**
 	 * Returns whether the task is valid.
 	 *
-	 * @TODO: disable if no indexables enabled, or no SEO analysis enabled.
-	 *
 	 * @return bool
 	 */
 	public function is_valid(): bool {
+		if ( ! $this->indexable_helper->should_index_indexables() ) {
+			return false;
+		}
+
+		$enabled_features = $this->enabled_analysis_features_repository->get_enabled_features()->to_array();
+		if ( ! isset( $enabled_features[ Keyphrase_Analysis::NAME ] ) || $enabled_features[ Keyphrase_Analysis::NAME ] === false ) {
+			return false;
+		}
+
 		return true;
 	}
 }

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Abstract_Improve_Content_SEO_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Abstract_Improve_Content_SEO_Test.php
@@ -5,6 +5,9 @@
 namespace Yoast\WP\SEO\Tests\Unit\Task_List\Application\Tasks\Improve_Content_SEO;
 
 use Mockery;
+use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
+use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Task_List\Application\Tasks\Improve_Content_SEO;
 use Yoast\WP\SEO\Task_List\Infrastructure\Indexables\Recent_Content_Indexable_Collector;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -24,6 +27,20 @@ abstract class Abstract_Improve_Content_SEO_Test extends TestCase {
 	protected $recent_content_indexable_collector;
 
 	/**
+	 * The indexable helper mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
+	 * The enabled analysis features repository mock.
+	 *
+	 * @var Mockery\MockInterface|Enabled_Analysis_Features_Repository
+	 */
+	protected $enabled_analysis_features_repository;
+
+	/**
 	 * Holds the instance.
 	 *
 	 * @var Improve_Content_SEO
@@ -39,10 +56,30 @@ abstract class Abstract_Improve_Content_SEO_Test extends TestCase {
 		parent::set_up();
 		$this->stubTranslationFunctions();
 
-		$this->recent_content_indexable_collector = Mockery::mock( Recent_Content_Indexable_Collector::class );
+		$this->recent_content_indexable_collector   = Mockery::mock( Recent_Content_Indexable_Collector::class );
+		$this->indexable_helper                     = Mockery::mock( Indexable_Helper::class );
+		$this->enabled_analysis_features_repository = Mockery::mock( Enabled_Analysis_Features_Repository::class );
+
+		$this->indexable_helper
+			->shouldReceive( 'should_index_indexables' )
+			->andReturn( true )
+			->byDefault();
+
+		$features_list = Mockery::mock( Analysis_Features_List::class );
+		$features_list
+			->shouldReceive( 'to_array' )
+			->andReturn( [ 'keyphraseAnalysis' => true ] )
+			->byDefault();
+
+		$this->enabled_analysis_features_repository
+			->shouldReceive( 'get_enabled_features' )
+			->andReturn( $features_list )
+			->byDefault();
 
 		$this->instance = new Improve_Content_SEO(
-			$this->recent_content_indexable_collector
+			$this->recent_content_indexable_collector,
+			$this->indexable_helper,
+			$this->enabled_analysis_features_repository
 		);
 	}
 }

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Improve_Content_SEO_Constructor_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Improve_Content_SEO_Constructor_Test.php
@@ -4,6 +4,8 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Task_List\Application\Tasks\Improve_Content_SEO;
 
+use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Task_List\Infrastructure\Indexables\Recent_Content_Indexable_Collector;
 
 /**
@@ -26,6 +28,14 @@ final class Improve_Content_SEO_Constructor_Test extends Abstract_Improve_Conten
 		$this->assertInstanceOf(
 			Recent_Content_Indexable_Collector::class,
 			$this->getPropertyValue( $this->instance, 'recent_content_indexable_collector' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexable_helper' )
+		);
+		$this->assertInstanceOf(
+			Enabled_Analysis_Features_Repository::class,
+			$this->getPropertyValue( $this->instance, 'enabled_analysis_features_repository' )
 		);
 	}
 }

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Improve_Content_SEO_Is_Valid_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO/Improve_Content_SEO_Is_Valid_Test.php
@@ -1,0 +1,78 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Task_List\Application\Tasks\Improve_Content_SEO;
+
+use Mockery;
+use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
+
+/**
+ * Test class for the Improve Content SEO is_valid method.
+ *
+ * @group Improve_Content_SEO
+ *
+ * @covers Yoast\WP\SEO\Task_List\Application\Tasks\Improve_Content_SEO::is_valid
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Improve_Content_SEO_Is_Valid_Test extends Abstract_Improve_Content_SEO_Test {
+
+	/**
+	 * Tests that is_valid returns true when indexables are enabled and keyphrase analysis is active.
+	 *
+	 * @return void
+	 */
+	public function test_is_valid_returns_true_when_all_conditions_met() {
+		$this->assertTrue( $this->instance->is_valid() );
+	}
+
+	/**
+	 * Tests that is_valid returns false when should_index_indexables returns false.
+	 *
+	 * @return void
+	 */
+	public function test_is_valid_returns_false_when_indexables_disabled() {
+		$this->indexable_helper
+			->shouldReceive( 'should_index_indexables' )
+			->andReturn( false );
+
+		$this->assertFalse( $this->instance->is_valid() );
+	}
+
+	/**
+	 * Tests that is_valid returns false when keyphrase analysis is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_is_valid_returns_false_when_keyphrase_analysis_disabled() {
+		$features_list = Mockery::mock( Analysis_Features_List::class );
+		$features_list
+			->shouldReceive( 'to_array' )
+			->andReturn( [ 'keyphraseAnalysis' => false ] );
+
+		$this->enabled_analysis_features_repository
+			->shouldReceive( 'get_enabled_features' )
+			->andReturn( $features_list );
+
+		$this->assertFalse( $this->instance->is_valid() );
+	}
+
+	/**
+	 * Tests that is_valid returns false when keyphrase analysis is not in the enabled features.
+	 *
+	 * @return void
+	 */
+	public function test_is_valid_returns_false_when_keyphrase_analysis_not_present() {
+		$features_list = Mockery::mock( Analysis_Features_List::class );
+		$features_list
+			->shouldReceive( 'to_array' )
+			->andReturn( [] );
+
+		$this->enabled_analysis_features_repository
+			->shouldReceive( 'get_enabled_features' )
+			->andReturn( $features_list );
+
+		$this->assertFalse( $this->instance->is_valid() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides tasks about content's SEO if indexables or the SEO analysis feature are disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check the `/wp-json/yoast/v1/get_tasks` GET request and confirm that you get the `improve-content-seo-post` task and its children (search for improve-content-seo- in the response and you will see them)
* Delete transients: `wp transient delete --all`
* Disable the indexables via the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` filter and repeat the GET request
  * This time you won't see the `improve-content-seo-post` task and its children (search for improve-content-seo- in the response and you will get no results
* Delete transients: `wp transient delete --all`
* Remove the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` filter
* Disable the SEO analysis feature from Yoast settings and repeat the GET request
  * This time you won't see the `improve-content-seo-post` task and its children (search for improve-content-seo- in the response and you will get no results
* Delete transients: `wp transient delete --all`
* Remove the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` filter
* Enable the SEO analysis feature from Yoast settings
* Disable the SEO analysis feature for your user only from the user profile and repeat the GET request
  * This time you won't see the `improve-content-seo-post` task and its children (search for improve-content-seo- in the response and you will get no results

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.
*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
