### PR TITLE
Remove unnecessary feedback string variables for gender category in the Inclusive language assessment

### DIFF
--- a/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
+++ b/packages/yoastseo/spec/scoring/assessments/inclusiveLanguage/configuration/genderAssessmentsSpec.js
@@ -229,7 +229,7 @@ describe( "Tests for phrases that are exclusionary UNLESS there is a condition w
 				identifier: "ladiesAndGentleman",
 				text: "This sentence contains the phrase ladies and gentlemen followed by something else.",
 				expectedFeedback: "Be careful when using <i>ladies and gentlemen</i> as it can be exclusionary. " +
-					"Unless you are sure that the group you refer to only consists of men and women, " +
+					"Unless you are sure that the group you refer to only consists of ladies and gentlemen, " +
 					"use an alternative, such as <i>everyone, folks, honored guests</i>." +
 					" <a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -238,7 +238,7 @@ describe( "Tests for phrases that are exclusionary UNLESS there is a condition w
 				identifier: "mothersAndFathers",
 				text: "This sentence contains the phrase mothers and fathers followed by something else.",
 				expectedFeedback: "Be careful when using <i>mothers and fathers</i> as it can be exclusionary. " +
-					"Unless you are sure that the group you refer to only consists of people who use this term, " +
+					"Unless you are sure that the group you refer to only consists of mothers and fathers, " +
 					"use an alternative, such as <i>parents</i>." +
 					" <a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -247,7 +247,7 @@ describe( "Tests for phrases that are exclusionary UNLESS there is a condition w
 				identifier: "mothersAndFathers",
 				text: "This sentence contains the phrase fathers and mothers followed by something else.",
 				expectedFeedback: "Be careful when using <i>fathers and mothers</i> as it can be exclusionary. " +
-					"Unless you are sure that the group you refer to only consists of people who use this term, " +
+					"Unless you are sure that the group you refer to only consists of fathers and mothers, " +
 					"use an alternative, such as <i>parents</i>." +
 					" <a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -261,7 +261,7 @@ describe( "Tests for phrases that are exclusionary UNLESS there is a condition w
 				identifier: "firemen",
 				text: "Look at those firemen! They're putting out the fire.",
 				expectedFeedback: "Be careful when using <i>firemen</i> as it can be exclusionary. " +
-					"Unless you are sure that the group you refer to only consists of men, use an alternative, " +
+					"Unless you are sure that the group you refer to only consists of firemen, use an alternative, " +
 					"such as <i>firefighters</i>. " +
 					"<a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>",
 				expectedScore: 6,
@@ -270,7 +270,7 @@ describe( "Tests for phrases that are exclusionary UNLESS there is a condition w
 				identifier: "policemen",
 				text: "Look at those policemen! They're doing something over there.",
 				expectedFeedback: "Be careful when using <i>policemen</i> as it can be exclusionary. " +
-					"Unless you are sure that the group you refer to only consists of men, use an alternative, " +
+					"Unless you are sure that the group you refer to only consists of policemen, use an alternative, " +
 					"such as <i>police officers</i>. " +
 					"<a href='https://yoa.st/inclusive-language-gender' target='_blank'>Learn more.</a>",
 				expectedScore: 6,

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/genderAssessmentStrings.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/genderAssessmentStrings.js
@@ -12,22 +12,6 @@
  */
 export const orangeExclusionaryUnless = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
 	"Unless you are sure that the group you refer to only consists of %1$s, use an alternative, such as %2$s.";
-// /*
-//  * Used for terms that are exclusionary unless the group this term describes only consists of men, for example "firemen"."
-//  *
-//  * Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of %1$s,
-//  *  use an alternative, such as %2$s."
-//  */
-// export const orangeExclusionaryUnlessMen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
-// 	"Unless you are sure that the group you refer to only consists of men, use an alternative, such as %2$s.";
-// /*
-//  * Used for terms that are exclusionary unless the group this term describes only consists of men and women, for example "ladies and gentlemen".
-//  *
-//  * "Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men and women,
-//  *  use an alternative, such as %2$s."
-//  */
-// export const orangeExclusionaryUnlessMenAndWomen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
-// 	"Unless you are sure that the group you refer to only consists of men and women, use an alternative, such as %2$s.";
 /*
  * Used for terms that are exclusionary unless the group this term describes only consists of two genders, for example "both genders".
  *
@@ -36,13 +20,3 @@ export const orangeExclusionaryUnless = "Be careful when using <i>%1$s</i> as it
  */
 export const orangeExclusionaryUnlessTwoGenders = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
 	"Unless you are sure that the group you refer to only consists of two genders, use an alternative, such as %2$s.";
-/*
- * Used for terms that are exclusionary unless all members of the group use this term to refer to themselves, for example "mothers and fathers".
- *
- * "Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of people who use
- *  this term, use an alternative, such as %2$s."
- */
-export const orangeExclusionaryUnlessUseTheTerm = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
-	"Unless you are sure that the group you refer to only consists of people who use this term, use an alternative, such as %2$s.";
-
-

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/genderAssessmentStrings.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/feedbackStrings/genderAssessmentStrings.js
@@ -5,29 +5,29 @@
 
 /*
  * Used for terms that are exclusionary unless they describe a group that only consists of the people that the term mentions.
- * For example, "boys and girls".
+ * For example, "boys and girls", or "firemen" is the group consists only of male firefighters.
  *
  * "Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of %1$s,
  *  use an alternative, such as %2$s."
  */
 export const orangeExclusionaryUnless = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
 	"Unless you are sure that the group you refer to only consists of %1$s, use an alternative, such as %2$s.";
-/*
- * Used for terms that are exclusionary unless the group this term describes only consists of men, for example "firemen"."
- *
- * Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of %1$s,
- *  use an alternative, such as %2$s."
- */
-export const orangeExclusionaryUnlessMen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
-	"Unless you are sure that the group you refer to only consists of men, use an alternative, such as %2$s.";
-/*
- * Used for terms that are exclusionary unless the group this term describes only consists of men and women, for example "ladies and gentlemen".
- *
- * "Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men and women,
- *  use an alternative, such as %2$s."
- */
-export const orangeExclusionaryUnlessMenAndWomen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
-	"Unless you are sure that the group you refer to only consists of men and women, use an alternative, such as %2$s.";
+// /*
+//  * Used for terms that are exclusionary unless the group this term describes only consists of men, for example "firemen"."
+//  *
+//  * Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of %1$s,
+//  *  use an alternative, such as %2$s."
+//  */
+// export const orangeExclusionaryUnlessMen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+// 	"Unless you are sure that the group you refer to only consists of men, use an alternative, such as %2$s.";
+// /*
+//  * Used for terms that are exclusionary unless the group this term describes only consists of men and women, for example "ladies and gentlemen".
+//  *
+//  * "Be careful when using <i>%1$s</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men and women,
+//  *  use an alternative, such as %2$s."
+//  */
+// export const orangeExclusionaryUnlessMenAndWomen = "Be careful when using <i>%1$s</i> as it can be exclusionary. " +
+// 	"Unless you are sure that the group you refer to only consists of men and women, use an alternative, such as %2$s.";
 /*
  * Used for terms that are exclusionary unless the group this term describes only consists of two genders, for example "both genders".
  *

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
@@ -8,10 +8,10 @@ import { alternative,
 	avoidDerogatory,
 } from "./feedbackStrings/generalFeedbackStrings";
 import { orangeExclusionaryUnless,
-	orangeExclusionaryUnlessMen,
-	orangeExclusionaryUnlessMenAndWomen,
+	// orangeExclusionaryUnlessMen,
+	// orangeExclusionaryUnlessMenAndWomen,
 	orangeExclusionaryUnlessTwoGenders,
-	orangeExclusionaryUnlessUseTheTerm,
+	// orangeExclusionaryUnlessUseTheTerm,
 } from "./feedbackStrings/genderAssessmentStrings";
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";
@@ -24,14 +24,14 @@ const genderAssessments = [
 		nonInclusivePhrases: [ "firemen" ],
 		inclusiveAlternatives: "<i>firefighters</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: orangeExclusionaryUnlessMen,
+		feedbackFormat: orangeExclusionaryUnless,
 	},
 	{
 		identifier: "policemen",
 		nonInclusivePhrases: [ "policemen" ],
 		inclusiveAlternatives: "<i>police officers</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: orangeExclusionaryUnlessMen,
+		feedbackFormat: orangeExclusionaryUnless,
 	},
 	{
 		identifier: "menAndWomen",
@@ -134,7 +134,7 @@ const genderAssessments = [
 		nonInclusivePhrases: [ "ladies and gentlemen" ],
 		inclusiveAlternatives: "<i>everyone, folks, honored guests</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: orangeExclusionaryUnlessMenAndWomen,
+		feedbackFormat: orangeExclusionaryUnless,
 	},
 	{
 		identifier: "husbandAndWife",
@@ -149,7 +149,7 @@ const genderAssessments = [
 		nonInclusivePhrases: [ "mothers and fathers", "fathers and mothers" ],
 		inclusiveAlternatives: "<i>parents</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: orangeExclusionaryUnlessUseTheTerm,
+		feedbackFormat: orangeExclusionaryUnless
 	},
 	{
 		identifier: "manHours",

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
@@ -8,10 +8,7 @@ import { alternative,
 	avoidDerogatory,
 } from "./feedbackStrings/generalFeedbackStrings";
 import { orangeExclusionaryUnless,
-	// orangeExclusionaryUnlessMen,
-	// orangeExclusionaryUnlessMenAndWomen,
 	orangeExclusionaryUnlessTwoGenders,
-	// orangeExclusionaryUnlessUseTheTerm,
 } from "./feedbackStrings/genderAssessmentStrings";
 import { SCORES } from "./scores";
 import { includesConsecutiveWords } from "../helpers/includesConsecutiveWords";

--- a/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
+++ b/packages/yoastseo/src/scoring/assessments/inclusiveLanguage/configuration/genderAssessments.js
@@ -146,7 +146,7 @@ const genderAssessments = [
 		nonInclusivePhrases: [ "mothers and fathers", "fathers and mothers" ],
 		inclusiveAlternatives: "<i>parents</i>",
 		score: SCORES.POTENTIALLY_NON_INCLUSIVE,
-		feedbackFormat: orangeExclusionaryUnless
+		feedbackFormat: orangeExclusionaryUnless,
 	},
 	{
 		identifier: "manHours",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In the previous version of the code, we had 5 types of feedback string variables for phrases that get an orange score (context-dependent phrases). Since the purpose of the variables `orangeExclusionaryUnlessMen`, `orangeExclusionaryUnlessMenAndWomen`, and `orangeExclusionaryUnlessUseTheTerm` fall under `orangeExclusionaryUnless`, they were suggested to be removed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates feedback strings for multiples phrases in the gender category of the _inclusive language assessment_.
* [yoastseo] Updates feedback strings for multiples phrases in the gender category of the _inclusive language assessment_.
* [shopify-seo] Updates feedback strings for multiples phrases in the gender category of the _inclusive language assessment_.
* [yoast-doc-extension] Updates feedback strings for multiples phrases in the gender category of the _inclusive language assessment_.
* [non-user-facing] Removes unnecessary feedback variables for gender in the _inclusive language assessment_.


## Relevant technical choices:

* `orangeExclusionaryUnlessTwoGenders` was also suggested for removal in the issue, but was not removed because there feedback string is useful for this specific case. If we replace `orangeExclusionaryUnlessTwoGenders`  variable with `orangeExclusionaryUnless` for the phrase "both genders", the feedback string will say "unless the group consists of both genders" instead of "unless the group consists only of **two genders.**". Since "both" implies there is only two in general, keeping the current version with "two genders" is better. It could be even better to change it from "two genders" to "men and women", but we can keep it as it is for now and see when addressing it in another issue.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO Free
* Activate the Inclusive language assessment in the settings
* Add a text of at least 300 words

Phrases with "ladies and gentlemen"

* Add the phrase "ladies and gentlemen" to the text
* Confirm that the assessment shows an orange bullet with the following feedback:
"Be careful when using <i>ladies and gentlemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of ladies and gentlemen, use an alternative, such as <i>everyone, folks, honored guests</i>. Learn more."
Previous feedback string:  "Be careful when using <i>ladies and gentlemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men and women, use an alternative, such as <i>everyone, folks, honored guests</i>. Learn more."

Phrases with "mothers and fathers"

* Add the phrase "mothers and fathers" to the text
* Confirm that the assessment shows an orange bullet with the following feedback:
"Be careful when using <i>mothers and fathers</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of mothers and fathers, use an alternative, such as <i>parents</i>. Learn more."
Previous feedback string:  "Be careful when using <i>mothers and fathers</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of people who use this term, use an alternative, such as <i>parents</i>. Learn more."

Phrases with "fathers and mothers"

* Add the phrase "fathers and mothers" to the text
* Confirm that the assessment shows an orange bullet with the following feedback:
"Be careful when using <i>fathers and mothers</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of fathers and mothers, use an alternative, such as <i>parents</i>. Learn more."
Previous feedback string:  "Be careful when using <i>fathers and mothers</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of people who use this term, use an alternative, such as <i>parents</i>. Learn more."

Phrases with "firemen"

* Add the phrase "firemen"
* Confirm that the assessment shows an orange bullet with the following feedback:
"Be careful when using <i>firemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of firemen, use an alternative, such as <i>firefighters</i>. Learn more."
Previous feedback string:  "Be careful when using <i>firemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men, use an alternative, such as <i>firefighters</i>. Learn more."

Phrases with "policemen"

* Add the phrase "policemen"
* Confirm that the assessment shows an orange bullet with the following feedback:
"Be careful when using <i>policemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of policemen, use an alternative, such as <i>police officers</i>. Learn more."
Previous feedback string:  "Be careful when using <i>policemen</i> as it can be exclusionary. Unless you are sure that the group you refer to only consists of men, use an alternative, such as <i>police officers</i>. Learn more."


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [x] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [x] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #https://github.com/Yoast/Lingo-AI/issues/14
