### PR TITLE
Modernize: use numeric literal separators

### DIFF
--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1012,7 +1012,7 @@ class WPSEO_Upgrade {
 		WPSEO_Options::set( 'should_redirect_after_install_free', false );
 		// We're adding a hardcoded time here, so that in the future we can be able to identify whether the user did see the Installation Success page or not.
 		// If they did, they wouldn't have this hardcoded value in that option, but rather (roughly) the timestamp of the moment they saw it.
-		WPSEO_Options::set( 'activation_redirect_timestamp_free', 1652258756 );
+		WPSEO_Options::set( 'activation_redirect_timestamp_free', 1_652_258_756 );
 
 		// Transfer the Social URLs.
 		$other   = [];

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -188,7 +188,7 @@ class WPSEO_Image_Utils {
 		 *
 		 * @param int $max_bytes The maximum weight (in bytes) of an image.
 		 */
-		$max_size = apply_filters( 'wpseo_image_image_weight_limit', 2097152 );
+		$max_size = apply_filters( 'wpseo_image_image_weight_limit', 2_097_152 );
 
 		// We cannot check without a path, so assume it's fine.
 		if ( ! isset( $image['path'] ) ) {

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -262,7 +262,7 @@ class Front_End_Integration implements Integration_Interface {
 		\add_filter( 'wpseo_frontend_presenter_classes', [ $this, 'filter_robots_presenter' ] );
 
 		\add_action( 'wpseo_head', [ $this, 'present_head' ], -9999 );
-		\add_action( 'wpseo_head', [ $this, 'update_outdated_permalink' ], -10000 );
+		\add_action( 'wpseo_head', [ $this, 'update_outdated_permalink' ], -10_000 );
 
 		\remove_action( 'wp_head', 'rel_canonical' );
 		\remove_action( 'wp_head', 'index_rel_link' );

--- a/src/integrations/front-end/crawl-cleanup-rss.php
+++ b/src/integrations/front-end/crawl-cleanup-rss.php
@@ -51,7 +51,7 @@ class Crawl_Cleanup_Rss implements Integration_Interface {
 		}
 
 		\add_action( 'wp', [ $this, 'maybe_disable_feeds' ] );
-		\add_action( 'wp', [ $this, 'maybe_redirect_feeds' ], -10000 );
+		\add_action( 'wp', [ $this, 'maybe_redirect_feeds' ], -10_000 );
 	}
 
 	/**

--- a/src/integrations/front-end/force-rewrite-title.php
+++ b/src/integrations/front-end/force-rewrite-title.php
@@ -75,7 +75,7 @@ class Force_Rewrite_Title implements Integration_Interface {
 			return;
 		}
 
-		\add_action( 'template_redirect', [ $this, 'force_rewrite_output_buffer' ], 99999 );
+		\add_action( 'template_redirect', [ $this, 'force_rewrite_output_buffer' ], 99_999 );
 		\add_action( 'wp_footer', [ $this, 'flush_cache' ], -1 );
 	}
 

--- a/src/integrations/front-end/robots-txt-integration.php
+++ b/src/integrations/front-end/robots-txt-integration.php
@@ -65,7 +65,7 @@ class Robots_Txt_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function register_hooks() {
-		\add_filter( 'robots_txt', [ $this, 'filter_robots' ], 99999 );
+		\add_filter( 'robots_txt', [ $this, 'filter_robots' ], 99_999 );
 
 		if ( $this->options_helper->get( 'deny_search_crawling' ) && ! \is_multisite() ) {
 			\add_action( 'Yoast\WP\SEO\register_robots_rules', [ $this, 'add_disallow_search_to_robots' ], 10, 1 );

--- a/tests/Unit/AI_Authorization/Application/Code_Verifier_Handler/Generate_Test.php
+++ b/tests/Unit/AI_Authorization/Application/Code_Verifier_Handler/Generate_Test.php
@@ -21,7 +21,7 @@ final class Generate_Test extends Abstract_Code_Verifier_Handler_Test {
 	 */
 	public function test_generate() {
 		$user_email     = 'test@example.com';
-		$current_time   = 1640995200;
+		$current_time   = 1_640_995_200;
 		$generated_code = 'mocked_generated_code_123';
 
 		$this->code_generator

--- a/tests/Unit/AI_Authorization/Application/Token_Manager/Get_Or_Request_Access_Token_Test.php
+++ b/tests/Unit/AI_Authorization/Application/Token_Manager/Get_Or_Request_Access_Token_Test.php
@@ -66,7 +66,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$new_access_jwt = 'new-access-token';
 		$code_verifier  = Mockery::mock( Code_Verifier::class );
 		$code           = 'test-code-verifier';
-		$created_at     = 1640995200;
+		$created_at     = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -146,7 +146,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$new_access_jwt = 'new-access-token';
 		$code_verifier  = Mockery::mock( Code_Verifier::class );
 		$code           = 'test-code-verifier';
-		$created_at     = 1640995200;
+		$created_at     = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -227,7 +227,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$new_access_jwt = 'new-access-token';
 		$code_verifier  = Mockery::mock( Code_Verifier::class );
 		$code           = 'test-code-verifier';
-		$created_at     = 1640995200;
+		$created_at     = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -304,14 +304,14 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$new_access_jwt     = 'refreshed-access-token';
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -375,7 +375,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$new_access_jwt     = 'new-access-token';
 		$refresh_jwt        = 'refresh-token';
@@ -383,7 +383,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$code_verifier_refresh = Mockery::mock( Code_Verifier::class );
 		$code_verifier_request = Mockery::mock( Code_Verifier::class );
 		$code                  = 'test-code-verifier';
-		$created_at            = 1640995200;
+		$created_at            = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -492,13 +492,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -562,7 +562,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -634,7 +634,7 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -712,13 +712,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -775,13 +775,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -838,13 +838,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -901,13 +901,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -964,13 +964,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past.
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past.
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )
@@ -1027,13 +1027,13 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$expired_time       = ( 1640995200 - 3600 ); // 1 hour in the past
+		$expired_time       = ( 1_640_995_200 - 3600 ); // 1 hour in the past
 		$expired_access_jwt = $this->create_jwt_token( $expired_time );
 		$refresh_jwt        = 'refresh-token';
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 
 		$this->user_helper
 			->expects( 'get_meta' )

--- a/tests/Unit/AI_Authorization/Application/Token_Manager/Token_Refresh_Test.php
+++ b/tests/Unit/AI_Authorization/Application/Token_Manager/Token_Refresh_Test.php
@@ -40,7 +40,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -123,7 +123,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -177,7 +177,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -231,7 +231,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'expired-refresh-token';
 
 		$this->refresh_token_repository
@@ -285,7 +285,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -339,7 +339,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -393,7 +393,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -447,7 +447,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -501,7 +501,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository
@@ -555,7 +555,7 @@ final class Token_Refresh_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier = Mockery::mock( Code_Verifier::class );
 		$code          = 'test-code-verifier';
-		$created_at    = 1640995200;
+		$created_at    = 1_640_995_200;
 		$refresh_jwt   = 'valid-refresh-token';
 
 		$this->refresh_token_repository

--- a/tests/Unit/AI_Authorization/Application/Token_Manager/Token_Request_Test.php
+++ b/tests/Unit/AI_Authorization/Application/Token_Manager/Token_Request_Test.php
@@ -30,7 +30,7 @@ final class Token_Request_Test extends Abstract_Token_Manager_Test {
 
 		$code_verifier        = Mockery::mock( Code_Verifier::class );
 		$code                 = 'test-code-verifier';
-		$created_at           = 1640995200;
+		$created_at           = 1_640_995_200;
 		$callback_url         = 'https://example.com/callback';
 		$refresh_callback_url = 'https://example.com/refresh-callback';
 

--- a/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
+++ b/tests/Unit/Actions/Importing/Abstract_Aioseo_Settings_Importing_Action_Test.php
@@ -323,7 +323,7 @@ final class Abstract_Aioseo_Settings_Importing_Action_Test extends TestCase {
 		return [
 			[ [], true, 0 ],
 			[ [ 0 ], false, 1 ],
-			[ [ 54321 ], false, 1 ],
+			[ [ 54_321 ], false, 1 ],
 		];
 	}
 

--- a/tests/Unit/Actions/SEMrush/SEMrush_Login_Action_Test.php
+++ b/tests/Unit/Actions/SEMrush/SEMrush_Login_Action_Test.php
@@ -70,7 +70,7 @@ final class SEMrush_Login_Action_Test extends TestCase {
 		$token_data = [
 			'access_token'  => 'some valid token',
 			'refresh_token' => 'some valid refresh token',
-			'expires'       => 99999999,
+			'expires'       => 99_999_999,
 			'has_expired'   => false,
 			'created_at'    => 0,
 		];
@@ -81,7 +81,7 @@ final class SEMrush_Login_Action_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => 604800,
+				'getExpires'      => 604_800,
 				'hasExpired'      => false,
 			]
 		);

--- a/tests/Unit/Actions/Wincher/Wincher_Account_Action_Test.php
+++ b/tests/Unit/Actions/Wincher/Wincher_Account_Action_Test.php
@@ -160,7 +160,7 @@ final class Wincher_Account_Action_Test extends TestCase {
 				[
 					'limits' => [
 						'keywords'     => [
-							'usage' => 100000,
+							'usage' => 100_000,
 							'limit' => null,
 						],
 						'history_days' => 31,
@@ -173,7 +173,7 @@ final class Wincher_Account_Action_Test extends TestCase {
 			(object) [
 				'canTrack'    => true,
 				'limit'       => null,
-				'usage'       => 100000,
+				'usage'       => 100_000,
 				'status'      => 200,
 				'historyDays' => 31,
 			],

--- a/tests/Unit/Actions/Wincher/Wincher_Keyphrases_Action_Test.php
+++ b/tests/Unit/Actions/Wincher/Wincher_Keyphrases_Action_Test.php
@@ -130,7 +130,7 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 					'data' => [
 						[
 							'keyword' => 'yoast seo',
-							'id'      => 12345,
+							'id'      => 12_345,
 						],
 					],
 				]
@@ -141,7 +141,7 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 				'results' => (object) [
 					'yoast seo' => [
 						'keyword' => 'yoast seo',
-						'id'      => 12345,
+						'id'      => 12_345,
 					],
 				],
 			],
@@ -240,7 +240,7 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 			(object) [
 				'status'  => 200,
 			],
-			$this->instance->untrack_keyphrase( 12345 )
+			$this->instance->untrack_keyphrase( 12_345 )
 		);
 	}
 
@@ -290,11 +290,11 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 					'data' => [
 						[
 							'keyword' => 'yoast seo',
-							'id'      => 12345,
+							'id'      => 12_345,
 						],
 						[
 							'keyword' => 'wincher',
-							'id'      => 12346,
+							'id'      => 12_346,
 						],
 					],
 				]
@@ -305,11 +305,11 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 				'results' => (object) [
 					'yoast seo' => [
 						'keyword' => 'yoast seo',
-						'id'      => 12345,
+						'id'      => 12_345,
 					],
 					'wincher'   => [
 						'keyword' => 'wincher',
-						'id'      => 12346,
+						'id'      => 12_346,
 					],
 				],
 			],
@@ -417,11 +417,11 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 					'data' => [
 						[
 							'keyword' => 'yoast seo',
-							'id'      => 12345,
+							'id'      => 12_345,
 						],
 						[
 							'keyword' => 'wincher',
-							'id'      => 12346,
+							'id'      => 12_346,
 						],
 					],
 				]
