### PR TITLE
Add content suggestions modal for AI Content Planner feature

### DIFF
--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -42,7 +42,7 @@ const getModalContent = ( isEmptyCanvas ) => {
  * @returns {JSX.Element} The ApproveModal content.
  */
 export const ApproveModal = ( { isEmptyCanvas, isPremium, isUpsell, onClick, upsellLink } ) => {
-	const { title, description } = getModalContent( isEmptyCanvas, isUpsell );
+	const { title, description } = getModalContent( isEmptyCanvas );
 	const svgAriaProps = useSvgAria();
 
 	return (

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -50,8 +50,8 @@ export const ApproveModal = ( { isEmptyCanvas, isPremium, isUpsell, onClick, ups
 			<div className="yst-w-12 yst-h-12 yst-rounded-full yst-bg-ai-100 yst-flex yst-items-center yst-justify-center yst-mx-auto yst-mb-4">
 				<GradientSparklesIcon className="yst-h-6 yst-w-6" { ...svgAriaProps } />
 			</div>
-			<h3 className="yst-text-slate-900 yst-font-medium yst-text-lg yst-mb-2">{ title }</h3>
-			<p className="yst-text-slate-600 yst-text-sm yst-mb-6 yst-mx-6">{ description }</p>
+			<Modal.Title className="yst-text-slate-900 yst-font-medium yst-text-lg yst-mb-2">{ title }</Modal.Title>
+			<Modal.Description className="yst-text-slate-600 yst-text-sm yst-mb-6 yst-mx-6">{ description }</Modal.Description>
 			{ isUpsell ? <Button
 				variant="upsell" as="a" href={ upsellLink } target="_blank" className="yst-w-full" rel="noopener noreferrer"
 			>

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -1,9 +1,7 @@
-import { Button, Modal, GradientSparklesIcon, Root, useSvgAria } from "@yoast/ui-library";
+import { Button, Modal, GradientSparklesIcon, useSvgAria } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { OneSparkNote } from "./one-spark-note";
-import { useCallback } from "@wordpress/element";
-
 /**
  * Get the content of the modal based on whether the canvas is empty or not.
  *
@@ -36,28 +34,19 @@ const getModalContent = ( isEmptyCanvas ) => {
 /**
  * The modal that is shown when the user clicks the "Get content suggestions" button.
  *
- * @param {boolean} isOpen Whether the modal is open or not.
- * @param {function} onClose The function to call when the modal is closed.
  * @param {boolean} isEmptyCanvas Whether the post has content or not.
  * @param {boolean} isPremium Whether the user has a premium subscription or not.
  * @param {boolean} isUpsell Whether the modal is shown as an upsell or not.
- * @param {function} onClick The function to call when the user clicks the "Get content suggestions" button in the modal.
+ * @param {function} onClick The function to call when the user clicks the "Get content suggestions" button.
  * @param {string} upsellLink The link to the upsell page.
- * @returns {JSX.Element} The Content Planner Approved Modal.
+ * @returns {JSX.Element} The ApproveModal content.
  */
-export const ApproveModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUpsell, onClick, upsellLink } ) => {
+export const ApproveModal = ( { isEmptyCanvas, isPremium, isUpsell, onClick, upsellLink } ) => {
 	const { title, description } = getModalContent( isEmptyCanvas, isUpsell );
 	const svgAriaProps = useSvgAria();
-	const handleOnClick = useCallback( () => {
-		onClick();
-		onClose();
-	}, [ onClick, onClose ] );
 
-	return <Root><Modal
-		isOpen={ isOpen }
-		onClose={ onClose }
-	>
-		<Modal.Panel className="yst-text-center yst-w-96">
+	return (
+		<Modal.Panel className="yst-text-center yst-w-96" closeButtonScreenReaderText={ __( "Close modal", "wordpress-seo" ) }>
 			<div className="yst-w-12 yst-h-12 yst-rounded-full yst-bg-ai-100 yst-flex yst-items-center yst-justify-center yst-mx-auto yst-mb-4">
 				<GradientSparklesIcon className="yst-h-6 yst-w-6" { ...svgAriaProps } />
 			</div>
@@ -72,8 +61,8 @@ export const ApproveModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUps
 					"Yoast SEO Premium"
 				) }
 			</Button>
-				: <Button onClick={ handleOnClick } variant="ai-primary" className="yst-w-full"> { __( "Get content suggestions", "wordpress-seo" ) } </Button> }
+				: <Button onClick={ onClick } variant="ai-primary" className="yst-w-full"> { __( "Get content suggestions", "wordpress-seo" ) } </Button> }
 			{ ! isPremium && ! isUpsell && <OneSparkNote className="yst-mt-2" /> }
 		</Modal.Panel>
-	</Modal></Root>;
+	);
 };

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -1,4 +1,4 @@
-import { Button, Modal, GradientSparklesIcon, Root } from "@yoast/ui-library";
+import { Button, Modal, GradientSparklesIcon, Root, useSvgAria } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { OneSparkNote } from "./one-spark-note";
@@ -47,6 +47,7 @@ const getModalContent = ( isEmptyCanvas ) => {
  */
 export const ApproveModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUpsell, onClick, upsellLink } ) => {
 	const { title, description } = getModalContent( isEmptyCanvas, isUpsell );
+	const svgAriaProps = useSvgAria();
 	const handleOnClick = useCallback( () => {
 		onClick();
 		onClose();
@@ -58,7 +59,7 @@ export const ApproveModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUps
 	>
 		<Modal.Panel className="yst-text-center yst-w-96">
 			<div className="yst-w-12 yst-h-12 yst-rounded-full yst-bg-ai-100 yst-flex yst-items-center yst-justify-center yst-mx-auto yst-mb-4">
-				<GradientSparklesIcon className="yst-h-6 yst-w-6" />
+				<GradientSparklesIcon className="yst-h-6 yst-w-6" { ...svgAriaProps } />
 			</div>
 			<h3 className="yst-text-slate-900 yst-font-medium yst-text-lg yst-mb-2">{ title }</h3>
 			<p className="yst-text-slate-600 yst-text-sm yst-mb-6 yst-mx-6">{ description }</p>

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -1,6 +1,8 @@
 import { __ } from "@wordpress/i18n";
 import { Button, Root, useToggleState } from "@yoast/ui-library";
 import { ApproveModal } from "./approve-modal";
+import { ContentSuggestionsModal } from "./content-suggestions-modal";
+import { get } from "lodash";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
@@ -14,6 +16,8 @@ import { ApproveModal } from "./approve-modal";
 export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
 	const [ isApproveModalOpen, , , openApproveModal, closeApproveModal ] = useToggleState( false );
 	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
+	// For testing purposes.
+	const isLoading = get( window, "contentPlanner.isLoading", false );
 
 	return <Root><div className="yst-p-4">
 		<Button variant="ai-secondary" onClick={ openApproveModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
@@ -28,6 +32,43 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 			// Will be addressed in future iterations.
 			isUpsell={ false }
 			upsellLink={ upsellLink }
+		/>
+		<ContentSuggestionsModal
+			isOpen={ isContentSuggestionModalOpen }
+			onClose={ closeContentSuggestionModal }
+			isLoading={ isLoading }
+			suggestions={ [
+				{
+					intent: "informational",
+					title: "How to train your dog",
+					description: "Tips and tricks on how to train your dog effectively.",
+				},
+				{
+					intent: "navigational",
+					title: "Best dog training schools in New York",
+					description: "A list of the best dog training schools in New York.",
+				},
+				{
+					intent: "commercial",
+					title: "Top 10 dog training tools",
+					description: "A review of the top 10 dog training tools on the market.",
+				},
+				{
+					intent: "informational",
+					title: "How to groom your dog",
+					description: "Step-by-step guide on how to groom your dog at home.",
+				},
+				{
+					intent: "navigational",
+					title: "Dog parks in Los Angeles",
+					description: "Find the best dog parks in Los Angeles for your furry friend.",
+				},
+				{
+					intent: "commercial",
+					title: "Best dog food brands",
+					description: "An overview of the best dog food brands for a healthy diet.",
+				},
+			] }
 		/>
 	</div>
 	</Root>;

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -2,7 +2,6 @@ import { __ } from "@wordpress/i18n";
 import { Button, Root, useToggleState } from "@yoast/ui-library";
 import { ApproveModal } from "./approve-modal";
 import { ContentSuggestionsModal } from "./content-suggestions-modal";
-import { get } from "lodash";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
@@ -16,8 +15,6 @@ import { get } from "lodash";
 export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
 	const [ isApproveModalOpen, , , openApproveModal, closeApproveModal ] = useToggleState( false );
 	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
-	// Used for testing only, will be addressed in future iterations.
-	const isLoading = get( window, "contentPlanner.isLoading", false );
 
 	return <Root><div className="yst-p-4">
 		<Button variant="ai-secondary" onClick={ openApproveModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
@@ -36,40 +33,7 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 		<ContentSuggestionsModal
 			isOpen={ isContentSuggestionModalOpen }
 			onClose={ closeContentSuggestionModal }
-			isLoading={ isLoading }
 			isPremium={ isPremium }
-			suggestions={ [
-				{
-					intent: "informational",
-					title: "How to train your dog",
-					description: "Tips and tricks on how to train your dog effectively.",
-				},
-				{
-					intent: "navigational",
-					title: "Best dog training schools in New York",
-					description: "A list of the best dog training schools in New York.",
-				},
-				{
-					intent: "commercial",
-					title: "Top 10 dog training tools",
-					description: "A review of the top 10 dog training tools on the market.",
-				},
-				{
-					intent: "informational",
-					title: "How to groom your dog",
-					description: "Step-by-step guide on how to groom your dog at home.",
-				},
-				{
-					intent: "navigational",
-					title: "Dog parks in Los Angeles",
-					description: "Find the best dog parks in Los Angeles for your furry friend.",
-				},
-				{
-					intent: "commercial",
-					title: "Best dog food brands",
-					description: "An overview of the best dog food brands for a healthy diet.",
-				},
-			] }
 		/>
 	</div>
 	</Root>;

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -1,7 +1,6 @@
 import { __ } from "@wordpress/i18n";
 import { Button, Root, useToggleState } from "@yoast/ui-library";
-import { ApproveModal } from "./approve-modal";
-import { ContentSuggestionsModal } from "./content-suggestions-modal";
+import { FeatureModal } from "./feature-modal";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
@@ -13,28 +12,18 @@ import { ContentSuggestionsModal } from "./content-suggestions-modal";
  * @returns {JSX.Element} The Content Planner section in the sidebar.
  */
 export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
-	const [ isApproveModalOpen, , , openApproveModal, closeApproveModal ] = useToggleState( false );
-	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
+	const [ isFeatureModalOpen, , , openFeatureModal, closeFeatureModal ] = useToggleState( false );
 
 	return <Root><div className="yst-p-4">
-		<Button variant="ai-secondary" onClick={ openApproveModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
+		<Button variant="ai-secondary" onClick={ openFeatureModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
 			{ __( "Get content suggestions", "wordpress-seo" ) }
 		</Button>
-		<ApproveModal
-			isOpen={ isApproveModalOpen }
-			onClose={ closeApproveModal }
+		<FeatureModal
+			isOpen={ isFeatureModalOpen }
+			onClose={ closeFeatureModal }
 			isEmptyCanvas={ isEmptyCanvas }
 			isPremium={ isPremium }
-			onClick={ openContentSuggestionModal }
-			// Will be addressed in future iterations.
-			isUpsell={ false }
 			upsellLink={ upsellLink }
 		/>
-		<ContentSuggestionsModal
-			isOpen={ isContentSuggestionModalOpen }
-			onClose={ closeContentSuggestionModal }
-			isPremium={ isPremium }
-		/>
-	</div>
-	</Root>;
+	</div></Root>;
 };

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -16,6 +16,8 @@ import { get } from "lodash";
 export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
 	const [ isApproveModalOpen, , , openApproveModal, closeApproveModal ] = useToggleState( false );
 	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
+	// Used for testing only, will be addressed in future iterations.
+	const isLoading = get( window, "contentPlanner.isLoading", false );
 
 	return <Root><div className="yst-p-4">
 		<Button variant="ai-secondary" onClick={ openApproveModal } className={ location === "sidebar" ? "yst-w-full" : "" }>

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -9,10 +9,11 @@ import { FeatureModal } from "./feature-modal";
  * @param {string}  props.location      The location where the editor item is rendered. Can be "sidebar" or "metabox".
  * @param {boolean} props.isPremium     Whether the user has a premium add-on activated.
  * @param {boolean} props.isEmptyCanvas Whether the editor canvas has no content.
+ * @param {boolean} props.isUpsell     Whether to show the upsell variant of the modal.
  * @param {string}  props.upsellLink   The link to the upsell page for the content planner feature.
  * @returns {JSX.Element} The Content Planner section in the sidebar.
  */
-export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
+export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, isUpsell, upsellLink } ) => {
 	const [ isFeatureModalOpen, , , openFeatureModal, closeFeatureModal ] = useToggleState( false );
 
 	return <Root><div className="yst-p-4">
@@ -24,6 +25,7 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 			onClose={ closeFeatureModal }
 			isEmptyCanvas={ isEmptyCanvas }
 			isPremium={ isPremium }
+			isUpsell={ isUpsell }
 			upsellLink={ upsellLink }
 		/>
 	</div></Root>;

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -35,6 +35,7 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 			isOpen={ isContentSuggestionModalOpen }
 			onClose={ closeContentSuggestionModal }
 			isLoading={ isLoading }
+			isPremium={ isPremium }
 			suggestions={ [
 				{
 					intent: "informational",

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -1,0 +1,146 @@
+import { Badge, Modal, Title, SkeletonLoader } from "@yoast/ui-library";
+import { __ } from "@wordpress/i18n";
+import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
+import { ReactComponent as Yoast } from "../../../images/yoast.svg";
+import { UsageCounter } from "@yoast/ai-frontend";
+import { useSelect } from "@wordpress/data";
+import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
+import { noop } from "lodash";
+import classNames from "classnames";
+
+const intentBadge = {
+	informational: {
+		classes: "yst-bg-blue-200 yst-text-blue-900",
+		Icon: BookOpenIcon,
+		label: __( "Informational", "wordpress-seo" ),
+	},
+	navigational: {
+		classes: "yst-bg-violet-200 yst-text-violet-900",
+		Icon: MapIcon,
+		label: __( "Navigational", "wordpress-seo" ),
+	},
+	commercial: {
+		classes: "yst-bg-yellow-200 yst-text-yellow-900",
+		Icon: StarIcon,
+		label: __( "Commercial", "wordpress-seo" ),
+	},
+};
+
+/**
+ * Suggestion button component.
+ *
+ * @param {string} intent The intent of the suggestion.
+ * @param {string} title The title of the suggestion.
+ * @param {string} description The description of the suggestion.
+ *
+ * @returns {JSX.Element} The SuggestionButton component.
+ */
+const SuggestionButton = ( { intent, title, description, onClick } ) => {
+	const Icon = intentBadge[ intent ] ? intentBadge[ intent ].Icon : BookOpenIcon;
+	return (
+		<button onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
+			{ intentBadge[ intent ] ? (
+				<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-mb-2 yst-text-xs", intentBadge[ intent ].classes ) }>
+					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } /> { intentBadge[ intent ].label }
+				</Badge>
+			) : (
+				<Badge>{ intent }</Badge>
+			) }
+			<div className="yst-font-medium yst-text-sm yst-mb-2 yst-text-slate-800">{ title }</div>
+			<p className="yst-text-slate-600">{ description }</p>
+		</button>
+	);
+};
+
+/**
+ * Loading skeleton for the SuggestionButton component.
+ *
+ * @returns {JSX.Element} The SuggestionButtonSkeleton component.
+ */
+const SuggestionButtonSkeleton = () => (
+	<div className="yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
+		<div className="yst-px-2 yst-py-1 yst-bg-white yst-inline-flex yst-gap-1 yst-items-center yst-justify-start yst-mb-2 yst-rounded-3xl yst-border yst-border-slate-300">
+			<SkeletonLoader className="yst-w-2 yst-h-2 yst-rounded-full" />
+			<SkeletonLoader className="yst-w-20 yst-h-3 yst-rounded" />
+		</div>
+		<SkeletonLoader className="yst-w-64 yst-h-[18px] yst-rounded yst-mb-3" />
+		<SkeletonLoader className="yst-w-full yst-h-[13px] yst-rounded yst-mb-2" />
+		<SkeletonLoader className="yst-w-2/3 yst-h-[13px] yst-rounded" />
+	</div>
+);
+
+const LoadingModalContent = () => (
+	<>
+		<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
+			<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" />
+			<div className="yst-italic yst-text-slate-500">{ __( "Analyzing your site content…", "wordpress-seo" ) }</div>
+		</div>
+		<div className="yst-reltive">
+			{ [ ...Array( 5 ) ].map( ( _, index ) => <SuggestionButtonSkeleton key={ index } /> ) }
+			{ // gradient overlay to create a fade effect at the bottom of the modal content
+			}
+			<div
+				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
+				aria-hidden="true"
+			/>
+		</div>
+	</>
+);
+
+/**
+ * @typedef {Object} Suggestion
+ * @property {string} intent The intent of the suggestion (e.g. "informational", "navigational", "commercial").
+ * @property {string} title The title of the suggestion.
+ * @property {string} description The description of the suggestion.
+ */
+
+/**
+ * ContentSuggestionsModal component.
+ *
+ * @param {boolean} isOpen Whether the modal is open or not.
+ * @param {Function} onClose The function to call when the modal should be closed.
+ * @param {boolean} isLoading Whether the content suggestions are being generated.
+ * @param {Suggestion[]} suggestions The content suggestions to display in the modal.
+ *
+ * @returns {JSX.Element} The ContentSuggestionsModal component.
+ */
+export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestions } ) => {
+	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
+	return (
+		<Modal
+			isOpen={ isOpen }
+			onClose={ onClose }
+		>
+			<Modal.Panel className="yst-p-0 yst-max-w-2xl">
+				<Modal.Container>
+					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
+						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
+						<Title size="2" className="yst-flex-grow"> { __( "Content suggestions", "wordpress-seo" ) } </Title>
+						<Badge size="small"> { __( "Beta", "wordpress-seo" ) } </Badge>
+						<UsageCounter
+							limit={ 10 }
+							requests={ 1 }
+							mentionBetaInTooltip={ isPremium }
+							mentionResetInTooltip={ isPremium }
+						/>
+					</Modal.Container.Header>
+					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
+						{ isLoading ? (
+							<LoadingModalContent />
+						) : (
+							<>
+								<p className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</p>
+								{ suggestions.map( ( suggestion, index ) => (
+									<SuggestionButton
+										key={ index }
+										{ ...suggestion }
+										onClick={ noop }
+									/>
+								) ) }
+							</> ) }
+					</Modal.Container.Content>
+				</Modal.Container>
+			</Modal.Panel>
+		</Modal>
+	);
+};

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -6,7 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
-import { Fragment, useRef, useEffect } from "@wordpress/element";
+import { Fragment, useRef, useEffect, useState } from "@wordpress/element";
 import { Transition } from "@headlessui/react";
 
 const intentBadge = {
@@ -153,11 +153,15 @@ const LoadingModalContent = () => {
 export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 	const svgAriaProps = useSvgAria();
 	const closeButtonRef = useRef( null );
+	const [ announceLoading, setAnnounceLoading ] = useState( false );
 
 	useEffect( () => {
 		if ( status === "content-suggestions-loading" ) {
 			closeButtonRef.current?.focus();
+			const timer = setTimeout( () => setAnnounceLoading( true ), 100 );
+			return () => clearTimeout( timer );
 		}
+		setAnnounceLoading( false );
 	}, [ status ] );
 
 	return (
@@ -183,7 +187,7 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 					<div className="yst-relative" aria-live="polite">
 						<Transition
 							as={ Fragment }
-							show={ status === "content-suggestions-loading" }
+							show={ announceLoading }
 							enter="yst-transition-opacity yst-duration-300"
 							enterFrom="yst-opacity-0"
 							enterTo="yst-opacity-100"

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -185,7 +185,7 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 						<Transition
 							as={ Fragment }
 							show={ status === "content-suggestions-success" }
-							enter="yst-transition-opacity yst-duration-300"
+							enter="yst-transition-opacity yst-duration-300 yst-delay-300"
 							enterFrom="yst-opacity-0"
 							enterTo="yst-opacity-100"
 							leave="yst-transition-opacity yst-duration-300"

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -117,6 +117,7 @@ const LoadingModalContent = () => {
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
 export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
+	const svgAriaProps = useSvgAria();
 	const suggestions = [
 		{
 			intent: "informational",
@@ -182,7 +183,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 			>
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
-						<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps }/>
+						<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />
 						<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
 						<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
 						<UsageCounter

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -130,7 +130,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 							mentionResetInTooltip={ isPremium }
 						/>
 					</Modal.Container.Header>
-					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
+					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0 aria-live="polite">
 						{ isLoading ? (
 							<LoadingModalContent />
 						) : (

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -27,6 +27,40 @@ const intentBadge = {
 	},
 };
 
+// Placeholder suggestions — will be replaced with real API data in a future iteration.
+const suggestions = [
+	{
+		intent: "informational",
+		title: "How to train your dog",
+		description: "Tips and tricks on how to train your dog effectively.",
+	},
+	{
+		intent: "navigational",
+		title: "Best dog training schools in New York",
+		description: "A list of the best dog training schools in New York.",
+	},
+	{
+		intent: "commercial",
+		title: "Top 10 dog training tools",
+		description: "A review of the top 10 dog training tools on the market.",
+	},
+	{
+		intent: "informational",
+		title: "How to groom your dog",
+		description: "Step-by-step guide on how to groom your dog at home.",
+	},
+	{
+		intent: "navigational",
+		title: "Dog parks in Los Angeles",
+		description: "Find the best dog parks in Los Angeles for your furry friend.",
+	},
+	{
+		intent: "commercial",
+		title: "Best dog food brands",
+		description: "An overview of the best dog food brands for a healthy diet.",
+	},
+];
+
 /**
  * Suggestion button component.
  *
@@ -111,8 +145,8 @@ const LoadingModalContent = () => {
  * ContentSuggestionsModal component.
  *
  * @param {Object} props The component props.
- * @param {boolean} props.isOpen Whether the modal is open or not.
- * @param {boolean} props.isPremium Whether the user has a premium add-on is activated or not.
+ * @param {string} props.status The current status of the modal ("content-suggestions-loading" or "content-suggestions-success").
+ * @param {boolean} props.isPremium Whether the user has a premium add-on activated or not.
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
@@ -125,38 +159,6 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 			closeButtonRef.current?.focus();
 		}
 	}, [ status ] );
-	const suggestions = [
-		{
-			intent: "informational",
-			title: "How to train your dog",
-			description: "Tips and tricks on how to train your dog effectively.",
-		},
-		{
-			intent: "navigational",
-			title: "Best dog training schools in New York",
-			description: "A list of the best dog training schools in New York.",
-		},
-		{
-			intent: "commercial",
-			title: "Top 10 dog training tools",
-			description: "A review of the top 10 dog training tools on the market.",
-		},
-		{
-			intent: "informational",
-			title: "How to groom your dog",
-			description: "Step-by-step guide on how to groom your dog at home.",
-		},
-		{
-			intent: "navigational",
-			title: "Dog parks in Los Angeles",
-			description: "Find the best dog parks in Los Angeles for your furry friend.",
-		},
-		{
-			intent: "commercial",
-			title: "Best dog food brands",
-			description: "An overview of the best dog food brands for a healthy diet.",
-		},
-	];
 
 	return (
 		<Modal.Panel
@@ -168,7 +170,7 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 				<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 					<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />
 					<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
-					<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
+					<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
 					<UsageCounter
 						limit={ 10 }
 						requests={ 1 }
@@ -191,6 +193,10 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 						>
 							<div><LoadingModalContent /></div>
 						</Transition>
+						{ /*
+						 * yst-delay-300 matches the approve modal's leave duration (yst-duration-300)
+						 * so the suggestions only fade in after the approve panel has faded out.
+						 */ }
 						<Transition
 							as={ Fragment }
 							show={ status === "content-suggestions-success" }
@@ -203,9 +209,10 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 						>
 							<div>
 								<Modal.Description className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</Modal.Description>
-								{ suggestions.map( ( suggestion, index ) => (
+								{ /* onClick is a placeholder — will be wired to real handler in a future iteration. */ }
+								{ suggestions.map( ( suggestion ) => (
 									<SuggestionButton
-										key={ index }
+										key={ suggestion.title }
 										{ ...suggestion }
 										onClick={ noop }
 									/>

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -180,7 +180,7 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 				</Modal.Container.Header>
 				<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
 					{ /* yst-relative enables absolute positioning of the leaving element to prevent layout stacking during cross-fade. */ }
-					<div className="yst-relative" aria-live="polite" aria-atomic="true">
+					<div className="yst-relative" aria-live="polite">
 						<Transition
 							as={ Fragment }
 							show={ status === "content-suggestions-loading" }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -130,20 +130,22 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 							mentionResetInTooltip={ isPremium }
 						/>
 					</Modal.Container.Header>
-					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0" aria-live="polite">
-						{ isLoading ? (
-							<LoadingModalContent />
-						) : (
-							<>
-								<p className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</p>
-								{ suggestions.map( ( suggestion, index ) => (
-									<SuggestionButton
-										key={ index }
-										{ ...suggestion }
-										onClick={ noop }
-									/>
-								) ) }
-							</> ) }
+					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
+						<div aria-live="polite">
+							{ isLoading ? (
+								<LoadingModalContent />
+							) : (
+								<>
+									<p className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</p>
+									{ suggestions.map( ( suggestion, index ) => (
+										<SuggestionButton
+											key={ index }
+											{ ...suggestion }
+											onClick={ noop }
+										/>
+									) ) }
+								</> ) }
+						</div>
 					</Modal.Container.Content>
 				</Modal.Container>
 			</Modal.Panel>

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -6,7 +6,8 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
-import { useEffect } from "@wordpress/element";
+import { Fragment, useEffect } from "@wordpress/element";
+import { Transition } from "@headlessui/react";
 
 const intentBadge = {
 	informational: {
@@ -194,10 +195,31 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 						/>
 					</Modal.Container.Header>
 					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
-						<div aria-live="polite" aria-atomic="true">
-							{ status === "loading" && <LoadingModalContent /> }
-							{ status === "success" && (
-								<>
+						{ /* yst-relative enables absolute positioning of the leaving element to prevent layout stacking during cross-fade. */ }
+						<div className="yst-relative" aria-live="polite" aria-atomic="true">
+							<Transition
+								as={ Fragment }
+								show={ status === "loading" }
+								enter="yst-transition-opacity yst-duration-300"
+								enterFrom="yst-opacity-0"
+								enterTo="yst-opacity-100"
+								leave="yst-transition-opacity yst-duration-300 yst-absolute yst-top-0 yst-left-0 yst-right-0"
+								leaveFrom="yst-opacity-100"
+								leaveTo="yst-opacity-0"
+							>
+								<div><LoadingModalContent /></div>
+							</Transition>
+							<Transition
+								as={ Fragment }
+								show={ status === "success" }
+								enter="yst-transition-opacity yst-duration-300"
+								enterFrom="yst-opacity-0"
+								enterTo="yst-opacity-100"
+								leave="yst-transition-opacity yst-duration-300"
+								leaveFrom="yst-opacity-100"
+								leaveTo="yst-opacity-0"
+							>
+								<div>
 									<Modal.Description className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</Modal.Description>
 									{ suggestions.map( ( suggestion, index ) => (
 										<SuggestionButton
@@ -206,8 +228,8 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 											onClick={ noop }
 										/>
 									) ) }
-								</>
-							) }
+								</div>
+							</Transition>
 						</div>
 					</Modal.Container.Content>
 				</Modal.Container>

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -32,13 +32,14 @@ const intentBadge = {
  * @param {string} intent The intent of the suggestion.
  * @param {string} title The title of the suggestion.
  * @param {string} description The description of the suggestion.
+ * @param {Function} onClick The function to call when the suggestion button is clicked.
  *
  * @returns {JSX.Element} The SuggestionButton component.
  */
 const SuggestionButton = ( { intent, title, description, onClick } ) => {
 	const Icon = intentBadge[ intent ] ? intentBadge[ intent ].Icon : BookOpenIcon;
 	return (
-		<button onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
+		<button type="button" onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
 			{ intentBadge[ intent ] ? (
 				<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-mb-2 yst-text-xs", intentBadge[ intent ].classes ) }>
 					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } /> { intentBadge[ intent ].label }
@@ -75,9 +76,9 @@ const LoadingModalContent = () => (
 			<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" />
 			<div className="yst-italic yst-text-slate-500">{ __( "Analyzing your site content…", "wordpress-seo" ) }</div>
 		</div>
-		<div className="yst-reltive">
+		<div className="yst-relative">
 			{ [ ...Array( 5 ) ].map( ( _, index ) => <SuggestionButtonSkeleton key={ index } /> ) }
-			{/* gradient overlay to create a fade effect at the bottom of the modal content */}
+			{ /* gradient overlay to create a fade effect at the bottom of the modal content */ }
 			<div
 				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
 				aria-hidden="true"
@@ -114,7 +115,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
-						<Title size="2" className="yst-flex-grow"> { __( "Content suggestions", "wordpress-seo" ) } </Title>
+						<Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) } </Title>
 						<Badge size="small"> { __( "Beta", "wordpress-seo" ) } </Badge>
 						<UsageCounter
 							limit={ 10 }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -130,7 +130,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 							mentionResetInTooltip={ isPremium }
 						/>
 					</Modal.Container.Header>
-					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0 aria-live="polite">
+					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0" aria-live="polite">
 						{ isLoading ? (
 							<LoadingModalContent />
 						) : (

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -28,10 +28,11 @@ const intentBadge = {
 /**
  * Suggestion button component.
  *
- * @param {string} intent The intent of the suggestion.
- * @param {string} title The title of the suggestion.
- * @param {string} description The description of the suggestion.
- * @param {Function} onClick The function to call when the suggestion button is clicked.
+ * @param {object} props The component props.
+ * @param {string} props.intent The intent of the suggestion.
+ * @param {string} props.title The title of the suggestion.
+ * @param {string} props.description The description of the suggestion.
+ * @param {Function} props.onClick The function to call when the suggestion button is clicked.
  *
  * @returns {JSX.Element} The SuggestionButton component.
  */
@@ -69,6 +70,11 @@ const SuggestionButtonSkeleton = () => (
 	</div>
 );
 
+/**
+ * The loading content for the ContentSuggestionsModal.
+ *
+ * @returns {JSX.Element} The loading content for the ContentSuggestionsModal.
+ */
 const LoadingModalContent = () => (
 	<>
 		<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
@@ -96,11 +102,12 @@ const LoadingModalContent = () => (
 /**
  * ContentSuggestionsModal component.
  *
- * @param {boolean} isOpen Whether the modal is open or not.
- * @param {Function} onClose The function to call when the modal should be closed.
- * @param {boolean} isLoading Whether the content suggestions are being generated.
- * @param {boolean} isPremium Whether the user has a premium add-on is activated or not.
- * @param {Suggestion[]} suggestions The content suggestions to display in the modal.
+ * @param {Object} props The component props.
+ * @param {boolean} props.isOpen Whether the modal is open or not.
+ * @param {Function} props.onClose The function to call when the modal should be closed.
+ * @param {boolean} props.isLoading Whether the content suggestions are being generated.
+ * @param {boolean} props.isPremium Whether the user has a premium add-on is activated or not.
+ * @param {Suggestion[]} props.suggestions The content suggestions to display in the modal.
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -182,7 +182,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 			>
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
-						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
+						<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps }/>
 						<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
 						<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
 						<UsageCounter

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -1,4 +1,4 @@
-import { Badge, Modal, Title, SkeletonLoader } from "@yoast/ui-library";
+import { Badge, Modal, SkeletonLoader, useToggleState, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
@@ -6,6 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
+import { useEffect } from "@wordpress/element";
 
 const intentBadge = {
 	informational: {
@@ -37,12 +38,13 @@ const intentBadge = {
  * @returns {JSX.Element} The SuggestionButton component.
  */
 const SuggestionButton = ( { intent, title, description, onClick } ) => {
+	const svgAriaProps = useSvgAria();
 	const Icon = intentBadge[ intent ] ? intentBadge[ intent ].Icon : BookOpenIcon;
 	return (
 		<button type="button" onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
 			{ intentBadge[ intent ] ? (
 				<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-mb-2 yst-text-xs", intentBadge[ intent ].classes ) }>
-					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } /> { intentBadge[ intent ].label }
+					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } { ...svgAriaProps } /> { intentBadge[ intent ].label }
 				</Badge>
 			) : (
 				<Badge>{ intent }</Badge>
@@ -75,22 +77,27 @@ const SuggestionButtonSkeleton = () => (
  *
  * @returns {JSX.Element} The loading content for the ContentSuggestionsModal.
  */
-const LoadingModalContent = () => (
-	<>
-		<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
-			<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" />
-			<div className="yst-italic yst-text-slate-500">{ __( "Analyzing your site content…", "wordpress-seo" ) }</div>
-		</div>
-		<div className="yst-relative">
-			{ [ ...Array( 5 ) ].map( ( _, index ) => <SuggestionButtonSkeleton key={ index } /> ) }
-			{ /* gradient overlay to create a fade effect at the bottom of the modal content */ }
-			<div
-				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
-				aria-hidden="true"
-			/>
-		</div>
-	</>
-);
+const LoadingModalContent = () => {
+	const svgAriaProps = useSvgAria();
+	return (
+		<>
+			<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
+				<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" { ...svgAriaProps } />
+				<Modal.Description className="yst-italic yst-text-slate-500">
+					<span className="yst-sr-only"> Yoast </span>
+					{ __( "Analyzing your site content…", "wordpress-seo" ) }</Modal.Description>
+			</div>
+			<div className="yst-relative">
+				{ [ ...Array( 5 ) ].map( ( _, index ) => <SuggestionButtonSkeleton key={ index } /> ) }
+				{ /* gradient overlay to create a fade effect at the bottom of the modal content */ }
+				<div
+					className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
+					aria-hidden="true"
+				/>
+			</div>
+		</>
+	);
+};
 
 /**
  * @typedef {Object} Suggestion
@@ -105,23 +112,78 @@ const LoadingModalContent = () => (
  * @param {Object} props The component props.
  * @param {boolean} props.isOpen Whether the modal is open or not.
  * @param {Function} props.onClose The function to call when the modal should be closed.
- * @param {boolean} props.isLoading Whether the content suggestions are being generated.
  * @param {boolean} props.isPremium Whether the user has a premium add-on is activated or not.
- * @param {Suggestion[]} props.suggestions The content suggestions to display in the modal.
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
-export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestions, isPremium } ) => {
+export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
+	const suggestions = [
+		{
+			intent: "informational",
+			title: "How to train your dog",
+			description: "Tips and tricks on how to train your dog effectively.",
+		},
+		{
+			intent: "navigational",
+			title: "Best dog training schools in New York",
+			description: "A list of the best dog training schools in New York.",
+		},
+		{
+			intent: "commercial",
+			title: "Top 10 dog training tools",
+			description: "A review of the top 10 dog training tools on the market.",
+		},
+		{
+			intent: "informational",
+			title: "How to groom your dog",
+			description: "Step-by-step guide on how to groom your dog at home.",
+		},
+		{
+			intent: "navigational",
+			title: "Dog parks in Los Angeles",
+			description: "Find the best dog parks in Los Angeles for your furry friend.",
+		},
+		{
+			intent: "commercial",
+			title: "Best dog food brands",
+			description: "An overview of the best dog food brands for a healthy diet.",
+		},
+	];
+
+	const [ status, , setStatus ] = useToggleState( "idle" );
+
+	// Simulate loading state when the content suggestions modal is opened.
+	useEffect( () => {
+		if ( isOpen ) {
+			const loadingTimer = setTimeout( () => {
+				setStatus( "loading" );
+			}, 100 );
+
+			const timer = setTimeout( () => {
+				setStatus( "success" );
+			}, 5000 );
+			return () => {
+				clearTimeout( loadingTimer );
+				clearTimeout( timer );
+			};
+		}
+		return () => {
+			setStatus( "idle" );
+		};
+	}, [ isOpen ] );
+
 	return (
 		<Modal
 			isOpen={ isOpen }
 			onClose={ onClose }
 		>
-			<Modal.Panel className="yst-p-0 yst-max-w-2xl">
+			<Modal.Panel
+				className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) }
+			>
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
-						<Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Title>
+						<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
 						<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
 						<UsageCounter
 							limit={ 10 }
@@ -131,12 +193,11 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 						/>
 					</Modal.Container.Header>
 					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
-						<div aria-live="polite">
-							{ isLoading ? (
-								<LoadingModalContent />
-							) : (
+						<div aria-live="polite" aria-atomic="true">
+							{ status === "loading" && <LoadingModalContent /> }
+							{ status === "success" && (
 								<>
-									<p className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</p>
+									<Modal.Description className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</Modal.Description>
 									{ suggestions.map( ( suggestion, index ) => (
 										<SuggestionButton
 											key={ index }
@@ -144,7 +205,8 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 											onClick={ noop }
 										/>
 									) ) }
-								</> ) }
+								</>
+							) }
 						</div>
 					</Modal.Container.Content>
 				</Modal.Container>

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -77,8 +77,7 @@ const LoadingModalContent = () => (
 		</div>
 		<div className="yst-reltive">
 			{ [ ...Array( 5 ) ].map( ( _, index ) => <SuggestionButtonSkeleton key={ index } /> ) }
-			{ // gradient overlay to create a fade effect at the bottom of the modal content
-			}
+			{/* gradient overlay to create a fade effect at the bottom of the modal content */}
 			<div
 				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
 				aria-hidden="true"

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -1,4 +1,4 @@
-import { Badge, Modal, SkeletonLoader, useToggleState, useSvgAria } from "@yoast/ui-library";
+import { Badge, Modal, SkeletonLoader, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
@@ -6,7 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
-import { Fragment, useEffect } from "@wordpress/element";
+import { Fragment } from "@wordpress/element";
 import { Transition } from "@headlessui/react";
 
 const intentBadge = {
@@ -112,12 +112,11 @@ const LoadingModalContent = () => {
  *
  * @param {Object} props The component props.
  * @param {boolean} props.isOpen Whether the modal is open or not.
- * @param {Function} props.onClose The function to call when the modal should be closed.
  * @param {boolean} props.isPremium Whether the user has a premium add-on is activated or not.
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
-export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
+export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 	const svgAriaProps = useSvgAria();
 	const suggestions = [
 		{
@@ -152,88 +151,61 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 		},
 	];
 
-	const [ status, , setStatus ] = useToggleState( "idle" );
-
-	// Simulate loading state when the content suggestions modal is opened.
-	useEffect( () => {
-		if ( isOpen ) {
-			const loadingTimer = setTimeout( () => {
-				setStatus( "loading" );
-			}, 100 );
-
-			const timer = setTimeout( () => {
-				setStatus( "success" );
-			}, 5000 );
-			return () => {
-				clearTimeout( loadingTimer );
-				clearTimeout( timer );
-			};
-		}
-		return () => {
-			setStatus( "idle" );
-		};
-	}, [ isOpen ] );
-
 	return (
-		<Modal
-			isOpen={ isOpen }
-			onClose={ onClose }
+		<Modal.Panel
+			className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) }
 		>
-			<Modal.Panel
-				className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) }
-			>
-				<Modal.Container>
-					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
-						<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />
-						<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
-						<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
-						<UsageCounter
-							limit={ 10 }
-							requests={ 1 }
-							mentionBetaInTooltip={ isPremium }
-							mentionResetInTooltip={ isPremium }
-						/>
-					</Modal.Container.Header>
-					<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
-						{ /* yst-relative enables absolute positioning of the leaving element to prevent layout stacking during cross-fade. */ }
-						<div className="yst-relative" aria-live="polite" aria-atomic="true">
-							<Transition
-								as={ Fragment }
-								show={ status === "loading" }
-								enter="yst-transition-opacity yst-duration-300"
-								enterFrom="yst-opacity-0"
-								enterTo="yst-opacity-100"
-								leave="yst-transition-opacity yst-duration-300 yst-absolute yst-top-0 yst-left-0 yst-right-0"
-								leaveFrom="yst-opacity-100"
-								leaveTo="yst-opacity-0"
-							>
-								<div><LoadingModalContent /></div>
-							</Transition>
-							<Transition
-								as={ Fragment }
-								show={ status === "success" }
-								enter="yst-transition-opacity yst-duration-300"
-								enterFrom="yst-opacity-0"
-								enterTo="yst-opacity-100"
-								leave="yst-transition-opacity yst-duration-300"
-								leaveFrom="yst-opacity-100"
-								leaveTo="yst-opacity-0"
-							>
-								<div>
-									<Modal.Description className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</Modal.Description>
-									{ suggestions.map( ( suggestion, index ) => (
-										<SuggestionButton
-											key={ index }
-											{ ...suggestion }
-											onClick={ noop }
-										/>
-									) ) }
-								</div>
-							</Transition>
-						</div>
-					</Modal.Container.Content>
-				</Modal.Container>
-			</Modal.Panel>
-		</Modal>
+			<Modal.Container>
+				<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
+					<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />
+					<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
+					<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
+					<UsageCounter
+						limit={ 10 }
+						requests={ 1 }
+						mentionBetaInTooltip={ isPremium }
+						mentionResetInTooltip={ isPremium }
+					/>
+				</Modal.Container.Header>
+				<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">
+					{ /* yst-relative enables absolute positioning of the leaving element to prevent layout stacking during cross-fade. */ }
+					<div className="yst-relative" aria-live="polite" aria-atomic="true">
+						<Transition
+							as={ Fragment }
+							show={ status === "content-suggestions-loading" }
+							enter="yst-transition-opacity yst-duration-300"
+							enterFrom="yst-opacity-0"
+							enterTo="yst-opacity-100"
+							leave="yst-transition-opacity yst-duration-300 yst-absolute yst-top-0 yst-left-0 yst-right-0"
+							leaveFrom="yst-opacity-100"
+							leaveTo="yst-opacity-0"
+						>
+							<div><LoadingModalContent /></div>
+						</Transition>
+						<Transition
+							as={ Fragment }
+							show={ status === "content-suggestions-success" }
+							enter="yst-transition-opacity yst-duration-300"
+							enterFrom="yst-opacity-0"
+							enterTo="yst-opacity-100"
+							leave="yst-transition-opacity yst-duration-300"
+							leaveFrom="yst-opacity-100"
+							leaveTo="yst-opacity-0"
+						>
+							<div>
+								<Modal.Description className="yst-mb-4">{ __( "Select a suggestion to generate a structured outline for your post.", "wordpress-seo" ) }</Modal.Description>
+								{ suggestions.map( ( suggestion, index ) => (
+									<SuggestionButton
+										key={ index }
+										{ ...suggestion }
+										onClick={ noop }
+									/>
+								) ) }
+							</div>
+						</Transition>
+					</div>
+				</Modal.Container.Content>
+			</Modal.Container>
+		</Modal.Panel>
 	);
 };

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -6,7 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
-import { Fragment } from "@wordpress/element";
+import { Fragment, useRef, useEffect } from "@wordpress/element";
 import { Transition } from "@headlessui/react";
 
 const intentBadge = {
@@ -118,6 +118,13 @@ const LoadingModalContent = () => {
  */
 export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 	const svgAriaProps = useSvgAria();
+	const closeButtonRef = useRef( null );
+
+	useEffect( () => {
+		if ( status === "content-suggestions-loading" ) {
+			closeButtonRef.current?.focus();
+		}
+	}, [ status ] );
 	const suggestions = [
 		{
 			intent: "informational",
@@ -153,8 +160,10 @@ export const ContentSuggestionsModal = ( { status, isPremium } ) => {
 
 	return (
 		<Modal.Panel
-			className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) }
+			className="yst-p-0 yst-max-w-2xl"
+			hasCloseButton={ false }
 		>
+			<Modal.CloseButton ref={ closeButtonRef } screenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) } />
 			<Modal.Container>
 				<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 					<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -3,7 +3,6 @@ import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
-import { useSelect } from "@wordpress/data";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
@@ -100,12 +99,12 @@ const LoadingModalContent = () => (
  * @param {boolean} isOpen Whether the modal is open or not.
  * @param {Function} onClose The function to call when the modal should be closed.
  * @param {boolean} isLoading Whether the content suggestions are being generated.
+ * @param {boolean} isPremium Whether the user has a premium add-on is activated or not.
  * @param {Suggestion[]} suggestions The content suggestions to display in the modal.
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
-export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestions } ) => {
-	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
+export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestions, isPremium } ) => {
 	return (
 		<Modal
 			isOpen={ isOpen }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -121,7 +121,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
-						<Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) } </Title>
+						<Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Title>
 						<Badge size="small"> { __( "Beta", "wordpress-seo" ) } </Badge>
 						<UsageCounter
 							limit={ 10 }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -41,7 +41,7 @@ const SuggestionButton = ( { intent, title, description, onClick } ) => {
 	const svgAriaProps = useSvgAria();
 	const Icon = intentBadge[ intent ] ? intentBadge[ intent ].Icon : BookOpenIcon;
 	return (
-		<button type="button" onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm">
+		<button type="button" onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500">
 			{ intentBadge[ intent ] ? (
 				<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-mb-2 yst-text-xs", intentBadge[ intent ].classes ) }>
 					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } { ...svgAriaProps } /> { intentBadge[ intent ].label }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -122,7 +122,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isLoading, suggestio
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
 						<Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Title>
-						<Badge size="small"> { __( "Beta", "wordpress-seo" ) } </Badge>
+						<Badge size="small"> { __( "Beta", "wordpress-seo" ) }</Badge>
 						<UsageCounter
 							limit={ 10 }
 							requests={ 1 }

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -16,13 +16,17 @@ import { Transition } from "@headlessui/react";
  * @returns {JSX.Element} The Content Planner Feature Modal.
  */
 export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUpsell, upsellLink } ) => {
-	const [ status, setStatus ] = useState( "idle" );
+	const [ status, setStatus ] = useState( null );
 
 	const handleGetSuggestionsClick = useCallback( () => {
 		setStatus( "content-suggestions-loading" );
 	}, [] );
 
 	useEffect( () => {
+		if ( status === null ) {
+			const timer = setTimeout( () => setStatus( "idle" ), 300 );
+			return () => clearTimeout( timer );
+		}
 		if ( status === "content-suggestions-loading" ) {
 			const timer = setTimeout( () => setStatus( "content-suggestions-success" ), 5000 );
 			return () => clearTimeout( timer );

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -1,0 +1,78 @@
+import { Modal } from "@yoast/ui-library";
+import { Fragment, useState, useEffect, useCallback } from "@wordpress/element";
+import { ApproveModal } from "./approve-modal";
+import { ContentSuggestionsModal } from "./content-suggestions-modal";
+import { Transition } from "@headlessui/react";
+
+/**
+ * The modal that is shown when the user clicks the "Get content suggestions" button.
+ *
+ * @param {boolean} isOpen Whether the modal is open or not.
+ * @param {function} onClose The function to call when the modal is closed.
+ * @param {boolean} isEmptyCanvas Whether the post has content or not.
+ * @param {boolean} isPremium Whether the user has a premium subscription or not.
+ * @param {boolean} isUpsell Whether the modal is shown as an upsell or not.
+ * @param {string} upsellLink The link to the upsell page.
+ * @returns {JSX.Element} The Content Planner Feature Modal.
+ */
+export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUpsell, upsellLink } ) => {
+	const [ status, setStatus ] = useState( "idle" );
+
+	const handleGetSuggestionsClick = useCallback( () => {
+		setStatus( "content-suggestions-loading" );
+	}, [] );
+
+	useEffect( () => {
+		if ( status === "content-suggestions-loading" ) {
+			const timer = setTimeout( () => setStatus( "content-suggestions-success" ), 5000 );
+			return () => clearTimeout( timer );
+		}
+	}, [ status ] );
+
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setStatus( "idle" );
+		}
+	}, [ isOpen ] );
+
+	return (
+		<Modal isOpen={ isOpen } onClose={ onClose }>
+			<div className="yst-relative yst-w-full yst-max-w-2xl">
+				<Transition
+					as={ Fragment }
+					show={ status === "idle" }
+					enter="yst-transition-opacity yst-duration-300"
+					enterFrom="yst-opacity-0"
+					enterTo="yst-opacity-100"
+					leave="yst-transition-opacity yst-duration-300 yst-absolute yst-inset-0 yst-m-auto"
+					leaveFrom="yst-opacity-100"
+					leaveTo="yst-opacity-0"
+				>
+					<div className="yst-w-96 yst-flex yst-items-center yst-justify-center yst-mx-auto">
+						<ApproveModal
+							isEmptyCanvas={ isEmptyCanvas }
+							isPremium={ isPremium }
+							isUpsell={ isUpsell }
+							onClick={ handleGetSuggestionsClick }
+							upsellLink={ upsellLink }
+						/>
+					</div>
+				</Transition>
+				<Transition
+					as={ Fragment }
+					show={ status === "content-suggestions-success" || status === "content-suggestions-loading" }
+					enter="yst-transition-opacity yst-duration-300 yst-delay-300"
+					enterFrom="yst-opacity-0"
+					enterTo="yst-opacity-100"
+					leave="yst-transition-opacity yst-duration-300"
+					leaveFrom="yst-opacity-100"
+					leaveTo="yst-opacity-0"
+				>
+					<div>
+						<ContentSuggestionsModal status={ status } isPremium={ isPremium } />
+					</div>
+				</Transition>
+			</div>
+		</Modal>
+	);
+};

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -23,6 +23,7 @@ export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUps
 	}, [] );
 
 	useEffect( () => {
+		// Delay setting the status to "idle" and "content-suggestions-success" to allow the assistive technology to announce the changes.
 		if ( status === null ) {
 			const timer = setTimeout( () => setStatus( "idle" ), 300 );
 			return () => clearTimeout( timer );

--- a/packages/js/tests/ai-content-planner/components/approve-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/approve-modal.test.js
@@ -1,8 +1,8 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { ApproveModal } from "../../../src/ai-content-planner/components/approve-modal";
+import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
 
 const renderModal = ( props ) => render(
-	<ApproveModal
+	<FeatureModal
 		isOpen={ true }
 		onClose={ jest.fn() }
 		isEmptyCanvas={ true }
@@ -13,22 +13,18 @@ const renderModal = ( props ) => render(
 );
 
 describe( "ApproveModal", () => {
-	describe( "visibility", () => {
-		it( "renders the modal when isOpen is true", () => {
-			renderModal( { isOpen: true } );
-			expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
+	describe( "close button", () => {
+		it( "calls onClose when the close button is clicked", () => {
+			const onClose = jest.fn();
+			renderModal( { onClose } );
+			fireEvent.click( screen.getByRole( "button", { name: "Close modal" } ) );
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( "does not render the modal when isOpen is false", () => {
-			renderModal( { isOpen: false } );
-			expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
-		} );
-
-		it( "calls onClick when the button is clicked", () => {
-			const onClick = jest.fn();
-			renderModal( { onClick } );
+		it( "transitions to the content suggestions view when the 'Get content suggestions' button is clicked", () => {
+			renderModal();
 			fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
-			expect( onClick ).toHaveBeenCalledTimes( 1 );
+			expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/components/approve-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/approve-modal.test.js
@@ -1,88 +1,95 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
+import { Modal } from "@yoast/ui-library";
+import { ApproveModal } from "../../../src/ai-content-planner/components/approve-modal";
 
-const renderModal = ( props ) => render(
-	<FeatureModal
-		isOpen={ true }
-		onClose={ jest.fn() }
-		isEmptyCanvas={ true }
-		isPremium={ false }
-		isUpsell={ false }
-		{ ...props }
-	/>
+const renderApproveModal = ( { onClose = jest.fn(), ...props } = {} ) => render(
+	<Modal isOpen={ true } onClose={ onClose }>
+		<div>
+			<ApproveModal
+				isEmptyCanvas={ true }
+				isPremium={ false }
+				isUpsell={ false }
+				onClick={ jest.fn() }
+				{ ...props }
+			/>
+		</div>
+	</Modal>
 );
 
 describe( "ApproveModal", () => {
 	describe( "close button", () => {
 		it( "calls onClose when the close button is clicked", () => {
 			const onClose = jest.fn();
-			renderModal( { onClose } );
+			renderApproveModal( { onClose } );
 			fireEvent.click( screen.getByRole( "button", { name: "Close modal" } ) );
 			expect( onClose ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( "transitions to the content suggestions view when the 'Get content suggestions' button is clicked", () => {
-			renderModal();
-			fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
-			expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( "empty canvas content", () => {
 		it( "shows the inspiration title when the canvas is empty", () => {
-			renderModal( { isEmptyCanvas: true } );
+			renderApproveModal( { isEmptyCanvas: true } );
 			expect( screen.getByText( "Looking for inspiration?" ) ).toBeInTheDocument();
 		} );
 
 		it( "shows the ai-primary button variant when the canvas is empty and not an upsell", () => {
-			renderModal( { isEmptyCanvas: true, isUpsell: false } );
+			renderApproveModal( { isEmptyCanvas: true, isUpsell: false } );
 			expect( screen.getByRole( "button", { name: "Get content suggestions" } ) ).toHaveClass( "yst-button--ai-primary" );
 		} );
 	} );
 
 	describe( "non-empty canvas content", () => {
 		it( "shows the 'Get content suggestions' title when the canvas has content", () => {
-			renderModal( { isEmptyCanvas: false } );
+			renderApproveModal( { isEmptyCanvas: false } );
 			expect( screen.getByRole( "heading", { name: "Get content suggestions" } ) ).toBeInTheDocument();
 		} );
 
 		it( "shows a note that content will be replaced when the canvas has content", () => {
-			renderModal( { isEmptyCanvas: false } );
+			renderApproveModal( { isEmptyCanvas: false } );
 			expect( screen.getByText( /Note: Applying a content suggestion will replace/ ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( "upsell variant", () => {
 		it( "shows the 'Unlock with Yoast SEO Premium' label when isUpsell is true", () => {
-			renderModal( { isUpsell: true } );
+			renderApproveModal( { isUpsell: true } );
 			expect( screen.getByText( "Unlock with Yoast SEO Premium" ) ).toBeInTheDocument();
 		} );
 
 		it( "renders the upsell button with the correct href when isUpsell is true", () => {
-			renderModal( { isUpsell: true, upsellLink: "https://yoa.st/content-planner-approve-modal" } );
+			renderApproveModal( { isUpsell: true, upsellLink: "https://yoa.st/content-planner-approve-modal" } );
 			expect( screen.getByRole( "link", { name: /Unlock with Yoast SEO Premium/ } ) ).toHaveAttribute( "href", "https://yoa.st/content-planner-approve-modal" );
 		} );
 
 		it( "opens the upsell link in a new tab", () => {
-			renderModal( { isUpsell: true, upsellLink: "https://yoa.st/content-planner-approve-modal" } );
+			renderApproveModal( { isUpsell: true, upsellLink: "https://yoa.st/content-planner-approve-modal" } );
 			expect( screen.getByRole( "link", { name: /Unlock with Yoast SEO Premium/ } ) ).toHaveAttribute( "target", "_blank" );
 		} );
 	} );
 
 	describe( "OneSparkNote visibility", () => {
 		it( "shows the spark note when the user is not premium and it is not an upsell", () => {
-			renderModal();
+			renderApproveModal( { isPremium: false, isUpsell: false } );
 			expect( screen.queryByText( "Using 1 spark" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the spark note when the user is premium", () => {
-			renderModal( { isPremium: true, isUpsell: false } );
+			renderApproveModal( { isPremium: true, isUpsell: false } );
 			expect( screen.queryByText( "Using 1 spark" ) ).not.toBeInTheDocument();
 		} );
 
 		it( "does not show the spark note when it is an upsell", () => {
-			renderModal( { isPremium: false, isUpsell: true } );
+			renderApproveModal( { isPremium: false, isUpsell: true } );
 			expect( screen.queryByText( "Using 1 spark" ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( "onClick", () => {
+		it( "calls onClick when the 'Get content suggestions' button is clicked", () => {
+			const onClick = jest.fn();
+			renderApproveModal( { isUpsell: false, onClick } );
+			fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
+			expect( onClick ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,0 +1,129 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useSelect } from "@wordpress/data";
+import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( "@yoast/ai-frontend", () => ( {
+	UsageCounter: () => null,
+} ) );
+
+const defaultSuggestions = [
+	{ intent: "informational", title: "How to write great content", description: "A guide to writing content that ranks." },
+	{ intent: "navigational", title: "Find the best tools", description: "Navigate to the best SEO tools." },
+	{ intent: "commercial", title: "Best SEO plugins", description: "Compare the top SEO plugins." },
+];
+
+const renderModal = ( props ) => render(
+	<ContentSuggestionsModal
+		isOpen={ true }
+		onClose={ jest.fn() }
+		isLoading={ false }
+		suggestions={ defaultSuggestions }
+		{ ...props }
+	/>
+);
+
+beforeEach( () => {
+	useSelect.mockImplementation( ( fn ) => fn( () => ( { getIsPremium: () => false } ) ) );
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( "ContentSuggestionsModal", () => {
+	describe( "visibility", () => {
+		it( "renders the modal when isOpen is true", () => {
+			renderModal( { isOpen: true } );
+			expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not render the modal when isOpen is false", () => {
+			renderModal( { isOpen: false } );
+			expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "calls onClose when the modal close button is clicked", () => {
+			const onClose = jest.fn();
+			renderModal( { onClose } );
+			fireEvent.click( screen.getByRole( "button", { name: /close/i } ) );
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( "header", () => {
+		it( "shows the 'Content suggestions' title", () => {
+			renderModal();
+			expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the 'Beta' badge", () => {
+			renderModal();
+			expect( screen.getByText( "Beta" ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "loading state", () => {
+		it( "shows the loading message when isLoading is true", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not show the intro text when isLoading is true", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.queryByText( /Select a suggestion/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( "does not show the loading message when isLoading is false", () => {
+			renderModal( { isLoading: false } );
+			expect( screen.queryByText( "Analyzing your site content…" ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( "suggestions list", () => {
+		it( "shows the intro text when not loading", () => {
+			renderModal();
+			expect( screen.getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
+		} );
+
+		it( "renders all suggestions", () => {
+			renderModal();
+			expect( screen.getByText( "How to write great content" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Find the best tools" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Best SEO plugins" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders suggestion descriptions", () => {
+			renderModal();
+			expect( screen.getByText( "A guide to writing content that ranks." ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the correct intent badge label for informational", () => {
+			renderModal( { suggestions: [ { intent: "informational", title: "Info post", description: "An informational post." } ] } );
+			expect( screen.getByText( "Informational" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the correct intent badge label for navigational", () => {
+			renderModal( { suggestions: [ { intent: "navigational", title: "Nav post", description: "A navigational post." } ] } );
+			expect( screen.getByText( "Navigational" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the correct intent badge label for commercial", () => {
+			renderModal( { suggestions: [ { intent: "commercial", title: "Commercial post", description: "A commercial post." } ] } );
+			expect( screen.getByText( "Commercial" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders an unknown intent as a badge with the raw value", () => {
+			renderModal( { suggestions: [ { intent: "transactional", title: "Transactional post", description: "A transactional post." } ] } );
+			expect( screen.getByText( "transactional" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders an empty list when suggestions is empty", () => {
+			renderModal( { suggestions: [] } );
+			expect( screen.queryByRole( "button", { name: /How to write/i } ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,44 +1,31 @@
-import { render, screen, fireEvent, within, act } from "@testing-library/react";
-import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { Modal } from "@yoast/ui-library";
+import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
 
 const mockUsageCounter = jest.fn( () => null );
 jest.mock( "@yoast/ai-frontend", () => ( {
 	UsageCounter: ( props ) => mockUsageCounter( props ),
 } ) );
 
-const renderModal = ( props ) => render(
-	<FeatureModal
-		isOpen={ true }
-		onClose={ jest.fn() }
-		isPremium={ false }
-		isEmptyCanvas={ false }
-		isUpsell={ false }
-		{ ...props }
-	/>
+const renderLoadingModal = ( { onClose = jest.fn(), ...props } = {} ) => render(
+	<Modal isOpen={ true } onClose={ onClose }>
+		<div>
+			<ContentSuggestionsModal status="content-suggestions-loading" isPremium={ false } { ...props } />
+		</div>
+	</Modal>
 );
 
-const renderLoadingModal = ( props ) => {
-	const result = renderModal( props );
-	fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
-	return result;
-};
-
-const renderSuccessModal = ( props ) => {
-	const result = renderLoadingModal( props );
-	act( () => {
-		jest.advanceTimersByTime( 5000 );
-	} );
-	return result;
-};
+const renderSuccessModal = ( { onClose = jest.fn(), ...props } = {} ) => render(
+	<Modal isOpen={ true } onClose={ onClose }>
+		<div>
+			<ContentSuggestionsModal status="content-suggestions-success" isPremium={ false } { ...props } />
+		</div>
+	</Modal>
+);
 
 describe( "ContentSuggestionsModal", () => {
 	beforeEach( () => {
 		mockUsageCounter.mockClear();
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
 	} );
 
 	describe( "header", () => {
@@ -74,6 +61,7 @@ describe( "ContentSuggestionsModal", () => {
 		it( "announces content via the aria-live region when status is success", () => {
 			renderSuccessModal();
 			const liveRegion = document.querySelector( "[aria-live='polite']" );
+			expect( liveRegion ).not.toBeNull();
 			expect( within( liveRegion ).getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
 		} );
 	} );
@@ -118,17 +106,17 @@ describe( "ContentSuggestionsModal", () => {
 
 		it( "renders informational intent badges", () => {
 			renderSuccessModal();
-			expect( screen.getAllByText( "Informational" ).length ).toBeGreaterThan( 0 );
+			expect( screen.getAllByText( "Informational" ) ).toHaveLength( 2 );
 		} );
 
 		it( "renders navigational intent badges", () => {
 			renderSuccessModal();
-			expect( screen.getAllByText( "Navigational" ).length ).toBeGreaterThan( 0 );
+			expect( screen.getAllByText( "Navigational" ) ).toHaveLength( 2 );
 		} );
 
 		it( "renders commercial intent badges", () => {
 			renderSuccessModal();
-			expect( screen.getAllByText( "Commercial" ).length ).toBeGreaterThan( 0 );
+			expect( screen.getAllByText( "Commercial" ) ).toHaveLength( 2 );
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, within, act } from "@testing-library/react";
-import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
+import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
 
 const mockUsageCounter = jest.fn( () => null );
 jest.mock( "@yoast/ai-frontend", () => ( {
@@ -7,16 +7,24 @@ jest.mock( "@yoast/ai-frontend", () => ( {
 } ) );
 
 const renderModal = ( props ) => render(
-	<ContentSuggestionsModal
+	<FeatureModal
 		isOpen={ true }
 		onClose={ jest.fn() }
 		isPremium={ false }
+		isEmptyCanvas={ false }
+		isUpsell={ false }
 		{ ...props }
 	/>
 );
 
-const renderLoadedModal = ( props ) => {
+const renderLoadingModal = ( props ) => {
 	const result = renderModal( props );
+	fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
+	return result;
+};
+
+const renderSuccessModal = ( props ) => {
+	const result = renderLoadingModal( props );
 	act( () => {
 		jest.advanceTimersByTime( 5000 );
 	} );
@@ -33,90 +41,68 @@ describe( "ContentSuggestionsModal", () => {
 		jest.useRealTimers();
 	} );
 
-	describe( "visibility", () => {
-		it( "renders the modal when isOpen is true", () => {
-			renderModal( { isOpen: true } );
-			expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
-		} );
-
-		it( "does not render the modal when isOpen is false", () => {
-			renderModal( { isOpen: false } );
-			expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
-		} );
-
-		it( "calls onClose when the modal close button is clicked", () => {
-			const onClose = jest.fn();
-			renderModal( { onClose } );
-			fireEvent.click( screen.getByRole( "button", { name: /close/i } ) );
-			expect( onClose ).toHaveBeenCalledTimes( 1 );
-		} );
-	} );
-
 	describe( "header", () => {
 		it( "shows the 'Content suggestions' title", () => {
-			renderModal();
+			renderLoadingModal();
 			expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
 		} );
 
 		it( "shows the 'Beta' badge", () => {
-			renderModal();
+			renderLoadingModal();
 			expect( screen.getByText( "Beta" ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( "accessibility", () => {
-		it( "announces the loading-to-loaded transition via the aria-live region", () => {
-			renderModal();
-			const liveRegion = document.querySelector( "[aria-live='polite']" );
-			act( () => {
-				jest.advanceTimersByTime( 5000 );
-			} );
-			expect( within( liveRegion ).getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
-		} );
-
 		it( "has a descriptive close button label", () => {
-			renderModal();
+			renderLoadingModal();
 			expect( screen.getByRole( "button", { name: "Close content suggestions modal" } ) ).toBeInTheDocument();
 		} );
 
 		it( "has an accessible dialog name from the title", () => {
-			renderModal();
+			renderLoadingModal();
 			expect( screen.getByRole( "dialog", { name: "Content suggestions" } ) ).toBeInTheDocument();
+		} );
+
+		it( "calls onClose when the close button is clicked", () => {
+			const onClose = jest.fn();
+			renderLoadingModal( { onClose } );
+			fireEvent.click( screen.getByRole( "button", { name: "Close content suggestions modal" } ) );
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "announces content via the aria-live region when status is success", () => {
+			renderSuccessModal();
+			const liveRegion = document.querySelector( "[aria-live='polite']" );
+			expect( within( liveRegion ).getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( "loading state", () => {
-		it( "shows the loading message on open", () => {
-			renderModal();
-			// wait 100ms for the loading state to be set
-			act( () => {
-				jest.advanceTimersByTime( 100 );
-			} );
+		it( "shows the loading message when loading", () => {
+			renderLoadingModal();
 			expect( screen.getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the intro text while loading", () => {
-			renderModal();
+			renderLoadingModal();
 			expect( screen.queryByText( /Select a suggestion/ ) ).not.toBeInTheDocument();
-		} );
-
-		it( "does not show the loading message after loading completes", () => {
-			renderModal();
-			act( () => {
-				jest.advanceTimersByTime( 5000 );
-			} );
-			expect( screen.queryByText( "Analyzing your site content…" ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( "suggestions list", () => {
-		it( "shows the intro text when not loading", () => {
-			renderLoadedModal();
+		it( "shows the intro text when success", () => {
+			renderSuccessModal();
 			expect( screen.getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
 		} );
 
+		it( "does not show the loading message when success", () => {
+			renderSuccessModal();
+			expect( screen.queryByText( "Analyzing your site content…" ) ).not.toBeInTheDocument();
+		} );
+
 		it( "renders all suggestions", () => {
-			renderLoadedModal();
+			renderSuccessModal();
 			expect( screen.getByText( "How to train your dog" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Best dog training schools in New York" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Top 10 dog training tools" ) ).toBeInTheDocument();
@@ -126,23 +112,41 @@ describe( "ContentSuggestionsModal", () => {
 		} );
 
 		it( "renders suggestion descriptions", () => {
-			renderLoadedModal();
+			renderSuccessModal();
 			expect( screen.getByText( "Tips and tricks on how to train your dog effectively." ) ).toBeInTheDocument();
 		} );
 
 		it( "renders informational intent badges", () => {
-			renderLoadedModal();
+			renderSuccessModal();
 			expect( screen.getAllByText( "Informational" ).length ).toBeGreaterThan( 0 );
 		} );
 
 		it( "renders navigational intent badges", () => {
-			renderLoadedModal();
+			renderSuccessModal();
 			expect( screen.getAllByText( "Navigational" ).length ).toBeGreaterThan( 0 );
 		} );
 
 		it( "renders commercial intent badges", () => {
-			renderLoadedModal();
+			renderSuccessModal();
 			expect( screen.getAllByText( "Commercial" ).length ).toBeGreaterThan( 0 );
+		} );
+	} );
+
+	describe( "UsageCounter", () => {
+		it( "passes mentionBetaInTooltip and mentionResetInTooltip as false when not premium", () => {
+			renderLoadingModal( { isPremium: false } );
+			expect( mockUsageCounter ).toHaveBeenCalledWith( expect.objectContaining( {
+				mentionBetaInTooltip: false,
+				mentionResetInTooltip: false,
+			} ) );
+		} );
+
+		it( "passes mentionBetaInTooltip and mentionResetInTooltip as true when premium", () => {
+			renderLoadingModal( { isPremium: true } );
+			expect( mockUsageCounter ).toHaveBeenCalledWith( expect.objectContaining( {
+				mentionBetaInTooltip: true,
+				mentionResetInTooltip: true,
+			} ) );
 		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,13 +1,9 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { useSelect } from "@wordpress/data";
 import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
 
-jest.mock( "@wordpress/data", () => ( {
-	useSelect: jest.fn(),
-} ) );
-
+const mockUsageCounter = jest.fn( () => null );
 jest.mock( "@yoast/ai-frontend", () => ( {
-	UsageCounter: () => null,
+	UsageCounter: ( props ) => mockUsageCounter( props ),
 } ) );
 
 const defaultSuggestions = [
@@ -22,19 +18,16 @@ const renderModal = ( props ) => render(
 		onClose={ jest.fn() }
 		isLoading={ false }
 		suggestions={ defaultSuggestions }
+		isPremium={ false }
 		{ ...props }
 	/>
 );
 
-beforeEach( () => {
-	useSelect.mockImplementation( ( fn ) => fn( () => ( { getIsPremium: () => false } ) ) );
-} );
-
-afterEach( () => {
-	jest.clearAllMocks();
-} );
-
 describe( "ContentSuggestionsModal", () => {
+	beforeEach( () => {
+		mockUsageCounter.mockClear();
+	} );
+
 	describe( "visibility", () => {
 		it( "renders the modal when isOpen is true", () => {
 			renderModal( { isOpen: true } );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -67,7 +67,9 @@ describe( "ContentSuggestionsModal", () => {
 			renderLoadingModal();
 			const liveRegion = document.querySelector( "[aria-live='polite']" );
 			expect( liveRegion ).not.toBeNull();
-			act( () => { jest.advanceTimersByTime( 100 ); } );
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( within( liveRegion ).getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
 		} );
 
@@ -87,13 +89,17 @@ describe( "ContentSuggestionsModal", () => {
 
 		it( "shows the loading message after 100ms", () => {
 			renderLoadingModal();
-			act( () => { jest.advanceTimersByTime( 100 ); } );
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the intro text while loading", () => {
 			renderLoadingModal();
-			act( () => { jest.advanceTimersByTime( 100 ); } );
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.queryByText( /Select a suggestion/ ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
 import { Modal } from "@yoast/ui-library";
 import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
 
@@ -26,6 +26,11 @@ const renderSuccessModal = ( { onClose = jest.fn(), ...props } = {} ) => render(
 describe( "ContentSuggestionsModal", () => {
 	beforeEach( () => {
 		mockUsageCounter.mockClear();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	describe( "header", () => {
@@ -58,6 +63,14 @@ describe( "ContentSuggestionsModal", () => {
 			expect( onClose ).toHaveBeenCalledTimes( 1 );
 		} );
 
+		it( "announces the loading message via the aria-live region after 100ms", () => {
+			renderLoadingModal();
+			const liveRegion = document.querySelector( "[aria-live='polite']" );
+			expect( liveRegion ).not.toBeNull();
+			act( () => { jest.advanceTimersByTime( 100 ); } );
+			expect( within( liveRegion ).getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
+		} );
+
 		it( "announces content via the aria-live region when status is success", () => {
 			renderSuccessModal();
 			const liveRegion = document.querySelector( "[aria-live='polite']" );
@@ -67,13 +80,20 @@ describe( "ContentSuggestionsModal", () => {
 	} );
 
 	describe( "loading state", () => {
-		it( "shows the loading message when loading", () => {
+		it( "does not show the loading message before 100ms have passed", () => {
 			renderLoadingModal();
+			expect( screen.queryByText( "Analyzing your site content…" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "shows the loading message after 100ms", () => {
+			renderLoadingModal();
+			act( () => { jest.advanceTimersByTime( 100 ); } );
 			expect( screen.getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the intro text while loading", () => {
 			renderLoadingModal();
+			act( () => { jest.advanceTimersByTime( 100 ); } );
 			expect( screen.queryByText( /Select a suggestion/ ) ).not.toBeInTheDocument();
 		} );
 	} );

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
 
 const mockUsageCounter = jest.fn( () => null );
@@ -56,6 +56,28 @@ describe( "ContentSuggestionsModal", () => {
 		it( "shows the 'Beta' badge", () => {
 			renderModal();
 			expect( screen.getByText( "Beta" ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "accessibility", () => {
+		it( "announces content changes to screen readers when loading completes", () => {
+			const { rerender } = renderModal( { isLoading: true } );
+
+			const liveRegion = screen.getByText( "Analyzing your site content…" ).closest( "[aria-live='polite']" );
+			expect( liveRegion ).toBeInTheDocument();
+			expect( within( liveRegion ).getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
+
+			rerender(
+				<ContentSuggestionsModal
+					isOpen={ true }
+					onClose={ jest.fn() }
+					isLoading={ false }
+					suggestions={ defaultSuggestions }
+					isPremium={ false }
+				/>
+			);
+
+			expect( within( liveRegion ).getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-suggestions-modal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from "@testing-library/react";
+import { render, screen, fireEvent, within, act } from "@testing-library/react";
 import { ContentSuggestionsModal } from "../../../src/ai-content-planner/components/content-suggestions-modal";
 
 const mockUsageCounter = jest.fn( () => null );
@@ -6,26 +6,31 @@ jest.mock( "@yoast/ai-frontend", () => ( {
 	UsageCounter: ( props ) => mockUsageCounter( props ),
 } ) );
 
-const defaultSuggestions = [
-	{ intent: "informational", title: "How to write great content", description: "A guide to writing content that ranks." },
-	{ intent: "navigational", title: "Find the best tools", description: "Navigate to the best SEO tools." },
-	{ intent: "commercial", title: "Best SEO plugins", description: "Compare the top SEO plugins." },
-];
-
 const renderModal = ( props ) => render(
 	<ContentSuggestionsModal
 		isOpen={ true }
 		onClose={ jest.fn() }
-		isLoading={ false }
-		suggestions={ defaultSuggestions }
 		isPremium={ false }
 		{ ...props }
 	/>
 );
 
+const renderLoadedModal = ( props ) => {
+	const result = renderModal( props );
+	act( () => {
+		jest.advanceTimersByTime( 5000 );
+	} );
+	return result;
+};
+
 describe( "ContentSuggestionsModal", () => {
 	beforeEach( () => {
 		mockUsageCounter.mockClear();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	describe( "visibility", () => {
@@ -60,85 +65,84 @@ describe( "ContentSuggestionsModal", () => {
 	} );
 
 	describe( "accessibility", () => {
-		it( "announces content changes to screen readers when loading completes", () => {
-			const { rerender } = renderModal( { isLoading: true } );
-
-			const liveRegion = screen.getByText( "Analyzing your site content…" ).closest( "[aria-live='polite']" );
-			expect( liveRegion ).toBeInTheDocument();
-			expect( within( liveRegion ).getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
-
-			rerender(
-				<ContentSuggestionsModal
-					isOpen={ true }
-					onClose={ jest.fn() }
-					isLoading={ false }
-					suggestions={ defaultSuggestions }
-					isPremium={ false }
-				/>
-			);
-
+		it( "announces the loading-to-loaded transition via the aria-live region", () => {
+			renderModal();
+			const liveRegion = document.querySelector( "[aria-live='polite']" );
+			act( () => {
+				jest.advanceTimersByTime( 5000 );
+			} );
 			expect( within( liveRegion ).getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
+		} );
+
+		it( "has a descriptive close button label", () => {
+			renderModal();
+			expect( screen.getByRole( "button", { name: "Close content suggestions modal" } ) ).toBeInTheDocument();
+		} );
+
+		it( "has an accessible dialog name from the title", () => {
+			renderModal();
+			expect( screen.getByRole( "dialog", { name: "Content suggestions" } ) ).toBeInTheDocument();
 		} );
 	} );
 
 	describe( "loading state", () => {
-		it( "shows the loading message when isLoading is true", () => {
-			renderModal( { isLoading: true } );
+		it( "shows the loading message on open", () => {
+			renderModal();
+			// wait 100ms for the loading state to be set
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByText( "Analyzing your site content…" ) ).toBeInTheDocument();
 		} );
 
-		it( "does not show the intro text when isLoading is true", () => {
-			renderModal( { isLoading: true } );
+		it( "does not show the intro text while loading", () => {
+			renderModal();
 			expect( screen.queryByText( /Select a suggestion/ ) ).not.toBeInTheDocument();
 		} );
 
-		it( "does not show the loading message when isLoading is false", () => {
-			renderModal( { isLoading: false } );
+		it( "does not show the loading message after loading completes", () => {
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 5000 );
+			} );
 			expect( screen.queryByText( "Analyzing your site content…" ) ).not.toBeInTheDocument();
 		} );
 	} );
 
 	describe( "suggestions list", () => {
 		it( "shows the intro text when not loading", () => {
-			renderModal();
+			renderLoadedModal();
 			expect( screen.getByText( "Select a suggestion to generate a structured outline for your post." ) ).toBeInTheDocument();
 		} );
 
 		it( "renders all suggestions", () => {
-			renderModal();
-			expect( screen.getByText( "How to write great content" ) ).toBeInTheDocument();
-			expect( screen.getByText( "Find the best tools" ) ).toBeInTheDocument();
-			expect( screen.getByText( "Best SEO plugins" ) ).toBeInTheDocument();
+			renderLoadedModal();
+			expect( screen.getByText( "How to train your dog" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Best dog training schools in New York" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Top 10 dog training tools" ) ).toBeInTheDocument();
+			expect( screen.getByText( "How to groom your dog" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Dog parks in Los Angeles" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Best dog food brands" ) ).toBeInTheDocument();
 		} );
 
 		it( "renders suggestion descriptions", () => {
-			renderModal();
-			expect( screen.getByText( "A guide to writing content that ranks." ) ).toBeInTheDocument();
+			renderLoadedModal();
+			expect( screen.getByText( "Tips and tricks on how to train your dog effectively." ) ).toBeInTheDocument();
 		} );
 
-		it( "renders the correct intent badge label for informational", () => {
-			renderModal( { suggestions: [ { intent: "informational", title: "Info post", description: "An informational post." } ] } );
-			expect( screen.getByText( "Informational" ) ).toBeInTheDocument();
+		it( "renders informational intent badges", () => {
+			renderLoadedModal();
+			expect( screen.getAllByText( "Informational" ).length ).toBeGreaterThan( 0 );
 		} );
 
-		it( "renders the correct intent badge label for navigational", () => {
-			renderModal( { suggestions: [ { intent: "navigational", title: "Nav post", description: "A navigational post." } ] } );
-			expect( screen.getByText( "Navigational" ) ).toBeInTheDocument();
+		it( "renders navigational intent badges", () => {
+			renderLoadedModal();
+			expect( screen.getAllByText( "Navigational" ).length ).toBeGreaterThan( 0 );
 		} );
 
-		it( "renders the correct intent badge label for commercial", () => {
-			renderModal( { suggestions: [ { intent: "commercial", title: "Commercial post", description: "A commercial post." } ] } );
-			expect( screen.getByText( "Commercial" ) ).toBeInTheDocument();
-		} );
-
-		it( "renders an unknown intent as a badge with the raw value", () => {
-			renderModal( { suggestions: [ { intent: "transactional", title: "Transactional post", description: "A transactional post." } ] } );
-			expect( screen.getByText( "transactional" ) ).toBeInTheDocument();
-		} );
-
-		it( "renders an empty list when suggestions is empty", () => {
-			renderModal( { suggestions: [] } );
-			expect( screen.queryByRole( "button", { name: /How to write/i } ) ).not.toBeInTheDocument();
+		it( "renders commercial intent badges", () => {
+			renderLoadedModal();
+			expect( screen.getAllByText( "Commercial" ).length ).toBeGreaterThan( 0 );
 		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
+
+const renderModal = ( props ) => render(
+	<FeatureModal
+		isOpen={ true }
+		onClose={ jest.fn() }
+		isEmptyCanvas={ true }
+		isPremium={ false }
+		isUpsell={ false }
+		{ ...props }
+	/>
+);
+
+describe( "FeatureModal", () => {
+	it( "does not render the dialog when isOpen is false", () => {
+		renderModal( { isOpen: false } );
+		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+	} );
+
+	it( "renders the approve modal initially when open", () => {
+		renderModal();
+		expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
+		expect( screen.getByText( "Looking for inspiration?" ) ).toBeInTheDocument();
+	} );
+
+	it( "calls onClose when the close button is clicked", () => {
+		const onClose = jest.fn();
+		renderModal( { onClose } );
+		fireEvent.click( screen.getByRole( "button", { name: "Close modal" } ) );
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "transitions to the content suggestions view when the 'Get content suggestions' button is clicked", () => {
+		renderModal();
+		fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
+		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -1,5 +1,9 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
+
+jest.mock( "@yoast/ai-frontend", () => ( {
+	UsageCounter: () => null,
+} ) );
 
 const renderModal = ( props ) => render(
 	<FeatureModal
@@ -13,6 +17,14 @@ const renderModal = ( props ) => render(
 );
 
 describe( "FeatureModal", () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
 	it( "does not render the dialog when isOpen is false", () => {
 		renderModal( { isOpen: false } );
 		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
@@ -20,6 +32,9 @@ describe( "FeatureModal", () => {
 
 	it( "renders the approve modal initially when open", () => {
 		renderModal();
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
 		expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
 		expect( screen.getByText( "Looking for inspiration?" ) ).toBeInTheDocument();
 	} );
@@ -27,12 +42,18 @@ describe( "FeatureModal", () => {
 	it( "calls onClose when the close button is clicked", () => {
 		const onClose = jest.fn();
 		renderModal( { onClose } );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
 		fireEvent.click( screen.getByRole( "button", { name: "Close modal" } ) );
 		expect( onClose ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( "transitions to the content suggestions view when the 'Get content suggestions' button is clicked", () => {
 		renderModal();
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
 		fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
 		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
 	} );


### PR DESCRIPTION
## Context
This PR adds the Content Suggestions Modal for the AI Content Planner feature. The modal displays AI-generated content suggestions after the user confirms they want to get suggestions, showing a loading skeleton while fetching and a list of selectable suggestion cards once results are ready.

## Summary
This PR can be summarized in the following changelog entry:

* Adds content suggestions modal with loading state and suggestion cards for the AI Content Planner feature.

## Relevant technical choices:

* The modal uses a loading skeleton with a gradient fade overlay while suggestions are being fetched.
* Each suggestion card displays an intent badge (informational, navigational, or commercial) with matching colors and icons.
* A `UsageCounter` component is shown in the modal header to display remaining spark usage.
* The component reads `isPremium` from the Yoast SEO editor store to conditionally show beta/reset information in the usage counter tooltip.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post in the block editor. Open the Yoast sidebar or go to the metabox.
* Click "Get content suggestions" in the editor and confirm the approve modal.
* Verify the content suggestions modal opens with dummy suggestions.
* Once loaded, verify suggestion cards appear with the correct design for intent badge, title, and description.
* Test loading state design.
* Close the modal and verify it closes correctly.

#### Accessibility:
  Setup                                                                    
   
  - macOS: Enable VoiceOver with Cmd + F5                                  
  - Windows: Start NVDA (Ctrl + Alt + N) or JAWS
  - Open the WordPress post editor with the Yoast SEO sidebar visible      
                                                                                                                                            
Test 1: Dialog is announced correctly on open                                                                       
 * With the screen reader active, click "Get content suggestions" in the
  Yoast sidebar and confirm the approve modal, triggering the content      
  suggestions modal.
  *  Expected: Screen reader announces "Content suggestions, web dialog"   
  (or equivalent for your screen reader).                                  
                                                                   
Test 2: Close button has a descriptive label                                            
  1. Open the modal.
  2. Navigate to the close button (Tab).                                   
  3. Expected: Screen reader announces "Close content suggestions modal".
  4. Not expected: Just "Close" or "button".                               
                                                                                                                 
Test 3: Loading state is announced                                                                                                          
 1. Open the modal.                             
 2. Wait approximately 100ms (the loading state appears after a short     
  delay).                     
 3. Expected: Screen reader announces "Yoast Analyzing your site content…"
  without the user navigating to it. 
 4. Focus is on the close button.                                    
 5. Expected: Announcement does not interrupt currently spoken text
  (polite, not assertive).                                                 
 6. When loading completes
 7. Expected: Screen reader announces "Select a suggestion to generate a  
  structured outline for your post."                                                                                                
                                                                                 
 Test 4: Suggestions are keyboard accessible
  1. When suggestions are visible, press Tab to navigate through them.
  2. Expected: Each suggestion is reachable and announced as a button with 
  its title.                                                                                                       
                                                 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* AI Content Planner sidebar/metabox editor item
* Content suggestions modal UI

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Content Planner: Create the modal for the content suggestions](https://github.com/Yoast/reserved-tasks/issues/1102)