### PR TITLE
ci: switch npm publish to OIDC trusted publishers

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      # Ensure npm 11.5.1 or later is installed - this is needed for OIDC support
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Extract packages to release from PR body
         id: packages
         env:
@@ -67,6 +71,7 @@ jobs:
       - name: Publish packages in order
         env:
           PACKAGE_LIST: ${{ steps.packages.outputs.list }}
+          NODE_AUTH_TOKEN: ''
         run: |
           set -euo pipefail
           if [ -z "${PACKAGE_LIST// /}" ]; then
@@ -92,22 +97,22 @@ jobs:
               npm run-script prepublishOnly
               if [ -d "dist" ]; then
                 pushd dist
-                npm publish --provenance --ignore-scripts
+                npm publish --provenance --access public --ignore-scripts
                 popd
               else
-                npm publish --provenance --ignore-scripts
+                npm publish --provenance --access public --ignore-scripts
               fi
 
             elif node -e "process.exit(require('./package.json').scripts?.build ? 0 : 1)" 2>/dev/null; then
               # Packages with a build step: build first, then publish.
               echo "Strategy: build"
               NODE_ENV=production npm run-script build
-              npm publish --provenance
+              npm publish --provenance --access public
 
             else
               # No build step needed (e.g. config-only packages like tailwindcss-preset).
               echo "Strategy: direct publish"
-              npm publish --provenance
+              npm publish --provenance --access public
             fi
 
             popd


### PR DESCRIPTION
## Context

The npm publish workflow was failing with a 404 error when publishing `@yoast/tailwindcss-preset@2.6.0` ([failed run](https://github.com/Yoast/wordpress-seo/actions/runs/23043433893/job/66952047319)). The root cause is the stored npm token being rejected due to 2FA/granular token restrictions on the `@yoast` npm org. This follows the same approach used in [Yoast/ai-frontend#152](https://github.com/Yoast/ai-frontend/pull/152) — switching from token-based auth to OIDC trusted publishers.

## Summary

This PR can be summarized in the following changelog entry:

* Switches npm publish to OIDC trusted publishers

## Relevant technical choices:

* Clears `NODE_AUTH_TOKEN` in the publish step so npm uses OIDC instead of the stored token.
* Updates npm to latest (>= 11.5.1) for OIDC support.
* Adds `--access public` to all `npm publish` commands, required for scoped packages with OIDC.
* The existing `id-token: write` permission and `registry-url` setup were already in place.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* **Prerequisites:** Configure each `@yoast/*` package as a Trusted Publisher on npm: npmjs.com → package settings → Publishing access → Add trusted publisher → repository: `Yoast/wordpress-seo`, workflow: `.github/workflows/publish-npm-packages.yml`.
* Trigger the workflow via `workflow_dispatch` with the PR number of the version increase PR.
* Verify all packages publish successfully without 404 errors.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

## Impact check

* CI/CD pipeline only — no plugin code affected.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project.
* [ ] I have added my hours to the WBSO document.