### PR TITLE
Add safeguard for null `served` parameters

### DIFF
--- a/src/schema-aggregator/user-interface/site-schema-response-header-integration.php
+++ b/src/schema-aggregator/user-interface/site-schema-response-header-integration.php
@@ -58,12 +58,12 @@ class Site_Schema_Response_Header_Integration implements Integration_Interface {
 	 * @codeCoverageIgnore ignore this since its needs to rely on headers being sent. Which does not work in integration tests.
 	 */
 	public function serve_custom_response( $served, $result, $request ): bool {
-		if ( \strpos( $request->get_route(), '/yoast/v1/schema-aggregator' ) !== 0 ) {
-			return $served;
+		if ( ! $request instanceof WP_REST_Request || \strpos( $request->get_route(), '/yoast/v1/schema-aggregator' ) !== 0 ) {
+			return (bool) $served;
 		}
 
 		if ( ! $result instanceof WP_REST_Response || $result->is_error() ) {
-			return $served;
+			return (bool) $served;
 		}
 
 		$this->schema_map_header_adapter->set_header_for_request( $result );

--- a/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
@@ -1,0 +1,226 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration;
+
+use Generator;
+use Mockery;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Test class for the serve_custom_response method.
+ *
+ * @group schema-aggregator
+ *
+ * @covers Yoast\WP\SEO\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration::serve_custom_response
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test extends Abstract_Site_Schema_Response_Header_Integration_Test {
+
+	/**
+	 * Tests that a non-matching route returns (bool) $served.
+	 *
+	 * @dataProvider serve_custom_response_non_matching_route_data
+	 *
+	 * @param mixed  $served   The served value passed to the filter.
+	 * @param string $route    The request route.
+	 * @param bool   $expected The expected return value.
+	 *
+	 * @return void
+	 */
+	public function test_returns_cast_served_for_non_matching_route( $served, $route, $expected ) {
+		$request  = Mockery::mock( WP_REST_Request::class );
+		$response = Mockery::mock( WP_REST_Response::class );
+
+		$request->expects( 'get_route' )->andReturn( $route );
+
+		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $response, $request ) );
+	}
+
+	/**
+	 * Tests that a non-WP_REST_Request returns (bool) $served.
+	 *
+	 * @dataProvider serve_custom_response_non_rest_request_data
+	 *
+	 * @param mixed $served   The served value passed to the filter.
+	 * @param bool  $expected The expected return value.
+	 *
+	 * @return void
+	 */
+	public function test_returns_cast_served_for_non_rest_request( $served, $expected ) {
+		$request = new \stdClass();
+		$result  = Mockery::mock( WP_REST_Response::class );
+
+		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $result, $request ) );
+	}
+
+	/**
+	 * Tests that a matching route with an error response returns (bool) $served.
+	 *
+	 * @dataProvider serve_custom_response_error_response_data
+	 *
+	 * @param mixed $served   The served value passed to the filter.
+	 * @param bool  $expected The expected return value.
+	 *
+	 * @return void
+	 */
+	public function test_returns_cast_served_for_error_response( $served, $expected ) {
+		$request  = Mockery::mock( WP_REST_Request::class );
+		$response = Mockery::mock( WP_REST_Response::class );
+
+		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
+		$response->expects( 'is_error' )->andReturn( true );
+
+		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $response, $request ) );
+	}
+
+	/**
+	 * Tests that a matching route with a non-WP_REST_Response result returns (bool) $served.
+	 *
+	 * @dataProvider serve_custom_response_non_rest_response_data
+	 *
+	 * @param mixed $served   The served value passed to the filter.
+	 * @param bool  $expected The expected return value.
+	 *
+	 * @return void
+	 */
+	public function test_returns_cast_served_for_non_rest_response( $served, $expected ) {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$result  = new \stdClass();
+
+		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
+
+		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $result, $request ) );
+	}
+
+	/**
+	 * Tests that a matching route with a valid response returns true.
+	 *
+	 * @dataProvider serve_custom_response_valid_request_data
+	 *
+	 * @param mixed $served The served value passed to the filter.
+	 *
+	 * @return void
+	 */
+	public function test_returns_true_for_valid_matching_request( $served ) {
+		$request  = Mockery::mock( WP_REST_Request::class );
+		$response = Mockery::mock( WP_REST_Response::class );
+
+		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
+		$response->expects( 'is_error' )->andReturn( false );
+
+		$this->schema_map_header_adapter
+			->expects( 'set_header_for_request' )
+			->once()
+			->with( $response );
+
+		$this->assertTrue( $this->instance->serve_custom_response( $served, $response, $request ) );
+	}
+
+	/**
+	 * Data provider for the non-matching route test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function serve_custom_response_non_matching_route_data() {
+		yield 'null served, unrelated route' => [
+			'served'   => null,
+			'route'    => '/wp/v2/posts',
+			'expected' => false,
+		];
+		yield 'false served, unrelated route' => [
+			'served'   => false,
+			'route'    => '/wp/v2/posts',
+			'expected' => false,
+		];
+		yield 'true served, unrelated route' => [
+			'served'   => true,
+			'route'    => '/wp/v2/posts',
+			'expected' => true,
+		];
+		yield 'null served, partial match not at start' => [
+			'served'   => null,
+			'route'    => '/other/yoast/v1/schema-aggregator',
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * Data provider for the non-WP_REST_Request test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function serve_custom_response_non_rest_request_data() {
+		yield 'null served' => [
+			'served'   => null,
+			'expected' => false,
+		];
+		yield 'false served' => [
+			'served'   => false,
+			'expected' => false,
+		];
+		yield 'true served' => [
+			'served'   => true,
+			'expected' => true,
+		];
+	}
+
+	/**
+	 * Data provider for the error response test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function serve_custom_response_error_response_data() {
+		yield 'null served' => [
+			'served'   => null,
+			'expected' => false,
+		];
+		yield 'false served' => [
+			'served'   => false,
+			'expected' => false,
+		];
+		yield 'true served' => [
+			'served'   => true,
+			'expected' => true,
+		];
+	}
+
+	/**
+	 * Data provider for the non-WP_REST_Response test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function serve_custom_response_non_rest_response_data() {
+		yield 'null served' => [
+			'served'   => null,
+			'expected' => false,
+		];
+		yield 'false served' => [
+			'served'   => false,
+			'expected' => false,
+		];
+		yield 'true served' => [
+			'served'   => true,
+			'expected' => true,
+		];
+	}
+
+	/**
+	 * Data provider for the valid matching request test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function serve_custom_response_valid_request_data() {
+		yield 'null served' => [
+			'served' => null,
+		];
+		yield 'false served' => [
+			'served' => false,
+		];
+		yield 'true served' => [
+			'served' => true,
+		];
+	}
+}

--- a/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
@@ -5,6 +5,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Schema_Aggregator\User_Interface\Site_Schema_R
 
 use Generator;
 use Mockery;
+use stdClass;
 use WP_REST_Request;
 use WP_REST_Response;
 
@@ -50,7 +51,7 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 * @return void
 	 */
 	public function test_returns_cast_served_for_non_rest_request( $served, $expected ) {
-		$request = new \stdClass();
+		$request = new stdClass();
 		$result  = Mockery::mock( WP_REST_Response::class );
 
 		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $result, $request ) );
@@ -88,7 +89,7 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 */
 	public function test_returns_cast_served_for_non_rest_response( $served, $expected ) {
 		$request = Mockery::mock( WP_REST_Request::class );
-		$result  = new \stdClass();
+		$result  = new stdClass();
 
 		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
 

--- a/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test.php
@@ -33,7 +33,7 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 */
 	public function test_returns_cast_served_for_non_matching_route( $served, $route, $expected ) {
 		$request  = Mockery::mock( WP_REST_Request::class );
-		$response = Mockery::mock( WP_REST_Response::class );
+		$response = new stdClass();
 
 		$request->expects( 'get_route' )->andReturn( $route );
 
@@ -52,7 +52,7 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 */
 	public function test_returns_cast_served_for_non_rest_request( $served, $expected ) {
 		$request = new stdClass();
-		$result  = Mockery::mock( WP_REST_Response::class );
+		$result  = new stdClass();
 
 		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $result, $request ) );
 	}
@@ -68,11 +68,15 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 * @return void
 	 */
 	public function test_returns_cast_served_for_error_response( $served, $expected ) {
-		$request  = Mockery::mock( WP_REST_Request::class );
-		$response = Mockery::mock( WP_REST_Response::class );
+		$request = Mockery::mock( WP_REST_Request::class );
+
+		Mockery::mock( 'overload:' . WP_REST_Response::class )
+			->expects( 'is_error' )
+			->andReturn( true );
+
+		$response = new WP_REST_Response();
 
 		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
-		$response->expects( 'is_error' )->andReturn( true );
 
 		$this->assertSame( $expected, $this->instance->serve_custom_response( $served, $response, $request ) );
 	}
