### PR TITLE
Fix edge case where readability being 0 breaks the task list

### DIFF
--- a/src/task-list/infrastructure/indexables/recent-content-indexable-collector.php
+++ b/src/task-list/infrastructure/indexables/recent-content-indexable-collector.php
@@ -126,7 +126,7 @@ class Recent_Content_Indexable_Collector {
 		$content_items = [];
 
 		foreach ( $raw_results as $result ) {
-			// @TODO: Instead of this inline quick fix, let's properly handle the case where readability_score is 0 in the repository method, and return 'bad' directly from there.
+			// @TODO: Instead of this inline quick fix, let's properly handle the case where readability_score is 0 in the repository method, and return 'bad' directly from there (SEO scores having a different logic might make this a bit harder).
 			// Also read as: The refactoring of https://github.com/Yoast/wordpress-seo/pull/22947 was not quite right.
 			if ( (int) $result['readability_score'] === 0 ) {
 				$score_name = 'bad';


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an edge case unreleased bug where having a post have a readability equal to 0 breaks the task list.

## Relevant technical choices:

* Not sure how a post can get a 0 readability score, but we have to treat it the same as we did in the dashboard widget.
* In https://github.com/Yoast/wordpress-seo/pull/22947/changes, we did a refactoring that created the `Abstract_Score_Groups_Repository` class for both SEO and Readability score groups. It wrongly assumed that SEO and Readability score groups have identical logic
* One difference between SEO and Readability score groups is that in the dashboard widget, when a post has a `0` SEO score, it is always classified as a `not analyzed` post. But when a post has a a `0` readability score, it might be classified as `not analyzed` OR as `bad`, depending on the estimated reading time

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a couple of posts modified the last 2 months
  * One with `Good` readability score
  * One with `Ok` readability score
  * One with `Needs Improvement` readability score
  * One that's created while Yoast was disabled - so it's `Not analyzed` in the relevant dashboard widget
* Confirm that with this PR and without, the `Improve the readability of your recent content: Posts` task shows exactly the same tasks, with exactly the same priorities to each child task
* Confirm that the number of child tasks in that task, match the number of not `Not analyzed` posts in the `Readability scores` dashboard widget. 
  * More specifically, take a look at the analyzers inside each child tasks and confirm that the analysis result match what that `Readability scores` dashboard widget says.
  * For example, if there's only one  child task that has the `Needs Improvement` analysis result, the Readability Scores dashboard widget should also say that there's one post that is classified as `Needs Improvement`.
* Go to one of the analyzed tasks' indexable and edit it likeso: Make its `readability_score` column into `0`.
  * To be extra sure, do the same change in the `_yoast_wpseo_content_score` column in the postmeta table for that post
* Delete all transients and refresh the task list
* Confirm that you no longer get a Fatal error (you would, without this PR)
* Confirm that the post whose indexable you tweaked, is now shown with HIGH priority and if you open it, it says `Needs improvement`
* Lastly, confirm that again the child tasks match to what the `Readability scores` dashboard widget says.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [z] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
