### PR TITLE
fix: use options.php as parent slug to avoid null page title deprecation

### DIFF
--- a/src/dashboard/user-interface/setup/setup-url-interceptor.php
+++ b/src/dashboard/user-interface/setup/setup-url-interceptor.php
@@ -89,7 +89,7 @@ class Setup_Url_Interceptor implements Integration_Interface {
 	 */
 	public function add_redirect_page( $pages ) {
 		\add_submenu_page(
-			'',
+			'options.php',
 			'',
 			'',
 			'wpseo_manage_options',

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -110,7 +110,7 @@ class Installation_Success_Integration implements Integration_Interface {
 	 */
 	public function add_submenu_page( $submenu_pages ) {
 		\add_submenu_page(
-			'',
+			'options.php',
 			\__( 'Installation Successful', 'wordpress-seo' ),
 			'',
 			'manage_options',

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -400,7 +400,7 @@ class Settings_Integration implements Integration_Interface {
 	public function add_settings_saved_page( $pages ) {
 		$runner = $this->runner;
 		\add_submenu_page(
-			'',
+			'options.php',
 			'',
 			'',
 			'wpseo_manage_options',


### PR DESCRIPTION
## Summary
Closes #22029.

This PR fixes the PHP 8.3 deprecation error `E_DEPRECATED: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated` by using a valid parent slug (`options.php`) instead of an empty string in `add_submenu_page()` calls.

## What changed
- `src/integrations/admin/installation-success-integration.php`: Changed parent slug from `''` to `'options.php'`
- `src/integrations/settings-integration.php`: Changed parent slug from `''` to `'options.php'`
- `src/dashboard/user-interface/setup/setup-url-interceptor.php`: Changed parent slug from `''` to `'options.php'`

## Why this helps
When `add_submenu_page()` receives an empty string as the parent slug, WordPress cannot determine the page title properly, leading to null being passed to `strip_tags()`. By using `'options.php'` as a valid parent slug, WordPress properly renders the page title and the deprecation error is avoided.

## Testing
- Visited the affected pages on PHP 8.3 and confirmed the deprecation error is gone
- Verified that page functionality remains unchanged

## Risk
Minimal - only changes the parent slug parameter in `add_submenu_page()` calls, which is specifically recommended in the issue comments as the correct fix.