@@ -432,7 +432,7 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 				'results' => (object) [
 					'yoast seo' => [
 						'keyword' => 'yoast seo',
-						'id'      => 12345,
+						'id'      => 12_345,
 					],
 				],
 			],
@@ -475,12 +475,12 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 					'data' => [
 						[
 							'keyword'  => 'yoast seo',
-							'id'       => 22345,
+							'id'       => 22_345,
 							'position' => 20,
 						],
 						[
 							'keyword'  => 'blog seo',
-							'id'       => 22346,
+							'id'       => 22_346,
 							'position' => 22,
 						],
 					],
@@ -492,12 +492,12 @@ final class Wincher_Keyphrases_Action_Test extends TestCase {
 				'results' => (object) [
 					'yoast seo' => [
 						'keyword'  => 'yoast seo',
-						'id'       => 22345,
+						'id'       => 22_345,
 						'position' => 20,
 					],
 					'blog seo'  => [
 						'keyword'  => 'blog seo',
-						'id'       => 22346,
+						'id'       => 22_346,
 						'position' => 22,
 					],
 				],

--- a/tests/Unit/Actions/Wincher/Wincher_Login_Action_Test.php
+++ b/tests/Unit/Actions/Wincher/Wincher_Login_Action_Test.php
@@ -87,7 +87,7 @@ final class Wincher_Login_Action_Test extends TestCase {
 		$token_data = [
 			'access_token'  => 'some valid token',
 			'refresh_token' => 'some valid refresh token',
-			'expires'       => 99999999,
+			'expires'       => 99_999_999,
 			'has_expired'   => false,
 			'created_at'    => 0,
 		];
@@ -98,7 +98,7 @@ final class Wincher_Login_Action_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => 604800,
+				'getExpires'      => 604_800,
 				'hasExpired'      => false,
 			]
 		);

