### PR TITLE
Fix progress bar styling and bottom space and remove child tasks pagination when it's only one page

### DIFF
--- a/packages/dashboard-frontend/src/task-list/components/child-tasks.js
+++ b/packages/dashboard-frontend/src/task-list/components/child-tasks.js
@@ -70,16 +70,17 @@ export const ChildTasks = ( { tasks, singleTaskOnClick } ) => {
 				completedTasks={ completedTasks }
 				totalTasks={ totalTasks }
 				size="small"
+				className="yst-mb-4"
 			/>
 			{ currentPageTasks.map( ( task ) => (
 				<SingleTaskButton
 					key={ task.id }
 					{ ...task }
 					onClick={ singleTaskOnClick }
-					className="yst-rounded-md yst-p-3 yst-pe-5 yst-border-b yst-border-slate-300 yst-shadow-sm yst-mt-3 yst-border hover:yst-bg-slate-50"
+					className="yst-rounded-md yst-p-3 yst-pe-5 yst-border-b yst-border-slate-300 yst-shadow-sm yst-mb-3 last:yst-mb-0 yst-border hover:yst-bg-slate-50"
 				/>
 			) ) }
-			<div className="yst-flex yst-justify-between yst-items-center yst-mt-3">
+			{ totalPages > 1 && <div className="yst-flex yst-justify-between yst-items-center yst-mt-3">
 				<div className="yst-text-slate-500 yst-text-xs">
 					{ sprintf(
 						/* translators: %1$d: current page number, %2$d: total number of pages */
@@ -112,7 +113,7 @@ export const ChildTasks = ( { tasks, singleTaskOnClick } ) => {
 							__( "Child tasks, current page %d", "wordpress-seo" ), currentPage ) }</span>
 					</Button>
 				</div>
-			</div>
+			</div> }
 		</div>
 	);
 };

--- a/packages/dashboard-frontend/src/task-list/components/tasks-progressbar.js
+++ b/packages/dashboard-frontend/src/task-list/components/tasks-progressbar.js
@@ -45,7 +45,7 @@ const LoadingProgressBar = ( { className, label, size } ) => (
 		<TasksProgressBarLabel label={ label } size={ size }>
 			<SkeletonLoader className="yst-w-9 yst-h-5" />
 		</TasksProgressBarLabel>
-		<SkeletonLoader className="yst-w-full yst-h-1.5" />
+		<SkeletonLoader className="yst-w-full yst-h-2" />
 	</div>
 );
 
@@ -63,7 +63,7 @@ const ErrorProgressBar = ( { className, label, size } ) => (
 		<TasksProgressBarLabel label={ label } size={ size }>
 			<span className="yst-w-9 yst-h-5 yst-bg-slate-200 yst-rounded" />
 		</TasksProgressBarLabel>
-		<div className="yst-w-full yst-h-1.5 yst-bg-slate-200 yst-rounded" />
+		<div className="yst-w-full yst-h-2 yst-bg-slate-200 yst-rounded" />
 	</div>
 );
 
