### PR TITLE
Modernize: use null coalesce equals operator

### DIFF
--- a/admin/class-admin-asset-dev-server-location.php
+++ b/admin/class-admin-asset-dev-server-location.php
@@ -30,9 +30,7 @@ final class WPSEO_Admin_Asset_Dev_Server_Location implements WPSEO_Admin_Asset_L
 	 * @param string|null $url Where the dev server is located.
 	 */
 	public function __construct( $url = null ) {
-		if ( $url === null ) {
-			$url = self::DEFAULT_URL;
-		}
+		$url ??= self::DEFAULT_URL;
 
 		$this->url = $url;
 	}

--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -41,9 +41,7 @@ class WPSEO_Admin_Asset_Manager {
 	 * @param string                          $prefix         The prefix for naming assets.
 	 */
 	public function __construct( ?WPSEO_Admin_Asset_Location $asset_location = null, $prefix = self::PREFIX ) {
-		if ( $asset_location === null ) {
-			$asset_location = self::create_default_location();
-		}
+		$asset_location ??= self::create_default_location();
 
 		$this->asset_location = $asset_location;
 		$this->prefix         = $prefix;

--- a/admin/class-primary-term-admin.php
+++ b/admin/class-primary-term-admin.php
@@ -159,9 +159,7 @@ class WPSEO_Primary_Term_Admin implements WPSEO_WordPress_Integration {
 	 * @return array
 	 */
 	protected function get_primary_term_taxonomies( $post_id = null ) {
-		if ( $post_id === null ) {
-			$post_id = $this->get_current_id();
-		}
+		$post_id ??= $this->get_current_id();
 
 		$taxonomies = wp_cache_get( 'primary_term_taxonomies_' . $post_id, 'wpseo' );
 		if ( $taxonomies !== false ) {

--- a/admin/class-yoast-dashboard-widget.php
+++ b/admin/class-yoast-dashboard-widget.php
@@ -37,9 +37,7 @@ class Yoast_Dashboard_Widget implements WPSEO_WordPress_Integration {
 	 * @param WPSEO_Statistics|null $statistics WPSEO_Statistics instance.
 	 */
 	public function __construct( ?WPSEO_Statistics $statistics = null ) {
-		if ( $statistics === null ) {
-			$statistics = new WPSEO_Statistics();
-		}
+		$statistics ??= new WPSEO_Statistics();
 
 		$this->statistics    = $statistics;
 		$this->asset_manager = new WPSEO_Admin_Asset_Manager();

--- a/admin/class-yoast-form.php
+++ b/admin/class-yoast-form.php
@@ -593,9 +593,7 @@ class Yoast_Form {
 	 * @return void
 	 */
 	public function hidden( $variable, $id = '', $val = null ) {
-		if ( $val === null ) {
-			$val = $this->get_field_value( $variable, '' );
-		}
+		$val ??= $this->get_field_value( $variable, '' );
 
 		if ( is_bool( $val ) ) {
 			$val = ( $val === true ) ? 'true' : 'false';

--- a/admin/class-yoast-network-settings-api.php
+++ b/admin/class-yoast-network-settings-api.php
@@ -155,9 +155,7 @@ class Yoast_Network_Settings_API {
 	 */
 	public static function get() {
 
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}

--- a/admin/class-yoast-notification-center.php
+++ b/admin/class-yoast-notification-center.php
@@ -90,9 +90,7 @@ class Yoast_Notification_Center {
 	 */
 	public static function get() {
 
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}

--- a/admin/class-yoast-notification.php
+++ b/admin/class-yoast-notification.php
@@ -359,9 +359,7 @@ class Yoast_Notification {
 			$message = $this->wrap_yoast_seo_icon( $this->message );
 		}
 
-		if ( $message === null ) {
-			$message = wpautop( $this->message );
-		}
+		$message ??= wpautop( $this->message );
 
 		// Build the output DIV.
 		return '<div ' . implode( ' ', $attributes ) . '>' . $message . '</div>' . PHP_EOL;
@@ -429,9 +427,7 @@ class Yoast_Notification {
 		}
 
 		// Set to the id of the current user if not supplied.
-		if ( $options['user_id'] === null ) {
-			$options['user_id'] = get_current_user_id();
-		}
+		$options['user_id'] ??= get_current_user_id();
 
 		return $options;
 	}

--- a/admin/class-yoast-plugin-conflict.php
+++ b/admin/class-yoast-plugin-conflict.php
@@ -102,9 +102,7 @@ class Yoast_Plugin_Conflict {
 			return false;
 		}
 
-		if ( $sections_checked === null ) {
-			$sections_checked = [];
-		}
+		$sections_checked ??= [];
 
 		if ( ! in_array( $plugin_section, $sections_checked, true ) ) {
 			$sections_checked[] = $plugin_section;

--- a/admin/menu/class-base-menu.php
+++ b/admin/menu/class-base-menu.php
@@ -46,9 +46,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 	 * @return array Formatted submenu.
 	 */
 	protected function get_submenu_page( $page_title, $page_slug, $callback = null, $hook = null ) {
-		if ( $callback === null ) {
-			$callback = $this->get_admin_page_callback();
-		}
+		$callback ??= $this->get_admin_page_callback();
 
 		return [
 			$this->get_page_identifier(),
@@ -256,9 +254,7 @@ abstract class WPSEO_Base_Menu implements WPSEO_WordPress_Integration {
 
 		_deprecated_function( __METHOD__, 'Yoast SEO 25.5' );
 
-		if ( $title === null ) {
-			$title = __( 'Upgrades', 'wordpress-seo' );
-		}
+		$title ??= __( 'Upgrades', 'wordpress-seo' );
 
 		if ( YoastSEO()->classes->get( Promotion_Manager::class )->is( 'black-friday-promotion' ) && ! YoastSEO()->helpers->product->is_premium() ) {
 			$title = __( 'Upgrades', 'wordpress-seo' ) . '<span class="yoast-menu-bf-sale-badge">' . __( '30% OFF', 'wordpress-seo' ) . '</span>';

--- a/admin/roles/class-role-manager-factory.php
+++ b/admin/roles/class-role-manager-factory.php
@@ -18,9 +18,7 @@ class WPSEO_Role_Manager_Factory {
 	public static function get() {
 		static $manager = null;
 
-		if ( $manager === null ) {
-			$manager = new WPSEO_Role_Manager_WP();
-		}
+		$manager ??= new WPSEO_Role_Manager_WP();
 
 		return $manager;
 	}

--- a/admin/views/class-yoast-feature-toggles.php
+++ b/admin/views/class-yoast-feature-toggles.php
@@ -36,9 +36,7 @@ class Yoast_Feature_Toggles {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}
@@ -49,9 +47,7 @@ class Yoast_Feature_Toggles {
 	 * @return array List of sorted Yoast_Feature_Toggle instances.
 	 */
 	public function get_all() {
-		if ( $this->toggles === null ) {
-			$this->toggles = $this->load_toggles();
-		}
+		$this->toggles ??= $this->load_toggles();
 
 		return $this->toggles;
 	}

--- a/admin/views/class-yoast-integration-toggles.php
+++ b/admin/views/class-yoast-integration-toggles.php
@@ -33,9 +33,7 @@ class Yoast_Integration_Toggles {
 	 * @return self Main instance.
 	 */
 	public static function instance() {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}
@@ -46,9 +44,7 @@ class Yoast_Integration_Toggles {
 	 * @return array List of sorted Yoast_Feature_Toggle instances.
 	 */
 	public function get_all() {
-		if ( $this->toggles === null ) {
-			$this->toggles = $this->load_toggles();
-		}
+		$this->toggles ??= $this->load_toggles();
 
 		return $this->toggles;
 	}

--- a/admin/watchers/class-slug-change-watcher.php
+++ b/admin/watchers/class-slug-change-watcher.php
@@ -184,9 +184,7 @@ class WPSEO_Slug_Change_Watcher implements WPSEO_WordPress_Integration {
 		$post_type_object = get_post_type_object( $post_type );
 
 		// If the post type of this post wasn't registered default back to post.
-		if ( $post_type_object === null ) {
-			$post_type_object = get_post_type_object( 'post' );
-		}
+		$post_type_object ??= get_post_type_object( 'post' );
 
 		return $post_type_object->labels->singular_name;
 	}

--- a/config/dependency-injection/custom-loader.php
+++ b/config/dependency-injection/custom-loader.php
@@ -135,9 +135,7 @@ class Custom_Loader extends PhpFileLoader {
 		if ( $excludePattern ) {
 			$excludePattern = $parameter_bag->unescapeValue( $parameter_bag->resolveValue( $excludePattern ) );
 			foreach ( $this->glob( $excludePattern, true, $resource ) as $path => $info ) {
-				if ( $exclude_prefix === null ) {
-					$exclude_prefix = $resource->getPrefix();
-				}
+				$exclude_prefix ??= $resource->getPrefix();
 
 				// Normalize Windows slashes.
 				$path                   = $this->normalize_slashes( $path );

--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -276,9 +276,7 @@ class WPSEO_Addon_Manager {
 	 * @return stdClass The list of addons activated for this site.
 	 */
 	public function get_myyoast_site_information() {
-		if ( $this->site_information === null ) {
-			$this->site_information = $this->get_site_information_transient();
-		}
+		$this->site_information ??= $this->get_site_information_transient();
 
 		if ( $this->site_information ) {
 			return $this->site_information;

--- a/inc/class-upgrade.php
+++ b/inc/class-upgrade.php
@@ -1402,9 +1402,7 @@ class WPSEO_Upgrade {
 	 * @return void
 	 */
 	protected function save_option_setting( $source_data, $source_setting, $target_setting = null ) {
-		if ( $target_setting === null ) {
-			$target_setting = $source_setting;
-		}
+		$target_setting ??= $source_setting;
 
 		if ( isset( $source_data[ $source_setting ] ) ) {
 			WPSEO_Options::set( $target_setting, $source_data[ $source_setting ] );

--- a/inc/class-wpseo-admin-bar-menu.php
+++ b/inc/class-wpseo-admin-bar-menu.php
@@ -156,9 +156,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool True if SEO score is enabled, false otherwise.
 	 */
 	protected function get_is_seo_enabled() {
-		if ( $this->is_seo_enabled === null ) {
-			$this->is_seo_enabled = ( new WPSEO_Metabox_Analysis_SEO() )->is_enabled();
-		}
+		$this->is_seo_enabled ??= ( new WPSEO_Metabox_Analysis_SEO() )->is_enabled();
 
 		return $this->is_seo_enabled;
 	}
@@ -169,9 +167,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool True if readability is enabled, false otherwise.
 	 */
 	protected function get_is_readability_enabled() {
-		if ( $this->is_readability_enabled === null ) {
-			$this->is_readability_enabled = ( new WPSEO_Metabox_Analysis_Readability() )->is_enabled();
-		}
+		$this->is_readability_enabled ??= ( new WPSEO_Metabox_Analysis_Readability() )->is_enabled();
 
 		return $this->is_readability_enabled;
 	}
@@ -182,9 +178,7 @@ class WPSEO_Admin_Bar_Menu implements WPSEO_WordPress_Integration {
 	 * @return bool|Indexable The indexable, false if none could be found.
 	 */
 	protected function get_current_indexable() {
-		if ( $this->current_indexable === null ) {
-			$this->current_indexable = $this->indexable_repository->for_current_page();
-		}
+		$this->current_indexable ??= $this->indexable_repository->for_current_page();
 
 		return $this->current_indexable;
 	}

--- a/inc/class-wpseo-content-images.php
+++ b/inc/class-wpseo-content-images.php
@@ -87,9 +87,7 @@ class WPSEO_Content_Images {
 	 * @return string The content of the supplied post.
 	 */
 	private function get_post_content( $post_id, $post ) {
-		if ( $post === null ) {
-			$post = get_post( $post_id );
-		}
+		$post ??= get_post( $post_id );
 
 		if ( $post === null ) {
 			return '';

--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -26,9 +26,7 @@ class WPSEO_Image_Utils {
 
 		static $uploads;
 
-		if ( $uploads === null ) {
-			$uploads = wp_get_upload_dir();
-		}
+		$uploads ??= wp_get_upload_dir();
 
 		// Don't try to do this for external URLs.
 		if ( strpos( $url, $uploads['baseurl'] ) !== 0 ) {
@@ -268,9 +266,7 @@ class WPSEO_Image_Utils {
 	public static function get_absolute_path( $path ) {
 		static $uploads;
 
-		if ( $uploads === null ) {
-			$uploads = wp_get_upload_dir();
-		}
+		$uploads ??= wp_get_upload_dir();
 
 		// Add the uploads basedir if the path does not start with it.
 		if ( empty( $uploads['error'] ) && strpos( $path, $uploads['basedir'] ) !== 0 ) {

--- a/inc/options/class-wpseo-options.php
+++ b/inc/options/class-wpseo-options.php
@@ -561,9 +561,7 @@ class WPSEO_Options {
 	protected static function is_multisite() {
 		static $is_multisite;
 
-		if ( $is_multisite === null ) {
-			$is_multisite = is_multisite();
-		}
+		$is_multisite ??= is_multisite();
 
 		return $is_multisite;
 	}

--- a/src/actions/wincher/wincher-keyphrases-action.php
+++ b/src/actions/wincher/wincher-keyphrases-action.php
@@ -188,9 +188,7 @@ class Wincher_Keyphrases_Action {
 	 */
 	public function get_tracked_keyphrases( $used_keyphrases = null, $permalink = null, $start_at = null ) {
 		try {
-			if ( $used_keyphrases === null ) {
-				$used_keyphrases = $this->collect_all_keyphrases();
-			}
+			$used_keyphrases ??= $this->collect_all_keyphrases();
 
 			// If we still have no keyphrases the API will return an error, so
 			// don't even bother sending a request.

--- a/src/config/badge-group-names.php
+++ b/src/config/badge-group-names.php
@@ -53,9 +53,7 @@ class Badge_Group_Names {
 
 		$group_version = $this::GROUP_NAMES[ $group ];
 
-		if ( $current_version === null ) {
-			$current_version = $this->version;
-		}
+		$current_version ??= $this->version;
 
 		return (bool) \version_compare( $group_version, $current_version, '>' );
 	}

--- a/src/context/meta-tags-context.php
+++ b/src/context/meta-tags-context.php
@@ -522,10 +522,8 @@ class Meta_Tags_Context extends Abstract_Presentation {
 				$type = 'CollectionPage';
 				break;
 			default:
-				$additional_type = $this->indexable->schema_page_type;
-				if ( $additional_type === null ) {
-					$additional_type = $this->options->get( 'schema-page-type-' . $this->indexable->object_sub_type );
-				}
+				$additional_type   = $this->indexable->schema_page_type;
+				$additional_type ??= $this->options->get( 'schema-page-type-' . $this->indexable->object_sub_type );
 
 				$type = [ 'WebPage', $additional_type ];
 
@@ -552,10 +550,8 @@ class Meta_Tags_Context extends Abstract_Presentation {
 	 * @return string|array<string> The schema article type.
 	 */
 	public function generate_schema_article_type() {
-		$additional_type = $this->indexable->schema_article_type;
-		if ( $additional_type === null ) {
-			$additional_type = $this->options->get( 'schema-article-type-' . $this->indexable->object_sub_type );
-		}
+		$additional_type   = $this->indexable->schema_article_type;
+		$additional_type ??= $this->options->get( 'schema-article-type-' . $this->indexable->object_sub_type );
 
 		/** This filter is documented in inc/options/class-wpseo-option-titles.php */
 		$allowed_article_types = \apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES );

--- a/src/deprecated/frontend/breadcrumbs.php
+++ b/src/deprecated/frontend/breadcrumbs.php
@@ -106,9 +106,7 @@ class WPSEO_Breadcrumbs {
 	 * @return static The instance.
 	 */
 	public static function get_instance() {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}

--- a/src/deprecated/frontend/frontend.php
+++ b/src/deprecated/frontend/frontend.php
@@ -92,9 +92,7 @@ class WPSEO_Frontend {
 	 * @return static The instance.
 	 */
 	public static function get_instance() {
-		if ( self::$instance === null ) {
-			self::$instance = new self();
-		}
+		self::$instance ??= new self();
 
 		return self::$instance;
 	}

--- a/src/helpers/home-url-helper.php
+++ b/src/helpers/home-url-helper.php
@@ -27,9 +27,7 @@ class Home_Url_Helper {
 	 * @return string The home url.
 	 */
 	public function get() {
-		if ( static::$home_url === null ) {
-			static::$home_url = \home_url();
-		}
+		static::$home_url ??= \home_url();
 
 		return static::$home_url;
 	}
@@ -40,9 +38,7 @@ class Home_Url_Helper {
 	 * @return array The parsed url.
 	 */
 	public function get_parsed() {
-		if ( static::$parsed_home_url === null ) {
-			static::$parsed_home_url = \wp_parse_url( $this->get() );
-		}
+		static::$parsed_home_url ??= \wp_parse_url( $this->get() );
 
 		return static::$parsed_home_url;
 	}

--- a/src/helpers/schema/article-helper.php
+++ b/src/helpers/schema/article-helper.php
@@ -15,9 +15,7 @@ class Article_Helper {
 	 * @return bool True if it has Article schema, false if not.
 	 */
 	public function is_article_post_type( $post_type = null ) {
-		if ( $post_type === null ) {
-			$post_type = \get_post_type();
-		}
+		$post_type ??= \get_post_type();
 
 		return $this->is_author_supported( $post_type );
 	}

--- a/src/helpers/url-helper.php
+++ b/src/helpers/url-helper.php
@@ -213,9 +213,7 @@ class Url_Helper {
 			return ( $is_image ) ? SEO_Links::TYPE_EXTERNAL_IMAGE : SEO_Links::TYPE_EXTERNAL;
 		}
 
-		if ( $home_url === null ) {
-			$home_url = \wp_parse_url( \home_url() );
-		}
+		$home_url ??= \wp_parse_url( \home_url() );
 
 		// When the base host is equal to the host.
 		if ( isset( $url['host'] ) && $url['host'] !== $home_url['host'] ) {

--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -501,9 +501,7 @@ class Front_End_Integration implements Integration_Interface {
 	 * @return Abstract_Indexable_Presenter[] The presenters.
 	 */
 	public function get_presenters( $page_type, $context = null ) {
-		if ( $context === null ) {
-			$context = $this->context_memoizer->for_current_page();
-		}
+		$context ??= $this->context_memoizer->for_current_page();
 
 		$needed_presenters = $this->get_needed_presenters( $page_type );
 

--- a/src/models/indexable-extension.php
+++ b/src/models/indexable-extension.php
@@ -22,9 +22,7 @@ abstract class Indexable_Extension extends Model {
 	 * @return Indexable The indexable.
 	 */
 	public function indexable() {
-		if ( $this->indexable === null ) {
-			$this->indexable = $this->belongs_to( 'Indexable', 'indexable_id', 'id' )->find_one();
-		}
+		$this->indexable ??= $this->belongs_to( 'Indexable', 'indexable_id', 'id' )->find_one();
 
 		return $this->indexable;
 	}

--- a/src/surfaces/meta-surface.php
+++ b/src/surfaces/meta-surface.php
@@ -145,9 +145,7 @@ class Meta_Surface {
 	 * @return Meta|false The meta values. False if none could be found.
 	 */
 	public function for_post_type_archive( $post_type = null ) {
-		if ( $post_type === null ) {
-			$post_type = \get_post_type();
-		}
+		$post_type ??= \get_post_type();
 
 		$indexable = $this->repository->find_for_post_type_archive( $post_type );
 
@@ -277,9 +275,7 @@ class Meta_Surface {
 		if ( ! \is_a( $indexable, Indexable::class ) ) {
 			return false;
 		}
-		if ( $page_type === null ) {
-			$page_type = $this->indexable_helper->get_page_type_for_indexable( $indexable );
-		}
+		$page_type ??= $this->indexable_helper->get_page_type_for_indexable( $indexable );
 
 		return $this->build_meta( $this->context_memoizer->get( $indexable, $page_type ) );
 	}
@@ -294,10 +290,8 @@ class Meta_Surface {
 	 */
 	public function for_indexables( $indexables, $page_type = null ) {
 		$closure = function ( $indexable ) use ( $page_type ) {
-			$this_page_type = $page_type;
-			if ( $this_page_type === null ) {
-				$this_page_type = $this->indexable_helper->get_page_type_for_indexable( $indexable );
-			}
+			$this_page_type   = $page_type;
+			$this_page_type ??= $this->indexable_helper->get_page_type_for_indexable( $indexable );
 
 			return $this->build_meta( $this->context_memoizer->get( $indexable, $this_page_type ) );
 		};

--- a/tests/Unit/Helpers/Indexable_Helper_Test.php
+++ b/tests/Unit/Helpers/Indexable_Helper_Test.php
@@ -360,18 +360,14 @@ final class Indexable_Helper_Test extends TestCase {
 			->andReturn( $is_production_mode );
 
 		// In order to test not having an overriding "Yoast\WP\SEO\should_index_indexables" filter.
-		if ( $should_index_indexables === null ) {
-			$should_index_indexables = $is_production_mode;
-		}
+		$should_index_indexables ??= $is_production_mode;
 		Monkey\Filters\expectApplied( 'Yoast\WP\SEO\should_index_indexables' )
 			->once()
 			->with( $is_production_mode )
 			->andReturn( $should_index_indexables );
 
 		// In order to test not having an overriding "wpseo_should_save_indexable" filter.
-		if ( $should_save_indexable === null ) {
-			$should_save_indexable = $should_index_indexables;
-		}
+		$should_save_indexable ??= $should_index_indexables;
 		Monkey\Filters\expectApplied( 'wpseo_should_save_indexable' )
 			->once()
 			->with( $should_index_indexables, $indexable )

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -1078,9 +1078,7 @@ final class Addon_Manager_Test extends TestCase {
 	 * @return string Future date.
 	 */
 	protected function get_future_date() {
-		if ( $this->future_date === null ) {
-			$this->future_date = \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() + \DAY_IN_SECONDS ) );
-		}
+		$this->future_date ??= \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() + \DAY_IN_SECONDS ) );
 
 		return $this->future_date;
 	}
@@ -1091,9 +1089,7 @@ final class Addon_Manager_Test extends TestCase {
 	 * @return string Past date.
 	 */
 	protected function get_past_date() {
-		if ( $this->past_date === null ) {
-			$this->past_date = \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() - \DAY_IN_SECONDS ) );
-		}
+		$this->past_date ??= \gmdate( 'Y-m-d\TH:i:s\Z', ( \time() - \DAY_IN_SECONDS ) );
 
 		return $this->past_date;
 	}

--- a/tests/WP/Doubles/Admin/Gutenberg_Compatibility_Double.php
+++ b/tests/WP/Doubles/Admin/Gutenberg_Compatibility_Double.php
@@ -17,9 +17,7 @@ class Gutenberg_Compatibility_Double extends WPSEO_Gutenberg_Compatibility {
 	 * @return void
 	 */
 	public function set_installed_gutenberg_version( $version = null ) {
-		if ( $version === null ) {
-			$version = $this->detect_installed_gutenberg_version();
-		}
+		$version ??= $this->detect_installed_gutenberg_version();
 
 		$this->current_version = $version;
 	}

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -55,12 +55,10 @@ if ( ! defined( 'WPSEO_NAMESPACES' ) ) {
 function wpseo_auto_load( $class_name ) {
 	static $classes = null;
 
-	if ( $classes === null ) {
-		$classes = [
-			'wp_list_table'   => ABSPATH . 'wp-admin/includes/class-wp-list-table.php',
-			'walker_category' => ABSPATH . 'wp-includes/category-template.php',
-		];
-	}
+	$classes ??= [
+		'wp_list_table'   => ABSPATH . 'wp-admin/includes/class-wp-list-table.php',
+		'walker_category' => ABSPATH . 'wp-includes/category-template.php',
+	];
 
 	$cn = strtolower( $class_name );
 


### PR DESCRIPTION
## Context

* Modernize codebase

## Summary
This PR can be summarized in the following changelog entry:

* Modernize codebase

## Relevant technical choices:

Use null coalesce equals operator as allowed and available since PHP 7.4.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_