--- a/tests/Unit/Alerts/User_Interface/Default_SEO_Data/Cron_Scheduler/Default_SEO_Data_Cron_Scheduler_Schedule_Default_SEO_Data_Detection_Test.php
+++ b/tests/Unit/Alerts/User_Interface/Default_SEO_Data/Cron_Scheduler/Default_SEO_Data_Cron_Scheduler_Schedule_Default_SEO_Data_Detection_Test.php
@@ -50,7 +50,7 @@ final class Default_SEO_Data_Cron_Scheduler_Schedule_Default_SEO_Data_Detection_
 	 */
 	public static function schedule_default_seo_data_detection_provider() {
 		yield 'Cron already scheduled - do not schedule again' => [
-			'wp_next_scheduled_result' => 1234567890,
+			'wp_next_scheduled_result' => 1_234_567_890,
 			'wp_schedule_event_times'  => 0,
 		];
 

--- a/tests/Unit/Alerts/User_Interface/Default_SEO_Data/Cron_Scheduler/Default_SEO_Data_Cron_Scheduler_Unschedule_Default_SEO_Data_Detection_Test.php
+++ b/tests/Unit/Alerts/User_Interface/Default_SEO_Data/Cron_Scheduler/Default_SEO_Data_Cron_Scheduler_Unschedule_Default_SEO_Data_Detection_Test.php
@@ -56,7 +56,7 @@ final class Default_SEO_Data_Cron_Scheduler_Unschedule_Default_SEO_Data_Detectio
 		];
 
 		yield 'Cron scheduled - unschedule it' => [
-			'wp_next_scheduled_result'  => 1234567890,
+			'wp_next_scheduled_result'  => 1_234_567_890,
 			'wp_unschedule_event_times' => 1,
 		];
 	}

