### PR TITLE
Add global indexable alert.

### DIFF
--- a/src/alerts/application/indexables-disabled/indexables-disabled-alert.php
+++ b/src/alerts/application/indexables-disabled/indexables-disabled-alert.php
@@ -1,0 +1,128 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Alerts\Application\Indexables_Disabled;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast_Notification;
+use Yoast_Notification_Center;
+
+/**
+ * Indexables_Disabled_Alert class.
+ */
+class Indexables_Disabled_Alert implements Integration_Interface {
+
+	public const NOTIFICATION_ID = 'wpseo-indexables-disabled';
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	private $notification_center;
+
+	/**
+	 * The indexable helper.
+	 *
+	 * @var Indexable_Helper
+	 */
+	private $indexable_helper;
+
+	/**
+	 * The short link helper.
+	 *
+	 * @var Short_Link_Helper
+	 */
+	private $short_link_helper;
+
+	/**
+	 * Indexables_Disabled_Alert constructor.
+	 *
+	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Indexable_Helper          $indexable_helper    The indexable helper.
+	 * @param Short_Link_Helper         $short_link_helper   The short link helper.
+	 */
+	public function __construct(
+		Yoast_Notification_Center $notification_center,
+		Indexable_Helper $indexable_helper,
+		Short_Link_Helper $short_link_helper
+	) {
+		$this->notification_center = $notification_center;
+		$this->indexable_helper    = $indexable_helper;
+		$this->short_link_helper   = $short_link_helper;
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'add_notifications' ] );
+	}
+
+	/**
+	 * Adds or removes notification based on whether indexables are disabled.
+	 *
+	 * @return void
+	 */
+	public function add_notifications() {
+		if ( $this->indexable_helper->should_index_indexables() ) {
+			$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+			return;
+		}
+
+		$notification = $this->get_indexables_disabled_notification();
+
+		$this->notification_center->add_notification( $notification );
+	}
+
+	/**
+	 * Builds the indexables-disabled notification.
+	 *
+	 * @return Yoast_Notification The indexables-disabled notification.
+	 */
+	private function get_indexables_disabled_notification(): Yoast_Notification {
+		$message = $this->get_message();
+
+		return new Yoast_Notification(
+			$message,
+			[
+				'id'           => self::NOTIFICATION_ID,
+				'type'         => Yoast_Notification::WARNING,
+				'capabilities' => [ 'wpseo_manage_options' ],
+			]
+		);
+	}
+
+	/**
+	 * Returns the notification message as an HTML string.
+	 *
+	 * @return string The HTML string representation of the notification.
+	 */
+	private function get_message(): string {
+		$shortlink = $this->short_link_helper->get( 'https://yoa.st/indexables-disabled' );
+
+		$message = \sprintf(
+			/* translators: %1$s expands to "Yoast", %2$s expands to an opening anchor tag, %3$s expands to a closing anchor tag. */
+			\esc_html__( '%1$s indexables are disabled because your site is in a non-production environment or custom code is blocking them. This may affect your SEO features. %2$sLearn more about this%3$s.', 'wordpress-seo' ),
+			'Yoast',
+			'<a href="' . \esc_url( $shortlink ) . '" target="_blank">',
+			'</a>'
+		);
+
+		return $message;
+	}
+}

--- a/tests/Unit/Alerts/Application/Indexables_Disabled/Abstract_Indexables_Disabled_Alert_Test.php
+++ b/tests/Unit/Alerts/Application/Indexables_Disabled/Abstract_Indexables_Disabled_Alert_Test.php
@@ -1,0 +1,69 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Indexables_Disabled;
+
+use Mockery;
+use Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert;
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
+
+/**
+ * Base class for the indexables disabled alert application tests.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Indexables_Disabled_Alert_Test extends TestCase {
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * The indexable helper.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Helper
+	 */
+	protected $indexable_helper;
+
+	/**
+	 * The short link helper.
+	 *
+	 * @var Mockery\MockInterface|Short_Link_Helper
+	 */
+	protected $short_link_helper;
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Indexables_Disabled_Alert
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+		$this->indexable_helper    = Mockery::mock( Indexable_Helper::class );
+		$this->short_link_helper   = Mockery::mock( Short_Link_Helper::class );
+
+		$this->instance = new Indexables_Disabled_Alert(
+			$this->notification_center,
+			$this->indexable_helper,
+			$this->short_link_helper
+		);
+	}
+}

