### PR TITLE
Modernize: use null coalesce

### DIFF
--- a/src/dashboard/infrastructure/browser-cache/browser-cache-configuration.php
+++ b/src/dashboard/infrastructure/browser-cache/browser-cache-configuration.php
@@ -42,7 +42,7 @@ class Browser_Cache_Configuration {
 		$current_user  = \wp_get_current_user();
 		$auth_cookie   = \wp_parse_auth_cookie();
 		$blog_id       = \get_current_blog_id();
-		$session_token = isset( $auth_cookie['token'] ) ? $auth_cookie['token'] : '';
+		$session_token = ( $auth_cookie['token'] ?? '' );
 
 		return \wp_hash( $current_user->user_login . '|' . $session_token . '|' . $blog_id );
 	}

--- a/src/dashboard/infrastructure/integrations/site-kit.php
+++ b/src/dashboard/infrastructure/integrations/site-kit.php
@@ -154,7 +154,7 @@ class Site_Kit {
 	 * @return bool If the user can read the data.
 	 */
 	private function can_read_data( array $module ): bool {
-		return ( $module['can_view'] !== null ? $module['can_view'] : false );
+		return ( $module['can_view'] ?? false );
 	}
 
 	/**


### PR DESCRIPTION
## Context

* Modernize codebase

## Summary
This PR can be summarized in the following changelog entry:

* Modernize codebase

## Relevant technical choices:

### CS/QA: no need for is_null() 

No need for a function call when a direct comparison will do. The `is_null()` function should generally only be used as a callback.

### Modernize: use null coalesce

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_