### PR TITLE
Fix: add missing repository field to package.json files for npm provenance

### DIFF
--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -8,6 +8,11 @@
     "build",
     "!*.map"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/dashboard-frontend"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "description": "e2e-tests implementation for Yoast SEO plugin",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/e2e-tests"
+  },
   "author": "Team Yoast",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.1",
   "description": "A Jest preset for Yoast packages.",
   "main": "jest-preset.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/jest-preset"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/postcss-preset/package.json
+++ b/packages/postcss-preset/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.1",
   "description": "A PostCSS preset for Yoast packages.",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/postcss-preset"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/related-keyphrase-suggestions/package.json
+++ b/packages/related-keyphrase-suggestions/package.json
@@ -8,6 +8,11 @@
     "build",
     "!*.map"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/related-keyphrase-suggestions"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/tailwindcss-preset/package.json
+++ b/packages/tailwindcss-preset/package.json
@@ -3,6 +3,11 @@
   "version": "2.6.0",
   "description": "A Tailwind CSS preset for Yoast packages.",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/tailwindcss-preset"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -8,6 +8,11 @@
     "build",
     "!*.map"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yoast/wordpress-seo",
+    "directory": "packages/ui-library"
+  },
   "author": "Team Yoast <support@yoast.com>",
   "license": "GPL-3.0",
   "private": false,


### PR DESCRIPTION
## Context
When publishing npm packages with `--provenance`, npm registry verifies that the `repository.url` in `package.json` matches the GitHub repository URL recorded in the provenance statement. Several packages were missing the `repository` field entirely (treated as `""`), causing a 422 error from the npm registry during publishing.

## Summary
This PR can be summarized in the following changelog entry:

* Adds missing `repository` field to `package.json` for packages that lacked it, fixing npm provenance verification during publishing.

## Relevant technical choices:

* Added the `repository` field with `type`, `url`, and `directory` to the seven `package.json` files that were missing it: `tailwindcss-preset`, `ui-library`, `related-keyphrase-suggestions`, `dashboard-frontend`, `e2e-tests`, `jest-preset`, and `postcss-preset`.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Trigger the "Publish NPM Packages" workflow and verify it no longer fails with a 422 provenance error.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* No user-facing changes. QA can verify the npm publish workflow runs successfully.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* npm publishing workflow only. No runtime plugin code is affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Release NPM packages](https://github.com/Yoast/reserved-tasks/issues/1079)