### PR TITLE
Fix image object id for Person schema

### DIFF
--- a/src/generators/schema/person.php
+++ b/src/generators/schema/person.php
@@ -187,7 +187,7 @@ class Person extends Abstract_Schema_Piece {
 
 		$data = $this->set_image_from_options( $data, $schema_id, $add_hash, $user_data );
 		if ( ! isset( $data['image'] ) ) {
-			$data = $this->set_image_from_avatar( $data, $user_data, $schema_id, $add_hash );
+			$data = $this->set_image_from_avatar( $data, $user_data, $add_hash );
 		}
 
 		if ( \is_array( $this->type ) && \in_array( 'Organization', $this->type, true ) ) {
@@ -213,7 +213,7 @@ class Person extends Abstract_Schema_Piece {
 			return $data;
 		}
 		if ( \is_array( $this->context->person_logo_meta ) ) {
-			$data['image'] = $this->helpers->schema->image->generate_from_attachment_meta( $schema_id, $this->context->person_logo_meta, $data['name'], $add_hash );
+			$data['image'] = $this->helpers->schema->image->generate_from_attachment_meta( $this->context->person_logo_meta['url'], $this->context->person_logo_meta, $data['name'], $add_hash );
 		}
 
 		return $data;
@@ -224,12 +224,11 @@ class Person extends Abstract_Schema_Piece {
 	 *
 	 * @param array<string|string[]> $data      The Person schema.
 	 * @param WP_User                $user_data User data.
-	 * @param string                 $schema_id The string used in the `@id` for the schema.
 	 * @param bool                   $add_hash  Wether or not the person's image url hash should be added to the image id.
 	 *
 	 * @return array<string|string[]> The Person schema.
 	 */
-	protected function set_image_from_avatar( $data, $user_data, $schema_id, $add_hash = false ) {
+	protected function set_image_from_avatar( $data, $user_data, $add_hash = false ) {
 		// If we don't have an image in our settings, fall back to an avatar, if we're allowed to.
 		$show_avatars = \get_option( 'show_avatars' );
 		if ( ! $show_avatars ) {
@@ -241,7 +240,7 @@ class Person extends Abstract_Schema_Piece {
 			return $data;
 		}
 
-		$data['image'] = $this->helpers->schema->image->simple_image_object( $schema_id, $url, $user_data->display_name, $add_hash );
+		$data['image'] = $this->helpers->schema->image->simple_image_object( $url, $url, $user_data->display_name, $add_hash );
 
 		return $data;
 	}

--- a/tests/Unit/Generators/Schema/Author_Test.php
+++ b/tests/Unit/Generators/Schema/Author_Test.php
@@ -6,7 +6,6 @@ use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
-use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Schema;
@@ -313,7 +312,7 @@ final class Author_Test extends TestCase {
 
 		$this->schema_image
 			->expects( 'simple_image_object' )
-			->with( Schema_IDs::PERSON_LOGO_HASH, $this->person_data['image']['url'], $user_data->display_name, false )
+			->with( $this->person_data['image']['url'], $this->person_data['image']['url'], $user_data->display_name, false )
 			->andReturn( $this->person_data['image'] );
 
 		$this->options->expects( 'get' )
@@ -457,7 +456,7 @@ final class Author_Test extends TestCase {
 		$this->schema_image
 			->expects( 'generate_from_attachment_meta' )
 			->with(
-				$this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH,
+				$this->instance->context->person_logo_meta['url'],
 				[
 					'height' => 100,
 					'width'  => 100,

--- a/tests/Unit/Generators/Schema/Person_Test.php
+++ b/tests/Unit/Generators/Schema/Person_Test.php
@@ -5,7 +5,6 @@ namespace Yoast\WP\SEO\Tests\Unit\Generators\Schema;
 use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
-use Yoast\WP\SEO\Config\Schema_IDs;
 use Yoast\WP\SEO\Generators\Schema\Person;
 use Yoast\WP\SEO\Helpers\Image_Helper;
 use Yoast\WP\SEO\Helpers\Schema\Article_Helper;
@@ -101,7 +100,7 @@ final class Person_Test extends TestCase {
 			'display_name' => 'John',
 			'description'  => 'Description',
 		];
-		$person_schema_logo_id = $this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
+		$person_schema_logo_id = $this->instance->context->person_logo_meta['url'];
 
 		$image_schema = [
 			'@type'      => 'ImageObject',
@@ -119,7 +118,7 @@ final class Person_Test extends TestCase {
 			'@id'         => 'person_id',
 			'name'        => 'John',
 			'pronouns'    => $pronouns,
-			'logo'        => [ '@id' => 'https://example.com/#/schema/person/image/' ],
+			'logo'        => [ '@id' => $person_schema_logo_id ],
 			'description' => 'Description',
 			'sameAs'      => [
 				'https://example.com/social/facebook',
@@ -277,7 +276,7 @@ final class Person_Test extends TestCase {
 			'@type'    => [ 'Person', 'Organization' ],
 			'@id'      => 'person_id',
 			'name'     => $user_data->display_name,
-			'logo'     => [ '@id' => 'https://example.com/#/schema/person/image/' ],
+			'logo'     => [ '@id' => $image_schema['@id'] ],
 			'image'    => $image_schema,
 		];
 
@@ -496,7 +495,7 @@ final class Person_Test extends TestCase {
 			'display_name' => 'John',
 			'description'  => 'Description',
 		];
-		$person_schema_logo_id = $this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH;
+		$person_schema_logo_id = $this->instance->context->person_logo_meta['url'];
 		$image_schema          = [
 			'@type'      => 'ImageObject',
 			'@id'        => $person_schema_logo_id,
@@ -524,7 +523,7 @@ final class Person_Test extends TestCase {
 			'@type'       => [ 'Person', 'Organization' ],
 			'@id'         => 'person_id',
 			'name'        => 'John',
-			'logo'        => [ '@id' => 'https://example.com/#/schema/person/image/' ],
+			'logo'        => [ '@id' => $person_schema_logo_id ],
 			'description' => 'Description',
 			'sameAs'      => [
 				'https://example.com/social/facebook',
@@ -663,16 +662,16 @@ final class Person_Test extends TestCase {
 	 * @return array<string, string|int> The image schema.
 	 */
 	protected function expects_for_set_image_from_avatar( $user_data, $scenario = 'default' ) {
+		$avatar_url   = 'https://example.com/image.png';
 		$image_schema = [
 			'@type'      => 'ImageObject',
-			'@id'        => $this->instance->context->site_url . Schema_IDs::PERSON_LOGO_HASH,
+			'@id'        => $avatar_url,
 			'inLanguage' => 'en-US',
-			'url'        => 'https://example.com/image.png',
+			'url'        => $avatar_url,
 			'width'      => 64,
 			'height'     => 128,
 			'caption'    => 'Person image',
 		];
-		$avatar_url   = $image_schema['url'];
 
 		switch ( $scenario ) {
 			case 'empty_avatar_url':


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where `ImageObject` id related to Person Schema was not a fully-qualified, absolute URL.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set your blog to represent a person
* Choose an image for that person
* Visit a page in the frontend and inspect the code
  * Look for the Schema piece where
  ```
   "@type": [
	                "Person",
	                "Organization"
	            ]
  ``` 
* Verify the `image` property has `@id` set to the fully-qualified, absolute URL, for example:
`http://example.site/wp-content/uploads/2026/01/test.jpg`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23007
