### PR TITLE
Add fallback title for empty content item titles in task list

### DIFF
--- a/src/task-list/application/tasks/child-tasks/content-score-child-task-trait.php
+++ b/src/task-list/application/tasks/child-tasks/content-score-child-task-trait.php
@@ -92,8 +92,14 @@ trait Content_Score_Child_Task_Trait {
 	 * @return Copy_Set
 	 */
 	public function get_copy_set(): Copy_Set {
+		$title = \html_entity_decode( $this->content_item_score_data->get_title(), \ENT_QUOTES, 'UTF-8' );
+		if ( empty( $title ) ) {
+			// Default to "(no title)" if the title is empty after decoding.
+			$title = \__( '(no title)', 'wordpress-seo' );
+		}
+
 		return new Copy_Set(
-			\html_entity_decode( $this->content_item_score_data->get_title(), \ENT_QUOTES, 'UTF-8' ),
+			$title,
 			$this->parent_task->get_copy_set()->get_about(),
 		);
 	}

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_Readability_Child/Improve_Content_Readability_Child_Copy_Set_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_Readability_Child/Improve_Content_Readability_Child_Copy_Set_Test.php
@@ -78,7 +78,7 @@ final class Improve_Content_Readability_Child_Copy_Set_Test extends Abstract_Imp
 		$copy_set = $instance->get_copy_set();
 		$array    = $copy_set->to_array();
 
-		$this->assertSame( 'Sarah\'s Blog Post', $array['title'] );
+		$this->assertSame( 'Sarah’s Blog Post', $array['title'] );
 	}
 
 	/**

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_Readability_Child/Improve_Content_Readability_Child_Copy_Set_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_Readability_Child/Improve_Content_Readability_Child_Copy_Set_Test.php
@@ -78,6 +78,35 @@ final class Improve_Content_Readability_Child_Copy_Set_Test extends Abstract_Imp
 		$copy_set = $instance->get_copy_set();
 		$array    = $copy_set->to_array();
 
-		$this->assertSame( 'Sarah’s Blog Post', $array['title'] );
+		$this->assertSame( 'Sarah\'s Blog Post', $array['title'] );
+	}
+
+	/**
+	 * Tests that get_copy_set uses "(no title)" fallback when title is empty.
+	 *
+	 * @return void
+	 */
+	public function test_get_copy_set_uses_no_title_fallback_when_title_is_empty() {
+		$content_item = new Content_Item_Score_Data( 456, '', 'ok', 'post' );
+
+		$parent_copy_set = new Copy_Set(
+			'Parent Title',
+			'<p>About text.</p>',
+		);
+
+		$this->parent_task
+			->shouldReceive( 'get_copy_set' )
+			->once()
+			->andReturn( $parent_copy_set );
+
+		$instance = new Improve_Content_Readability_Child(
+			$this->parent_task,
+			$content_item,
+		);
+
+		$copy_set = $instance->get_copy_set();
+		$array    = $copy_set->to_array();
+
+		$this->assertSame( '(no title)', $array['title'] );
 	}
 }

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO_Child/Improve_Content_SEO_Child_Copy_Set_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO_Child/Improve_Content_SEO_Child_Copy_Set_Test.php
@@ -78,6 +78,35 @@ final class Improve_Content_SEO_Child_Copy_Set_Test extends Abstract_Improve_Con
 		$copy_set = $instance->get_copy_set();
 		$array    = $copy_set->to_array();
 
-		$this->assertSame( 'Sarah’s Blog Post', $array['title'] );
+		$this->assertSame( 'Sarah\'s Blog Post', $array['title'] );
+	}
+
+	/**
+	 * Tests that get_copy_set uses "(no title)" fallback when title is empty.
+	 *
+	 * @return void
+	 */
+	public function test_get_copy_set_uses_no_title_fallback_when_title_is_empty() {
+		$content_item = new Content_Item_Score_Data( 456, '', 'ok', 'post' );
+
+		$parent_copy_set = new Copy_Set(
+			'Parent Title',
+			'<p>About text.</p>',
+		);
+
+		$this->parent_task
+			->shouldReceive( 'get_copy_set' )
+			->once()
+			->andReturn( $parent_copy_set );
+
+		$instance = new Improve_Content_SEO_Child(
+			$this->parent_task,
+			$content_item,
+		);
+
+		$copy_set = $instance->get_copy_set();
+		$array    = $copy_set->to_array();
+
+		$this->assertSame( '(no title)', $array['title'] );
 	}
 }

--- a/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO_Child/Improve_Content_SEO_Child_Copy_Set_Test.php
+++ b/tests/Unit/Task_List/Application/Tasks/Improve_Content_SEO_Child/Improve_Content_SEO_Child_Copy_Set_Test.php
@@ -78,7 +78,7 @@ final class Improve_Content_SEO_Child_Copy_Set_Test extends Abstract_Improve_Con
 		$copy_set = $instance->get_copy_set();
 		$array    = $copy_set->to_array();
 
-		$this->assertSame( 'Sarah\'s Blog Post', $array['title'] );
+		$this->assertSame( 'Sarah’s Blog Post', $array['title'] );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This pull request adds a fallback mechanism for content item titles in child tasks, ensuring that if a title is empty after decoding HTML entities, it defaults to "(no title)". It also updates unit tests to verify this behavior and corrects the expected decoded output for titles containing HTML entities.
* This changes in an enhancement as:
   * Screen readers need text content. Hence this change improve accessibility
   * We are aligning with WordPress. For example on post overview page, post without title is displayed with `(no content)` 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Sets the title of a child task to "(no title)" when the item has no title in task list.

## Relevant technical choices:

* In line with WordPress behaviour, `(no title)` is translatable.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Also activate Premium's PR/RC 
* Create a post or page with an empty title and:
  * a bad SEO score
  * a bad readability score
  * no meta description
* Navigate to task list and go to the "Improve the readability of your recent content" task (or the "Improve the SEO of your recent content: Posts" or the "Improve default meta descriptions of your recent content: Posts" task or the "Set social sharing images in your recent content: Posts" task)
* Confirm that you see the post/page that you just created
* Confirm that the title says `(no title)`
* **Before**: no title was displayed
* Click on the child task
* Confirm that the modal title of the child task also says `(no title)`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
