### PR TITLE
Fix: 'Set opt-in notification as seen' returns 400 on repeat visits

### DIFF
--- a/packages/js/src/general/components/opt-in-container.js
+++ b/packages/js/src/general/components/opt-in-container.js
@@ -23,5 +23,9 @@ export const OptInContainer = () => {
 		hideOptInNotification( "task_list" );
 	}, [ hideOptInNotification ] );
 
+	if ( ! isOpen ) {
+		return null;
+	}
+
 	return <TaskListOptInNotification isOpen={ isOpen } onClose={ onClose } />;
 };

--- a/src/general/user-interface/opt-in-route.php
+++ b/src/general/user-interface/opt-in-route.php
@@ -98,8 +98,20 @@ class Opt_In_Route implements Route_Interface {
 	public function set_opt_in_seen( $request ) {
 		$key             = $request->get_param( 'key' );
 		$current_user_id = $this->user_helper->get_current_user_id();
+		$meta_key        = '_yoast_wpseo_' . $key . '_opt_in_notification_seen';
 
-		$result  = $this->user_helper->update_meta( $current_user_id, '_yoast_wpseo_' . $key . '_opt_in_notification_seen', true );
+		// If already seen, return success immediately (update_user_meta returns false when the value is unchanged).
+		if ( $this->user_helper->get_meta( $current_user_id, $meta_key, true ) === '1' ) {
+			return new WP_REST_Response(
+				(object) [
+					'success' => true,
+					'status'  => 200,
+				],
+				200,
+			);
+		}
+
+		$result  = $this->user_helper->update_meta( $current_user_id, $meta_key, true );
 		$success = $result !== false;
 		$status  = ( $success ) ? 200 : 400;
 

--- a/tests/WP/General/User_Interface/Set_Opt_In_Seen_Test.php
+++ b/tests/WP/General/User_Interface/Set_Opt_In_Seen_Test.php
@@ -160,6 +160,30 @@ final class Set_Opt_In_Seen_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that calling the endpoint twice returns 200 both times (idempotent).
+	 *
+	 * @return void
+	 */
+	public function test_set_opt_in_seen_is_idempotent() {
+		$user = $this->factory->user->create_and_get( [ 'role' => 'administrator' ] );
+		$user->add_cap( 'wpseo_manage_options' );
+		\wp_set_current_user( $user->ID );
+
+		$request = new WP_REST_Request( 'POST', '/yoast/v1/seen-opt-in-notification' );
+		$request->set_param( 'key', 'task_list' );
+
+		// First call: sets the meta.
+		$response = \rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->status );
+		$this->assertTrue( $response->get_data()->success );
+
+		// Second call: meta already set, should still return 200.
+		$response = \rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->status );
+		$this->assertTrue( $response->get_data()->success );
+	}
+
+	/**
 	 * Tests setting opt-in notification as seen without key parameter.
 	 *
 	 * @return void


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When a user visits the General page after the task list opt-in notification has already been seen, the browser console logs: `Error setting opt-in notification as seen: Object { success: false, status: 400 }`. This happens on **every page load** after the first time.

### Root cause

This was introduced by #22960, which replaced the `Toast` with a `ModalNotification` (HeadlessUI `Dialog`). As part of that change, `OptInContainer` was refactored to **always render** `TaskListOptInNotification` and control visibility via the `isOpen` prop, instead of conditionally mounting/unmounting it.

Previously, `TaskListOptInNotification` only mounted when the notification needed to be shown. Its `useEffect` (with `[]` deps) called `setOptInNotificationSeen("task_list")` on mount — which was correct, since mounting only happened once when the notification was actually visible.

After #22960, the component **always mounts** (even when `isOpen=false`), so two things go wrong:

1. **JS**: The `useEffect` fires on every page load regardless of whether the notification is visible, sending a POST to `/yoast/v1/seen-opt-in-notification` every time.
2. **PHP**: On subsequent loads the user meta is already `'1'`, so `update_user_meta()` returns `false` (no change was made). The endpoint interprets `false` as failure and returns a 400 status.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where a 400 error was logged in the console on every General page load after the task list opt-in notification had already been seen.

## Relevant technical choices:

* **JS — Conditional rendering restored** (`opt-in-container.js`): `OptInContainer` now returns `null` when `isOpen` is false, so `TaskListOptInNotification` only mounts when the notification is actually visible. This prevents the `useEffect` from firing unnecessary API calls. The `ModalNotification` component works fine being mounted/unmounted — there's no need to keep it always mounted.
* **PHP — Idempotent endpoint** (`opt-in-route.php`): Before calling `update_user_meta`, the endpoint checks if the meta is already set to `true`. If so, it returns `{ success: true, status: 200 }` immediately. This is a safety net against the well-known `update_user_meta` footgun where unchanged values return `false`.
* **Test — Idempotency test** (`Set_Opt_In_Seen_Test.php`): Added a test that calls the endpoint twice and verifies both calls return 200.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. With Yoast Free installed and active, go to the database and remove `_yoast_wpseo_task_list_opt_in_notification_seen` from `wp_usermeta` for your user.
2. Open the browser console.
3. Navigate to the Yoast General page.
4. Confirm the opt-in notification appears and no errors are in the console.
5. Reload the page.
6. Confirm the notification does **not** appear and there are **no 400 errors** in the console.
7. Navigate to the post editor (e.g. edit a post).
8. Confirm there are **no `seen-opt-in-notification` errors** in the console.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Check the console for any 400 errors related to `seen-opt-in-notification`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Task list opt-in notification on the General page — verify it still shows correctly for new users and dismisses properly.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [2896](https://github.com/Yoast/plugins-automated-testing/issues/2896)