### PR TITLE
Update the finish step copy of the Firts time configuration feature

### DIFF
--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -52,7 +52,11 @@ export default function FinishStep( { state } ) {
 					target="_blank"
 					data-hiive-event-name="clicked_to_onboarding_page"
 				>
-					{ __( "Learn how to get the most out of your Yoast plugin", "wordpress-seo" ) }
+					{ sprintf(
+						/* translators: 1: Yoast SEO. */
+						__( "Learn how to get the most out of your %1$s plugin", "wordpress-seo" ),
+						"Yoast"
+					) }
 					<span className="yst-sr-only">
 						{
 							/* translators: Hidden accessibility text. */

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -39,16 +39,10 @@ export default function FinishStep( { state } ) {
 		<div className="yst-flex yst-flex-row yst-justify-between yst-items-center yst-mt-4">
 			<div>
 				<p className="yst-text-sm yst-mb-4">
-					{
-						sprintf(
-							/* translators: 1: Yoast. */
-							__( "Great work! Thanks to the details you've provided, %1$s has enhanced your site for search engines, giving them a clearer picture of what your site is all about.", "wordpress-seo" ),
-							"Yoast"
-						)
-					}
+					{ __( "Setup complete! Your site is now ready for discovery.", "wordpress-seo" ) }
 				</p>
 				<p className="yst-text-sm yst-mb-6">
-					{ __( "If your goal is to increase your rankings, you need to work on your SEO regularly. That can be overwhelming, so let's tackle it one step at a time!", "wordpress-seo" ) }
+					{ __( "Turning that visibility into sustainable organic growth is a journey, but you don't have to do it alone. Let's take it one step at a time to ensure your content is always understood, properly represented, and engaged with.", "wordpress-seo" ) }
 				</p>
 				<Button
 					as="a"
@@ -58,11 +52,7 @@ export default function FinishStep( { state } ) {
 					target="_blank"
 					data-hiive-event-name="clicked_to_onboarding_page"
 				>
-					{ sprintf(
-						/* translators: 1: Yoast SEO. */
-						__( "Learn how to increase your rankings with %1$s", "wordpress-seo" ),
-						"Yoast SEO"
-					) }
+					{ __( "Learn how to get the most out of your Yoast plugin", "wordpress-seo" ) }
 					<span className="yst-sr-only">
 						{
 							/* translators: Hidden accessibility text. */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull request updates the messaging in the final step of the first-time configuration flow for Yoast SEO, focusing on clearer, more encouraging language for users completing setup. The changes primarily revise text content to better guide users toward ongoing SEO improvement and plugin utilization.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Updates the completion message and changes the call-to-action button text of the First-time configuration.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install and activate Yoast SEO
* Navigate to Yoast SEO > Settings > First-time configuration
* Fill in the steps until you reach the final one
* Confirm that now you see the following copy:
<img width="586" height="241" alt="Screenshot 2026-03-13 at 09 07 27" src="https://github.com/user-attachments/assets/35dabae7-37a2-4741-b6ee-c58fedf01c36" />

**Before**: 
<img width="722" height="244" alt="Screenshot 2026-03-13 at 09 18 34" src="https://github.com/user-attachments/assets/7e8b5738-d17c-4279-82da-d15745422255" />

* Hover over the CTA button and confirm that the shortlink stays the same: "https://yoa.st/webinar-intro-first-time-config"

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1107
