### PR TITLE
Fix PHPDoc spelling in migrations, repositories, and health checks

### DIFF
--- a/lib/migrations/table.php
+++ b/lib/migrations/table.php
@@ -180,7 +180,7 @@ class Table {
 	 *
 	 * @return bool|string
 	 *
-	 * @throws Exception If the table definition has not been intialized.
+	 * @throws Exception If the table definition has not been initialized.
 	 */
 	public function finish( $wants_sql = false ) {
 		if ( ! $this->initialized ) {

--- a/src/repositories/seo-links-repository.php
+++ b/src/repositories/seo-links-repository.php
@@ -93,7 +93,7 @@ class SEO_Links_Repository {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return bool Whether or not the delete was succesfull.
+	 * @return bool Whether or not the delete was successful.
 	 */
 	public function delete_all_by_post_id( $post_id ) {
 		return $this->query()
@@ -106,7 +106,7 @@ class SEO_Links_Repository {
 	 *
 	 * @param int $post_id The post ID.
 	 *
-	 * @return bool Whether or not the delete was succesfull.
+	 * @return bool Whether or not the delete was successful.
 	 */
 	public function delete_all_by_post_id_where_indexable_id_null( $post_id ) {
 		return $this->query()
@@ -120,7 +120,7 @@ class SEO_Links_Repository {
 	 *
 	 * @param int $indexable_id The indexable ID.
 	 *
-	 * @return bool Whether or not the delete was succesfull.
+	 * @return bool Whether or not the delete was successful.
 	 */
 	public function delete_all_by_indexable_id( $indexable_id ) {
 		return $this->query()
@@ -192,7 +192,7 @@ class SEO_Links_Repository {
 	 *
 	 * @param int[] $ids The seo link ids.
 	 *
-	 * @return bool Whether or not the delete was succesfull.
+	 * @return bool Whether or not the delete was successful.
 	 */
 	public function delete_many_by_id( $ids ) {
 		return $this->query()
@@ -205,7 +205,7 @@ class SEO_Links_Repository {
 	 *
 	 * @param SEO_Links[] $links The seo links to be inserted.
 	 *
-	 * @return bool Whether or not the insert was succesfull.
+	 * @return bool Whether or not the insert was successful.
 	 */
 	public function insert_many( $links ) {
 		return $this->query()

--- a/src/services/health-check/default-tagline-runner.php
+++ b/src/services/health-check/default-tagline-runner.php
@@ -37,7 +37,7 @@ class Default_Tagline_Runner implements Runner_Interface {
 	/**
 	 * Returns true if the tagline is set to a non-default tagline.
 	 *
-	 * @return bool The boolean indicating if the health check was succesful.
+	 * @return bool The boolean indicating if the health check was successful.
 	 */
 	public function is_successful() {
 		return ! $this->has_default_tagline;

--- a/src/services/health-check/links-table-runner.php
+++ b/src/services/health-check/links-table-runner.php
@@ -54,7 +54,7 @@ class Links_Table_Runner implements Runner_Interface {
 	/**
 	 * Returns true if the links table is accessible
 	 *
-	 * @return bool The boolean indicating if the health check was succesful.
+	 * @return bool The boolean indicating if the health check was successful.
 	 */
 	public function is_successful() {
 		return $this->links_table_accessible;


### PR DESCRIPTION
## Context

Spelling mistakes in PHPDoc comments across migration, repository, and health-check classes make the documentation less professional and can cause confusion. This PR corrects them.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes some PHPDoc spelling mistakes. Props to [@meravi](https://github.com/meravi).

## Relevant technical choices:

* Docs-only change — no runtime behaviour is affected.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

* This PR only changes PHPDoc comments; no functional behaviour was altered. Verify the corrected spellings in the changed files:
  - `lib/migrations/table.php` — `@throws` docblock on `finish()`
  - `src/repositories/seo-links-repository.php` — `@return` docblocks on `delete_all_by_post_id()`, `delete_all_by_post_id_where_indexable_id_null()`, `delete_all_by_indexable_id()`, `delete_many_by_id()`, and `insert_many()`
  - `src/services/health-check/default-tagline-runner.php` — `@return` docblock on `is_successful()`
  - `src/services/health-check/links-table-runner.php` — `@return` docblock on `is_successful()`

#### Relevant test scenarios

* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* NA

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* No runtime code was changed; only PHPDoc comments were corrected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #