### PR TITLE
Fix: correct repository URL casing and format for npm provenance

### DIFF
--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/analysis-report"
   },
   "scripts": {

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/babel-preset"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/browserslist-config/package.json
+++ b/packages/browserslist-config/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.5",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/browserslist-config"
   },
   "description": "The browserslist configuration for Yoast projects",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/components"
   },
   "author": "Yoast",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/dashboard-frontend"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/e2e-tests"
   },
   "author": "Team Yoast",

--- a/packages/feature-flag/package.json
+++ b/packages/feature-flag/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/feature-flag"
   },
   "author": "Team Yoast",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/helpers"
   },
   "scripts": {

--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -5,7 +5,7 @@
   "main": "jest-preset.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/jest-preset"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/postcss-preset/package.json
+++ b/packages/postcss-preset/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/postcss-preset"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/related-keyphrase-suggestions/package.json
+++ b/packages/related-keyphrase-suggestions/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/related-keyphrase-suggestions"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/replacement-variable-editor/package.json
+++ b/packages/replacement-variable-editor/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Yoast/javascript.git",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/replacement-variable-editor"
   },
   "author": "Team Yoast",

--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/search-metadata-previews"
   },
   "author": "Team Yoast",

--- a/packages/social-metadata-forms/package.json
+++ b/packages/social-metadata-forms/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/social-metadata-forms"
   },
   "author": "Team Yoast",

--- a/packages/social-metadata-previews/package.json
+++ b/packages/social-metadata-previews/package.json
@@ -8,7 +8,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/social-metadata-previews"
   },
   "author": "Team Yoast",

--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/style-guide"
   },
   "author": "Yoast",

--- a/packages/tailwindcss-preset/package.json
+++ b/packages/tailwindcss-preset/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/tailwindcss-preset"
   },
   "author": "Team Yoast <support@yoast.com>",

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/yoast/wordpress-seo",
+    "url": "https://github.com/Yoast/wordpress-seo.git",
     "directory": "packages/ui-library"
   },
   "author": "Team Yoast <support@yoast.com>",


### PR DESCRIPTION
## Context
When publishing npm packages with \`--provenance\`, the npm registry verifies that \`repository.url\` in \`package.json\` matches the GitHub repository URL from the OIDC token (\`https://github.com/Yoast/wordpress-seo\`). The 7 packages in the current release had incorrect URLs (\`https://github.com/yoast/wordpress-seo\` — lowercase, no \`.git\`) or pointed to the wrong repo entirely (\`replacement-variable-editor\` had \`Yoast/javascript.git\`), causing 422 errors from the npm registry during publishing.

## Summary
This PR can be summarized in the following changelog entry:

* Fixes `repository.url` all the `package.json` of the monorepo packages to use `https://github.com/Yoast/wordpress-seo.git`, resolving npm provenance verification failures.

## Relevant technical choices:

* Changed all 18 affected `package.json` files to use `https://github.com/Yoast/wordpress-seo.git` (correct casing + `.git` suffix). This matches the format already used by `@yoast/yoastseo` and `@yoast/eslint`, which publish successfully. npm normalizes this URL to `git+https://github.com/Yoast/wordpress-seo.git`; the registry then strips `git+` and `.git` to compare against the OIDC provenance URL.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Trigger the "Publish NPM Packages" workflow and verify it no longer fails with a 422 provenance URL mismatch error.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* No user-facing changes. QA can verify the npm publish workflow runs successfully.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* npm publishing workflow only. No runtime plugin code is affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #