### PR TITLE
Fix: Guard against wp_parse_url() returning false in Pagination_Helper

### DIFF
--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -70,8 +70,11 @@ class Pagination_Helper {
 		}
 
 		if ( $wp_rewrite->using_permalinks() && ! $key_query_loop ) {
-			$url_parts      = \wp_parse_url( $url );
-			$has_url_params = \array_key_exists( 'query', $url_parts );
+			$url_parts = \wp_parse_url( $url );
+            if ( ! is_array( $url_parts ) ) {
+                return $url;
+            }
+            $has_url_params = \array_key_exists( 'query', $url_parts );
 
 			if ( $has_url_params ) {
 				// We need to first remove the query params, before potentially adding the pagination parts.


### PR DESCRIPTION
## Context

When `wp_parse_url()` receives a malformed URL (e.g., `http:///` caused by a missing `Host` header), it returns `false` instead of an array. The subsequent `array_key_exists('query', false)` call throws a `TypeError` on PHP 8.x, resulting in a fatal error.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a fatal `TypeError` occurred in `pagination-helper.php` when `wp_parse_url()` returned `false` due to a malformed URL (e.g., requests without a `Host` header on Bitnami WordPress environments).

## Relevant technical choices:

* Added an early return guard clause (`if ( ! is_array( $url_parts ) ) return $url;`) before accessing the parsed URL array. This is the minimal, defensive fix that preserves existing behavior for all valid URLs while gracefully handling the edge case.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Set up a WordPress instance with PHP 8.x and Yoast SEO installed.
2. Temporarily modify `wp-config.php` to set `WP_HOME` to a malformed URL such as `http:///` (simulating a missing `Host` header scenario).
3. Visit any frontend page that triggers pagination (e.g., a blog archive with multiple pages).
4. **Before fix:** A fatal `TypeError` is thrown at `pagination-helper.php:74`.
5. **After fix:** The page loads without error; the original URL is returned as-is when parsing fails.
6. Revert `WP_HOME` to its normal value and confirm pagination still works correctly on archive pages.

#### Relevant test scenarios
- [x] Changes should be tested with the browser console open
- [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
- [ ] Changes should be tested on different editors
- [x] Changes should be tested on different browsers
- [ ] Changes should be tested on multisite

Console should show no PHP errors or warnings after the fix is applied.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* `src/helpers/pagination-helper.php` — specifically the `get_paginated_url()` method. Regression testing should confirm that normal pagination (rel next/prev) continues to work on archive and paginated pages.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [ ] I have added unit tests to verify the code works as intended.
- [x] I have checked that the base branch is correctly set.

## Innovation

- [x] No innovation project is applicable for this PR.

Fixes #23057