--- a/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Add_Notifications_Test.php
+++ b/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Add_Notifications_Test.php
@@ -1,0 +1,104 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Indexables_Disabled;
+
+use Brain\Monkey\Functions;
+use Generator;
+use Mockery;
+
+/**
+ * Test class adding notifications.
+ *
+ * @group Indexables_Disabled
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::add_notifications
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::get_indexables_disabled_notification
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::get_message
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Indexables_Disabled_Alert_Add_Notifications_Test extends Abstract_Indexables_Disabled_Alert_Test {
+
+	/**
+	 * Tests adding notifications.
+	 *
+	 * @dataProvider add_notifications_data
+	 *
+	 * @param bool   $should_index_indexables   Whether the indexables should be indexed.
+	 * @param int    $remove_notification_times The number of times we are removing a notification.
+	 * @param int    $get_shortlink_times       The number of times we are getting the shortlink.
+	 * @param string $shortlink                 The shortlink to return.
+	 * @param int    $add_notification_times    The number of times we are adding a notification.
+	 * @param string $expected_message          The expected notification message.
+	 *
+	 * @return void
+	 */
+	public function test_add_notifications(
+		$should_index_indexables,
+		$remove_notification_times,
+		$get_shortlink_times,
+		$shortlink,
+		$add_notification_times,
+		$expected_message
+	) {
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
+
+		Functions\expect( 'get_current_user_id' )
+			->andReturn( $admin_user->ID );
+
+		$this->indexable_helper
+			->expects( 'should_index_indexables' )
+			->once()
+			->andReturn( $should_index_indexables );
+
+		$this->notification_center
+			->expects( 'remove_notification_by_id' )
+			->times( $remove_notification_times )
+			->with( 'wpseo-indexables-disabled' );
+
+		$this->short_link_helper
+			->expects( 'get' )
+			->with( 'https://yoa.st/indexables-disabled' )
+			->times( $get_shortlink_times )
+			->andReturn( $shortlink );
+
+		$this->notification_center
+			->expects( 'add_notification' )
+			->times( $add_notification_times )
+			->withArgs(
+				static function ( $notification ) use ( $expected_message ) {
+					$notification_array = $notification->to_array();
+					return $notification_array['message'] === $expected_message;
+				}
+			);
+
+		$this->instance->add_notifications();
+	}
+
+	/**
+	 * Data provider for the test_add_notifications test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function add_notifications_data() {
+		yield 'Indexables enabled - removes notification' => [
+			'should_index_indexables'   => true,
+			'remove_notification_times' => 1,
+			'get_shortlink_times'       => 0,
+			'shortlink'                 => 'irrelevant',
+			'add_notification_times'    => 0,
+			'expected_message'          => 'irrelevant',
+		];
+
+		yield 'Indexables disabled - adds notification' => [
+			'should_index_indexables'   => false,
+			'remove_notification_times' => 0,
+			'get_shortlink_times'       => 1,
+			'shortlink'                 => 'https://yoa.st/indexables-disabled?some=params',
+			'add_notification_times'    => 1,
+			'expected_message'          => 'Yoast indexables are disabled because your site is in a non-production environment or custom code is blocking them. This may affect your SEO features. <a href="https://yoa.st/indexables-disabled?some=params" target="_blank">Learn more about this</a>.',
+		];
+	}
+}

--- a/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Constructor_Test.php
+++ b/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Constructor_Test.php
@@ -1,0 +1,40 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Indexables_Disabled;
+
+use Yoast\WP\SEO\Helpers\Indexable_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast_Notification_Center;
+
+/**
+ * Test class for the constructor.
+ *
+ * @group Indexables_Disabled
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::__construct
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Indexables_Disabled_Alert_Constructor_Test extends Abstract_Indexables_Disabled_Alert_Test {
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Yoast_Notification_Center::class,
+			$this->getPropertyValue( $this->instance, 'notification_center' )
+		);
+		$this->assertInstanceOf(
+			Indexable_Helper::class,
+			$this->getPropertyValue( $this->instance, 'indexable_helper' )
+		);
+		$this->assertInstanceOf(
+			Short_Link_Helper::class,
+			$this->getPropertyValue( $this->instance, 'short_link_helper' )
+		);
+	}
+}

--- a/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Get_Conditionals_Test.php
+++ b/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Get_Conditionals_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Indexables_Disabled;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+
+/**
+ * Test class getting the conditionals.
+ *
+ * @group Indexables_Disabled
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::get_conditionals
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Indexables_Disabled_Alert_Get_Conditionals_Test extends Abstract_Indexables_Disabled_Alert_Test {
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$expected = [ Admin_Conditional::class ];
+
+		$this->assertEquals( $expected, $this->instance->get_conditionals() );
+	}
+}

--- a/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Register_Hooks_Test.php
+++ b/tests/Unit/Alerts/Application/Indexables_Disabled/Indexables_Disabled_Alert_Register_Hooks_Test.php
@@ -1,0 +1,33 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Indexables_Disabled;
+
+/**
+ * Test class for registering hooks.
+ *
+ * @group Indexables_Disabled
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Indexables_Disabled\Indexables_Disabled_Alert::register_hooks
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Indexables_Disabled_Alert_Register_Hooks_Test extends Abstract_Indexables_Disabled_Alert_Test {
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertEquals(
+			10,
+			\has_action(
+				'admin_init',
+				[ $this->instance, 'add_notifications' ]
+			)
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to show a global notification in the alert centre

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a notification in the Alert centre when indexables are disabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure indexables are enabled and go to the alert centre.
* Make sure there is no notification with the content:
```
Yoast indexables are disabled because your site is in a non-production environment or custom code is blocking them. This may affect your SEO features. [Learn more about this](https://yoa.st/indexables-disabled).
```
Add the following filter:
```
add_filter( 'Yoast\WP\SEO\should_index_indexables', function( $should_index ) {
	return false;
}, 10, 1 );
```
* make sure you see the notification now.
* Remove the filter and add the `define( 'WP_ENVIRONMENT_TYPE', 'local' );` define, which will make your site be a non-production environment.
* make sure you still see the notification.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