@@ -105,8 +105,8 @@ export const TasksProgressBar = ( { completedTasks, totalTasks, isLoading, class
 				progress={ completedTasks }
 				min={ 0 }
 				max={ totalTasks }
-				className="yst-h-1.5"
-				progressClassName="yst-bg-green-500"
+				className="yst-h-2"
+				progressClassName="yst-bg-green-500 yst-h-2"
 			/>
 			<span className="yst-sr-only">{ screenReaderText }</span>
 		</div>

--- a/packages/dashboard-frontend/tests/task-list/child-tasks.test.js
+++ b/packages/dashboard-frontend/tests/task-list/child-tasks.test.js
@@ -158,7 +158,7 @@ describe( "ChildTasks", () => {
 		render( <ChildTasks tasks={ fourTasks } singleTaskOnClick={ mockOnClick } /> );
 		expect( screen.queryByText( "Page 1 out of 1" ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( "Next" ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( "Next" ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( "Previous" ) ).not.toBeInTheDocument();
 	} );
 
 	it( "renders correctly with only 1 task", () => {

--- a/packages/dashboard-frontend/tests/task-list/child-tasks.test.js
+++ b/packages/dashboard-frontend/tests/task-list/child-tasks.test.js
@@ -156,12 +156,9 @@ describe( "ChildTasks", () => {
 	it( "renders correctly with exactly 4 tasks (single page)", () => {
 		const fourTasks = mockTasks.slice( 0, 4 );
 		render( <ChildTasks tasks={ fourTasks } singleTaskOnClick={ mockOnClick } /> );
-
-		expect( screen.getByText( "Page 1 out of 1" ) ).toBeInTheDocument();
-		const nextButton = screen.getByText( "Next" ).closest( "button" );
-		const previousButton = screen.getByText( "Previous" ).closest( "button" );
-		expect( nextButton ).toBeDisabled();
-		expect( previousButton ).toBeDisabled();
+		expect( screen.queryByText( "Page 1 out of 1" ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( "Next" ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( "Next" ) ).not.toBeInTheDocument();
 	} );
 
 	it( "renders correctly with only 1 task", () => {
@@ -169,7 +166,7 @@ describe( "ChildTasks", () => {
 		render( <ChildTasks tasks={ singleTask } singleTaskOnClick={ mockOnClick } /> );
 
 		expect( screen.getByText( "First child task" ) ).toBeInTheDocument();
-		expect( screen.getByText( "Page 1 out of 1" ) ).toBeInTheDocument();
+		expect( screen.queryByText( "Page 1 out of 1" ) ).not.toBeInTheDocument();
 		expect( screen.getByText( ( content, element ) => element.textContent === "1/1" ) ).toBeInTheDocument();
 	} );
 
@@ -184,16 +181,28 @@ describe( "ChildTasks", () => {
 		render( <ChildTasks tasks={ nineTasks } singleTaskOnClick={ mockOnClick } /> );
 
 		expect( screen.getByText( "Page 1 out of 3" ) ).toBeInTheDocument();
+		// Check previous button is disabled on first page and next button is enabled
+		const previousButton = screen.getByText( "Previous" ).closest( "button" );
+		expect( previousButton ).toBeDisabled();
+		const nextButton = screen.getByText( "Next" ).closest( "button" );
+		expect( nextButton ).not.toBeDisabled();
 
 		// Navigate to page 2
-		const nextButton = screen.getByText( "Next" ).closest( "button" );
 		fireEvent.click( nextButton );
 		expect( screen.getByText( "Page 2 out of 3" ) ).toBeInTheDocument();
+
+		// Check previous button is enabled and next button is not disabled on page 2
+		expect( previousButton ).not.toBeDisabled();
+		expect( nextButton ).not.toBeDisabled();
 
 		// Navigate to page 3
 		fireEvent.click( nextButton );
 		expect( screen.getByText( "Page 3 out of 3" ) ).toBeInTheDocument();
 		expect( screen.getByText( "Ninth task" ) ).toBeInTheDocument();
+
+		// Check next button is disabled on last page and previous button is enabled
+		expect( previousButton ).not.toBeDisabled();
+		expect( nextButton ).toBeDisabled();
 	} );
 
 	it( "resets to page 1 when parentTaskId changes", () => {

--- a/packages/js/src/general/routes/task-list.js
+++ b/packages/js/src/general/routes/task-list.js
@@ -79,7 +79,7 @@ export const TaskList = () => {
 					className="yst-max-w-screen-sm"
 					label={ __( "Tasks", "wordpress-seo" ) }
 				/>
-				<TaskListTable className="yst-mt-4">
+				<TaskListTable className="yst-mt-6">
 					{ isEmpty( tasks ) && isPending && loadingTasksTitleWidth.map( ( width, index ) => <TaskRow.Loading key={ `${index}-loading-task` } titleClassName={ `yst-w-20 ${width}` } /> ) }
 					{ tasksStatus === ASYNC_ACTION_STATUS.error && <GetTasksErrorRow message={ tasksError } /> }
 					{ ! isEmpty( sortedTasks ) && values( sortedTasks ).filter( task => ! task.parentTaskId ).map( ( task ) => (


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the styling of the task list progress bar and hides child tasks pagination for tasks under 5 child tasks.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open Yoast SEO -> General -> Task list
* Check the progress bar width is 8px and the space between the progress bar and the list is 24px. (it's the margin top of the list)
* Have parent task with more than 4 child tasks 
* Check progress bar height is 8px and space between the progressbar and the child task list is 16px (it's the margin-bottom of the progress bar).
* Check you have pagination at the bottom of the child tasks list.
* Have a parent task with less or 4 child tasks.
* Check there is no pagination at the bottom of the child task list.

For DEVS:
* Spin the dashboard-frontend storybook.
* Check the Task progress bar height is 8px on loading and error state.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/2895
