### PR TITLE
Fix grammar in UI library button size docs

### DIFF
--- a/packages/ui-library/src/elements/button/docs/sizes.md
+++ b/packages/ui-library/src/elements/button/docs/sizes.md
@@ -1,7 +1,7 @@
 The aforementioned button variants can be used in four different sizes:
 
 1. **Extra large**<br>
-The extra large button size is often used ads and upsells that require significant user attention. It can also be useful for touch interfaces, where extra large buttons are easier to tap.
+The extra large button size is often used for ads and upsells that require significant user attention. It can also be useful for touch interfaces, where extra large buttons are easier to tap.
 
 2. **Large**<br>
 The large button size is used next to form input fields, by default it has the same height.


### PR DESCRIPTION
## Summary
- fix grammar in the UI library button sizes documentation
- change `used ads and upsells` to `used for ads and upsells`

## Context
This is a docs-only change with no runtime impact.