### PR TITLE
Harden `maybe_redirect` in Installation Success Integration

### DIFF
--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -101,6 +101,15 @@ class Installation_Success_Integration implements Integration_Interface {
 			return;
 		}
 
+		/**
+		 * Filter: 'wpseo_should_redirect_after_install' - Allows skipping the redirect to the installation success page.
+		 *
+		 * @param bool $should_redirect Whether to redirect. Default true.
+		 */
+		if ( ! \apply_filters( 'wpseo_should_redirect_after_install', true ) ) {
+			return;
+		}
+
 		\wp_safe_redirect( \admin_url( 'admin.php?page=wpseo_installation_successful_free' ), 302, 'Yoast SEO' );
 		$this->terminate_execution();
 	}

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -70,7 +70,7 @@ class Installation_Success_Integration implements Integration_Interface {
 	 * @return void
 	 */
 	public function maybe_redirect() {
-		if ( \defined( 'DOING_AJAX' ) && \DOING_AJAX ) {
+		if ( \wp_doing_ajax() || \wp_doing_cron() || \wp_is_serving_rest_request() || \wp_is_json_request() ) {
 			return;
 		}
 

--- a/src/integrations/admin/installation-success-integration.php
+++ b/src/integrations/admin/installation-success-integration.php
@@ -74,6 +74,10 @@ class Installation_Success_Integration implements Integration_Interface {
 			return;
 		}
 
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
 		if ( ! $this->options_helper->get( 'should_redirect_after_install_free', false ) ) {
 			return;
 		}

--- a/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
@@ -188,6 +188,10 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'is_plugin_active_for_network' )
 			->andReturn( false );
 
+		Monkey\Filters\expectApplied( 'wpseo_should_redirect_after_install' )
+			->with( true )
+			->andReturn( true );
+
 		$redirect_url = 'http://basic.wordpress.test/wp-admin/admin.php?page=wpseo_installation_successful_free';
 
 		Monkey\Functions\expect( 'admin_url' )
@@ -435,6 +439,58 @@ final class Installation_Success_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_plugin_active_for_network' )
 			->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when the wpseo_should_redirect_after_install filter returns false.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_filter_prevents_redirect() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'should_redirect_after_install_free', false )
+			->andReturnTrue();
+
+		$this->options_helper
+			->expects( 'set' )
+			->with( 'should_redirect_after_install_free', false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'activation_redirect_timestamp_free', 0 )
+			->andReturn( 0 );
+
+		$this->options_helper
+			->expects( 'set' )
+			->withSomeOfArgs( 'activation_redirect_timestamp_free' );
+
+		$this->product_helper
+			->expects( 'is_premium' )
+			->andReturnFalse();
+
+		Monkey\Functions\expect( 'is_network_admin' )
+			->andReturn( false );
+
+		Monkey\Functions\expect( 'is_plugin_active_for_network' )
+			->andReturn( false );
+
+		Monkey\Filters\expectApplied( 'wpseo_should_redirect_after_install' )
+			->with( true )
+			->andReturn( false );
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();

--- a/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
@@ -158,6 +158,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -215,6 +216,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -239,6 +241,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -272,6 +275,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -313,6 +317,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -352,6 +357,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -398,6 +404,7 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( true );
 
 		$this->options_helper
 			->expects( 'get' )
@@ -498,6 +505,26 @@ final class Installation_Success_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
 		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur when the user is not authenticated.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_unauthenticated_user() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+		Monkey\Functions\expect( 'current_user_can' )->with( 'manage_options' )->andReturn( false );
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();

--- a/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Installation_Success_Integration_Test.php
@@ -154,6 +154,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_successful() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -206,6 +211,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_already_happened() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -225,6 +235,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_not_first_time_install() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -253,6 +268,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_premium_active() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -289,6 +309,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_bulk_activation() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -323,6 +348,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_network_admin() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -364,6 +394,11 @@ final class Installation_Success_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_maybe_redirect_network_active() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( false );
+
 		$this->options_helper
 			->expects( 'get' )
 			->with( 'should_redirect_after_install_free', false )
@@ -393,6 +428,76 @@ final class Installation_Success_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_plugin_active_for_network' )
 			->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur during an AJAX request.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_during_ajax() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur during a cron request.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_during_cron() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur during a REST API request.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_during_rest_request() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( true );
+
+		Monkey\Functions\expect( 'wp_safe_redirect' )
+			->never();
+
+		$this->instance->maybe_redirect();
+	}
+
+	/**
+	 * Tests that the redirection does not occur during a JSON request.
+	 *
+	 * @covers ::maybe_redirect
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_during_json_request() {
+		Monkey\Functions\expect( 'wp_doing_ajax' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_doing_cron' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_serving_rest_request' )->andReturn( false );
+		Monkey\Functions\expect( 'wp_is_json_request' )->andReturn( true );
 
 		Monkey\Functions\expect( 'wp_safe_redirect' )
 			->never();


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* The `maybe_redirect` method in `Installation_Success_Integration` only checked for AJAX via the `DOING_AJAX` constant. This caused issues (e.g. Bluehost SSO broken) because the redirect could fire during cron, REST, and JSON requests. Additionally, there was no capability check and no way for third-party code to skip the redirect.
## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."\
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....\
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....\
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:
* Fixes a bug where the installation success redirect was incorrectly fire during AJAX, cron, REST API, or JSON requests, breaking integrations such as the Bluehost SSO.
## Relevant technical choices:
* Replaced the legacy `DOING_AJAX` constant check with the WordPress helper functions `wp_doing_ajax()`, `wp_doing_cron()`, `wp_is_serving_rest_request()`, and `wp_is_json_request()`.
* Added a `current_user_can( 'manage_options' )` capability check so only admin users trigger the redirect.
* Added a `wpseo_should_redirect_after_install` filter (defaults to `true`) so third-party code can prevent the redirect by returning `false`.
* Extended the unit test suite with tests covering all the new early-return paths (AJAX, cron, REST, JSON, unauthenticated user, filter returning `false`).
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Prerequisites:** Have WP-CLI available, or be comfortable running SQL queries / using a DB tool to update the `wpseo` option.

#### 1. Normal redirect (happy path)
1. Deactivate Yoast SEO (if active).
2. Activate Yoast SEO on a fresh site (or one where it has never been activated before).
3. Visit any `wp-admin` page.
4. **Expected:** You are redirected to the Installation Success page (`wp-admin/admin.php?page=wpseo_installation_successful_free`).

#### 2. No redirect during AJAX
This is the most important case, because `admin-ajax.php` runs under `is_admin()` and fires `admin_init`.
1. Re-arm the redirect option:
   ```bash
   wp option patch update wpseo should_redirect_after_install_free 1
   wp option patch delete wpseo activation_redirect_timestamp_free
   ```
2. While logged in as admin, open the browser console and run:
   ```js
   fetch('/wp-admin/admin-ajax.php?action=heartbeat', { method: 'POST', credentials: 'same-origin' })
     .then(r => { console.log('Status:', r.status, 'Redirected:', r.redirected, 'URL:', r.url); return r.text(); })
     .then(t => console.log('Body:', t));
   ```
3. **Expected:** The response status is `200` (or `400` for an invalid nonce), `Redirected` is `false`, and the URL is **not** the Installation Success page. The AJAX request was not hijacked by a redirect.
4. Verify the option was not consumed — it should still be `1`:
   ```bash
   wp option pluck wpseo should_redirect_after_install_free
   ```

#### 3. No redirect for non-admin users
1. Re-arm the redirect option (same commands as step 2.1).
2. Log in as a user with the **Editor** role (no `manage_options` capability).
3. Visit any `wp-admin` page.
4. **Expected:** No redirect to the Installation Success page.

#### 4. No redirect when `wpseo_should_redirect_after_install` filter returns false
1. Add the following to a mu-plugin (`wp-content/mu-plugins/skip-yoast-redirect.php`):
   ```php
   <?php
   add_filter( 'wpseo_should_redirect_after_install', '__return_false' );
   ```
2. Re-arm the redirect option (same commands as step 2.1).
3. Log in as admin and visit any `wp-admin` page.
4. **Expected:** No redirect to the Installation Success page.
5. Clean up: remove the mu-plugin.

#### 5. Cron / REST / JSON (defensive guards)
These request types don't normally load the admin context (`is_admin()` is `false`), so `admin_init` doesn't fire and the integration doesn't run. The guards are defensive. They are fully covered by unit tests and don't require separate manual verification.
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->
* [ ] QA should use the same steps as above.
<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

**Prerequisites:** Have WP-CLI available, or be comfortable running SQL queries / using a DB tool to update the `wpseo` option.

#### 1. Normal redirect (happy path)
1. Deactivate Yoast SEO (if active).
2. Activate Yoast SEO on a fresh site (or one where it has never been activated before).
3. **Expected:** You are redirected to the Installation Success page (`wp-admin/admin.php?page=wpseo_installation_successful_free`).

#### 2. No redirect when `wpseo_should_redirect_after_install` filter returns false
1. Add the following to a mu-plugin (`wp-content/mu-plugins/skip-yoast-redirect.php`):
   ```php
   <?php
   add_filter( 'wpseo_should_redirect_after_install', '__return_false' );
   ```
2. Re-arm the redirect option:
   ```bash
   wp option patch update wpseo should_redirect_after_install_free 1
   wp option patch delete wpseo activation_redirect_timestamp_free
   ```
3. visit/reload any `wp-admin` page.
4. **Expected:** No redirect to the Installation Success page.
5. Clean up: remove the mu-plugin.



## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:
* The installation success redirect flow (`Installation_Success_Integration::maybe_redirect`). Any hosting environment or plugin that triggers admin requests (AJAX/REST/cron) during activation could be affected.
## Other environments
* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.
## Documentation
* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.
## Quality assurance
* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.
## Innovation
* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
Fixes #

