### PR TITLE
Implements different query for performance increase 

### DIFF
--- a/src/actions/indexing/post-link-indexing-action.php
+++ b/src/actions/indexing/post-link-indexing-action.php
@@ -81,19 +81,24 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 		return $this->wpdb->prepare(
 			"SELECT COUNT(P.ID)
 			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN $links_table AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')',
+			WHERE P.post_status = 'publish'
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM ' . $indexable_table . " AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM $links_table AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)",
 			$public_post_types,
 		);
 	}
@@ -122,19 +127,24 @@ class Post_Link_Indexing_Action extends Abstract_Link_Indexing_Action {
 			"
 			SELECT P.ID, P.post_content
 			FROM {$this->wpdb->posts} AS P
-			LEFT JOIN $indexable_table AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN $links_table AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ")
+			WHERE P.post_status = 'publish'
+				AND P.post_type IN (" . \implode( ', ', \array_fill( 0, \count( $public_post_types ), '%s' ) ) . ')
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM ' . $indexable_table . " AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM $links_table AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)
 			$limit_query",
 			$replacements,
 		);

--- a/tests/Unit/Actions/Indexing/Post_Link_Indexing_Action_Test.php
+++ b/tests/Unit/Actions/Indexing/Post_Link_Indexing_Action_Test.php
@@ -136,19 +136,24 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN wp_yoast_seo_links AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (%s, %s)";
+			WHERE P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM wp_yoast_indexable AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM wp_yoast_seo_links AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)";
 
 		$this->wpdb
 			->expects( 'prepare' )
@@ -192,19 +197,24 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 
 		$expected_query = "SELECT COUNT(P.ID)
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN wp_yoast_seo_links AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
-				AND P.post_type IN (%s, %s)";
+			WHERE P.post_status = 'publish'
+				AND P.post_type IN (%s, %s)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM wp_yoast_indexable AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM wp_yoast_seo_links AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)";
 
 		$this->wpdb
 			->expects( 'prepare' )
@@ -254,19 +264,24 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN wp_yoast_seo_links AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
+			WHERE P.post_status = 'publish'
 				AND P.post_type IN (%s, %s)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM wp_yoast_indexable AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM wp_yoast_seo_links AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)
 			LIMIT %d";
 
 		$this->wpdb
@@ -318,19 +333,24 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN wp_yoast_seo_links AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
+			WHERE P.post_status = 'publish'
 				AND P.post_type IN (%s, %s)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM wp_yoast_indexable AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM wp_yoast_seo_links AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)
 			LIMIT %d";
 
 		$this->wpdb
@@ -396,19 +416,24 @@ final class Post_Link_Indexing_Action_Test extends TestCase {
 		$expected_query = "
 			SELECT P.ID, P.post_content
 			FROM wp_posts AS P
-			LEFT JOIN wp_yoast_indexable AS I
-				ON P.ID = I.object_id
-				AND I.link_count IS NOT NULL
-				AND I.object_type = 'post'
-			LEFT JOIN wp_yoast_seo_links AS L
-				ON L.post_id = P.ID
-				AND L.target_indexable_id IS NULL
-				AND L.type = 'internal'
-				AND L.target_post_id IS NOT NULL
-				AND L.target_post_id != 0
-			WHERE ( I.object_id IS NULL OR L.post_id IS NOT NULL )
-				AND P.post_status = 'publish'
+			WHERE P.post_status = 'publish'
 				AND P.post_type IN (%s, %s)
+				AND (
+					NOT EXISTS (
+						SELECT 1 FROM wp_yoast_indexable AS I
+						WHERE I.object_id = P.ID
+							AND I.link_count IS NOT NULL
+							AND I.object_type = 'post'
+					)
+					OR EXISTS (
+						SELECT 1 FROM wp_yoast_seo_links AS L
+						WHERE L.post_id = P.ID
+							AND L.target_indexable_id IS NULL
+							AND L.type = 'internal'
+							AND L.target_post_id IS NOT NULL
+							AND L.target_post_id != 0
+					)
+				)
 			LIMIT %d";
 
 		$this->wpdb


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR introduces a new query to calculate missing SEO_Link indexables.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a performance increase when calculating if the SEO optimization is completed for internal links. Props to [@adconecto](https://github.com/adconecto).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Without this PR/RC make a site with lots of content 1000 posts and links. You can use the internal linking cli command shared here https://yoast.slack.com/archives/C03RAL4QPAQ/p1771490505341159 to make this happen. And the normal WP cli for the posts.
* Finish your SEOO and take not of the amount of indexables and SEO_links in the database.
* Install this PR/RC reset your SEOO and run it again and make sure the results are the same.
* 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