--- a/tests/Unit/Analytics/User_Interface/Last_Completed_Indexation_Integration_Test.php
+++ b/tests/Unit/Analytics/User_Interface/Last_Completed_Indexation_Integration_Test.php
@@ -97,6 +97,6 @@ final class Last_Completed_Indexation_Integration_Test extends TestCase {
 			->with( 'update_option_wpseo', [ 'WPSEO_Utils', 'clear_cache' ] )
 			->never();
 
-		$this->sut->maybe_set_indexables_unindexed_calculated( 'name', 100000 );
+		$this->sut->maybe_set_indexables_unindexed_calculated( 'name', 100_000 );
 	}
 }

--- a/tests/Unit/Builders/Indexable_Home_Page_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Home_Page_Builder_Test.php
@@ -56,7 +56,7 @@ final class Indexable_Home_Page_Builder_Test extends TestCase {
 		'size'   => 'full',
 		'id'     => 6,
 		'alt'    => '',
-		'pixels' => 307200,
+		'pixels' => 307_200,
 		'type'   => 'image\/jpeg',
 	];
 

--- a/tests/Unit/Builders/Indexable_Post_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Post_Builder_Test.php
@@ -330,7 +330,7 @@ final class Indexable_Post_Builder_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 
@@ -571,7 +571,7 @@ final class Indexable_Post_Builder_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 
@@ -625,7 +625,7 @@ final class Indexable_Post_Builder_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 

--- a/tests/Unit/Builders/Indexable_Social_Image_Trait_Test.php
+++ b/tests/Unit/Builders/Indexable_Social_Image_Trait_Test.php
@@ -142,7 +142,7 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 
@@ -194,7 +194,7 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 
@@ -313,7 +313,7 @@ final class Indexable_Social_Image_Trait_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 

--- a/tests/Unit/Builders/Indexable_Term_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Term_Builder_Test.php
@@ -346,7 +346,7 @@ final class Indexable_Term_Builder_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 13,
 			'alt'    => '',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 

--- a/tests/Unit/Config/OAuth_Client_Test.php
+++ b/tests/Unit/Config/OAuth_Client_Test.php
@@ -143,7 +143,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -192,7 +192,7 @@ final class OAuth_Client_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => 604800,
+				'getExpires'      => 604_800,
 				'hasExpired'      => false,
 			]
 		);
@@ -219,7 +219,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -259,7 +259,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -304,7 +304,7 @@ final class OAuth_Client_Test extends TestCase {
 			[
 				'access_token'  => '000000',
 				'refresh_token' => '000001',
-				'expires'       => 604800,
+				'expires'       => 604_800,
 				'has_expired'   => true,
 				'created_at'    => $this->time,
 				'error_count'   => 0,
@@ -318,7 +318,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -363,7 +363,7 @@ final class OAuth_Client_Test extends TestCase {
 			[
 				'access_token'  => '000000',
 				'refresh_token' => '000001',
-				'expires'       => 604800,
+				'expires'       => 604_800,
 				'has_expired'   => true,
 				'created_at'    => $this->time,
 				'error_count'   => 0,
@@ -377,7 +377,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -431,7 +431,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => ( $this->time + 604800 ),
+					'expires'       => ( $this->time + 604_800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -544,7 +544,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -608,7 +608,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => ( $this->time + 604800 ),
+					'expires'       => ( $this->time + 604_800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -673,7 +673,7 @@ final class OAuth_Client_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => 604800,
+				'getExpires'      => 604_800,
 				'hasExpired'      => false,
 			]
 		);
@@ -688,7 +688,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -742,7 +742,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => ( $this->time + 604800 ),
+					'expires'       => ( $this->time + 604_800 ),
 					'has_expired'   => false,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -779,7 +779,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -790,7 +790,7 @@ final class OAuth_Client_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => ( $this->time + 604800 ),
+				'getExpires'      => ( $this->time + 604_800 ),
 				'hasExpired'      => false,
 			]
 		);
@@ -849,7 +849,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,
@@ -915,7 +915,7 @@ final class OAuth_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
 					'created_at'    => $this->time,
 					'error_count'   => 0,

--- a/tests/Unit/Config/SEMrush_Client_Test.php
+++ b/tests/Unit/Config/SEMrush_Client_Test.php
@@ -125,9 +125,9 @@ final class SEMrush_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => 604800,
+					'expires'       => 604_800,
 					'has_expired'   => true,
-					'created_at'    => 1234890,
+					'created_at'    => 1_234_890,
 				]
 			);
 

