### PR TITLE
Fix task list selector for completed and total tasks.

### DIFF
--- a/packages/dashboard-frontend/src/store/task-list.js
+++ b/packages/dashboard-frontend/src/store/task-list.js
@@ -211,14 +211,22 @@ export const taskListSelectors = {
 		( state ) => get( state, [ TASK_LIST_NAME, "tasks" ], {} ),
 		( tasks ) => sortTasks( tasks )
 	),
-	selectTotalParentTasksCount: ( state ) => {
+	selectTotalTasksCount: ( state, includeChildTasks = false ) => {
 		const tasks = get( state, [ TASK_LIST_NAME, "tasks" ], {} );
+		if ( includeChildTasks ) {
+			return size( tasks );
+		}
 		return size(
 			values( tasks ).filter( task => ! task.parentTaskId )
 		);
 	},
-	selectCompletedParentTasksCount: ( state ) => {
+	selectCompletedTasksCount: ( state, includeChildTasks = false ) => {
 		const tasks = get( state, [ TASK_LIST_NAME, "tasks" ], {} );
+		if ( includeChildTasks ) {
+			return size(
+				values( tasks ).filter( task => task.isCompleted )
+			);
+		}
 		return size(
 			values( tasks ).filter( task => task.isCompleted && ! task.parentTaskId )
 		);

--- a/packages/dashboard-frontend/tests/store/task-list.test.js
+++ b/packages/dashboard-frontend/tests/store/task-list.test.js
@@ -261,15 +261,15 @@ describe( "taskListSelectors", () => {
 			expect( taskListSelectors.selectTasksError( state ) ).toBe( "Failed to fetch tasks" );
 		} );
 	} );
-	describe( "selectTotalParentTasksCount", () => {
+	describe( "selectTotalTasksCount", () => {
 		it( "should return 0 when task list slice is missing", () => {
 			const state = {};
-			expect( taskListSelectors.selectTotalParentTasksCount( state ) ).toBe( 0 );
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 0 );
 		} );
 
 		it( "should return 0 when tasks property is missing", () => {
 			const state = { taskList: {} };
-			expect( taskListSelectors.selectTotalParentTasksCount( state ) ).toBe( 0 );
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 0 );
 		} );
 
 		it( "should return the total number of tasks when present", () => {
@@ -285,18 +285,33 @@ describe( "taskListSelectors", () => {
 					},
 				},
 			};
-			expect( taskListSelectors.selectTotalParentTasksCount( state ) ).toBe( 3 );
+			expect( taskListSelectors.selectTotalTasksCount( state ) ).toBe( 3 );
+		} );
+		it( "should return the total number of tasks including child tasks when includeChildTasks is true", () => {
+			const state = {
+				taskList: {
+					tasks: {
+						task1: { id: "task1" },
+						task2: { id: "task2" },
+						task3: { id: "task3" },
+						task4: { id: "task4", parentTaskId: "task1" },
+						task5: { id: "task5", parentTaskId: "task2" },
+						task6: { id: "task6", parentTaskId: "task3" },
+					},
+				},
+			};
+			expect( taskListSelectors.selectTotalTasksCount( state, true ) ).toBe( 6 );
 		} );
 	} );
-	describe( "selectCompletedParentTasksCount", () => {
+	describe( "selectCompletedTasksCount", () => {
 		it( "should return 0 when task list slice is missing", () => {
 			const state = {};
-			expect( taskListSelectors.selectCompletedParentTasksCount( state ) ).toBe( 0 );
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 0 );
 		} );
 
 		it( "should return 0 when tasks property is missing", () => {
 			const state = { taskList: {} };
-			expect( taskListSelectors.selectCompletedParentTasksCount( state ) ).toBe( 0 );
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 0 );
 		} );
 
 		it( "should return the number of completed parent tasks", () => {
@@ -312,7 +327,22 @@ describe( "taskListSelectors", () => {
 					},
 				},
 			};
-			expect( taskListSelectors.selectCompletedParentTasksCount( state ) ).toBe( 2 );
+			expect( taskListSelectors.selectCompletedTasksCount( state ) ).toBe( 2 );
+		} );
+		it( "should return the number of completed tasks including child tasks when includeChildTasks is true", () => {
+			const state = {
+				taskList: {
+					tasks: {
+						task1: { id: "task1", isCompleted: true },
+						task2: { id: "task2", isCompleted: false },
+						task3: { id: "task3", isCompleted: true },
+						task4: { id: "task4", isCompleted: true, parentTaskId: "task1" },
+						task5: { id: "task5", isCompleted: false, parentTaskId: "task2" },
+						task6: { id: "task6", isCompleted: true, parentTaskId: "task3" },
+					},
+				},
+			};
+			expect( taskListSelectors.selectCompletedTasksCount( state, true ) ).toBe( 4 );
 		} );
 	} );
 	describe( "selectSortedTasks", () => {

--- a/packages/js/src/general/routes/task-list.js
+++ b/packages/js/src/general/routes/task-list.js
@@ -35,8 +35,8 @@ export const TaskList = () => {
 		tasksStatus,
 		tasksError,
 		sortedTasks,
-		totalParentTasksCount,
-		completedParentTasksCount,
+		totalTasksCount,
+		completedTasksCount,
 		userLocale,
 	} = useSelect( ( select ) => {
 		const state = select( STORE_NAME );
@@ -48,8 +48,8 @@ export const TaskList = () => {
 			tasksStatus: state.selectTasksStatus(),
 			tasksError: state.selectTasksError(),
 			sortedTasks: state.selectSortedTasks(),
-			totalParentTasksCount: state.selectTotalParentTasksCount(),
-			completedParentTasksCount: state.selectCompletedParentTasksCount(),
+			totalTasksCount: state.selectTotalTasksCount(),
+			completedTasksCount: state.selectCompletedTasksCount(),
 			userLocale: state.selectPreference( "userLocale" ),
 		};
 	}, [] );
@@ -73,8 +73,8 @@ export const TaskList = () => {
 		<Paper.Content>
 			<TaskListProvider locale={ userLocale }>
 				<TasksProgressBar
-					completedTasks={ completedParentTasksCount }
-					totalTasks={ totalParentTasksCount }
+					completedTasks={ completedTasksCount }
+					totalTasks={ totalTasksCount }
 					isLoading={ isPending }
 					className="yst-max-w-screen-sm"
 				/>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix the values for the task list main progress bar to not include child tasks.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the main progress bar in the task list to include only parent tasks. 

## Relevant technical choices:

* I added a flag for including the child tasks in the selector.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO -> General -> Task list
* Check the progress bar includes only parent tasks and parent completed tasks.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Task-list [frontend]: Progress bar at main list view shouldnt account for child tasks](https://github.com/Yoast/reserved-tasks/issues/1061)
