### PR TITLE
Restore Additional CSS class(es) field in link settings

### DIFF
--- a/packages/js/src/inline-links/css-classes-setting.js
+++ b/packages/js/src/inline-links/css-classes-setting.js
@@ -1,6 +1,6 @@
 import { CheckboxControl, __experimentalInputControl as InputControl, __experimentalVStack as VStack } from "@wordpress/components";
 import { useInstanceId } from "@wordpress/compose";
-import { useState } from "@wordpress/element";
+import { useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 
 /**
@@ -31,6 +31,11 @@ export default function CSSClassesSetting( { value, onChange } ) {
 	const [ isExpanded, setIsExpanded ] = useState( Boolean( value?.cssClasses ) );
 	const instanceId = useInstanceId( CSSClassesSetting, "css-classes-setting" );
 	const inputId = `${ instanceId }-input`;
+
+	// Sync expanded state when value changes externally (e.g. undo/redo, selecting a different link).
+	useEffect( () => {
+		setIsExpanded( Boolean( value?.cssClasses ) );
+	}, [ value?.cssClasses ] );
 
 	const handleCheckboxChange = ( checked ) => {
 		setIsExpanded( checked );

--- a/packages/js/src/inline-links/inline.js
+++ b/packages/js/src/inline-links/inline.js
@@ -145,7 +145,8 @@ function InlineLinkUI( {
 		return linkValue.url === nextValue.url && (
 			linkValue.opensInNewTab !== nextValue.opensInNewTab ||
 			linkValue.noFollow !== nextValue.noFollow ||
-			linkValue.sponsored !== nextValue.sponsored
+			linkValue.sponsored !== nextValue.sponsored ||
+			linkValue.cssClasses !== nextValue.cssClasses
 		);
 	};
 

--- a/packages/js/tests/inline-links/css-classes-setting.test.js
+++ b/packages/js/tests/inline-links/css-classes-setting.test.js
@@ -124,4 +124,30 @@ describe( "CSSClassesSetting", () => {
 		const checkbox = screen.getByRole( "checkbox", { name: "Additional CSS class(es)" } );
 		expect( checkbox ).not.toBeChecked();
 	} );
+
+	it( "syncs expanded state when value changes externally", () => {
+		const { rerender } = render( <CSSClassesSetting value={ {} } onChange={ onChange } /> );
+
+		const checkbox = screen.getByRole( "checkbox" );
+		expect( checkbox ).not.toBeChecked();
+
+		// Simulate an external value change (e.g. undo/redo or selecting a different link).
+		rerender( <CSSClassesSetting value={ { cssClasses: "new-class" } } onChange={ onChange } /> );
+
+		expect( checkbox ).toBeChecked();
+		expect( screen.getByRole( "textbox" ) ).toHaveValue( "new-class" );
+	} );
+
+	it( "collapses expanded state when value is cleared externally", () => {
+		const { rerender } = render( <CSSClassesSetting value={ { cssClasses: "my-class" } } onChange={ onChange } /> );
+
+		expect( screen.getByRole( "checkbox" ) ).toBeChecked();
+		expect( screen.getByRole( "textbox" ) ).toBeInTheDocument();
+
+		// Simulate external clear.
+		rerender( <CSSClassesSetting value={ { cssClasses: "" } } onChange={ onChange } /> );
+
+		expect( screen.getByRole( "checkbox" ) ).not.toBeChecked();
+		expect( screen.queryByRole( "textbox" ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* WordPress 6.9 added an "Additional CSS class(es)" field to the link popover via the `LinkControl` component's `settings` prop. Because Yoast SEO replaces the `core/link` format with its own implementation, this field was missing when Yoast is active.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the "Additional CSS class(es)" field was missing from the link popover when Yoast SEO was active. Props to [somecodeiwrote](https://github.com/somecodeiwrote).

## Relevant technical choices:

* Created a new `CSSClassesSetting` component (`packages/js/src/inline-links/css-classes-setting.js`) that renders a checkbox toggling a text input for CSS classes, matching the WordPress core behavior.
* The component sanitizes input by replacing commas with spaces and collapsing multiple spaces, and trims whitespace on blur.
* Added the `cssClasses` setting entry to the `settings` array in `inline.js` with a custom `render` function that delegates to the new component.
*`LinkControl` uses `value.cssClasses`, while the internal format uses `className`/`class`. The `linkValue` object now includes both `className` and `cssClasses` mapped from `activeAttributes.class`, and `onChangeLink` reads `nextValue.cssClasses ?? nextValue.className` when calling `createLinkFormat`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### With Yoast SEO deactivated
1. Use WordPress 6.9+ (or latest trunk with Gutenberg).
2. Create or edit a post in the block editor.
3. Select some text and add a link using the toolbar.
4. Click the link to open the popover, then click the pencil icon to edit the link.
<img width="781" height="312" alt="image" src="https://github.com/user-attachments/assets/a118845e-4436-4fff-b5b0-43f5ce94f313" />

5. Scroll down to the "Advanced" section in the link popover.
6. . Confirm the "Additional CSS class(es)" checkbox is visible.
7. Check the checkbox,  a text input should appear.
<img width="340" height="134" alt="image" src="https://github.com/user-attachments/assets/455f5979-4efc-4736-af82-a0ab63bf18af" />

8. Enter one or more CSS classes (e.g. `my-custom-class`).
11. Press Enter or click away to apply the link.
12. Save the post.
13. Open the browser console and verify the class attribute is present on the link by running:
    ```wp.data.select('core/editor').getEditedPostContent()```
    The output should contain `class="my-custom-link` on the `<a>` tag.
    
#### With Yoast SEO activated
1. Activate the Yoast SEO plugin
2. Go back to the post where you added the link previously. 
3. Click on edit the link and confirm that the `Additional CSS class(es)` option is still present with the value of the class in the edit field. 
<img width="552" height="672" alt="image" src="https://github.com/user-attachments/assets/651effbe-cc4e-4ea0-8334-4be04518f0e9" />

4. Change the custom class in the edit field and save it. 
5. Reload the page, click the link again, and confirm the CSS classes persist in the popover UI.
6. Check the ```wp.data.select('core/editor').getEditedPostContent()``` value in the console and confirm that it has been updated. 
7. Test comma-separated input (e.g. `class-one,class-two`) — commas should be replaced with spaces.
8. Test that leading/trailing spaces are trimmed when the input loses focus.
9. Uncheck the checkbox — the CSS classes should be cleared. 
10. Click on apply, save the post and reload the page. 
11. Check the link and confirm that the additional class is still unchecked and empty. 
12. Add a new link in the text with Additonal class(es) and save the post.
13. Deactivate the Yoast SEO plugin and open again the post with the links.
14. Check both links, the one with empty classes and the one with classes. 
15. Confirm that they both kept the values changed with the Yoast SEO plugin active. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
The console check is needed to verify the class attribute is applied to the anchor element (step 11).
Test on posts and pages to ensure the link format works across content types.
Test on Chrome, Firefox, and Safari to ensure cross-browser compatibility.
-->

### Test instructions for QA when the code is in the RC
<!--
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The inline link popover UI in the block editor (custom `core/link` format replacement).
* Link creation and editing — the `class` attribute is now written to anchor tags when CSS classes are provided.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23010