### PR TITLE
Update in-product webinar banner copy on admin pages

### DIFF
--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -33,11 +33,12 @@ const WebinarPromoNotification = ( {
 		>
 			{ safeCreateInterpolateElement(
 				sprintf(
-					/* translators: 1: bold open tag; 2: "FREE"; 3: bold close tag. */
-					__( "Access our %1$s%2$s%3$s webinars and podcasts to get started with Yoast SEO and build the foundational skills and confidence needed for sustainable success.", "wordpress-seo" ),
+					/* translators: 1: bold open tag; 2: "FREE"; 3: bold close tag; 4: "Yoast SEO". */
+					__( "Access our %1$s%2$s%3$s webinars and podcasts to get started with %4$s and build the foundational skills and confidence needed for sustainable success.", "wordpress-seo" ),
 					"<strong>",
 					"FREE",
-					"</strong>"
+					"</strong>",
+					"Yoast SEO"
 				), {
 					strong: <strong />,
 				}

--- a/packages/js/src/components/WebinarPromoNotification.js
+++ b/packages/js/src/components/WebinarPromoNotification.js
@@ -1,4 +1,5 @@
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../helpers/i18n";
 import { useSelect } from "@wordpress/data";
 import PropTypes from "prop-types";
 
@@ -25,12 +26,22 @@ const WebinarPromoNotification = ( {
 			alertKey="webinar-promo-notification"
 			store={ store }
 			id="webinar-promo-notification"
-			title={ __( "Join our FREE webinar for SEO success", "wordpress-seo" ) }
+			title={ __( "Ready to boost your online visibility?", "wordpress-seo" ) }
 			image={ Image }
 			url={ url }
 			{ ...props }
 		>
-			{ __( "Feeling lost when it comes to optimizing your site for the search engines? Join our FREE webinar to gain the confidence that you need in order to start optimizing like a pro! You'll obtain the knowledge and tools to start effectively implementing SEO.", "wordpress-seo" ) }
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: 1: bold open tag; 2: "FREE"; 3: bold close tag. */
+					__( "Access our %1$s%2$s%3$s webinars and podcasts to get started with Yoast SEO and build the foundational skills and confidence needed for sustainable success.", "wordpress-seo" ),
+					"<strong>",
+					"FREE",
+					"</strong>"
+				), {
+					strong: <strong />,
+				}
+			) }
 			&nbsp;<a href={ url } target="_blank" rel="noreferrer">
 				{ __( "Sign up today!", "wordpress-seo" ) }
 			</a>


### PR DESCRIPTION
## Context
This PR updates the webinar promotional banner copy displayed to free Yoast SEO users on admin pages. 

## This PR can be summarized in the following changelog entry:

* Updates the webinar promotion banner copy on admin pages.

## Relevant technical choices

- Used `safeCreateInterpolateElement` with `sprintf` to render **FREE** in bold (`<strong>`), following the same pattern used across the integrations page components.
- The shortlink URL and "Sign up today!" call-to-action remain unchanged.

## Test instructions for the acceptance test before the PR gets merged

1. Install and activate the free Yoast SEO plugin (make sure Premium is **not** active).
2. Go to any admin page where the webinar promo banner appears (e.g., **Posts > Add New** and open the Yoast SEO sidebar, or visit the Yoast SEO dashboard).
3. If you have previously dismissed the banner, reset it by clearing the `webinar-promo-notification` dismissal (e.g., via the browser console or by resetting the user meta).
4. Verify the banner now shows:
   - **Header:** "Ready to boost your online visibility?"
   - **Body:** "Access our **FREE** webinars and podcasts to get started with Yoast SEO and build the foundational skills and confidence needed for sustainable success. Sign up today!"
   - The word **FREE** should be displayed in bold.
   - The "Sign up today!" link should still work and open in a new tab.
5. Verify the banner does **not** appear when Yoast SEO Premium is active.

## Relevant test scenarios

- [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
- [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
- [ ] Changes should be tested with the browser console open
- [ ] Changes should be tested on different browsers
- [ ] Changes should be tested on multisite

The banner appears in both the block editor sidebar and settings pages — verify the copy is correct in both contexts.

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- The webinar promotional notification component (`WebinarPromoNotification.js`) used on admin pages for free users.

## Other environments

- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [ ] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation

- [x] No innovation project is applicable for this PR.
- [ ] This PR falls under an innovation project. I have attached the innovation label.
- [ ] I have added my hours to the WBSO document.

Fixes Yoast/reserved-tasks#1108