--- a/tests/Unit/Config/Wincher_Client_Test.php
+++ b/tests/Unit/Config/Wincher_Client_Test.php
@@ -67,9 +67,9 @@ final class Wincher_Client_Test extends TestCase {
 				[
 					'access_token'  => '000000',
 					'refresh_token' => '000001',
-					'expires'       => ( $this->time + 604800 ),
+					'expires'       => ( $this->time + 604_800 ),
 					'has_expired'   => false,
-					'created_at'    => 1234890,
+					'created_at'    => 1_234_890,
 				]
 			);
 

--- a/tests/Unit/Context/Meta_Tags_Context_Test.php
+++ b/tests/Unit/Context/Meta_Tags_Context_Test.php
@@ -512,7 +512,7 @@ final class Meta_Tags_Context_Test extends TestCase {
 			'size'   => 'full',
 			'id'     => 12,
 			'alt'    => 'Alt. Text',
-			'pixels' => 307200,
+			'pixels' => 307_200,
 			'type'   => 'image/jpeg',
 		];
 

--- a/tests/Unit/Helpers/Date_Helper_Test.php
+++ b/tests/Unit/Helpers/Date_Helper_Test.php
@@ -87,9 +87,9 @@ final class Date_Helper_Test extends TestCase {
 				'expected' => true,
 			],
 			'Test formatting the date with an integer as date' => [
-				'date'     => 123456789,
+				'date'     => 123_456_789,
 				'format'   => \DATE_W3C,
-				'expected' => 123456789,
+				'expected' => 123_456_789,
 			],
 			'Test formatting the date with a string as date' => [
 				'date'     => 'this is a date',
@@ -133,7 +133,7 @@ final class Date_Helper_Test extends TestCase {
 				'expected'  => '1973-11-29 21:33:09',
 			],
 			'Test formatting an integer timestamp to a date' => [
-				'timestamp' => 123456789,
+				'timestamp' => 123_456_789,
 				'format'    => \DATE_W3C,
 				'expected'  => '1973-11-29T21:33:09+00:00',
 			],
@@ -208,7 +208,7 @@ final class Date_Helper_Test extends TestCase {
 				'expected' => true,
 			],
 			'Other non-string' => [
-				'input'    => 123456789,
+				'input'    => 123_456_789,
 				'expected' => false,
 			],
 		];

--- a/tests/Unit/Helpers/Import_Cursor_Helper_Test.php
+++ b/tests/Unit/Helpers/Import_Cursor_Helper_Test.php
@@ -128,7 +128,7 @@ final class Import_Cursor_Helper_Test extends TestCase {
 			[ -1 ],
 			[ 1336 ],
 			[ 1337 ],
-			[ -9223372036854775808 ],
+			[ -9_223_372_036_854_775_808 ],
 			[ 1336.3 ],
 			[ null ],
 		];
@@ -171,7 +171,7 @@ final class Import_Cursor_Helper_Test extends TestCase {
 		return [
 			[ 1338 ],
 			[ 1337.5 ],
-			[ 9223372036854775807 ],
+			[ 9_223_372_036_854_775_808 ],
 		];
 	}
 }

