### PR TITLE
remove extra space if there are not children

### DIFF
--- a/packages/dashboard-frontend/src/task-list/components/child-tasks.js
+++ b/packages/dashboard-frontend/src/task-list/components/child-tasks.js
@@ -64,7 +64,7 @@ export const ChildTasks = ( { tasks, singleTaskOnClick } ) => {
 	const isNextDisabled = currentPage === totalPages || totalPages === 0;
 
 	return (
-		<div className="yst-mt-6">
+		<div>
 			<TasksProgressBar
 				label={ __( "Progress", "wordpress-seo" ) }
 				completedTasks={ completedTasks }

--- a/packages/dashboard-frontend/src/task-list/components/task-modal.js
+++ b/packages/dashboard-frontend/src/task-list/components/task-modal.js
@@ -123,7 +123,7 @@ export const TaskModal = ( {
 						<Modal.CloseButton ref={ closeButtonRef } onClick={ onClose } />
 					</div>
 				</Modal.Container.Header>
-				<Modal.Container.Content className="yst-py-6 yst-px-6 yst-mx-0 yst-overflow-y-auto yst-relative">
+				<Modal.Container.Content className="yst-pt-6 yst-px-6 yst-mx-0 yst-overflow-y-auto yst-relative">
 					{ isError && <Alert
 						role="alert"
 						variant="error"
@@ -143,15 +143,15 @@ export const TaskModal = ( {
 						{ __( "About this task", "wordpress-seo" ) }
 					</Title>
 					<div
-						className="yst-text-sm yst-text-slate-600 [&>p:not(:last-child)]:yst-mb-4"
+						className="yst-text-sm yst-text-slate-600 [&>p:not(:last-child)]:yst-mb-4 yst-mb-6"
 						dangerouslySetInnerHTML={ { __html: sanitizedAbout } }
 					/>
 
 					{ children }
-					<div
-						className="yst-sticky -yst-left-6 -yst-right-6 -yst-bottom-6 yst-h-16 yst-pointer-events-none yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
+					{ children && <div
+						className="yst-sticky -yst-left-6 -yst-right-6 yst-bottom-0 yst-h-10 yst-pointer-events-none yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
 						aria-hidden="true"
-					/>
+					/> }
 				</Modal.Container.Content>
 				<Modal.Container.Footer className="yst-flex yst-justify-end yst-gap-3 yst-p-6 yst-border-t yst-border-slate-200">
 					<Button variant="secondary" onClick={ onClose }>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Remved extra space in task modal.

## Relevant technical choices:

* The gradient element used for the bottom of the scroll takes space, it will now render only when there is children to the modal, I moved the bottom padding to to the content, in that way the gradient element will also take the place of the padding bottom.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEO -> Task list
* Open a task without child tasks and check there is 24px space between the about content and the footer.
* Open a task with children
* Check there is a scroll and agradient overlay at the bottom.
*Scroll to the end untell the gradient disappears.
<img width="812" height="388" alt="Screenshot 2026-02-24 at 14 55 29" src="https://github.com/user-attachments/assets/52832f96-8686-4ccc-b0ba-5d07638ede41" />
<img width="772" height="352" alt="Screenshot 2026-02-24 at 14 55 34" src="https://github.com/user-attachments/assets/3cb1dcab-ba30-401a-9c45-9834bf653de4" />


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Task lise: Remove extra space in task modal](https://github.com/Yoast/reserved-tasks/issues/1080)

