### PR TITLE
Remove is_debug since its no longer needed.

### DIFF
--- a/src/schema-aggregator/application/aggregate-site-schema-command-handler.php
+++ b/src/schema-aggregator/application/aggregate-site-schema-command-handler.php
@@ -64,6 +64,6 @@ class Aggregate_Site_Schema_Command_Handler {
 		);
 
 		$aggregated_schema_pieces = $this->schema_piece_aggregator->aggregate( $schema_pieces );
-		return $this->schema_response_composer->compose( $aggregated_schema_pieces, $command->is_debug() );
+		return $this->schema_response_composer->compose( $aggregated_schema_pieces );
 	}
 }

--- a/src/schema-aggregator/application/aggregate-site-schema-command.php
+++ b/src/schema-aggregator/application/aggregate-site-schema-command.php
@@ -18,23 +18,14 @@ class Aggregate_Site_Schema_Command {
 	private $page_controls;
 
 	/**
-	 * Whether debug mode is enabled.
-	 *
-	 * @var bool
-	 */
-	private $is_debug;
-
-	/**
 	 * The constructor.
 	 *
 	 * @param int    $page      The current page.
 	 * @param int    $per_page  The number of items per page.
 	 * @param string $post_type The post type to aggregate schema for.
-	 * @param bool   $is_debug  Whether debug mode is enabled.
 	 */
-	public function __construct( int $page, int $per_page, string $post_type, bool $is_debug = false ) {
+	public function __construct( int $page, int $per_page, string $post_type ) {
 		$this->page_controls = new Page_Controls( $page, $per_page, $post_type );
-		$this->is_debug      = $is_debug;
 	}
 
 	/**
@@ -44,14 +35,5 @@ class Aggregate_Site_Schema_Command {
 	 */
 	public function get_page_controls(): Page_Controls {
 		return $this->page_controls;
-	}
-
-	/**
-	 * Checks if debug mode is enabled.
-	 *
-	 * @return bool
-	 */
-	public function is_debug(): bool {
-		return $this->is_debug;
 	}
 }

--- a/src/schema-aggregator/application/schema-aggregator-response-composer.php
+++ b/src/schema-aggregator/application/schema-aggregator-response-composer.php
@@ -15,11 +15,10 @@ class Schema_Aggregator_Response_Composer {
 	 * Composes the final schema response.
 	 *
 	 * @param Schema_Piece_Collection $schema_pieces The schema pieces to include in the response.
-	 * @param bool                    $is_debug      Whether debug mode is enabled.
 	 *
 	 * @return array<string> The composed schema response.
 	 */
-	public function compose( Schema_Piece_Collection $schema_pieces, bool $is_debug ): array {
+	public function compose( Schema_Piece_Collection $schema_pieces ): array {
 		$composed_pieces = [];
 		foreach ( $schema_pieces->to_array() as $piece ) {
 			$composed_pieces[] = \array_merge(
@@ -29,16 +28,6 @@ class Schema_Aggregator_Response_Composer {
 				$piece->get_data(),
 			);
 		}
-		if ( $is_debug ) {
-			$composed_pieces[] =
-				[
-					'@context'   => 'https://schema.org',
-					'@type'      => 'Thing',
-					'name'       => 'Yoast SEO schema aggregator version',
-					'identifier' => '1.0',
-				];
-		}
-
 		return $composed_pieces;
 	}
 }

--- a/src/schema-aggregator/user-interface/site-schema-aggregator-route.php
+++ b/src/schema-aggregator/user-interface/site-schema-aggregator-route.php
@@ -164,17 +164,13 @@ class Site_Schema_Aggregator_Route implements Route_Interface {
 			);
 		}
 
-		$is_debug = (bool) $request->get_param( 'debug' );
 		$page     = ( $request->get_param( 'page' ) ?? 1 );
 		$per_page = $this->config->get_per_page( $post_type );
 
 		$output = $this->cache_manager->get( $post_type, $page, $per_page );
-		if ( $is_debug ) {
-			$output = null;
-		}
 		if ( $output === null ) {
 			try {
-				$output = $this->aggregate_site_schema_command_handler->handle( new Aggregate_Site_Schema_Command( $page, $per_page, $post_type, $is_debug ) );
+				$output = $this->aggregate_site_schema_command_handler->handle( new Aggregate_Site_Schema_Command( $page, $per_page, $post_type ) );
 				$this->cache_manager->set( $post_type, $page, $per_page, $output );
 
 			} catch ( Exception $exception ) {

--- a/tests/Unit/Schema_Aggregator/Application/Aggregate_Site_Schema_Command_Handler/Handle_Test.php
+++ b/tests/Unit/Schema_Aggregator/Application/Aggregate_Site_Schema_Command_Handler/Handle_Test.php
@@ -56,7 +56,7 @@ final class Handle_Test extends Abstract_Aggregate_Site_Schema_Command_Handler_T
 		$this->schema_response_composer
 			->expects( 'compose' )
 			->once()
-			->with( $aggregated_pieces, false )
+			->with( $aggregated_pieces )
 			->andReturn( $composed_response );
 
 		$result = $this->instance->handle( $command );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to remove this before going live.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes no longer needed is_debug flag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add ?debug=true to an wp-json/yoast/v1/schema-aggregator/get-schema/post call and make sure you do not see `Yoast SEO schema aggregator version`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
