### PR TITLE
Avoid executing Schema aggregator code when the feature is turned off

### DIFF
--- a/src/schema-aggregator/user-interface/site-schema-response-header-integration.php
+++ b/src/schema-aggregator/user-interface/site-schema-response-header-integration.php
@@ -4,8 +4,8 @@ namespace Yoast\WP\SEO\Schema_Aggregator\User_Interface;
 
 use WP_REST_Request;
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Aggregator_Conditional;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Map\Schema_Map_Header_Adapter;
 
 /**
@@ -13,14 +13,21 @@ use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Map\Schema_Map_Header_A
  */
 class Site_Schema_Response_Header_Integration implements Integration_Interface {
 
-	use No_Conditionals;
-
 	/**
 	 * The schema map header adapter.
 	 *
 	 * @var Schema_Map_Header_Adapter
 	 */
 	private $schema_map_header_adapter;
+
+	/**
+	 * Returns the conditional for this route.
+	 *
+	 * @return array<string> The conditionals that must be met to load this.
+	 */
+	public static function get_conditionals() {
+		return [ Schema_Aggregator_Conditional::class ];
+	}
 
 	/**
 	 * Constructor.

--- a/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Get_Conditionals_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Site_Schema_Response_Header_Integration/Site_Schema_Response_Header_Integration_Get_Conditionals_Test.php
@@ -1,0 +1,32 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration;
+
+use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Aggregator_Conditional;
+use Yoast\WP\SEO\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration;
+
+/**
+ * Test class for the get_conditionals method.
+ *
+ * @group schema-aggregator
+ * @group Site_Schema_Response_Header_Integration
+ *
+ * @covers Yoast\WP\SEO\Schema_Aggregator\User_Interface\Site_Schema_Response_Header_Integration::get_conditionals
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Site_Schema_Response_Header_Integration_Get_Conditionals_Test extends Abstract_Site_Schema_Response_Header_Integration_Test {
+
+	/**
+	 * Tests if the expected conditionals are in place.
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals(
+			[ Schema_Aggregator_Conditional::class ],
+			Site_Schema_Response_Header_Integration::get_conditionals(),
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*  In `src/schema-aggregator/user-interface/site-schema-response-header-integration.php` we don't check the `Schema_Aggregation_Conditional`: the result is that ALL REST requests pass through the integration even when the Schema aggregator is off.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Schema aggregator response headers processor was called even when the feature was off.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have the Schema aggreation feature turned on
* Edit `src/schema-aggregator/user-interface/site-schema-response-header-integration.php`, change the `serve_custom_response` method declaration at line 67 as follows:
  ```
  	public function serve_custom_response( $served, $result, $request ): bool {
		die( "test" );
	}
  ```
* Call `http://YOUR-BLOG-URL/wp-json/yoast/v1/`
  * Verify you get an empty page with `test` in it
* Turn off the Schema aggregation feature
* Call `http://YOUR-BLOG-URL/wp-json/yoast/v1/` again
  * Verify you now get a list of the available REST endpoints

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23059
