### PR TITLE
Adds a check to make sure that the input cannot be null

### DIFF
--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -239,9 +239,7 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 						// The data is stringified JSON. Use `json_decode` and `json_encode` around the sanitation.
 						$input = json_decode( $meta_data[ $key ], true );
 						// If something is wrong with the JSON make sure this cannot break.
-						if ( $input === null ) {
-							$input = [];
-						}
+						$input       ??= [];
 						$sanitized     = array_map( [ 'WPSEO_Utils', 'sanitize_text_field' ], $input );
 						$clean[ $key ] = WPSEO_Utils::format_json_encode( $sanitized );
 					}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to fix a bug that when you have bad data in the database saving a term can cause a fatal error.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a error could occur when saving a taxonomy under circumstances that haven't been discovered.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

I could not figure out how to test this without changing the code midway through execution with Xdebug. But since this occurs on yoast.com make sure to test this RC there to verify it all works.

For devs:
* Make sure premium is enabled.
* add two taxonomies (for example categories).
* For both of them add a `Related keyphrase` and `synonym`.
* Make sure both are saved.
* In the code place a breakpoint in `/inc/options/class-wpseo-taxonomy-meta.php` line`238`
* `Without` this PR. save a term and you should hit your breakpoint. hit `Step over` once and go into the `Console`.
* Add the following code: `$input = null` this simulates the json_decode failing.
* Hit Resume program and you should get a fatal.
* `With` this PR.
* save a term and you should hit your breakpoint. Look at the `$input` variable and fine the contents of your term by hitting `Resume program` untill you find your input.
* hit `Step over` once and go into the `Console`.
* Add the following code: `$input = null` this simulates the json_decode failing.
* Hit Resume program and you should NOT get a fatal.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* As mentioned above you need Xdebug to follow the code so test this on yoast.com staging.
* you should not get a fatal when you save a term, with Premium enabled (ask Rolf for replication steps of the original issue)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Saving Keyphrase Synonyms for taxnomies.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
