### PR TITLE
Optimize Post_Link_Indexing_Action queries (replace LEFT JOIN + OR with EXISTS)

### DIFF
--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -78,24 +78,31 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 
 		// Warning: If this query is changed, makes sure to update the query in get_select_query as well.
-		return $this->wpdb->prepare(
-			"SELECT COUNT(P.ID)
-			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN $links_table AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')',
-			$public_post_types,
-		);
+        return $this->wpdb->prepare(
+            "SELECT COUNT(*)
+             FROM {$this->wpdb->posts} AS P
+             WHERE P.post_status = 'publish'
+               AND P.post_type IN (" . \implode(', ', \array_fill(0, \count($public_post_types), '%s')) . ")
+               AND (
+                 NOT EXISTS (
+                     SELECT 1
+                     FROM $indexable_table AS I
+                     WHERE I.object_id = P.ID
+                       AND I.object_type = 'post'
+                       AND I.link_count IS NOT NULL
+                 )
+                 OR EXISTS (
+                     SELECT 1
+                     FROM $links_table AS L
+                     WHERE L.post_id = P.ID
+                       AND L.type = 'internal'
+                       AND L.target_indexable_id IS NULL
+                       AND L.target_post_id IS NOT NULL
+                       AND L.target_post_id != 0
+                 )
+               )",
+            $public_post_types
+        );
 	}
 
 	/**
@@ -111,32 +118,38 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		$links_table       = Model::get_table_name( 'SEO_Links' );
 		$replacements      = $public_post_types;
 
-		$limit_query = '';
-		if ( $limit ) {
-			$limit_query    = 'LIMIT %d';
-			$replacements[] = $limit;
-		}
+        $limit_query = '';
+        if ($limit !== false) {
+            $limit_query = 'LIMIT %d';
+            $replacements[] = (int)$limit;
+        }
 
-		// Warning: If this query is changed, makes sure to update the query in get_count_query as well.
-		return $this->wpdb->prepare(
-			"
-			SELECT P.ID, P.post_content
-			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN $links_table AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ")
-			$limit_query",
-			$replacements,
-		);
+        // Warning: If this query is changed, makes sure to update the query in get_count_query as well.
+        return $this->wpdb->prepare(
+            "SELECT P.ID, P.post_content
+            FROM {$this->wpdb->posts} AS P
+            WHERE P.post_status = 'publish'
+              AND P.post_type IN (" . \implode(', ', \array_fill(0, \count($public_post_types), '%s')) . ")
+              AND (
+                NOT EXISTS (
+                    SELECT 1
+                    FROM $indexable_table AS I
+                    WHERE I.object_id = P.ID
+                      AND I.link_count IS NOT NULL
+                      AND I.object_type = 'post'
+                )
+                OR EXISTS (
+                    SELECT 1
+                    FROM $links_table AS L
+                    WHERE L.post_id = P.ID
+                      AND L.target_indexable_id IS NULL
+                      AND L.type = 'internal'
+                      AND L.target_post_id IS NOT NULL
+                      AND L.target_post_id != 0
+                )
+              )
+            $limit_query",
+            $replacements
+        );
 	}
 }


### PR DESCRIPTION
# Replace LEFT JOIN with EXISTS in Post_Link_Indexing_Action queries

## Context
The queries in Post_Link_Indexing_Action::get_count_query() and
Post_Link_Indexing_Action::get_select_query() use a LEFT JOIN + OR pattern:

```sql
LEFT JOIN wp_yoast_indexable ...
LEFT JOIN wp_yoast_seo_links ...
WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
```

On medium-sized datasets (~25k posts / ~33k seo_links rows), this structure results in very slow execution times (60+ seconds).

The issue is not dataset scale but query structure.
The LEFT JOIN + OR combination prevents efficient index usage and can lead to suboptimal execution plans and table scans.

This PR rewrites the queries using EXISTS / NOT EXISTS, which allows MySQL/MariaDB to:

- Perform indexed lookups per post
- Avoid large intermediate join result sets
- Significantly reduce execution time

## Summary

This PR can be summarized in the following changelog entry:

Improves performance of internal link indexing by replacing a LEFT JOIN + OR query pattern with EXISTS / NOT EXISTS in Post_Link_Indexing_Action.

Label: changelog: enhancement

## Relevant technical choices:

- Replaced LEFT JOIN usage with correlated EXISTS / NOT EXISTS subqueries
- Maintained identical logical behavior
- Ensured both get_count_query() and get_select_query() remain in sync
- Did not change return structure or public API
- No schema changes required

Original problematic pattern:

```sql
LEFT JOIN ...
WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
```

New pattern: 
```sql 
WHERE (
    NOT EXISTS ( ... )
    OR EXISTS ( ... )
)
```

This allows the database optimizer to:

- Use indexes on object_id and post_id
- Avoid join result explosion
- Short-circuit evaluation per row

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install Yoast SEO on a site with a moderate amount of content (e.g. 10k+ posts)
2. Ensure indexables and internal link data are generated
3. Trigger internal link indexing
4. Verify:
    - No errors occur
    - The indexing process completes successfully
    - No regression in functionality
5. Optionally compare query execution time before and after this PR

Expected result:

- Identical functional behavior
- Noticeably improved execution time on larger datasets

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects:

- Internal link indexing logic
- Database query performance for:
    - get_count_query()
    - get_select_query()

- No UI components or front-end rendering are affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

See also https://github.com/Yoast/wordpress-seo/issues/22997