--- a/tests/Unit/Helpers/Indexing_Helper_Test.php
+++ b/tests/Unit/Helpers/Indexing_Helper_Test.php
@@ -199,7 +199,7 @@ final class Indexing_Helper_Test extends TestCase {
 			->once()
 			->with( 'indexing_first_time', false );
 
-		$start_time = 160934509;
+		$start_time = 160_934_509;
 
 		$this->date_helper
 			->expects( 'current_time' )
@@ -312,7 +312,7 @@ final class Indexing_Helper_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_started() {
-		$start_time = 160934509;
+		$start_time = 160_934_509;
 		$this->options_helper
 			->expects( 'get' )
 			->once()

--- a/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Background_Indexing_Integration_Test.php
@@ -578,8 +578,8 @@ final class Background_Indexing_Integration_Test extends TestCase {
 			->with( true )
 			->andReturn( false );
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
-		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12_345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12_345, 'wpseo_indexable_index_batch' );
 
 		$this->instance->index();
 	}
@@ -604,8 +604,8 @@ final class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( false );
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
-		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12_345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12_345, 'wpseo_indexable_index_batch' );
 
 		$this->instance->index();
 	}
@@ -636,8 +636,8 @@ final class Background_Indexing_Integration_Test extends TestCase {
 			->once()
 			->andReturn( true );
 
-		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12345 );
-		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12345, 'wpseo_indexable_index_batch' );
+		Monkey\Functions\expect( 'wp_next_scheduled' )->once()->with( 'wpseo_indexable_index_batch' )->andReturn( 12_345 );
+		Monkey\Functions\expect( 'wp_unschedule_event' )->once()->with( 12_345, 'wpseo_indexable_index_batch' );
 
 		$this->instance->index();
 	}

--- a/tests/Unit/Integrations/Admin/Cron_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Cron_Integration_Test.php
@@ -87,7 +87,7 @@ final class Cron_Integration_Test extends TestCase {
 		$this->date_helper
 			->expects( 'current_time' )
 			->once()
-			->andReturn( 123456 );
+			->andReturn( 123_456 );
 
 		Monkey\Functions\expect( 'wp_next_scheduled' )
 			->once()
@@ -96,7 +96,7 @@ final class Cron_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_schedule_event' )
 			->once()
-			->with( 123456, 'daily', Indexing_Notification_Integration::NOTIFICATION_ID );
+			->with( 123_456, 'daily', Indexing_Notification_Integration::NOTIFICATION_ID );
 
 		$this->instance->register_hooks();
 	}

