### PR TITLE
Replace content analysis buttons with ui-library Button

### DIFF
--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -23,8 +23,10 @@
   "author": "Team Yoast",
   "license": "GPL-3.0",
   "dependencies": {
+    "@heroicons/react": "^1.0.6",
     "@wordpress/i18n": "^5.8.2",
     "@yoast/components": "^3.0.0-alpha.3",
+    "@yoast/ui-library": "^4.4.0",
     "@yoast/helpers": "^0.17.0-alpha.2",
     "@yoast/style-guide": "^0.14.0-alpha.1",
     "lodash": "^4.17.21",

--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@heroicons/react": "^1.0.6",
     "@wordpress/i18n": "^5.8.2",
+    "classnames": "^2.3.2",
     "@yoast/components": "^3.0.0-alpha.3",
     "@yoast/ui-library": "^4.4.0",
     "@yoast/helpers": "^0.17.0-alpha.2",

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,7 +1,9 @@
 import { BetaBadge, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
 import { Button } from "@yoast/ui-library";
-import { EyeIcon, PencilIcon } from "@heroicons/react/solid";
+import classNames from "classnames";
+import { EyeIcon } from "@heroicons/react/outline";
+import { PencilIcon } from "@heroicons/react/solid";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -72,16 +74,17 @@ const createMarkButton = ( {
 	isPressed,
 } ) => {
 	return <Button
-		variant="secondary"
+		variant={ isPressed ? "primary" : "secondary" }
 		size="small"
-		icon={ EyeIcon }
-		className={ className }
+		className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
 		onClick={ onClick }
 		id={ id }
 		disabled={ status === "disabled" }
 		aria-pressed={ isPressed }
 		aria-label={ ariaLabel }
-	/>;
+	>
+		<EyeIcon className="yst-w-4 yst-h-4" />
+	</Button>;
 };
 
 /**
@@ -192,12 +195,13 @@ const AnalysisResult = ( {
 					<Button
 						variant="secondary"
 						size="small"
-						icon={ PencilIcon }
-						className={ editButtonClassName }
+						className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0" ) }
 						onClick={ onButtonClickEdit }
 						id={ buttonIdEdit }
 						aria-label={ ariaLabelEdit }
-					/>
+					>
+						<PencilIcon className="yst-w-4 yst-h-4" />
+					</Button>
 				}
 				{ renderAIOptimizeButton( hasAIFixes, id ) }
 			</ResultButtonsContainer>

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,9 +1,9 @@
 import { BetaBadge, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
-import { Button } from "@yoast/ui-library";
+import { Button, Root, Tooltip } from "@yoast/ui-library";
 import classNames from "classnames";
 import { EyeIcon } from "@heroicons/react/outline";
-import { PencilIcon } from "@heroicons/react/solid";
+import { PencilIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -54,7 +54,7 @@ const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
 };
 
 /**
- * Factory method which creates a new instance of the default mark button.
+ * The default mark button component.
  *
  * @param {string} ariaLabel 	The button aria-label.
  * @param {string} id 			The button id.
@@ -65,7 +65,7 @@ const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
  *
  * @returns {JSX.Element} A new mark button.
  */
-const createMarkButton = ( {
+const MarkButton = ( {
 	ariaLabel,
 	id,
 	className,
@@ -73,18 +73,56 @@ const createMarkButton = ( {
 	onClick,
 	isPressed,
 } ) => {
-	return <Button
-		variant={ isPressed ? "primary" : "secondary" }
-		size="small"
-		className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
-		onClick={ onClick }
-		id={ id }
-		disabled={ status === "disabled" }
-		aria-pressed={ isPressed }
-		aria-label={ ariaLabel }
-	>
-		<EyeIcon className="yst-w-4 yst-h-4" />
-	</Button>;
+	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
+
+	return <Root>
+		<div className="yst-relative yst-inline-flex">
+			<Button
+				variant={ isPressed ? "primary" : "secondary" }
+				size="small"
+				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+				onClick={ onClick }
+				id={ id }
+				disabled={ status === "disabled" }
+				aria-pressed={ isPressed }
+				aria-label={ ariaLabel }
+				onPointerEnter={ () => setIsTooltipOpen( true ) }
+				onPointerLeave={ () => setIsTooltipOpen( false ) }
+			>
+				<EyeIcon className="yst-w-4 yst-h-4" />
+			</Button>
+			{ isTooltipOpen && ! isPressed && (
+				<Tooltip position="left">
+					{ ariaLabel }
+				</Tooltip>
+			) }
+		</div>
+	</Root>;
+};
+
+MarkButton.propTypes = {
+	ariaLabel: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	status: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+	isPressed: PropTypes.bool.isRequired,
+};
+
+MarkButton.defaultProps = {
+	className: "",
+	status: "enabled",
+};
+
+/**
+ * The default mark button factory wrapping the MarkButton component.
+ *
+ * @param {Object} props The mark button props.
+ *
+ * @returns {JSX.Element} A new mark button.
+ */
+const createMarkButton = ( props ) => {
+	return <MarkButton { ...props } />;
 };
 
 /**
@@ -146,6 +184,7 @@ const AnalysisResult = ( {
 	text,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
+	const [ isEditTooltipOpen, setIsEditTooltipOpen ] = useState( false );
 
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
 	const openModal = useCallback( () => setIsOpen( true ), [] );
@@ -192,16 +231,27 @@ const AnalysisResult = ( {
 				{ renderHighlightingUpsell( isOpen, closeModal ) }
 				{
 					hasEditButton && isPremium &&
-					<Button
-						variant="secondary"
-						size="small"
-						className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0" ) }
-						onClick={ onButtonClickEdit }
-						id={ buttonIdEdit }
-						aria-label={ ariaLabelEdit }
-					>
-						<PencilIcon className="yst-w-4 yst-h-4" />
-					</Button>
+					<Root>
+						<div className="yst-relative yst-inline-flex">
+							<Button
+								variant="secondary"
+								size="small"
+								className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0" ) }
+								onClick={ onButtonClickEdit }
+								id={ buttonIdEdit }
+								aria-label={ ariaLabelEdit }
+								onPointerEnter={ () => setIsEditTooltipOpen( true ) }
+								onPointerLeave={ () => setIsEditTooltipOpen( false ) }
+							>
+								<PencilIcon className="yst-w-4 yst-h-4" />
+							</Button>
+							{ isEditTooltipOpen && (
+								<Tooltip position="left">
+									{ ariaLabelEdit }
+								</Tooltip>
+							) }
+						</div>
+					</Root>
 				}
 				{ renderAIOptimizeButton( hasAIFixes, id ) }
 			</ResultButtonsContainer>

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -2,8 +2,7 @@ import { BetaBadge, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
 import { Button, Root, Tooltip } from "@yoast/ui-library";
 import classNames from "classnames";
-import { EyeIcon } from "@heroicons/react/outline";
-import { PencilIcon } from "@heroicons/react/outline";
+import { EyeIcon, PencilIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -68,12 +67,14 @@ const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
 const MarkButton = ( {
 	ariaLabel,
 	id,
-	className,
-	status,
+	className = "",
+	status = "enabled",
 	onClick,
 	isPressed,
 } ) => {
 	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
+	const showTooltip = useCallback( () => setIsTooltipOpen( true ), [] );
+	const hideTooltip = useCallback( () => setIsTooltipOpen( false ), [] );
 
 	return <Root>
 		<div className="yst-relative yst-inline-flex">
@@ -86,8 +87,8 @@ const MarkButton = ( {
 				disabled={ status === "disabled" }
 				aria-pressed={ isPressed }
 				aria-label={ ariaLabel }
-				onPointerEnter={ () => setIsTooltipOpen( true ) }
-				onPointerLeave={ () => setIsTooltipOpen( false ) }
+				onPointerEnter={ showTooltip }
+				onPointerLeave={ hideTooltip }
 			>
 				<EyeIcon className="yst-w-4 yst-h-4" />
 			</Button>
@@ -107,11 +108,6 @@ MarkButton.propTypes = {
 	status: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	isPressed: PropTypes.bool.isRequired,
-};
-
-MarkButton.defaultProps = {
-	className: "",
-	status: "enabled",
 };
 
 /**
@@ -188,6 +184,8 @@ const AnalysisResult = ( {
 
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
 	const openModal = useCallback( () => setIsOpen( true ), [] );
+	const showEditTooltip = useCallback( () => setIsEditTooltipOpen( true ), [] );
+	const hideEditTooltip = useCallback( () => setIsEditTooltipOpen( false ), [] );
 
 	markButtonFactory = markButtonFactory || createMarkButton;
 
@@ -240,8 +238,8 @@ const AnalysisResult = ( {
 								onClick={ onButtonClickEdit }
 								id={ buttonIdEdit }
 								aria-label={ ariaLabelEdit }
-								onPointerEnter={ () => setIsEditTooltipOpen( true ) }
-								onPointerLeave={ () => setIsEditTooltipOpen( false ) }
+								onPointerEnter={ showEditTooltip }
+								onPointerLeave={ hideEditTooltip }
 							>
 								<PencilIcon className="yst-w-4 yst-h-4" />
 							</Button>

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,6 +1,6 @@
 import { BetaBadge, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
-import { Button, Root, Tooltip } from "@yoast/ui-library";
+import { Button, Root, TooltipContainer, TooltipWithContext, useTooltipContext } from "@yoast/ui-library";
 import classNames from "classnames";
 import { EyeIcon, PencilIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
@@ -53,7 +53,7 @@ const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
 };
 
 /**
- * The default mark button component.
+ * Inner mark button that accesses the TooltipContainer context.
  *
  * @param {string} ariaLabel 	The button aria-label.
  * @param {string} id 			The button id.
@@ -62,42 +62,63 @@ const areMarkButtonsHidden = function( hasMarksButton, marksButtonStatus ) {
  * @param {function} onClick 	Onclick handler.
  * @param {boolean} isPressed 	Whether the button is in a pressed state.
  *
+ * @returns {JSX.Element} The inner mark button with tooltip context.
+ */
+const MarkButtonInner = ( { ariaLabel, id, className = "", status = "enabled", onClick, isPressed } ) => {
+	const { show, hide } = useTooltipContext();
+	const tooltipId = `${ id }-tooltip`;
+
+	const handleShow = useCallback( () => {
+		if ( ! isPressed ) {
+			show();
+		}
+	}, [ isPressed, show ] );
+
+	return <>
+		<Button
+			variant={ isPressed ? "primary" : "secondary" }
+			size="small"
+			className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+			onClick={ onClick }
+			id={ id }
+			disabled={ status === "disabled" }
+			aria-pressed={ isPressed }
+			aria-label={ ariaLabel }
+			aria-describedby={ isPressed ? null : tooltipId }
+			onPointerEnter={ handleShow }
+			onPointerLeave={ hide }
+			onFocus={ handleShow }
+			onBlur={ hide }
+		>
+			<EyeIcon className="yst-w-4 yst-h-4" />
+		</Button>
+		<TooltipWithContext id={ tooltipId } position="left">
+			{ ariaLabel }
+		</TooltipWithContext>
+	</>;
+};
+
+MarkButtonInner.propTypes = {
+	ariaLabel: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	status: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+	isPressed: PropTypes.bool.isRequired,
+};
+
+/**
+ * The default mark button component.
+ *
+ * @param {Object} props The mark button props.
+ *
  * @returns {JSX.Element} A new mark button.
  */
-const MarkButton = ( {
-	ariaLabel,
-	id,
-	className = "",
-	status = "enabled",
-	onClick,
-	isPressed,
-} ) => {
-	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
-	const showTooltip = useCallback( () => setIsTooltipOpen( true ), [] );
-	const hideTooltip = useCallback( () => setIsTooltipOpen( false ), [] );
-
+const MarkButton = ( { className = "", status = "enabled", ...props } ) => {
 	return <Root>
-		<div className="yst-relative yst-inline-flex">
-			<Button
-				variant={ isPressed ? "primary" : "secondary" }
-				size="small"
-				className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
-				onClick={ onClick }
-				id={ id }
-				disabled={ status === "disabled" }
-				aria-pressed={ isPressed }
-				aria-label={ ariaLabel }
-				onPointerEnter={ showTooltip }
-				onPointerLeave={ hideTooltip }
-			>
-				<EyeIcon className="yst-w-4 yst-h-4" />
-			</Button>
-			{ isTooltipOpen && ! isPressed && (
-				<Tooltip position="left">
-					{ ariaLabel }
-				</Tooltip>
-			) }
-		</div>
+		<TooltipContainer as="div" className="yst-relative yst-inline-flex">
+			<MarkButtonInner className={ className } status={ status } { ...props } />
+		</TooltipContainer>
 	</Root>;
 };
 
@@ -108,6 +129,49 @@ MarkButton.propTypes = {
 	status: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	isPressed: PropTypes.bool.isRequired,
+};
+
+/**
+ * Inner edit button that accesses the TooltipContainer context.
+ *
+ * @param {string} ariaLabel 	The button aria-label.
+ * @param {string} id 			The button id.
+ * @param {string} className 	The button class name.
+ * @param {function} onClick 	Onclick handler.
+ *
+ * @returns {JSX.Element} The inner edit button with tooltip context.
+ */
+const EditButtonInner = ( { ariaLabel, id, className = "", onClick } ) => {
+	const { show, hide } = useTooltipContext();
+	const tooltipId = `${ id }-tooltip`;
+
+	return <>
+		<Button
+			variant="secondary"
+			size="small"
+			className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0" ) }
+			onClick={ onClick }
+			id={ id }
+			aria-label={ ariaLabel }
+			aria-describedby={ tooltipId }
+			onPointerEnter={ show }
+			onPointerLeave={ hide }
+			onFocus={ show }
+			onBlur={ hide }
+		>
+			<PencilIcon className="yst-w-4 yst-h-4" />
+		</Button>
+		<TooltipWithContext id={ tooltipId } position="left">
+			{ ariaLabel }
+		</TooltipWithContext>
+	</>;
+};
+
+EditButtonInner.propTypes = {
+	ariaLabel: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
 };
 
 /**
@@ -180,12 +244,9 @@ const AnalysisResult = ( {
 	text,
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ isEditTooltipOpen, setIsEditTooltipOpen ] = useState( false );
 
 	const closeModal = useCallback( () => setIsOpen( false ), [] );
 	const openModal = useCallback( () => setIsOpen( true ), [] );
-	const showEditTooltip = useCallback( () => setIsEditTooltipOpen( true ), [] );
-	const hideEditTooltip = useCallback( () => setIsEditTooltipOpen( false ), [] );
 
 	markButtonFactory = markButtonFactory || createMarkButton;
 
@@ -230,25 +291,14 @@ const AnalysisResult = ( {
 				{
 					hasEditButton && isPremium &&
 					<Root>
-						<div className="yst-relative yst-inline-flex">
-							<Button
-								variant="secondary"
-								size="small"
-								className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0" ) }
-								onClick={ onButtonClickEdit }
+						<TooltipContainer as="div" className="yst-relative yst-inline-flex">
+							<EditButtonInner
+								ariaLabel={ ariaLabelEdit }
 								id={ buttonIdEdit }
-								aria-label={ ariaLabelEdit }
-								onPointerEnter={ showEditTooltip }
-								onPointerLeave={ hideEditTooltip }
-							>
-								<PencilIcon className="yst-w-4 yst-h-4" />
-							</Button>
-							{ isEditTooltipOpen && (
-								<Tooltip position="left">
-									{ ariaLabelEdit }
-								</Tooltip>
-							) }
-						</div>
+								className={ editButtonClassName }
+								onClick={ onButtonClickEdit }
+							/>
+						</TooltipContainer>
 					</Root>
 				}
 				{ renderAIOptimizeButton( hasAIFixes, id ) }

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -74,15 +74,14 @@ const createMarkButton = ( {
 	return <Button
 		variant="secondary"
 		size="small"
-		disabled={ status === "disabled" }
+		icon={ EyeIcon }
 		className={ className }
 		onClick={ onClick }
 		id={ id }
+		disabled={ status === "disabled" }
 		aria-pressed={ isPressed }
 		aria-label={ ariaLabel }
-	>
-		<EyeIcon className="yst-w-[18px] yst-h-[18px]" />
-	</Button>;
+	/>;
 };
 
 /**
@@ -193,13 +192,12 @@ const AnalysisResult = ( {
 					<Button
 						variant="secondary"
 						size="small"
+						icon={ PencilIcon }
 						className={ editButtonClassName }
 						onClick={ onButtonClickEdit }
 						id={ buttonIdEdit }
 						aria-label={ ariaLabelEdit }
-					>
-						<PencilIcon className="yst-w-[18px] yst-h-[18px]" />
-					</Button>
+					/>
 				}
 				{ renderAIOptimizeButton( hasAIFixes, id ) }
 			</ResultButtonsContainer>

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -81,7 +81,7 @@ const MarkButton = ( {
 			<Button
 				variant={ isPressed ? "primary" : "secondary" }
 				size="small"
-				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+				className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
 				onClick={ onClick }
 				id={ id }
 				disabled={ status === "disabled" }
@@ -234,7 +234,7 @@ const AnalysisResult = ( {
 							<Button
 								variant="secondary"
 								size="small"
-								className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0" ) }
+								className={ classNames( editButtonClassName, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0" ) }
 								onClick={ onButtonClickEdit }
 								id={ buttonIdEdit }
 								aria-label={ ariaLabelEdit }

--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -1,5 +1,7 @@
-import { BetaBadge, IconButtonToggle, IconCTAEditButton, SvgIcon } from "@yoast/components";
+import { BetaBadge, SvgIcon } from "@yoast/components";
 import { strings } from "@yoast/helpers";
+import { Button } from "@yoast/ui-library";
+import { EyeIcon, PencilIcon } from "@heroicons/react/solid";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect, useState } from "react";
@@ -69,15 +71,18 @@ const createMarkButton = ( {
 	onClick,
 	isPressed,
 } ) => {
-	return <IconButtonToggle
-		marksButtonStatus={ status }
+	return <Button
+		variant="secondary"
+		size="small"
+		disabled={ status === "disabled" }
 		className={ className }
 		onClick={ onClick }
 		id={ id }
-		icon="eye"
-		pressed={ isPressed }
-		ariaLabel={ ariaLabel }
-	/>;
+		aria-pressed={ isPressed }
+		aria-label={ ariaLabel }
+	>
+		<EyeIcon className="yst-w-[18px] yst-h-[18px]" />
+	</Button>;
 };
 
 /**
@@ -185,13 +190,16 @@ const AnalysisResult = ( {
 				{ renderHighlightingUpsell( isOpen, closeModal ) }
 				{
 					hasEditButton && isPremium &&
-					<IconCTAEditButton
+					<Button
+						variant="secondary"
+						size="small"
 						className={ editButtonClassName }
 						onClick={ onButtonClickEdit }
 						id={ buttonIdEdit }
-						icon="edit"
-						ariaLabel={ ariaLabelEdit }
-					/>
+						aria-label={ ariaLabelEdit }
+					>
+						<PencilIcon className="yst-w-[18px] yst-h-[18px]" />
+					</Button>
 				}
 				{ renderAIOptimizeButton( hasAIFixes, id ) }
 			</ResultButtonsContainer>

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -79,15 +79,19 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
       className="yst-root"
     >
       <div
-        className="yst-relative yst-inline-flex"
+        className="yst-tooltip-container yst-relative yst-inline-flex"
+        onKeyDown={[Function]}
       >
         <button
+          aria-describedby={null}
           aria-label="SEOResult"
           aria-pressed={true}
           className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={false}
           id="Result button"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
           onPointerEnter={[Function]}
           onPointerLeave={[Function]}
           type="button"
@@ -113,6 +117,14 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
             />
           </svg>
         </button>
+        <div
+          className="yst-tooltip yst-tooltip--left yst-hidden"
+          id="Result button-tooltip"
+          role="tooltip"
+          variant="dark"
+        >
+          SEOResult
+        </div>
       </div>
     </div>
   </div>
@@ -203,14 +215,18 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
       className="yst-root"
     >
       <div
-        className="yst-relative yst-inline-flex"
+        className="yst-tooltip-container yst-relative yst-inline-flex"
+        onKeyDown={[Function]}
       >
         <button
+          aria-describedby="Result button edit-tooltip"
           aria-label="SEOResultEdit"
           className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0"
           disabled={false}
           id="Result button edit"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
           onPointerEnter={[Function]}
           onPointerLeave={[Function]}
           type="button"
@@ -231,6 +247,14 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
             />
           </svg>
         </button>
+        <div
+          className="yst-tooltip yst-tooltip--left yst-hidden"
+          id="Result button edit-tooltip"
+          role="tooltip"
+          variant="dark"
+        >
+          SEOResultEdit
+        </div>
       </div>
     </div>
   </div>
@@ -399,15 +423,19 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
       className="yst-root"
     >
       <div
-        className="yst-relative yst-inline-flex"
+        className="yst-tooltip-container yst-relative yst-inline-flex"
+        onKeyDown={[Function]}
       >
         <button
+          aria-describedby={null}
           aria-label="SEOResult"
           aria-pressed={true}
           className="yst-button yst-button--primary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={true}
           id="Result button"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
           onPointerEnter={[Function]}
           onPointerLeave={[Function]}
           type="button"
@@ -433,6 +461,14 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
             />
           </svg>
         </button>
+        <div
+          className="yst-tooltip yst-tooltip--left yst-hidden"
+          id="Result button-tooltip"
+          role="tooltip"
+          variant="dark"
+        >
+          SEOResult
+        </div>
       </div>
     </div>
   </div>
@@ -596,15 +632,19 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
       className="yst-root"
     >
       <div
-        className="yst-relative yst-inline-flex"
+        className="yst-tooltip-container yst-relative yst-inline-flex"
+        onKeyDown={[Function]}
       >
         <button
+          aria-describedby={null}
           aria-label="SEOResult"
           aria-pressed={true}
           className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={false}
           id="Result button"
+          onBlur={[Function]}
           onClick={[Function]}
+          onFocus={[Function]}
           onPointerEnter={[Function]}
           onPointerLeave={[Function]}
           type="button"
@@ -630,6 +670,14 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
             />
           </svg>
         </button>
+        <div
+          className="yst-tooltip yst-tooltip--left yst-hidden"
+          id="Result button-tooltip"
+          role="tooltip"
+          variant="dark"
+        >
+          SEOResult
+        </div>
       </div>
     </div>
   </div>

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -84,7 +84,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
         <button
           aria-label="SEOResult"
           aria-pressed={true}
-          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={false}
           id="Result button"
           onClick={[Function]}
@@ -207,7 +207,7 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
       >
         <button
           aria-label="SEOResultEdit"
-          className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0"
+          className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0"
           disabled={false}
           id="Result button edit"
           onClick={[Function]}
@@ -404,7 +404,7 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
         <button
           aria-label="SEOResult"
           aria-pressed={true}
-          className="yst-button yst-button--primary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          className="yst-button yst-button--primary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={true}
           id="Result button"
           onClick={[Function]}
@@ -601,7 +601,7 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
         <button
           aria-label="SEOResult"
           aria-pressed={true}
-          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
           disabled={false}
           id="Result button"
           onClick={[Function]}

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -9,49 +9,6 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   flex: none;
 }
 
-.c6 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #a4286a;
-  box-shadow: inset 0 2px 0 rgba( 93,35,122,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c5:hover {
-  border-color: #fff;
-}
-
-.c5:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c4 {
   display: grid;
   grid-template-rows: 1fr;
@@ -118,30 +75,46 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
   <div
     className="c4"
   >
-    <button
-      aria-label="SEOResult"
-      aria-pressed={true}
-      className="c5"
-      disabled={false}
-      id="Result button"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="yst-root"
     >
-      <svg
-        aria-hidden={true}
-        className="c6 yoast-svg-icon yoast-svg-icon-eye"
-        fill="#fff"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="yst-relative yst-inline-flex"
       >
-        <path
-          d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-        />
-      </svg>
-    </button>
+        <button
+          aria-label="SEOResult"
+          aria-pressed={true}
+          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          disabled={false}
+          id="Result button"
+          onClick={[Function]}
+          onPointerEnter={[Function]}
+          onPointerLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="yst-w-4 yst-h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </li>
 `;
@@ -153,42 +126,6 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-}
-
-.c6 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: #ccc;
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c5:hover {
-  border-color: #fff;
 }
 
 .c4 {
@@ -262,28 +199,40 @@ exports[`the AnalysisResult component with a activated premium matches the snaps
   <div
     className="c4"
   >
-    <button
-      aria-label="SEOResultEdit"
-      className="c5"
-      id="Result button edit"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="yst-root"
     >
-      <svg
-        aria-hidden={true}
-        className="c6 yoast-svg-icon yoast-svg-icon-edit"
-        fill="#555"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="yst-relative yst-inline-flex"
       >
-        <path
-          d="M491 1536l91-91-235-235-91 91v107h128v128h107zm523-928q0-22-22-22-10 0-17 7l-542 542q-7 7-7 17 0 22 22 22 10 0 17-7l542-542q7-7 7-17zm-54-192l416 416-832 832h-416v-416zm683 96q0 53-37 90l-166 166-416-416 166-165q36-38 90-38 53 0 91 38l235 234q37 39 37 91z"
-        />
-      </svg>
-    </button>
+        <button
+          aria-label="SEOResultEdit"
+          className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0"
+          disabled={false}
+          id="Result button edit"
+          onClick={[Function]}
+          onPointerEnter={[Function]}
+          onPointerLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="yst-w-4 yst-h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </li>
 `;
@@ -380,49 +329,6 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
   flex: none;
 }
 
-.c6 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #a4286a;
-  box-shadow: inset 0 2px 0 rgba( 93,35,122,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c5:hover {
-  border-color: #fff;
-}
-
-.c5:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c4 {
   display: grid;
   grid-template-rows: 1fr;
@@ -489,30 +395,46 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
   <div
     className="c4"
   >
-    <button
-      aria-label="SEOResult"
-      aria-pressed={true}
-      className="c5"
-      disabled={true}
-      id="Result button"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="yst-root"
     >
-      <svg
-        aria-hidden={true}
-        className="c6 yoast-svg-icon yoast-svg-icon-eye"
-        fill="#ddd"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="yst-relative yst-inline-flex"
       >
-        <path
-          d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-        />
-      </svg>
-    </button>
+        <button
+          aria-label="SEOResult"
+          aria-pressed={true}
+          className="yst-button yst-button--primary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          disabled={true}
+          id="Result button"
+          onClick={[Function]}
+          onPointerEnter={[Function]}
+          onPointerLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="yst-w-4 yst-h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </li>
 `;
@@ -604,49 +526,6 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   flex: none;
 }
 
-.c6 {
-  width: 18px;
-  height: 18px;
-  -webkit-flex: none;
-  -ms-flex: none;
-  flex: none;
-}
-
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #a4286a;
-  box-shadow: inset 0 2px 0 rgba( 93,35,122,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c5:hover {
-  border-color: #fff;
-}
-
-.c5:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c4 {
   display: grid;
   grid-template-rows: 1fr;
@@ -713,30 +592,46 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
   <div
     className="c4"
   >
-    <button
-      aria-label="SEOResult"
-      aria-pressed={true}
-      className="c5"
-      disabled={false}
-      id="Result button"
-      onClick={[Function]}
-      type="button"
+    <div
+      className="yst-root"
     >
-      <svg
-        aria-hidden={true}
-        className="c6 yoast-svg-icon yoast-svg-icon-eye"
-        fill="#fff"
-        focusable="false"
-        role="img"
-        size="18px"
-        viewBox="0 0 1792 1792"
-        xmlns="http://www.w3.org/2000/svg"
+      <div
+        className="yst-relative yst-inline-flex"
       >
-        <path
-          d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-        />
-      </svg>
-    </button>
+        <button
+          aria-label="SEOResult"
+          aria-pressed={true}
+          className="yst-button yst-button--primary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+          disabled={false}
+          id="Result button"
+          onClick={[Function]}
+          onPointerEnter={[Function]}
+          onPointerLeave={[Function]}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="yst-w-4 yst-h-4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   </div>
 </li>
 `;

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -425,15 +425,19 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="1Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -459,6 +463,14 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="1Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -726,15 +738,19 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -760,6 +776,14 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -1194,15 +1218,19 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="1Mark-tooltip"
                 aria-label="Highlighting is currently disabled"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={true}
                 id="1Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -1228,6 +1256,14 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="1Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlighting is currently disabled
+              </div>
             </div>
           </div>
         </div>
@@ -1495,15 +1531,19 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlighting is currently disabled"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={true}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -1529,6 +1569,14 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlighting is currently disabled
+              </div>
             </div>
           </div>
         </div>
@@ -2650,15 +2698,19 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="1Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -2684,6 +2736,14 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="1Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -2951,15 +3011,19 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -2985,6 +3049,14 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -3459,15 +3531,19 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="1Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -3493,6 +3569,14 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="1Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -3760,15 +3844,19 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -3794,6 +3882,14 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -4228,15 +4324,19 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="1Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -4262,6 +4362,14 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="1Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -4529,15 +4637,19 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -4563,6 +4675,14 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -5079,15 +5199,19 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -5113,6 +5237,14 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -5629,15 +5761,19 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -5663,6 +5799,14 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -6268,15 +6412,19 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -6302,6 +6450,14 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>
@@ -6729,15 +6885,19 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
             className="yst-root"
           >
             <div
-              className="yst-relative yst-inline-flex"
+              className="yst-tooltip-container yst-relative yst-inline-flex"
+              onKeyDown={[Function]}
             >
               <button
+                aria-describedby="3Mark-tooltip"
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
                 className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
+                onBlur={[Function]}
                 onClick={[Function]}
+                onFocus={[Function]}
                 onPointerEnter={[Function]}
                 onPointerLeave={[Function]}
                 type="button"
@@ -6763,6 +6923,14 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
                   />
                 </svg>
               </button>
+              <div
+                className="yst-tooltip yst-tooltip--left yst-hidden"
+                id="3Mark-tooltip"
+                role="tooltip"
+                variant="dark"
+              >
+                Highlight this result in the text
+              </div>
             </div>
           </div>
         </div>

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -139,41 +139,6 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
   margin-left: 8px;
 }
 
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c22:hover {
-  border-color: #fff;
-}
-
-.c22:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -257,6 +222,19 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
   color: #1e1e1e;
 }
 
+.c22 {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #1e1e1e !important;
+}
+
+.c22 .c13 {
+  font-weight: 500;
+  color: #1e1e1e;
+}
+
 .c23 {
   margin: 0 !important;
   padding: 0 !important;
@@ -279,19 +257,6 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
 }
 
 .c24 .c13 {
-  font-weight: 500;
-  color: #1e1e1e;
-}
-
-.c25 {
-  margin: 0 !important;
-  padding: 0 !important;
-  font-size: 13px !important;
-  font-weight: 500 !important;
-  color: #1e1e1e !important;
-}
-
-.c25 .c13 {
   font-weight: 500;
   color: #1e1e1e;
 }
@@ -456,30 +421,46 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="1Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="1Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -488,7 +469,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
     className="c1 c2"
   >
     <h4
-      className="c23"
+      className="c22"
     >
       <button
         aria-expanded={true}
@@ -564,7 +545,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
     className="c1 c2"
   >
     <h4
-      className="c24"
+      className="c23"
     >
       <button
         aria-expanded={true}
@@ -640,7 +621,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
     className="c1 c2"
   >
     <h4
-      className="c25"
+      className="c24"
     >
       <button
         aria-expanded={true}
@@ -741,30 +722,46 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -911,41 +908,6 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   margin-left: 8px;
 }
 
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c22:hover {
-  border-color: #fff;
-}
-
-.c22:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -1029,6 +991,19 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
   color: #1e1e1e;
 }
 
+.c22 {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #1e1e1e !important;
+}
+
+.c22 .c13 {
+  font-weight: 500;
+  color: #1e1e1e;
+}
+
 .c23 {
   margin: 0 !important;
   padding: 0 !important;
@@ -1051,19 +1026,6 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
 }
 
 .c24 .c13 {
-  font-weight: 500;
-  color: #1e1e1e;
-}
-
-.c25 {
-  margin: 0 !important;
-  padding: 0 !important;
-  font-size: 13px !important;
-  font-weight: 500 !important;
-  color: #1e1e1e !important;
-}
-
-.c25 .c13 {
   font-weight: 500;
   color: #1e1e1e;
 }
@@ -1228,30 +1190,46 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlighting is currently disabled"
-            aria-pressed={false}
-            className="c22"
-            disabled={true}
-            id="1Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#ddd"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlighting is currently disabled"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={true}
+                id="1Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -1260,7 +1238,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
     className="c1 c2"
   >
     <h4
-      className="c23"
+      className="c22"
     >
       <button
         aria-expanded={true}
@@ -1336,7 +1314,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
     className="c1 c2"
   >
     <h4
-      className="c24"
+      className="c23"
     >
       <button
         aria-expanded={true}
@@ -1412,7 +1390,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
     className="c1 c2"
   >
     <h4
-      className="c25"
+      className="c24"
     >
       <button
         aria-expanded={true}
@@ -1513,30 +1491,46 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlighting is currently disabled"
-            aria-pressed={false}
-            className="c22"
-            disabled={true}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#ddd"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlighting is currently disabled"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={true}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -2370,41 +2364,6 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   margin-left: 8px;
 }
 
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c22:hover {
-  border-color: #fff;
-}
-
-.c22:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -2488,6 +2447,19 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
   color: #1e1e1e;
 }
 
+.c22 {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #1e1e1e !important;
+}
+
+.c22 .c13 {
+  font-weight: 500;
+  color: #1e1e1e;
+}
+
 .c23 {
   margin: 0 !important;
   padding: 0 !important;
@@ -2510,19 +2482,6 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
 }
 
 .c24 .c13 {
-  font-weight: 500;
-  color: #1e1e1e;
-}
-
-.c25 {
-  margin: 0 !important;
-  padding: 0 !important;
-  font-size: 13px !important;
-  font-weight: 500 !important;
-  color: #1e1e1e !important;
-}
-
-.c25 .c13 {
   font-weight: 500;
   color: #1e1e1e;
 }
@@ -2687,30 +2646,46 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="1Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="1Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -2719,7 +2694,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
     className="c1 c2"
   >
     <h3
-      className="c23"
+      className="c22"
     >
       <button
         aria-expanded={true}
@@ -2795,7 +2770,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
     className="c1 c2"
   >
     <h3
-      className="c24"
+      className="c23"
     >
       <button
         aria-expanded={true}
@@ -2871,7 +2846,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
     className="c1 c2"
   >
     <h3
-      className="c25"
+      className="c24"
     >
       <button
         aria-expanded={true}
@@ -2972,30 +2947,46 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -3142,41 +3133,6 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
   margin-left: 8px;
 }
 
-.c23 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c23:hover {
-  border-color: #fff;
-}
-
-.c23:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -3268,6 +3224,19 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
   color: #1e1e1e;
 }
 
+.c23 {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #1e1e1e !important;
+}
+
+.c23 .c13 {
+  font-weight: 500;
+  color: #1e1e1e;
+}
+
 .c24 {
   margin: 0 !important;
   padding: 0 !important;
@@ -3290,19 +3259,6 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
 }
 
 .c25 .c13 {
-  font-weight: 500;
-  color: #1e1e1e;
-}
-
-.c26 {
-  margin: 0 !important;
-  padding: 0 !important;
-  font-size: 13px !important;
-  font-weight: 500 !important;
-  color: #1e1e1e !important;
-}
-
-.c26 .c13 {
   font-weight: 500;
   color: #1e1e1e;
 }
@@ -3499,30 +3455,46 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c23"
-            disabled={false}
-            id="1Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="1Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -3531,7 +3503,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
     className="c1 c2"
   >
     <h4
-      className="c24"
+      className="c23"
     >
       <button
         aria-expanded={true}
@@ -3607,7 +3579,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
     className="c1 c2"
   >
     <h4
-      className="c25"
+      className="c24"
     >
       <button
         aria-expanded={true}
@@ -3683,7 +3655,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
     className="c1 c2"
   >
     <h4
-      className="c26"
+      className="c25"
     >
       <button
         aria-expanded={true}
@@ -3784,30 +3756,46 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c23"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -3954,41 +3942,6 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   margin-left: 8px;
 }
 
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c22:hover {
-  border-color: #fff;
-}
-
-.c22:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -4072,6 +4025,19 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
   color: #1e1e1e;
 }
 
+.c22 {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #1e1e1e !important;
+}
+
+.c22 .c13 {
+  font-weight: 500;
+  color: #1e1e1e;
+}
+
 .c23 {
   margin: 0 !important;
   padding: 0 !important;
@@ -4094,19 +4060,6 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
 }
 
 .c24 .c13 {
-  font-weight: 500;
-  color: #1e1e1e;
-}
-
-.c25 {
-  margin: 0 !important;
-  padding: 0 !important;
-  font-size: 13px !important;
-  font-weight: 500 !important;
-  color: #1e1e1e !important;
-}
-
-.c25 .c13 {
   font-weight: 500;
   color: #1e1e1e;
 }
@@ -4271,30 +4224,46 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="1Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="1Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -4303,7 +4272,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
     className="c1 c2"
   >
     <h4
-      className="c23"
+      className="c22"
     >
       <button
         aria-expanded={true}
@@ -4379,7 +4348,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
     className="c1 c2"
   >
     <h4
-      className="c24"
+      className="c23"
     >
       <button
         aria-expanded={true}
@@ -4455,7 +4424,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
     className="c1 c2"
   >
     <h4
-      className="c25"
+      className="c24"
     >
       <button
         aria-expanded={true}
@@ -4556,30 +4525,46 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -4726,41 +4711,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
   margin-left: 8px;
 }
 
-.c23 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c23:hover {
-  border-color: #fff;
-}
-
-.c23:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
-}
-
 .c20 {
   display: grid;
   grid-template-rows: 1fr;
@@ -5125,30 +5075,46 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c23"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -5293,41 +5259,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
 
 .c10 svg:last-child {
   margin-left: 8px;
-}
-
-.c23 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c23:hover {
-  border-color: #fff;
-}
-
-.c23:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
 }
 
 .c20 {
@@ -5694,30 +5625,46 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c23"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -5862,41 +5809,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
 
 .c10 svg:last-child {
   margin-left: 8px;
-}
-
-.c24 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c24:hover {
-  border-color: #fff;
-}
-
-.c24:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
 }
 
 .c20 {
@@ -6352,30 +6264,46 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c24"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>
@@ -6520,41 +6448,6 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
 
 .c10 svg:last-child {
   margin-left: 8px;
-}
-
-.c22 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  box-sizing: border-box;
-  min-width: 32px;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  border: 1px solid #ccc;
-  background-color: #f7f7f7;
-  box-shadow: 0 1px 0 rgba( 204,204,204,0.7 );
-  border-radius: 3px;
-  cursor: pointer;
-  padding: 0;
-  height: 24px;
-}
-
-.c22:hover {
-  border-color: #fff;
-}
-
-.c22:disabled {
-  background-color: #f7f7f7;
-  box-shadow: none;
-  border: none;
-  cursor: default;
 }
 
 .c20 {
@@ -6832,30 +6725,46 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
         <div
           className="c20"
         >
-          <button
-            aria-label="Highlight this result in the text"
-            aria-pressed={false}
-            className="c22"
-            disabled={false}
-            id="3Mark"
-            onClick={[Function]}
-            type="button"
+          <div
+            className="yst-root"
           >
-            <svg
-              aria-hidden={true}
-              className="c11 yoast-svg-icon yoast-svg-icon-eye"
-              fill="#555"
-              focusable="false"
-              role="img"
-              size="18px"
-              viewBox="0 0 1792 1792"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              className="yst-relative yst-inline-flex"
             >
-              <path
-                d="M1664 960q-152-236-381-353 61 104 61 225 0 185-131.5 316.5t-316.5 131.5-316.5-131.5-131.5-316.5q0-121 61-225-229 117-381 353 133 205 333.5 326.5t434.5 121.5 434.5-121.5 333.5-326.5zm-720-384q0-20-14-34t-34-14q-125 0-214.5 89.5t-89.5 214.5q0 20 14 34t34 14 34-14 14-34q0-86 61-147t147-61q20 0 34-14t14-34zm848 384q0 34-20 69-140 230-376.5 368.5t-499.5 138.5-499.5-139-376.5-368q-20-35-20-69t20-69q140-229 376.5-368t499.5-139 499.5 139 376.5 368q20 35 20 69z"
-              />
-            </svg>
-          </button>
+              <button
+                aria-label="Highlight this result in the text"
+                aria-pressed={false}
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                disabled={false}
+                id="3Mark"
+                onClick={[Function]}
+                onPointerEnter={[Function]}
+                onPointerLeave={[Function]}
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="yst-w-4 yst-h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                  <path
+                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
         </div>
       </li>
     </ul>

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -430,7 +430,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
                 onClick={[Function]}
@@ -731,7 +731,7 @@ exports[`ContentAnalysis the ContentAnalysis component with custom result catego
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -1199,7 +1199,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
               <button
                 aria-label="Highlighting is currently disabled"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={true}
                 id="1Mark"
                 onClick={[Function]}
@@ -1500,7 +1500,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
               <button
                 aria-label="Highlighting is currently disabled"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-button--disabled yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={true}
                 id="3Mark"
                 onClick={[Function]}
@@ -2655,7 +2655,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
                 onClick={[Function]}
@@ -2956,7 +2956,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -3464,7 +3464,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
                 onClick={[Function]}
@@ -3765,7 +3765,7 @@ exports[`ContentAnalysis the ContentAnalysis component with upsell results match
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -4233,7 +4233,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="1Mark"
                 onClick={[Function]}
@@ -4534,7 +4534,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -5084,7 +5084,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -5634,7 +5634,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -6273,7 +6273,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}
@@ -6734,7 +6734,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
               <button
                 aria-label="Highlight this result in the text"
                 aria-pressed={false}
-                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10"
+                className="yst-button yst-button--secondary yst-button--small yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10"
                 disabled={false}
                 id="3Mark"
                 onClick={[Function]}

--- a/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/InclusiveLanguageAnalysis.js
@@ -87,7 +87,6 @@ const InclusiveLanguageAnalysis = ( {
 				</AnalysisHeader>
 				<Results
 					results={ results }
-					marksButtonClassName="yoast-tooltip yoast-tooltip-w"
 					marksButtonStatus={ marksButtonStatus }
 					resultCategoryLabels={ {
 						problems: __( "Non-inclusive", "wordpress-seo" ),

--- a/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/ReadabilityAnalysis.js
@@ -71,7 +71,6 @@ class ReadabilityAnalysis extends Component {
 				<Results
 					results={ this.props.results }
 					upsellResults={ upsellResults }
-					marksButtonClassName="yoast-tooltip yoast-tooltip-w"
 					marksButtonStatus={ this.props.marksButtonStatus }
 					location={ location }
 					id={ location ? `yoast-readability-analysis-results-${ location }` : "" }

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -1,7 +1,6 @@
 import { ContentAnalysis } from "@yoast/analysis-report";
-import { IconButtonToggle } from "@yoast/components";
-import { Badge } from "@yoast/ui-library";
-import { LockClosedIcon } from "@heroicons/react/solid";
+import { Badge, Button } from "@yoast/ui-library";
+import { EyeIcon, LockClosedIcon } from "@heroicons/react/solid";
 import { __ } from "@wordpress/i18n";
 import { Component, Fragment } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
@@ -85,15 +84,18 @@ class Results extends Component {
 		isPressed,
 	} ) {
 		return <Fragment>
-			<IconButtonToggle
-				marksButtonStatus={ status }
+			<Button
+				variant="secondary"
+				size="small"
+				disabled={ status === "disabled" }
 				className={ className }
 				onClick={ onClick }
 				id={ id }
-				icon="eye"
-				pressed={ isPressed }
-				ariaLabel={ ariaLabel }
-			/>
+				aria-pressed={ isPressed }
+				aria-label={ ariaLabel }
+			>
+				<EyeIcon className="yst-w-[18px] yst-h-[18px]" />
+			</Button>
 			{ this.props.shouldUpsellHighlighting &&
 				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">
 					<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" role="img" aria-hidden={ true } focusable={ false } />

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -1,6 +1,8 @@
 import { ContentAnalysis } from "@yoast/analysis-report";
 import { Badge, Button } from "@yoast/ui-library";
-import { EyeIcon, LockClosedIcon } from "@heroicons/react/solid";
+import { EyeIcon } from "@heroicons/react/outline";
+import { LockClosedIcon } from "@heroicons/react/solid";
+import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
 import { Component, Fragment } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
@@ -85,16 +87,17 @@ class Results extends Component {
 	} ) {
 		return <Fragment>
 			<Button
-				variant="secondary"
+				variant={ isPressed ? "primary" : "secondary" }
 				size="small"
-				icon={ EyeIcon }
-				className={ className }
+				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
 				onClick={ onClick }
 				id={ id }
 				disabled={ status === "disabled" }
 				aria-pressed={ isPressed }
 				aria-label={ ariaLabel }
-			/>
+			>
+				<EyeIcon className="yst-w-4 yst-h-4" />
+			</Button>
 			{ this.props.shouldUpsellHighlighting &&
 				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">
 					<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" role="img" aria-hidden={ true } focusable={ false } />

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -4,7 +4,7 @@ import { EyeIcon } from "@heroicons/react/outline";
 import { LockClosedIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
-import { Component, Fragment, useState } from "@wordpress/element";
+import { Component, Fragment, useCallback, useState } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 
 import { isUndefined } from "lodash";
@@ -24,13 +24,15 @@ import { PremiumSEOAnalysisModal } from "../modals/PremiumSEOAnalysisModal";
 const MarkButtonWithUpsell = ( {
 	ariaLabel,
 	id,
-	className,
-	status,
+	className = "",
+	status = "enabled",
 	onClick,
 	isPressed,
-	shouldUpsellHighlighting,
+	shouldUpsellHighlighting = false,
 } ) => {
 	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
+	const showTooltip = useCallback( () => setIsTooltipOpen( true ), [] );
+	const hideTooltip = useCallback( () => setIsTooltipOpen( false ), [] );
 
 	return <Root>
 		<div className="yst-relative yst-inline-flex">
@@ -43,8 +45,8 @@ const MarkButtonWithUpsell = ( {
 				disabled={ status === "disabled" }
 				aria-pressed={ isPressed }
 				aria-label={ ariaLabel }
-				onPointerEnter={ () => setIsTooltipOpen( true ) }
-				onPointerLeave={ () => setIsTooltipOpen( false ) }
+				onPointerEnter={ showTooltip }
+				onPointerLeave={ hideTooltip }
 			>
 				<EyeIcon className="yst-w-4 yst-h-4" />
 			</Button>
@@ -72,12 +74,6 @@ MarkButtonWithUpsell.propTypes = {
 	onClick: PropTypes.func.isRequired,
 	isPressed: PropTypes.bool.isRequired,
 	shouldUpsellHighlighting: PropTypes.bool,
-};
-
-MarkButtonWithUpsell.defaultProps = {
-	className: "",
-	status: "enabled",
-	shouldUpsellHighlighting: false,
 };
 
 /**

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -87,15 +87,14 @@ class Results extends Component {
 			<Button
 				variant="secondary"
 				size="small"
-				disabled={ status === "disabled" }
+				icon={ EyeIcon }
 				className={ className }
 				onClick={ onClick }
 				id={ id }
+				disabled={ status === "disabled" }
 				aria-pressed={ isPressed }
 				aria-label={ ariaLabel }
-			>
-				<EyeIcon className="yst-w-[18px] yst-h-[18px]" />
-			</Button>
+			/>
 			{ this.props.shouldUpsellHighlighting &&
 				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">
 					<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" role="img" aria-hidden={ true } focusable={ false } />

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -40,7 +40,7 @@ const MarkButtonWithUpsell = ( {
 			<Button
 				variant={ isPressed ? "primary" : "secondary" }
 				size="small"
-				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+				className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
 				onClick={ onClick }
 				id={ id }
 				disabled={ status === "disabled" }

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -1,10 +1,10 @@
 import { ContentAnalysis } from "@yoast/analysis-report";
-import { Badge, Button, Root, Tooltip } from "@yoast/ui-library";
+import { Badge, Button, Root, TooltipContainer, TooltipWithContext, useTooltipContext } from "@yoast/ui-library";
 import { EyeIcon } from "@heroicons/react/outline";
 import { LockClosedIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
-import { Component, Fragment, useCallback, useState } from "@wordpress/element";
+import { Component, Fragment, useCallback } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 
 import { isUndefined } from "lodash";
@@ -15,13 +15,67 @@ import mapResults from "./mapResults";
 import { PremiumSEOAnalysisModal } from "../modals/PremiumSEOAnalysisModal";
 
 /**
+ * Inner mark button that accesses the TooltipContainer context.
+ *
+ * @param {string} ariaLabel 	The button aria-label.
+ * @param {string} id 			The button id.
+ * @param {string} className 	The button class name.
+ * @param {string} status 		Status of the buttons. Supports: "enabled", "disabled", "hidden".
+ * @param {function} onClick 	Onclick handler.
+ * @param {boolean} isPressed 	Whether the button is in a pressed state.
+ *
+ * @returns {JSX.Element} The inner mark button with tooltip context.
+ */
+const MarkButtonInner = ( { ariaLabel, id, className = "", status = "enabled", onClick, isPressed } ) => {
+	const { show, hide } = useTooltipContext();
+	const tooltipId = `${ id }-tooltip`;
+
+	const handleShow = useCallback( () => {
+		if ( ! isPressed ) {
+			show();
+		}
+	}, [ isPressed, show ] );
+
+	return <>
+		<Button
+			variant={ isPressed ? "primary" : "secondary" }
+			size="small"
+			className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+			onClick={ onClick }
+			id={ id }
+			disabled={ status === "disabled" }
+			aria-pressed={ isPressed }
+			aria-label={ ariaLabel }
+			aria-describedby={ isPressed ? null : tooltipId }
+			onPointerEnter={ handleShow }
+			onPointerLeave={ hide }
+			onFocus={ handleShow }
+			onBlur={ hide }
+		>
+			<EyeIcon className="yst-w-4 yst-h-4" />
+		</Button>
+		<TooltipWithContext id={ tooltipId } position="left">
+			{ ariaLabel }
+		</TooltipWithContext>
+	</>;
+};
+
+MarkButtonInner.propTypes = {
+	ariaLabel: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	status: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+	isPressed: PropTypes.bool.isRequired,
+};
+
+/**
  * Mark button with optional upsell badge and tooltip.
  *
  * @param {Object} props The component props.
  *
  * @returns {JSX.Element} The mark button.
  */
-// eslint-disable-next-line complexity -- Component has straightforward branching for button variant, tooltip, and upsell badge.
 const MarkButtonWithUpsell = ( {
 	ariaLabel,
 	id,
@@ -31,32 +85,17 @@ const MarkButtonWithUpsell = ( {
 	isPressed,
 	shouldUpsellHighlighting = false,
 } ) => {
-	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
-	const showTooltip = useCallback( () => setIsTooltipOpen( true ), [] );
-	const hideTooltip = useCallback( () => setIsTooltipOpen( false ), [] );
-
 	return <Root>
-		<div className="yst-relative yst-inline-flex">
-			<Button
-				variant={ isPressed ? "primary" : "secondary" }
-				size="small"
-				className={ classNames( className, "yst-px-2 yst-rounded-md yst-shadow-none yst-border-0 focus:yst-z-10" ) }
-				onClick={ onClick }
+		<TooltipContainer as="div" className="yst-relative yst-inline-flex">
+			<MarkButtonInner
+				ariaLabel={ ariaLabel }
 				id={ id }
-				disabled={ status === "disabled" }
-				aria-pressed={ isPressed }
-				aria-label={ ariaLabel }
-				onPointerEnter={ showTooltip }
-				onPointerLeave={ hideTooltip }
-			>
-				<EyeIcon className="yst-w-4 yst-h-4" />
-			</Button>
-			{ isTooltipOpen && ! isPressed && (
-				<Tooltip position="left">
-					{ ariaLabel }
-				</Tooltip>
-			) }
-		</div>
+				className={ className }
+				status={ status }
+				onClick={ onClick }
+				isPressed={ isPressed }
+			/>
+		</TooltipContainer>
 		{ shouldUpsellHighlighting &&
 			<div>
 				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -1,10 +1,10 @@
 import { ContentAnalysis } from "@yoast/analysis-report";
-import { Badge, Button } from "@yoast/ui-library";
+import { Badge, Button, Root, Tooltip } from "@yoast/ui-library";
 import { EyeIcon } from "@heroicons/react/outline";
 import { LockClosedIcon } from "@heroicons/react/solid";
 import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
-import { Component, Fragment } from "@wordpress/element";
+import { Component, Fragment, useState } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";
 
 import { isUndefined } from "lodash";
@@ -13,6 +13,72 @@ import { Paper } from "yoastseo";
 
 import mapResults from "./mapResults";
 import { PremiumSEOAnalysisModal } from "../modals/PremiumSEOAnalysisModal";
+
+/**
+ * Mark button with optional upsell badge and tooltip.
+ *
+ * @param {Object} props The component props.
+ *
+ * @returns {JSX.Element} The mark button.
+ */
+const MarkButtonWithUpsell = ( {
+	ariaLabel,
+	id,
+	className,
+	status,
+	onClick,
+	isPressed,
+	shouldUpsellHighlighting,
+} ) => {
+	const [ isTooltipOpen, setIsTooltipOpen ] = useState( false );
+
+	return <Root>
+		<div className="yst-relative yst-inline-flex">
+			<Button
+				variant={ isPressed ? "primary" : "secondary" }
+				size="small"
+				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
+				onClick={ onClick }
+				id={ id }
+				disabled={ status === "disabled" }
+				aria-pressed={ isPressed }
+				aria-label={ ariaLabel }
+				onPointerEnter={ () => setIsTooltipOpen( true ) }
+				onPointerLeave={ () => setIsTooltipOpen( false ) }
+			>
+				<EyeIcon className="yst-w-4 yst-h-4" />
+			</Button>
+			{ isTooltipOpen && ! isPressed && (
+				<Tooltip position="left">
+					{ ariaLabel }
+				</Tooltip>
+			) }
+		</div>
+		{ shouldUpsellHighlighting &&
+			<div>
+				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">
+					<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" role="img" aria-hidden={ true } focusable={ false } />
+				</Badge>
+			</div>
+		}
+	</Root>;
+};
+
+MarkButtonWithUpsell.propTypes = {
+	ariaLabel: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	className: PropTypes.string,
+	status: PropTypes.string,
+	onClick: PropTypes.func.isRequired,
+	isPressed: PropTypes.bool.isRequired,
+	shouldUpsellHighlighting: PropTypes.bool,
+};
+
+MarkButtonWithUpsell.defaultProps = {
+	className: "",
+	status: "enabled",
+	shouldUpsellHighlighting: false,
+};
 
 /**
  * Wrapper to provide functionality to the ContentAnalysis component.
@@ -85,25 +151,15 @@ class Results extends Component {
 		onClick,
 		isPressed,
 	} ) {
-		return <Fragment>
-			<Button
-				variant={ isPressed ? "primary" : "secondary" }
-				size="small"
-				className={ classNames( className, "yst-px-2 yst-rounded-lg yst-shadow-none yst-border-0 focus:yst-z-10" ) }
-				onClick={ onClick }
-				id={ id }
-				disabled={ status === "disabled" }
-				aria-pressed={ isPressed }
-				aria-label={ ariaLabel }
-			>
-				<EyeIcon className="yst-w-4 yst-h-4" />
-			</Button>
-			{ this.props.shouldUpsellHighlighting &&
-				<Badge className="yst-absolute yst-px-[3px] yst-py-[3px] yst--end-[6.5px] yst--top-[6.5px]" size="small" variant="upsell">
-					<LockClosedIcon className="yst-w-2.5 yst-h-2.5 yst-shrink-0" role="img" aria-hidden={ true } focusable={ false } />
-				</Badge>
-			}
-		</Fragment>;
+		return <MarkButtonWithUpsell
+			ariaLabel={ ariaLabel }
+			id={ id }
+			className={ className }
+			status={ status }
+			onClick={ onClick }
+			isPressed={ isPressed }
+			shouldUpsellHighlighting={ this.props.shouldUpsellHighlighting }
+		/>;
 	}
 
 	/**

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -21,6 +21,7 @@ import { PremiumSEOAnalysisModal } from "../modals/PremiumSEOAnalysisModal";
  *
  * @returns {JSX.Element} The mark button.
  */
+// eslint-disable-next-line complexity -- Component has straightforward branching for button variant, tooltip, and upsell badge.
 const MarkButtonWithUpsell = ( {
 	ariaLabel,
 	id,

--- a/packages/js/src/components/contentAnalysis/SeoAnalysis.js
+++ b/packages/js/src/components/contentAnalysis/SeoAnalysis.js
@@ -119,8 +119,6 @@ class SeoAnalysis extends Component {
 											</AnalysisHeader>
 											<Results
 												results={ this.props.results }
-												marksButtonClassName="yoast-tooltip yoast-tooltip-w"
-												editButtonClassName="yoast-tooltip yoast-tooltip-w"
 												marksButtonStatus={ this.props.marksButtonStatus }
 												location={ location }
 												id={ `yoast-seo-analysis-results-${ location }` }

--- a/packages/ui-library/src/components/tooltip-container/index.js
+++ b/packages/ui-library/src/components/tooltip-container/index.js
@@ -155,6 +155,9 @@ export const TooltipWithContext = ( { className = "", children = null, ...props 
 	const tooltipRef = useRef();
 
 	useEffect( () => {
+		if ( ! tooltipRef.current ) {
+			return;
+		}
 		const rect = tooltipRef.current.getBoundingClientRect();
 		setTooltipPosition( {
 			top: rect.top,

--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -33,6 +33,7 @@ export const classNameMap = {
  * @param {boolean} [isLoading=false] Whether to show a spinner.
  * @param {boolean} [disabled=false] Whether the button is disabled.
  * @param {string} [className=""] CSS class.
+ * @param {JSX.elementType} [icon=null] Optional icon component rendered before children.
  * @returns {JSX.Element} Button component.
  */
 const Button = forwardRef( ( {
@@ -44,6 +45,7 @@ const Button = forwardRef( ( {
 	isLoading,
 	disabled,
 	className,
+	icon: Icon,
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -65,13 +67,14 @@ const Button = forwardRef( ( {
 	>
 		{ isLoading && <Spinner size={ size === "small" ? "3" : "4" } className="yst-button--loading"  { ...svgAriaProps } /> }
 		{ variant.startsWith( "ai-" ) && <SparklesIcon className="yst-button--sparkles-icon yst-shrink-0" { ...svgAriaProps } /> }
+		{ Icon && <Icon className="yst-button--icon" { ...svgAriaProps } /> }
 		{ children }
 	</Component>;
 } );
 
 Button.displayName = "Button";
 Button.propTypes = {
-	children: PropTypes.node.isRequired,
+	children: PropTypes.node,
 	as: PropTypes.elementType,
 	type: PropTypes.oneOf( [ "button", "submit", "reset" ] ),
 	variant: PropTypes.oneOf( keys( classNameMap.variant ) ),
@@ -79,8 +82,10 @@ Button.propTypes = {
 	isLoading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
+	icon: PropTypes.elementType,
 };
 Button.defaultProps = {
+	children: null,
 	as: "button",
 	// eslint-disable-next-line no-undefined
 	type: undefined,
@@ -89,6 +94,7 @@ Button.defaultProps = {
 	isLoading: false,
 	disabled: false,
 	className: "",
+	icon: null,
 };
 
 export default Button;

--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -33,7 +33,6 @@ export const classNameMap = {
  * @param {boolean} [isLoading=false] Whether to show a spinner.
  * @param {boolean} [disabled=false] Whether the button is disabled.
  * @param {string} [className=""] CSS class.
- * @param {JSX.elementType} [icon=null] Optional icon component rendered before children.
  * @returns {JSX.Element} Button component.
  */
 const Button = forwardRef( ( {
@@ -45,7 +44,6 @@ const Button = forwardRef( ( {
 	isLoading,
 	disabled,
 	className,
-	icon: Icon,
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -67,14 +65,13 @@ const Button = forwardRef( ( {
 	>
 		{ isLoading && <Spinner size={ size === "small" ? "3" : "4" } className="yst-button--loading"  { ...svgAriaProps } /> }
 		{ variant.startsWith( "ai-" ) && <SparklesIcon className="yst-button--sparkles-icon yst-shrink-0" { ...svgAriaProps } /> }
-		{ Icon && <Icon className={ size === "small" ? "yst-w-4 yst-h-4" : "yst-w-5 yst-h-5" } { ...svgAriaProps } /> }
 		{ children }
 	</Component>;
 } );
 
 Button.displayName = "Button";
 Button.propTypes = {
-	children: PropTypes.node,
+	children: PropTypes.node.isRequired,
 	as: PropTypes.elementType,
 	type: PropTypes.oneOf( [ "button", "submit", "reset" ] ),
 	variant: PropTypes.oneOf( keys( classNameMap.variant ) ),
@@ -82,10 +79,8 @@ Button.propTypes = {
 	isLoading: PropTypes.bool,
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
-	icon: PropTypes.elementType,
 };
 Button.defaultProps = {
-	children: null,
 	as: "button",
 	// eslint-disable-next-line no-undefined
 	type: undefined,
@@ -94,7 +89,6 @@ Button.defaultProps = {
 	isLoading: false,
 	disabled: false,
 	className: "",
-	icon: null,
 };
 
 export default Button;

--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -67,7 +67,7 @@ const Button = forwardRef( ( {
 	>
 		{ isLoading && <Spinner size={ size === "small" ? "3" : "4" } className="yst-button--loading"  { ...svgAriaProps } /> }
 		{ variant.startsWith( "ai-" ) && <SparklesIcon className="yst-button--sparkles-icon yst-shrink-0" { ...svgAriaProps } /> }
-		{ Icon && <Icon className="yst-button--icon" { ...svgAriaProps } /> }
+		{ Icon && <Icon className={ size === "small" ? "yst-w-4 yst-h-4" : "yst-w-5 yst-h-5" } { ...svgAriaProps } /> }
 		{ children }
 	</Component>;
 } );

--- a/packages/ui-library/src/elements/button/style.css
+++ b/packages/ui-library/src/elements/button/style.css
@@ -210,4 +210,14 @@
 		yst--ms-1
 		yst-me-2;
 	}
+
+	/* Icon sizing */
+
+	.yst-button--icon {
+		@apply yst-w-[18px] yst-h-[18px];
+	}
+
+	.yst-button--small .yst-button--icon {
+		@apply yst-w-4 yst-h-4;
+	}
 }

--- a/packages/ui-library/src/elements/button/style.css
+++ b/packages/ui-library/src/elements/button/style.css
@@ -211,13 +211,4 @@
 		yst-me-2;
 	}
 
-	/* Icon sizing */
-
-	.yst-button--icon {
-		@apply yst-w-[18px] yst-h-[18px];
-	}
-
-	.yst-button--small .yst-button--icon {
-		@apply yst-w-4 yst-h-4;
-	}
 }


### PR DESCRIPTION
## Context

As part of the effort to move away from legacy `@yoast/components`, this PR replaces the Highlight (mark) button and Edit button in content analysis results with the `Button` component from `@yoast/ui-library`, using `@heroicons/react` icons (`EyeIcon`, `PencilIcon`). It also replaces the legacy CSS tooltip classes with the `TooltipContainer`/`TooltipWithContext` components from `@yoast/ui-library`, providing keyboard-accessible tooltips.

## Summary

This PR can be summarized in the following changelog entry:

* changelog: enhancement - Replaces legacy `IconButtonToggle` and `IconCTAEditButton` components with `@yoast/ui-library` `Button`, `TooltipContainer`, and `@heroicons/react` icons in content analysis results.

## Relevant technical choices:

### Button replacement
* Replaced `IconButtonToggle` (highlight button) with `Button` variant="secondary"/"primary" size="small" + `EyeIcon` from `@heroicons/react/outline`
* Replaced `IconCTAEditButton` (edit button) with `Button` variant="secondary" size="small" + `PencilIcon` from `@heroicons/react/outline`
* Button styling uses `yst-px-2 yst-rounded-md yst-shadow-none yst-border-0` to match the AI optimize button appearance
* Highlight button toggles between `variant="secondary"` (unpressed) and `variant="primary"` (pressed)

### Tooltip replacement
* Uses `TooltipContainer`/`useTooltipContext()`/`TooltipWithContext` from `@yoast/ui-library`
* `MarkButtonInner` and `EditButtonInner` components consume `useTooltipContext()` for `show`/`hide`
* Tooltips support both pointer (`onPointerEnter`/`onPointerLeave`) and keyboard (`onFocus`/`onBlur`)
* Proper `aria-describedby` wiring links buttons to their tooltips
* Mark button tooltip is hidden when pressed (active highlighting state)
* `TooltipContainer` provides Escape key dismissal automatically
* Each button+tooltip pair is wrapped in `<Root>` from `@yoast/ui-library` to ensure the Tailwind preflight CSS (`.yst-root ::before { border-width: 0 }`) is properly scoped, which is required for the tooltip arrow to render correctly

### Component restructuring
* `MarkButtonInner` + `MarkButton` wrapper pattern in `AnalysisResult.js`
* `EditButtonInner` component in `AnalysisResult.js`
* `MarkButtonInner` + `MarkButtonWithUpsell` wrapper pattern in `Results.js`
* Null guard added to `TooltipWithContext` in tooltip-container for test compatibility
* Removed now-unnecessary `marksButtonClassName=""` and `editButtonClassName=""` props from `SeoAnalysis.js`, `ReadabilityAnalysis.js`, and `InclusiveLanguageAnalysis.js` (the defaults in `Results.js` are already `""`)

### Dependencies
* Added `@heroicons/react`, `@yoast/ui-library`, and `classnames` as dependencies to `@yoast/analysis-report` package.json

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open a post/page in the editor (Block or Classic)
* Verify the SEO analysis and Readability analysis results display correctly
* Verify the **highlight (eye) button** renders with the outlined eye icon and is clickable
* Verify hovering over the highlight button shows a tooltip with "Highlight this result in the text" and a left-pointing arrow
* Verify clicking the highlight button toggles text highlighting in the editor and the button switches to primary (filled) style
* Verify the tooltip is hidden when the button is in pressed/active state
* Verify the highlight button shows a disabled state when appropriate (e.g. when shortcodes are being parsed)
* Verify the **edit (pencil) button** renders with the outlined pencil icon and is clickable (Premium only)
* Verify hovering over the edit button shows a tooltip with the appropriate label and arrow
* Verify clicking the edit button navigates to the relevant input field
* Verify tooltip appears when **tabbing** to the highlight/edit button (keyboard focus)
* Verify tooltip disappears when tabbing away (blur)
* Verify pressing **Escape** dismisses the tooltip
* Verify the upsell badge (lock icon) still appears on the highlight button for free users
* Verify the AI Optimize button still works alongside the new buttons and all buttons are visually consistent in size and style

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Content analysis results buttons (highlight and edit) in the SEO and Readability analysis panels
* Tooltip rendering on highlight and edit buttons

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to the WBSO document.