@@ -106,11 +110,15 @@ final class Site_Schema_Response_Header_Integration_Serve_Custom_Response_Test e
 	 * @return void
 	 */
 	public function test_returns_true_for_valid_matching_request( $served ) {
-		$request  = Mockery::mock( WP_REST_Request::class );
-		$response = Mockery::mock( WP_REST_Response::class );
+		$request = Mockery::mock( WP_REST_Request::class );
+
+		Mockery::mock( 'overload:' . WP_REST_Response::class )
+			->expects( 'is_error' )
+			->andReturn( false );
+
+		$response = new WP_REST_Response();
 
 		$request->expects( 'get_route' )->andReturn( '/yoast/v1/schema-aggregator/schema' );
-		$response->expects( 'is_error' )->andReturn( false );
 
 		$this->schema_map_header_adapter
 			->expects( 'set_header_for_request' )


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make sure that if another plugin returns `null` from the filter we use we don't break.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Schema aggregator could break if another plugin returns `null` from the `rest_pre_serve_request` filter.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the following code to your theme file (not a MU plugin because than the YoastSEO() is broken:
```php
use Yoast\WP\SEO\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration;

$integration = YoastSEO()->classes->get( Site_Schema_Response_Header_Integration::class );
remove_all_filters( 'rest_pre_serve_request' );
$integration->register_hooks();

$server = new WP_REST_Server();
$request1 = new WP_REST_Request();
$request1->set_route( '/wp/v2/posts' );
var_dump( apply_filters( 'rest_pre_serve_request', null, new WP_REST_Response(), $request1, $server ));
die;
```

* With this pr you should just see a `false` since we now corretly cast `null` to `false`.
* Without this PR your system will give a fatal error on every page so make sure you can revert this change :)

---
Another way to test this fix:
* Imagine we have a plugin activated that does the wrong thing and use `rest_pre_serve_request` to return a non-boolean value
* We can replicate that by adding the following snippet in a mu-plugin:
```
add_filter(
    'rest_pre_serve_request',
    function ( bool $served, WP_HTTP_Response $response ) {
        return [];
    },
    1,
    2
);
```
* **Without this PR**: every REST request to the REST WP API will fail with a Fatal error.
  * For example, if you GET request `http://dev.local/wp-json/yoast/v1/get_tasks`, you will get a Fatal and a 500 response
  * Which also means that if you go to the Dashboard page, you will see our score widgets showing a `Something went wrong` message
* **With this PR**: REST requests to the REST WP API work properly
  * For example, if you GET request `http://dev.local/wp-json/yoast/v1/get_tasks`, you will get the same response that you would, if you didnt add have that snippet 
  * Which also means that if you go to the Dashboard page, you will see our score widgets working properly.


---
 For regression testing:
 
* with this PR go to `/wp-json/yoast/v1/schema-aggregator/get-xml` and take a look at the response headers. They should still show `content-type: application/xml; charset=UTF-8`
* Go to `wp-json/yoast/v1/schema-aggregator/get-schema/post/1` and make sure you still see all the JSON-L lines.
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