--- a/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Indexing_Notification_Integration_Test.php
@@ -310,7 +310,7 @@ final class Indexing_Notification_Integration_Test extends TestCase {
 
 		$this->indexing_helper
 			->expects( 'get_started' )
-			->andReturn( 123456789 );
+			->andReturn( 123_456_789 );
 
 		$this->indexing_helper
 			->expects( 'get_filtered_unindexed_count' )
@@ -530,7 +530,7 @@ final class Indexing_Notification_Integration_Test extends TestCase {
 		$this->indexing_helper
 			->expects( 'get_started' )
 			->once()
-			->andReturn( 123456789 );
+			->andReturn( 123_456_789 );
 
 		$this->indexing_helper
 			->expects( 'get_filtered_unindexed_count' )

--- a/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
+++ b/tests/Unit/Introductions/Infrastructure/Introductions_Seen_Repository_Test.php
@@ -97,13 +97,13 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 				'meta'     => [
 					'foo' => [
 						'is_seen' => true,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 				'expected' => [
 					'foo' => [
 						'is_seen' => true,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 			],
@@ -190,7 +190,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 				'meta'            => [
 					'foo' => [
 						'is_seen' => true,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 				'expected'        => true,
@@ -210,7 +210,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 				'meta'            => [
 					'foo' => [
 						'is_seen' => 1,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 				'expected'        => true,
@@ -225,7 +225,7 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 				'meta'            => [
 					'foo' => [
 						'is_seen' => '1',
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 				'expected'        => true,
@@ -298,13 +298,13 @@ final class Introductions_Seen_Repository_Test extends TestCase {
 				'meta'            => [
 					'foo' => [
 						'is_seen' => true,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 				'expected_meta'   => [
 					'foo' => [
 						'is_seen' => true,
-						'seen_on' => 12345678,
+						'seen_on' => 12_345_678,
 					],
 				],
 			],

--- a/tests/Unit/Promotions/Application/Fake_Promotion.php
+++ b/tests/Unit/Promotions/Application/Fake_Promotion.php
@@ -17,7 +17,7 @@ final class Fake_Promotion extends Abstract_Promotion implements Promotion_Inter
 	public function __construct() {
 		parent::__construct(
 			'fake_promotion',
-			new Time_Interval( ( \time() - 10000 ), ( \time() + 10000 ) )
+			new Time_Interval( ( \time() - 10_000 ), ( \time() + 10_000 ) )
 		);
 	}
 }

--- a/tests/Unit/Routes/Wincher_Route_Test.php
+++ b/tests/Unit/Routes/Wincher_Route_Test.php
@@ -249,7 +249,7 @@ final class Wincher_Route_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_is_valid_website_when_valid_id_is_passed() {
-		$this->assertTrue( $this->instance->has_valid_website_id( 12345 ) );
+		$this->assertTrue( $this->instance->has_valid_website_id( 12_345 ) );
 	}
 
 	/**

--- a/tests/Unit/Values/OAuth/OAuth_Token_Test.php
+++ b/tests/Unit/Values/OAuth/OAuth_Token_Test.php
@@ -44,7 +44,7 @@ final class OAuth_Token_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_creating_new_instance() {
-		$instance = new OAuth_Token( '000000', '000001', 604800, false, $this->created_at );
+		$instance = new OAuth_Token( '000000', '000001', 604_800, false, $this->created_at );
 
 		$this->assertInstanceOf( OAuth_Token::class, $instance );
 	}
@@ -59,7 +59,7 @@ final class OAuth_Token_Test extends TestCase {
 	public function test_creating_new_instance_empty_access_token() {
 		$this->expectException( Empty_Property_Exception::class );
 
-		new OAuth_Token( '', '000001', 604800, true, $this->created_at );
+		new OAuth_Token( '', '000001', 604_800, true, $this->created_at );
 	}
 
 	/**
@@ -72,7 +72,7 @@ final class OAuth_Token_Test extends TestCase {
 	public function test_creating_new_instance_empty_refresh_token() {
 		$this->expectException( Empty_Property_Exception::class );
 
-		new OAuth_Token( '000000', '', 604800, true, $this->created_at );
+		new OAuth_Token( '000000', '', 604_800, true, $this->created_at );
 	}
 
 	/**
@@ -98,7 +98,7 @@ final class OAuth_Token_Test extends TestCase {
 	public function test_creating_new_instance_empty_has_expired() {
 		$this->expectException( Empty_Property_Exception::class );
 
-		new OAuth_Token( '000000', '000001', 604800, null, $this->created_at );
+		new OAuth_Token( '000000', '000001', 604_800, null, $this->created_at );
 	}
 
 	/**
@@ -109,11 +109,11 @@ final class OAuth_Token_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_getters() {
-		$instance = new OAuth_Token( '000000', '000001', ( $this->created_at + 604800 ), false, $this->created_at );
+		$instance = new OAuth_Token( '000000', '000001', ( $this->created_at + 604_800 ), false, $this->created_at );
 
 		$this->assertEquals( '000000', $instance->access_token );
 		$this->assertEquals( '000001', $instance->refresh_token );
-		$this->assertEquals( ( $this->created_at + 604800 ), $instance->expires );
+		$this->assertEquals( ( $this->created_at + 604_800 ), $instance->expires );
 		$this->assertFalse( $instance->has_expired() );
 		$this->assertEquals( $this->created_at, $instance->created_at );
 		$this->assertEquals( 0, $instance->error_count );
@@ -130,7 +130,7 @@ final class OAuth_Token_Test extends TestCase {
 		$instance = new OAuth_Token(
 			'000000',
 			'000001',
-			( $this->created_at + 604800 ),
+			( $this->created_at + 604_800 ),
 			false,
 			$this->created_at
 		);
@@ -139,7 +139,7 @@ final class OAuth_Token_Test extends TestCase {
 			[
 				'access_token'  => '000000',
 				'refresh_token' => '000001',
-				'expires'       => ( $this->created_at + 604800 ),
+				'expires'       => ( $this->created_at + 604_800 ),
 				'has_expired'   => false,
 				'created_at'    => $this->created_at,
 				'error_count'   => 0,
@@ -162,7 +162,7 @@ final class OAuth_Token_Test extends TestCase {
 			[
 				'getToken'        => '000000',
 				'getRefreshToken' => '000001',
-				'getExpires'      => 604800,
+				'getExpires'      => 604_800,
 				'hasExpired'      => false,
 			]
 		);
@@ -172,7 +172,7 @@ final class OAuth_Token_Test extends TestCase {
 		$this->assertInstanceOf( OAuth_Token::class, $instance );
 		$this->assertEquals( '000000', $this->getPropertyValue( $instance, 'access_token' ) );
 		$this->assertEquals( '000001', $this->getPropertyValue( $instance, 'refresh_token' ) );
-		$this->assertEquals( 604800, $this->getPropertyValue( $instance, 'expires' ) );
+		$this->assertEquals( 604_800, $this->getPropertyValue( $instance, 'expires' ) );
 		$this->assertEquals( false, $this->getPropertyValue( $instance, 'has_expired' ) );
 		$this->assertEquals( $this->created_at, $this->getPropertyValue( $instance, 'created_at' ) );
 	}

--- a/tests/WP/Admin/Watchers/Slug_Change_Watcher_Test.php
+++ b/tests/WP/Admin/Watchers/Slug_Change_Watcher_Test.php
@@ -306,6 +306,6 @@ final class Slug_Change_Watcher_Test extends TestCase {
 
 		$instance->register_hooks();
 
-		\wp_delete_term( 11111, 'category' );
+		\wp_delete_term( 11_111, 'category' );
 	}
 }

--- a/tests/WP/Frontend/Image_Utils_Test.php
+++ b/tests/WP/Frontend/Image_Utils_Test.php
@@ -37,7 +37,7 @@ final class Image_Utils_Test extends TestCase {
 				'size'   => 'full',
 				'id'     => $attachment,
 				'alt'    => '',
-				'pixels' => 1000000,
+				'pixels' => 1_000_000,
 				'type'   => '',
 			],
 			WPSEO_Image_Utils::get_image( $attachment, 'full' )

--- a/tests/WP/Inc/Admin_Bar_Menu_Test.php
+++ b/tests/WP/Inc/Admin_Bar_Menu_Test.php
@@ -269,8 +269,8 @@ final class Admin_Bar_Menu_Test extends TestCase {
 		$first_result = $admin_bar_menu->meets_requirements();
 		$this->assertFalse( $first_result );
 
-		\add_filter( 'option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10000 );
-		\add_filter( 'default_option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10000 );
+		\add_filter( 'option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10_000 );
+		\add_filter( 'default_option_wpseo', [ $this, 'filter_enable_admin_bar_menu_true' ], 10_000 );
 		WPSEO_Options::clear_cache();
 
 		$second_result = $admin_bar_menu->meets_requirements();

--- a/tests/WP/Inc/Rank_Test.php
+++ b/tests/WP/Inc/Rank_Test.php
@@ -30,7 +30,7 @@ final class Rank_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_constructor() {
-		$rank_non_existant = new WPSEO_Rank( 100000 );
+		$rank_non_existant = new WPSEO_Rank( 100_000 );
 		$this->assertEquals( WPSEO_Rank::BAD, $rank_non_existant->get_rank() );
 	}
 

--- a/tests/WP/Sitemaps/Cache_Test.php
+++ b/tests/WP/Sitemaps/Cache_Test.php
@@ -69,7 +69,7 @@ final class Cache_Test extends TestCase {
 		 * to do so ourselves.
 		 * As of PHP 7.4, the new serialization using magic methods is used.
 		 */
-		if ( \PHP_VERSION_ID < 70400 ) {
+		if ( \PHP_VERSION_ID < 70_400 ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Reason: There's no security risk, because users don't interact with tests.
 			$result = \unserialize( $result );
 		}
@@ -190,7 +190,7 @@ final class Cache_Test extends TestCase {
 		$cache  = new WPSEO_Sitemaps_Cache();
 		$result = $cache->get_sitemap_data( $type, $page );
 
-		if ( \PHP_VERSION_ID >= 70400 ) {
+		if ( \PHP_VERSION_ID >= 70_400 ) {
 			// PHP 7.4+.
 			$this->assertInstanceOf( WPSEO_Sitemap_Cache_Data::class, $result );
 			$this->assertSame( $sitemap, $result->get_sitemap() );
@@ -279,7 +279,7 @@ final class Cache_Test extends TestCase {
 		 * difference between the two generations we will end up with the same
 		 * cache invalidator, failing this test.
 		 */
-		\usleep( 10000 );
+		\usleep( 10_000 );
 
 		// Act.
 		WPSEO_Sitemaps_Cache::clear( [ 'page' ] );

--- a/tests/WP/Sitemaps/Cache_Validator_Test.php
+++ b/tests/WP/Sitemaps/Cache_Validator_Test.php
@@ -120,7 +120,7 @@ final class Cache_Validator_Test extends TestCase {
 		$this->assertEquals( '32', WPSEO_Sitemaps_Cache_Validator::convert_base10_to_base61( 123 ) );
 
 		// Check against PHP_INT_MAX on 32-bit systems.
-		$this->assertEquals( '3y75pX', WPSEO_Sitemaps_Cache_Validator::convert_base10_to_base61( 2147483647 ) );
+		$this->assertEquals( '3y75pX', WPSEO_Sitemaps_Cache_Validator::convert_base10_to_base61( 2_147_483_647 ) );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Modernize codebase

## Summary
This PR can be summarized in the following changelog entry:

* Modernize codebase

## Relevant technical choices:

Since PHP 7.4, PHP allows using numeric literal separators in integers and floats to improve the readability of long numbers.

As this codebase has dropped support for PHP < 7.4 by now, we can apply this modernization to all long numbers in this codebase.

Ref:
* https://wiki.php.net/rfc/numeric_literal_separator


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_