### PR TITLE
Add Content Outline Modal with drag-and-drop structure reordering

### DIFF
--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -1,4 +1,5 @@
 import { Badge, Button, Modal, SkeletonLoader, Toggle, useSvgAria } from "@yoast/ui-library";
+import { Transition } from "@headlessui/react";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
@@ -197,7 +198,6 @@ const SkeletonFormField = ( { label, multiline = false } ) => (
  *
  * @param {boolean}            isOpen      Whether the modal is open or not.
  * @param {Function}           onClose     The function to call when the modal should be closed.
- * @param {boolean}            isLoading   Whether the content outline is being generated.
  * @param {Function}           onBack      The function to call to go back to content suggestions.
  * @param {Function}           onAddOutline The function to call to add the outline to the post.
  * @param {OutlineSuggestion}  suggestion  The content outline suggestion to display.
@@ -215,12 +215,35 @@ const SkeletonFormField = ( { label, multiline = false } ) => (
  */
 const withIds = ( items ) => items.map( ( item, i ) => ( { ...item, id: `${ i }-${ item.level }-${ item.title }` } ) );
 
-export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAddOutline, suggestion, sparksLimit, sparksUsage, category } ) => {
+export const ContentOutlineModal = ( { isOpen, onClose, onBack, onAddOutline, suggestion, sparksLimit, sparksUsage, category } ) => {
 	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
+	const svgAriaProps = useSvgAria();
 	const [ isCategoryEnabled, setIsCategoryEnabled ] = useState( true );
+	const [ status, setStatus ] = useState( "idle" );
 	const [ structure, setStructure ] = useState( () => withIds( suggestion.structure ) );
 	const [ dragOverIndex, setDragOverIndex ] = useState( null );
 	const dragIndexRef = useRef( null );
+	const isLoading = status === "loading" || status === "idle";
+
+	// Simulate loading state when the outline modal is opened.
+	useEffect( () => {
+		if ( isOpen ) {
+			const loadingTimer = setTimeout( () => {
+				setStatus( "loading" );
+			}, 100 );
+
+			const timer = setTimeout( () => {
+				setStatus( "success" );
+			}, 3000 );
+			return () => {
+				clearTimeout( loadingTimer );
+				clearTimeout( timer );
+			};
+		}
+		return () => {
+			setStatus( "idle" );
+		};
+	}, [ isOpen ] );
 
 	useEffect( () => {
 		setStructure( withIds( suggestion.structure ) );
@@ -290,7 +313,7 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 			<Modal.Panel className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content outline", "wordpress-seo" ) }>
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
-						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
+						<YoastIcon className="yst-fill-primary-500 yst-w-4" { ...svgAriaProps } />
 						<Modal.Title size="2" className="yst-flex-grow"> { __( "Content outline", "wordpress-seo" ) } </Modal.Title>
 						<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
 						{ sparksLimit && (
@@ -341,14 +364,31 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 								</div>
 							) }
 
-							{ isLoading ? (
+							<Transition
+								show={ isLoading }
+								enter="yst-transition-all yst-duration-300 yst-ease-out"
+								enterFrom="yst-opacity-0"
+								enterTo="yst-opacity-100"
+								leave="yst-transition-all yst-duration-200 yst-ease-in"
+								leaveFrom="yst-opacity-100"
+								leaveTo="yst-opacity-0"
+							>
 								<div className="yst-flex yst-flex-col yst-gap-4">
 									<SkeletonFormField label={ __( "Focus Keyphrase", "wordpress-seo" ) } />
 									<SkeletonFormField label={ __( "Title", "wordpress-seo" ) } />
 									<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
 								</div>
-							) : (
-								<>
+							</Transition>
+							<Transition
+								show={ ! isLoading }
+								enter="yst-transition-all yst-duration-300 yst-ease-out"
+								enterFrom="yst-opacity-0"
+								enterTo="yst-opacity-100"
+								leave="yst-transition-all yst-duration-200 yst-ease-in"
+								leaveFrom="yst-opacity-100"
+								leaveTo="yst-opacity-0"
+							>
+								<div className="yst-flex yst-flex-col yst-gap-6">
 									<div className="yst-flex yst-flex-col yst-gap-4">
 										<FormField
 											label={ __( "Focus Keyphrase", "wordpress-seo" ) }
@@ -367,36 +407,34 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 
 									<hr className="yst-border-slate-200" />
 
-									<div className="yst-flex yst-flex-col yst-gap-2">
-										<div className="yst-flex yst-items-end yst-justify-between">
-											<span className="yst-font-medium yst-text-sm yst-text-slate-800">
-												{ __( "Blog post structure", "wordpress-seo" ) }
-											</span>
-											<span className="yst-text-xs yst-text-slate-500">
-												{ __( "Drag to reorder", "wordpress-seo" ) }
-											</span>
-										</div>
-										<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) }>
-											{ structure.map( ( item, index ) => (
-												<StructureRow
-													key={ item.id }
-													index={ index }
-													level={ item.level }
-													title={ item.title }
-													dragOverIndex={ dragOverIndex }
-													onDragStart={ handleDragStart }
-													onDragOver={ handleDragOver }
-													onDrop={ handleDrop }
-													onDragEnd={ handleDragEnd }
-													onMoveUp={ handleMoveUp }
-													onMoveDown={ handleMoveDown }
-													totalItems={ structure.length }
-												/>
-											) ) }
-										</div>
+									<div className="yst-flex yst-items-end yst-justify-between">
+										<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+											{ __( "Blog post structure", "wordpress-seo" ) }
+										</span>
+										<span className="yst-text-xs yst-text-slate-500">
+											{ __( "Drag to reorder", "wordpress-seo" ) }
+										</span>
 									</div>
-								</>
-							) }
+									<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) } className="yst-flex yst-flex-col yst-gap-2">
+										{ structure.map( ( item, index ) => (
+											<StructureRow
+												key={ item.id }
+												index={ index }
+												level={ item.level }
+												title={ item.title }
+												dragOverIndex={ dragOverIndex }
+												onDragStart={ handleDragStart }
+												onDragOver={ handleDragOver }
+												onDrop={ handleDrop }
+												onDragEnd={ handleDragEnd }
+												onMoveUp={ handleMoveUp }
+												onMoveDown={ handleMoveDown }
+												totalItems={ structure.length }
+											/>
+										) ) }
+									</div>
+								</div>
+							</Transition>
 						</div>
 						<div
 							className="yst-sticky -yst-left-6 -yst-right-6 yst-bottom-0 yst-h-10 yst-pointer-events-none yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -1,7 +1,6 @@
 import { Badge, Button, Modal, Title, SkeletonLoader, Toggle } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
-import { ReactComponent as Yoast } from "../../../images/yoast.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { useSelect } from "@wordpress/data";
 import { useState, useCallback, useRef, useEffect } from "@wordpress/element";
@@ -127,48 +126,33 @@ const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDrag
 };
 
 /**
- * Loading skeleton for the content outline modal.
+ * Skeleton form field with a real label and a skeleton value.
  *
- * @returns {JSX.Element} The LoadingOutlineContent component.
+ * @param {string}  label     The field label.
+ * @param {boolean} multiline Whether to render a taller skeleton area.
+ *
+ * @returns {JSX.Element} The SkeletonFormField component.
  */
-const LoadingOutlineContent = () => (
-	<>
-		<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
-			<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" />
-			<div className="yst-italic yst-text-slate-500">{ __( "Generating your content outline…", "wordpress-seo" ) }</div>
+const SkeletonFormField = ( { label, multiline = false } ) => (
+	<div className="yst-flex yst-flex-col yst-gap-2">
+		<span className="yst-font-medium yst-text-sm yst-text-slate-800">{ label }</span>
+		<div
+			className={ classNames(
+				"yst-bg-white yst-border yst-border-slate-300 yst-rounded-md yst-shadow-sm yst-px-3 yst-py-2",
+				multiline ? "yst-min-h-20 yst-flex yst-flex-col yst-gap-1" : "yst-h-10 yst-flex yst-items-center"
+			) }
+		>
+			{ multiline ? (
+				<>
+					<SkeletonLoader className="yst-w-full yst-h-4 yst-rounded" />
+					<SkeletonLoader className="yst-w-full yst-h-4 yst-rounded" />
+					<SkeletonLoader className="yst-w-1/2 yst-h-4 yst-rounded" />
+				</>
+			) : (
+				<SkeletonLoader className="yst-w-1/3 yst-h-4 yst-rounded" />
+			) }
 		</div>
-		<div className="yst-relative">
-			{ /* Skeleton for IntentCallout */ }
-			<div className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-mb-4">
-				<div className="yst-flex yst-items-center yst-gap-2 yst-mb-2">
-					<SkeletonLoader className="yst-w-24 yst-h-5 yst-rounded-full" />
-					<SkeletonLoader className="yst-w-28 yst-h-4 yst-rounded" />
-				</div>
-				<SkeletonLoader className="yst-w-full yst-h-4 yst-rounded yst-mb-1" />
-				<SkeletonLoader className="yst-w-3/4 yst-h-4 yst-rounded" />
-			</div>
-			{ /* Skeleton for form fields */ }
-			<SkeletonLoader className="yst-w-48 yst-h-4 yst-rounded yst-mb-4" />
-			<div className="yst-h-px yst-bg-slate-200 yst-mb-6" />
-			{ [ ...Array( 3 ) ].map( ( _, index ) => (
-				<div key={ index } className="yst-mb-4">
-					<SkeletonLoader className="yst-w-24 yst-h-4 yst-rounded yst-mb-2" />
-					<SkeletonLoader className="yst-w-full yst-h-10 yst-rounded" />
-				</div>
-			) ) }
-			{ /* Skeleton for structure rows */ }
-			<div className="yst-h-px yst-bg-slate-200 yst-my-6" />
-			<SkeletonLoader className="yst-w-32 yst-h-4 yst-rounded yst-mb-2" />
-			{ [ ...Array( 5 ) ].map( ( _, index ) => (
-				<SkeletonLoader key={ `structure-${ index }` } className="yst-w-full yst-h-10 yst-rounded yst-mb-2" />
-			) ) }
-			{ /* Gradient overlay for fade effect */ }
-			<div
-				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
-				aria-hidden="true"
-			/>
-		</div>
-	</>
+	</div>
 );
 
 /**
@@ -271,104 +255,110 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 						) }
 					</Modal.Container.Header>
 					<Modal.Container.Content className="yst-overflow-y-auto yst-pt-6 yst-px-6 yst-pb-0 yst-m-0 yst-relative">
-						{ isLoading ? (
-							<LoadingOutlineContent />
-						) : (
-							<div className="yst-flex yst-flex-col yst-gap-6 yst-pb-6">
-								<IntentCallout
-									intent={ suggestion.intent }
-									description={ suggestion.description }
-								/>
+						<div className="yst-flex yst-flex-col yst-gap-6 yst-pb-6">
+							<IntentCallout
+								intent={ suggestion.intent }
+								description={ suggestion.description }
+							/>
 
-								<p className="yst-text-sm yst-text-slate-600">
-									{ __( "Review and customize your content outline before adding it to your post", "wordpress-seo" ) }
-								</p>
+							<p className="yst-text-sm yst-text-slate-600">
+								{ __( "Review and customize your content outline before adding it to your post", "wordpress-seo" ) }
+							</p>
 
-								<hr className="yst-border-slate-200" />
+							<hr className="yst-border-slate-200" />
 
-								{ category && (
-									<div className="yst-flex yst-flex-col yst-gap-3">
-										<div className="yst-flex yst-flex-col yst-gap-1.5">
-											<div className="yst-flex yst-items-center yst-gap-6">
-												<span className="yst-font-medium yst-text-sm yst-text-slate-800">
-													{ __( "Suggest category", "wordpress-seo" ) }
-												</span>
-												<Toggle
-													id="suggest-category-toggle"
-													checked={ isCategoryEnabled }
-													onChange={ handleCategoryToggle }
-													screenReaderLabel={ __( "Suggest category", "wordpress-seo" ) }
-												/>
-											</div>
-											<p className="yst-text-sm yst-text-slate-600">
-												{ __( "Adds post to an existing category, when applicable.", "wordpress-seo" ) }
-											</p>
+							{ category && (
+								<div className="yst-flex yst-flex-col yst-gap-3 yst-max-w-sm">
+									<div className="yst-flex yst-flex-col yst-gap-1.5">
+										<div className="yst-flex yst-items-center yst-justify-between">
+											<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+												{ __( "Suggest category", "wordpress-seo" ) }
+											</span>
+											<Toggle
+												id="suggest-category-toggle"
+												checked={ isCategoryEnabled }
+												onChange={ handleCategoryToggle }
+												screenReaderLabel={ __( "Suggest category", "wordpress-seo" ) }
+											/>
 										</div>
-										{ isCategoryEnabled && (
-											<Badge variant="plain" className="yst-w-fit">{ category }</Badge>
-										) }
+										<p className="yst-text-sm yst-text-slate-600">
+											{ __( "Adds post to an existing category, when applicable.", "wordpress-seo" ) }
+										</p>
 									</div>
-								) }
+									{ isCategoryEnabled && (
+										isLoading
+											? <SkeletonLoader className="yst-w-20 yst-h-6 yst-rounded-full" />
+											: <Badge variant="plain" className="yst-w-fit">{ category }</Badge>
+									) }
+								</div>
+							) }
 
+							{ isLoading ? (
 								<div className="yst-flex yst-flex-col yst-gap-4">
-									<FormField
-										label={ __( "Focus Keyphrase", "wordpress-seo" ) }
-										value={ suggestion.focusKeyphrase }
-									/>
-									<FormField
-										label={ __( "Title", "wordpress-seo" ) }
-										value={ suggestion.title }
-									/>
-									<FormField
-										label={ __( "Meta description", "wordpress-seo" ) }
-										value={ suggestion.metaDescription }
-										multiline={ true }
-									/>
+									<SkeletonFormField label={ __( "Focus Keyphrase", "wordpress-seo" ) } />
+									<SkeletonFormField label={ __( "Title", "wordpress-seo" ) } />
+									<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
 								</div>
-
-								<hr className="yst-border-slate-200" />
-
-								<div className="yst-flex yst-flex-col yst-gap-2">
-									<div className="yst-flex yst-items-end yst-justify-between">
-										<span className="yst-font-medium yst-text-sm yst-text-slate-800">
-											{ __( "Blog post structure", "wordpress-seo" ) }
-										</span>
-										<span className="yst-text-xs yst-text-slate-500">
-											{ __( "Drag to reorder", "wordpress-seo" ) }
-										</span>
-									</div>
-									{ structure.map( ( item, index ) => (
-										<StructureRow
-											key={ `${ item.level }-${ item.title }` }
-											index={ index }
-											level={ item.level }
-											title={ item.title }
-											dragOverIndex={ dragOverIndex }
-											onDragStart={ handleDragStart }
-											onDragOver={ handleDragOver }
-											onDrop={ handleDrop }
-											onDragEnd={ handleDragEnd }
+							) : (
+								<>
+									<div className="yst-flex yst-flex-col yst-gap-4">
+										<FormField
+											label={ __( "Focus Keyphrase", "wordpress-seo" ) }
+											value={ suggestion.focusKeyphrase }
 										/>
-									) ) }
-								</div>
-							</div>
-						) }
+										<FormField
+											label={ __( "Title", "wordpress-seo" ) }
+											value={ suggestion.title }
+										/>
+										<FormField
+											label={ __( "Meta description", "wordpress-seo" ) }
+											value={ suggestion.metaDescription }
+											multiline={ true }
+										/>
+									</div>
+
+									<hr className="yst-border-slate-200" />
+
+									<div className="yst-flex yst-flex-col yst-gap-2">
+										<div className="yst-flex yst-items-end yst-justify-between">
+											<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+												{ __( "Blog post structure", "wordpress-seo" ) }
+											</span>
+											<span className="yst-text-xs yst-text-slate-500">
+												{ __( "Drag to reorder", "wordpress-seo" ) }
+											</span>
+										</div>
+										{ structure.map( ( item, index ) => (
+											<StructureRow
+												key={ `${ item.level }-${ item.title }` }
+												index={ index }
+												level={ item.level }
+												title={ item.title }
+												dragOverIndex={ dragOverIndex }
+												onDragStart={ handleDragStart }
+												onDragOver={ handleDragOver }
+												onDrop={ handleDrop }
+												onDragEnd={ handleDragEnd }
+											/>
+										) ) }
+									</div>
+								</>
+							) }
+						</div>
 						<div
 							className="yst-sticky -yst-left-6 -yst-right-6 yst-bottom-0 yst-h-10 yst-pointer-events-none yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
 							aria-hidden="true"
 						/>
 					</Modal.Container.Content>
-					{ ! isLoading && (
-						<Modal.Container.Footer className="yst-flex yst-items-center yst-justify-between yst-p-6 yst-border-t yst-border-slate-200">
-							<Button variant="secondary" onClick={ onBack } className="yst-flex yst-items-center yst-gap-1.5">
-								<ArrowLeftIcon className="yst-w-4 yst-h-4" />
-								{ __( "Content suggestions", "wordpress-seo" ) }
-							</Button>
-							<Button variant="ai-primary" onClick={ onAddOutline }>
-								{ __( "Add outline to post", "wordpress-seo" ) }
-							</Button>
-						</Modal.Container.Footer>
-					) }
+					<Modal.Container.Footer className="yst-flex yst-items-center yst-justify-between yst-p-6 yst-border-t yst-border-slate-200">
+						<Button variant="secondary" onClick={ onBack } className="yst-flex yst-items-center yst-gap-1.5">
+							<ArrowLeftIcon className="yst-w-4 yst-h-4" />
+							{ __( "Content suggestions", "wordpress-seo" ) }
+						</Button>
+						<Button variant="ai-primary" onClick={ onAddOutline }>
+							{ __( "Add outline to post", "wordpress-seo" ) }
+						</Button>
+					</Modal.Container.Footer>
 				</Modal.Container>
 			</Modal.Panel>
 		</Modal>

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -207,15 +207,23 @@ const SkeletonFormField = ( { label, multiline = false } ) => (
  *
  * @returns {JSX.Element} The ContentOutlineModal component.
  */
+/**
+ * Assigns stable unique IDs to structure items for use as React keys.
+ *
+ * @param {StructureItem[]} items The structure items.
+ * @returns {Array} Items with `id` property added.
+ */
+const withIds = ( items ) => items.map( ( item, i ) => ( { ...item, id: `${ i }-${ item.level }-${ item.title }` } ) );
+
 export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAddOutline, suggestion, sparksLimit, sparksUsage, category } ) => {
 	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
 	const [ isCategoryEnabled, setIsCategoryEnabled ] = useState( true );
-	const [ structure, setStructure ] = useState( suggestion.structure );
+	const [ structure, setStructure ] = useState( () => withIds( suggestion.structure ) );
 	const [ dragOverIndex, setDragOverIndex ] = useState( null );
 	const dragIndexRef = useRef( null );
 
 	useEffect( () => {
-		setStructure( suggestion.structure );
+		setStructure( withIds( suggestion.structure ) );
 	}, [ suggestion.structure ] );
 
 	const handleCategoryToggle = useCallback( () => {
@@ -371,7 +379,7 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 										<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) }>
 											{ structure.map( ( item, index ) => (
 												<StructureRow
-													key={ `${ index }-${ item.level }-${ item.title }` }
+													key={ item.id }
 													index={ index }
 													level={ item.level }
 													title={ item.title }

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -1,4 +1,4 @@
-import { Badge, Button, Modal, Title, SkeletonLoader, Toggle } from "@yoast/ui-library";
+import { Badge, Button, Modal, SkeletonLoader, Toggle, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
@@ -36,13 +36,14 @@ const intentBadge = {
 const IntentCallout = ( { intent, description } ) => {
 	const badge = intentBadge[ intent ];
 	const Icon = badge ? badge.Icon : BookOpenIcon;
+	const svgAriaProps = useSvgAria();
 
 	return (
 		<div role="note" className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-flex yst-flex-col yst-gap-2">
 			<div className="yst-flex yst-items-center yst-gap-2">
 				{ badge ? (
 					<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-text-xs", badge.classes ) }>
-						<Icon className={ classNames( "yst-w-3", badge.classes ) } /> { badge.label }
+						<Icon className={ classNames( "yst-w-3", badge.classes ) } { ...svgAriaProps } /> { badge.label }
 					</Badge>
 				) : (
 					<Badge>{ intent }</Badge>
@@ -94,6 +95,7 @@ const FormField = ( { label, value, multiline = false } ) => (
  * @returns {JSX.Element} The StructureRow component.
  */
 const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd, onMoveUp, onMoveDown, totalItems } ) => {
+	const svgAriaProps = useSvgAria();
 	const handleDragStart = useCallback( ( e ) => onDragStart( e, index ), [ onDragStart, index ] );
 	const handleDragOver = useCallback( ( e ) => onDragOver( e, index ), [ onDragOver, index ] );
 	const handleDrop = useCallback( ( e ) => onDrop( e, index ), [ onDrop, index ] );
@@ -129,7 +131,7 @@ const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDrag
 		onKeyDown={ handleKeyDown }
 	>
 		{ /* Drag handle icon (6-dot grip) */ }
-		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
+		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" { ...svgAriaProps }>
 			<circle cx="2" cy="2" r="1.5" />
 			<circle cx="8" cy="2" r="1.5" />
 			<circle cx="2" cy="8" r="1.5" />
@@ -277,11 +279,11 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 			isOpen={ isOpen }
 			onClose={ onClose }
 		>
-			<Modal.Panel className="yst-p-0 yst-max-w-2xl">
+			<Modal.Panel className="yst-p-0 yst-max-w-2xl" closeButtonScreenReaderText={ __( "Close content outline", "wordpress-seo" ) }>
 				<Modal.Container>
 					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
-						<Title size="2" className="yst-flex-grow"> { __( "Content outline", "wordpress-seo" ) } </Title>
+						<Modal.Title size="2" className="yst-flex-grow"> { __( "Content outline", "wordpress-seo" ) } </Modal.Title>
 						<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
 						{ sparksLimit && (
 							<UsageCounter
@@ -299,9 +301,9 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 								description={ suggestion.description }
 							/>
 
-							<p className="yst-text-sm yst-text-slate-600">
+							<Modal.Description className="yst-text-sm yst-text-slate-600">
 								{ __( "Review and customize your content outline before adding it to your post", "wordpress-seo" ) }
-							</p>
+							</Modal.Description>
 
 							<hr className="yst-border-slate-200" />
 

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -6,6 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { useSelect } from "@wordpress/data";
 import { useState, useCallback, useRef, useEffect } from "@wordpress/element";
 import { BookOpenIcon, StarIcon, MapIcon, ArrowLeftIcon } from "@heroicons/react/outline";
+import { get } from "lodash";
 import classNames from "classnames";
 
 const intentBadge = {
@@ -194,6 +195,39 @@ const SkeletonFormField = ( { label, multiline = false } ) => (
  */
 
 /**
+ * Hook that simulates loading state with timers.
+ * Set window.contentPlanner.isOutlineLoading = true to force loading state for testing.
+ *
+ * @param {boolean} isOpen Whether the modal is currently open.
+ * @returns {boolean} Whether the modal content is in a loading state.
+ */
+const useSimulatedLoading = ( isOpen ) => {
+	const [ status, setStatus ] = useState( "idle" );
+	const forceLoading = get( window, "contentPlanner.isOutlineLoading", false );
+
+	useEffect( () => {
+		if ( isOpen && ! forceLoading ) {
+			const loadingTimer = setTimeout( () => {
+				setStatus( "loading" );
+			}, 100 );
+
+			const timer = setTimeout( () => {
+				setStatus( "success" );
+			}, 3000 );
+			return () => {
+				clearTimeout( loadingTimer );
+				clearTimeout( timer );
+			};
+		}
+		return () => {
+			setStatus( "idle" );
+		};
+	}, [ isOpen, forceLoading ] );
+
+	return forceLoading || status === "loading" || status === "idle";
+};
+
+/**
  * Content Outline Modal component.
  *
  * @param {boolean}            isOpen      Whether the modal is open or not.
@@ -219,31 +253,10 @@ export const ContentOutlineModal = ( { isOpen, onClose, onBack, onAddOutline, su
 	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
 	const svgAriaProps = useSvgAria();
 	const [ isCategoryEnabled, setIsCategoryEnabled ] = useState( true );
-	const [ status, setStatus ] = useState( "idle" );
+	const isLoading = useSimulatedLoading( isOpen );
 	const [ structure, setStructure ] = useState( () => withIds( suggestion.structure ) );
 	const [ dragOverIndex, setDragOverIndex ] = useState( null );
 	const dragIndexRef = useRef( null );
-	const isLoading = status === "loading" || status === "idle";
-
-	// Simulate loading state when the outline modal is opened.
-	useEffect( () => {
-		if ( isOpen ) {
-			const loadingTimer = setTimeout( () => {
-				setStatus( "loading" );
-			}, 100 );
-
-			const timer = setTimeout( () => {
-				setStatus( "success" );
-			}, 3000 );
-			return () => {
-				clearTimeout( loadingTimer );
-				clearTimeout( timer );
-			};
-		}
-		return () => {
-			setStatus( "idle" );
-		};
-	}, [ isOpen ] );
 
 	useEffect( () => {
 		setStructure( withIds( suggestion.structure ) );

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -4,7 +4,7 @@ import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.sv
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { useSelect } from "@wordpress/data";
-import { useState, useCallback } from "@wordpress/element";
+import { useState, useCallback, useRef, useEffect } from "@wordpress/element";
 import { BookOpenIcon, StarIcon, MapIcon, ArrowLeftIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
 
@@ -81,15 +81,35 @@ const FormField = ( { label, value, multiline = false } ) => (
 );
 
 /**
- * A single row in the blog post structure list.
+ * A single draggable row in the blog post structure list.
  *
- * @param {string} level The heading level (e.g. "H2") or type indicator.
- * @param {string} title The section title.
+ * @param {string}   level       The heading level (e.g. "H2") or type indicator.
+ * @param {string}   title       The section title.
+ * @param {number}   index       The index of the row in the list.
+ * @param {number}   dragOverIndex The index of the row currently being dragged over.
+ * @param {Function} onDragStart  Callback when drag starts.
+ * @param {Function} onDragOver   Callback when dragging over this row.
+ * @param {Function} onDrop       Callback when dropped.
+ * @param {Function} onDragEnd    Callback when drag ends.
  *
  * @returns {JSX.Element} The StructureRow component.
  */
-const StructureRow = ( { level, title } ) => (
-	<div className="yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow-sm yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2">
+const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd } ) => {
+	const handleDragStart = useCallback( ( e ) => onDragStart( e, index ), [ onDragStart, index ] );
+	const handleDragOver = useCallback( ( e ) => onDragOver( e, index ), [ onDragOver, index ] );
+	const handleDrop = useCallback( ( e ) => onDrop( e, index ), [ onDrop, index ] );
+
+	return ( <div
+		className={ classNames(
+			"yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-cursor-grab yst-select-none yst-transition-all",
+			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
+		) }
+		draggable="true"
+		onDragStart={ handleDragStart }
+		onDragOver={ handleDragOver }
+		onDrop={ handleDrop }
+		onDragEnd={ onDragEnd }
+	>
 		{ /* Drag handle icon (6-dot grip) */ }
 		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
 			<circle cx="2" cy="2" r="1.5" />
@@ -99,10 +119,12 @@ const StructureRow = ( { level, title } ) => (
 			<circle cx="2" cy="14" r="1.5" />
 			<circle cx="8" cy="14" r="1.5" />
 		</svg>
-		<span className="yst-font-medium yst-text-sm yst-text-slate-500 yst-shrink-0">{ level }</span>
-		<span className="yst-text-sm yst-text-slate-600 yst-flex-1 yst-min-w-0">{ title }</span>
-	</div>
-);
+		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0 yst-text-sm">
+			<span className="yst-font-medium yst-text-slate-500 yst-shrink-0">{ level }</span>
+			<span className="yst-text-slate-600">{ title }</span>
+		</div>
+	</div> );
+};
 
 /**
  * Loading skeleton for the content outline modal.
@@ -183,9 +205,49 @@ const LoadingOutlineContent = () => (
 export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAddOutline, suggestion, sparksLimit, sparksUsage, category } ) => {
 	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
 	const [ isCategoryEnabled, setIsCategoryEnabled ] = useState( true );
+	const [ structure, setStructure ] = useState( suggestion.structure );
+	const [ dragOverIndex, setDragOverIndex ] = useState( null );
+	const dragIndexRef = useRef( null );
+
+	useEffect( () => {
+		setStructure( suggestion.structure );
+	}, [ suggestion.structure ] );
 
 	const handleCategoryToggle = useCallback( () => {
 		setIsCategoryEnabled( ( prev ) => ! prev );
+	}, [] );
+
+	const handleDragStart = useCallback( ( e, index ) => {
+		dragIndexRef.current = index;
+		e.dataTransfer.effectAllowed = "move";
+	}, [] );
+
+	const handleDragOver = useCallback( ( e, index ) => {
+		e.preventDefault();
+		e.dataTransfer.dropEffect = "move";
+		setDragOverIndex( index );
+	}, [] );
+
+	const handleDrop = useCallback( ( e, dropIndex ) => {
+		e.preventDefault();
+		const dragIndex = dragIndexRef.current;
+		if ( dragIndex === null || dragIndex === dropIndex ) {
+			setDragOverIndex( null );
+			return;
+		}
+		setStructure( ( prev ) => {
+			const updated = [ ...prev ];
+			const [ moved ] = updated.splice( dragIndex, 1 );
+			updated.splice( dropIndex, 0, moved );
+			return updated;
+		} );
+		setDragOverIndex( null );
+		dragIndexRef.current = null;
+	}, [] );
+
+	const handleDragEnd = useCallback( () => {
+		setDragOverIndex( null );
+		dragIndexRef.current = null;
 	}, [] );
 
 	return (
@@ -275,11 +337,17 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 											{ __( "Drag to reorder", "wordpress-seo" ) }
 										</span>
 									</div>
-									{ suggestion.structure.map( ( item, index ) => (
+									{ structure.map( ( item, index ) => (
 										<StructureRow
-											key={ index }
+											key={ `${ item.level }-${ item.title }` }
+											index={ index }
 											level={ item.level }
 											title={ item.title }
+											dragOverIndex={ dragOverIndex }
+											onDragStart={ handleDragStart }
+											onDragOver={ handleDragOver }
+											onDrop={ handleDrop }
+											onDragEnd={ handleDragEnd }
 										/>
 									) ) }
 								</div>

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -1,0 +1,308 @@
+import { Badge, Button, Modal, Title, SkeletonLoader, Toggle } from "@yoast/ui-library";
+import { __ } from "@wordpress/i18n";
+import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
+import { ReactComponent as Yoast } from "../../../images/yoast.svg";
+import { UsageCounter } from "@yoast/ai-frontend";
+import { useSelect } from "@wordpress/data";
+import { useState, useCallback } from "@wordpress/element";
+import { BookOpenIcon, StarIcon, MapIcon, ArrowLeftIcon } from "@heroicons/react/outline";
+import classNames from "classnames";
+
+const intentBadge = {
+	informational: {
+		classes: "yst-bg-blue-200 yst-text-blue-900",
+		Icon: BookOpenIcon,
+		label: __( "Informational", "wordpress-seo" ),
+	},
+	navigational: {
+		classes: "yst-bg-violet-200 yst-text-violet-900",
+		Icon: MapIcon,
+		label: __( "Navigational", "wordpress-seo" ),
+	},
+	commercial: {
+		classes: "yst-bg-yellow-200 yst-text-yellow-900",
+		Icon: StarIcon,
+		label: __( "Commercial", "wordpress-seo" ),
+	},
+};
+
+/**
+ * Blue callout box showing the intent badge and reasoning for the suggestion.
+ *
+ * @param {string} intent The intent type (e.g. "informational").
+ * @param {string} description The reason for the suggestion.
+ *
+ * @returns {JSX.Element} The IntentCallout component.
+ */
+const IntentCallout = ( { intent, description } ) => {
+	const badge = intentBadge[ intent ];
+	const Icon = badge ? badge.Icon : BookOpenIcon;
+
+	return (
+		<div className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-flex yst-flex-col yst-gap-2">
+			<div className="yst-flex yst-items-center yst-gap-2">
+				{ badge ? (
+					<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-text-xs", badge.classes ) }>
+						<Icon className={ classNames( "yst-w-3", badge.classes ) } /> { badge.label }
+					</Badge>
+				) : (
+					<Badge>{ intent }</Badge>
+				) }
+				<span className="yst-font-medium yst-text-sm yst-text-blue-900">
+					{ __( "Why this content?", "wordpress-seo" ) }
+				</span>
+			</div>
+			<p className="yst-text-sm yst-text-blue-900">{ description }</p>
+		</div>
+	);
+};
+
+/**
+ * Read-only form field displaying a label and value.
+ *
+ * @param {string}  label     The field label.
+ * @param {string}  value     The field value.
+ * @param {boolean} multiline Whether to render as a taller textarea-like area.
+ *
+ * @returns {JSX.Element} The FormField component.
+ */
+const FormField = ( { label, value, multiline = false } ) => (
+	<div className="yst-flex yst-flex-col yst-gap-2">
+		<span className="yst-font-medium yst-text-sm yst-text-slate-800">{ label }</span>
+		<div
+			className={ classNames(
+				"yst-bg-white yst-border yst-border-slate-300 yst-rounded-md yst-shadow-sm yst-px-3 yst-py-2 yst-text-sm yst-text-slate-600",
+				multiline && "yst-min-h-20"
+			) }
+		>
+			{ value }
+		</div>
+	</div>
+);
+
+/**
+ * A single row in the blog post structure list.
+ *
+ * @param {string} level The heading level (e.g. "H2") or type indicator.
+ * @param {string} title The section title.
+ *
+ * @returns {JSX.Element} The StructureRow component.
+ */
+const StructureRow = ( { level, title } ) => (
+	<div className="yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow-sm yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2">
+		{ /* Drag handle icon (6-dot grip) */ }
+		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
+			<circle cx="2" cy="2" r="1.5" />
+			<circle cx="8" cy="2" r="1.5" />
+			<circle cx="2" cy="8" r="1.5" />
+			<circle cx="8" cy="8" r="1.5" />
+			<circle cx="2" cy="14" r="1.5" />
+			<circle cx="8" cy="14" r="1.5" />
+		</svg>
+		<span className="yst-font-medium yst-text-sm yst-text-slate-500 yst-shrink-0">{ level }</span>
+		<span className="yst-text-sm yst-text-slate-600 yst-flex-1 yst-min-w-0">{ title }</span>
+	</div>
+);
+
+/**
+ * Loading skeleton for the content outline modal.
+ *
+ * @returns {JSX.Element} The LoadingOutlineContent component.
+ */
+const LoadingOutlineContent = () => (
+	<>
+		<div className="yst-flex yst-flex-col yst-items-center yst-pb-8">
+			<Yoast className="yst-w-24 yst-text-primary-300 yst-mb-2" />
+			<div className="yst-italic yst-text-slate-500">{ __( "Generating your content outline…", "wordpress-seo" ) }</div>
+		</div>
+		<div className="yst-relative">
+			{ /* Skeleton for IntentCallout */ }
+			<div className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-mb-4">
+				<div className="yst-flex yst-items-center yst-gap-2 yst-mb-2">
+					<SkeletonLoader className="yst-w-24 yst-h-5 yst-rounded-full" />
+					<SkeletonLoader className="yst-w-28 yst-h-4 yst-rounded" />
+				</div>
+				<SkeletonLoader className="yst-w-full yst-h-4 yst-rounded yst-mb-1" />
+				<SkeletonLoader className="yst-w-3/4 yst-h-4 yst-rounded" />
+			</div>
+			{ /* Skeleton for form fields */ }
+			<SkeletonLoader className="yst-w-48 yst-h-4 yst-rounded yst-mb-4" />
+			<div className="yst-h-px yst-bg-slate-200 yst-mb-6" />
+			{ [ ...Array( 3 ) ].map( ( _, index ) => (
+				<div key={ index } className="yst-mb-4">
+					<SkeletonLoader className="yst-w-24 yst-h-4 yst-rounded yst-mb-2" />
+					<SkeletonLoader className="yst-w-full yst-h-10 yst-rounded" />
+				</div>
+			) ) }
+			{ /* Skeleton for structure rows */ }
+			<div className="yst-h-px yst-bg-slate-200 yst-my-6" />
+			<SkeletonLoader className="yst-w-32 yst-h-4 yst-rounded yst-mb-2" />
+			{ [ ...Array( 5 ) ].map( ( _, index ) => (
+				<SkeletonLoader key={ `structure-${ index }` } className="yst-w-full yst-h-10 yst-rounded yst-mb-2" />
+			) ) }
+			{ /* Gradient overlay for fade effect */ }
+			<div
+				className="yst-absolute yst-inset-0 yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
+				aria-hidden="true"
+			/>
+		</div>
+	</>
+);
+
+/**
+ * @typedef {Object} StructureItem
+ * @property {string} level The heading level (e.g. "H2") or type indicator (e.g. a list icon).
+ * @property {string} title The section title.
+ */
+
+/**
+ * @typedef {Object} OutlineSuggestion
+ * @property {string}          intent          The intent type (e.g. "informational", "navigational", "commercial").
+ * @property {string}          title           The suggested post title.
+ * @property {string}          description     The reasoning behind the suggestion.
+ * @property {string}          focusKeyphrase  The suggested focus keyphrase.
+ * @property {string}          metaDescription The suggested meta description.
+ * @property {StructureItem[]} structure       The suggested blog post structure.
+ */
+
+/**
+ * Content Outline Modal component.
+ *
+ * @param {boolean}            isOpen      Whether the modal is open or not.
+ * @param {Function}           onClose     The function to call when the modal should be closed.
+ * @param {boolean}            isLoading   Whether the content outline is being generated.
+ * @param {Function}           onBack      The function to call to go back to content suggestions.
+ * @param {Function}           onAddOutline The function to call to add the outline to the post.
+ * @param {OutlineSuggestion}  suggestion  The content outline suggestion to display.
+ * @param {number}             sparksLimit Optional. If provided, show the UsageCounter.
+ * @param {number}             sparksUsage Optional. Current sparks usage count.
+ * @param {string}             category    Optional. If provided, show the suggest category section.
+ *
+ * @returns {JSX.Element} The ContentOutlineModal component.
+ */
+export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAddOutline, suggestion, sparksLimit, sparksUsage, category } ) => {
+	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
+	const [ isCategoryEnabled, setIsCategoryEnabled ] = useState( true );
+
+	const handleCategoryToggle = useCallback( () => {
+		setIsCategoryEnabled( ( prev ) => ! prev );
+	}, [] );
+
+	return (
+		<Modal
+			isOpen={ isOpen }
+			onClose={ onClose }
+		>
+			<Modal.Panel className="yst-p-0 yst-max-w-2xl">
+				<Modal.Container>
+					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
+						<YoastIcon className="yst-fill-primary-500 yst-w-4" />
+						<Title size="2" className="yst-flex-grow"> { __( "Content outline", "wordpress-seo" ) } </Title>
+						<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
+						{ sparksLimit && (
+							<UsageCounter
+								limit={ sparksLimit }
+								requests={ sparksUsage }
+								mentionBetaInTooltip={ isPremium }
+								mentionResetInTooltip={ isPremium }
+							/>
+						) }
+					</Modal.Container.Header>
+					<Modal.Container.Content className="yst-overflow-y-auto yst-pt-6 yst-px-6 yst-pb-0 yst-m-0 yst-relative">
+						{ isLoading ? (
+							<LoadingOutlineContent />
+						) : (
+							<div className="yst-flex yst-flex-col yst-gap-6 yst-pb-6">
+								<IntentCallout
+									intent={ suggestion.intent }
+									description={ suggestion.description }
+								/>
+
+								<p className="yst-text-sm yst-text-slate-600">
+									{ __( "Review and customize your content outline before adding it to your post", "wordpress-seo" ) }
+								</p>
+
+								<hr className="yst-border-slate-200" />
+
+								{ category && (
+									<div className="yst-flex yst-flex-col yst-gap-3">
+										<div className="yst-flex yst-flex-col yst-gap-1.5">
+											<div className="yst-flex yst-items-center yst-gap-6">
+												<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+													{ __( "Suggest category", "wordpress-seo" ) }
+												</span>
+												<Toggle
+													id="suggest-category-toggle"
+													checked={ isCategoryEnabled }
+													onChange={ handleCategoryToggle }
+													screenReaderLabel={ __( "Suggest category", "wordpress-seo" ) }
+												/>
+											</div>
+											<p className="yst-text-sm yst-text-slate-600">
+												{ __( "Adds post to an existing category, when applicable.", "wordpress-seo" ) }
+											</p>
+										</div>
+										{ isCategoryEnabled && (
+											<Badge variant="plain" className="yst-w-fit">{ category }</Badge>
+										) }
+									</div>
+								) }
+
+								<div className="yst-flex yst-flex-col yst-gap-4">
+									<FormField
+										label={ __( "Focus Keyphrase", "wordpress-seo" ) }
+										value={ suggestion.focusKeyphrase }
+									/>
+									<FormField
+										label={ __( "Title", "wordpress-seo" ) }
+										value={ suggestion.title }
+									/>
+									<FormField
+										label={ __( "Meta description", "wordpress-seo" ) }
+										value={ suggestion.metaDescription }
+										multiline={ true }
+									/>
+								</div>
+
+								<hr className="yst-border-slate-200" />
+
+								<div className="yst-flex yst-flex-col yst-gap-2">
+									<div className="yst-flex yst-items-end yst-justify-between">
+										<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+											{ __( "Blog post structure", "wordpress-seo" ) }
+										</span>
+										<span className="yst-text-xs yst-text-slate-500">
+											{ __( "Drag to reorder", "wordpress-seo" ) }
+										</span>
+									</div>
+									{ suggestion.structure.map( ( item, index ) => (
+										<StructureRow
+											key={ index }
+											level={ item.level }
+											title={ item.title }
+										/>
+									) ) }
+								</div>
+							</div>
+						) }
+						<div
+							className="yst-sticky -yst-left-6 -yst-right-6 yst-bottom-0 yst-h-10 yst-pointer-events-none yst-bg-gradient-to-t yst-from-white yst-to-transparent yst-transition-opacity"
+							aria-hidden="true"
+						/>
+					</Modal.Container.Content>
+					{ ! isLoading && (
+						<Modal.Container.Footer className="yst-flex yst-items-center yst-justify-between yst-p-6 yst-border-t yst-border-slate-200">
+							<Button variant="secondary" onClick={ onBack } className="yst-flex yst-items-center yst-gap-1.5">
+								<ArrowLeftIcon className="yst-w-4 yst-h-4" />
+								{ __( "Content suggestions", "wordpress-seo" ) }
+							</Button>
+							<Button variant="ai-primary" onClick={ onAddOutline }>
+								{ __( "Add outline to post", "wordpress-seo" ) }
+							</Button>
+						</Modal.Container.Footer>
+					) }
+				</Modal.Container>
+			</Modal.Panel>
+		</Modal>
+	);
+};

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -38,7 +38,7 @@ const IntentCallout = ( { intent, description } ) => {
 	const Icon = badge ? badge.Icon : BookOpenIcon;
 
 	return (
-		<div className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-flex yst-flex-col yst-gap-2">
+		<div role="note" className="yst-bg-blue-50 yst-border yst-border-blue-200 yst-rounded-md yst-p-4 yst-flex yst-flex-col yst-gap-2">
 			<div className="yst-flex yst-items-center yst-gap-2">
 				{ badge ? (
 					<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-text-xs", badge.classes ) }>
@@ -93,12 +93,30 @@ const FormField = ( { label, value, multiline = false } ) => (
  *
  * @returns {JSX.Element} The StructureRow component.
  */
-const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd } ) => {
+const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd, onMoveUp, onMoveDown, totalItems } ) => {
 	const handleDragStart = useCallback( ( e ) => onDragStart( e, index ), [ onDragStart, index ] );
 	const handleDragOver = useCallback( ( e ) => onDragOver( e, index ), [ onDragOver, index ] );
 	const handleDrop = useCallback( ( e ) => onDrop( e, index ), [ onDrop, index ] );
+	const handleKeyDown = useCallback( ( e ) => {
+		if ( ! e.altKey ) {
+			return;
+		}
+		if ( e.key === "ArrowUp" && index > 0 ) {
+			e.preventDefault();
+			onMoveUp( index );
+		}
+		if ( e.key === "ArrowDown" && index < totalItems - 1 ) {
+			e.preventDefault();
+			onMoveDown( index );
+		}
+	}, [ index, totalItems, onMoveUp, onMoveDown ] );
 
 	return ( <div
+		role="option"
+		aria-selected="false"
+		aria-label={ `${ level } ${ title }` }
+		aria-roledescription={ __( "Draggable section", "wordpress-seo" ) }
+		tabIndex="0"
 		className={ classNames(
 			"yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-cursor-grab yst-select-none yst-transition-all",
 			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
@@ -108,6 +126,7 @@ const StructureRow = ( { level, title, index, dragOverIndex, onDragStart, onDrag
 		onDragOver={ handleDragOver }
 		onDrop={ handleDrop }
 		onDragEnd={ onDragEnd }
+		onKeyDown={ handleKeyDown }
 	>
 		{ /* Drag handle icon (6-dot grip) */ }
 		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true">
@@ -222,7 +241,8 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 		setStructure( ( prev ) => {
 			const updated = [ ...prev ];
 			const [ moved ] = updated.splice( dragIndex, 1 );
-			updated.splice( dropIndex, 0, moved );
+			const destinationIndex = dragIndex < dropIndex ? dropIndex - 1 : dropIndex;
+			updated.splice( destinationIndex, 0, moved );
 			return updated;
 		} );
 		setDragOverIndex( null );
@@ -232,6 +252,24 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 	const handleDragEnd = useCallback( () => {
 		setDragOverIndex( null );
 		dragIndexRef.current = null;
+	}, [] );
+
+	const handleMoveUp = useCallback( ( index ) => {
+		setStructure( ( prev ) => {
+			const updated = [ ...prev ];
+			const [ moved ] = updated.splice( index, 1 );
+			updated.splice( index - 1, 0, moved );
+			return updated;
+		} );
+	}, [] );
+
+	const handleMoveDown = useCallback( ( index ) => {
+		setStructure( ( prev ) => {
+			const updated = [ ...prev ];
+			const [ moved ] = updated.splice( index, 1 );
+			updated.splice( index + 1, 0, moved );
+			return updated;
+		} );
 	}, [] );
 
 	return (
@@ -254,7 +292,7 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 							/>
 						) }
 					</Modal.Container.Header>
-					<Modal.Container.Content className="yst-overflow-y-auto yst-pt-6 yst-px-6 yst-pb-0 yst-m-0 yst-relative">
+					<Modal.Container.Content className="yst-overflow-y-auto yst-pt-6 yst-px-6 yst-pb-0 yst-m-0 yst-relative" aria-busy={ isLoading }>
 						<div className="yst-flex yst-flex-col yst-gap-6 yst-pb-6">
 							<IntentCallout
 								intent={ suggestion.intent }
@@ -328,19 +366,24 @@ export const ContentOutlineModal = ( { isOpen, onClose, isLoading, onBack, onAdd
 												{ __( "Drag to reorder", "wordpress-seo" ) }
 											</span>
 										</div>
-										{ structure.map( ( item, index ) => (
-											<StructureRow
-												key={ `${ item.level }-${ item.title }` }
-												index={ index }
-												level={ item.level }
-												title={ item.title }
-												dragOverIndex={ dragOverIndex }
-												onDragStart={ handleDragStart }
-												onDragOver={ handleDragOver }
-												onDrop={ handleDrop }
-												onDragEnd={ handleDragEnd }
-											/>
-										) ) }
+										<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) }>
+											{ structure.map( ( item, index ) => (
+												<StructureRow
+													key={ `${ index }-${ item.level }-${ item.title }` }
+													index={ index }
+													level={ item.level }
+													title={ item.title }
+													dragOverIndex={ dragOverIndex }
+													onDragStart={ handleDragStart }
+													onDragOver={ handleDragOver }
+													onDrop={ handleDrop }
+													onDragEnd={ handleDragEnd }
+													onMoveUp={ handleMoveUp }
+													onMoveDown={ handleMoveDown }
+													totalItems={ structure.length }
+												/>
+											) ) }
+										</div>
 									</div>
 								</>
 							) }

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -2,6 +2,9 @@ import { __ } from "@wordpress/i18n";
 import { Button, Root, useToggleState } from "@yoast/ui-library";
 import { ApproveModal } from "./approve-modal";
 import { ContentSuggestionsModal } from "./content-suggestions-modal";
+import { ContentOutlineModal } from "./content-outline-modal";
+import { get, noop } from "lodash";
+import { useCallback, useState } from "@wordpress/element";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
@@ -10,11 +13,28 @@ import { ContentSuggestionsModal } from "./content-suggestions-modal";
  * @param {string}  props.location      The location where the editor item is rendered. Can be "sidebar" or "metabox".
  * @param {boolean} props.isPremium     Whether the user has a premium subscription.
  * @param {boolean} props.isEmptyCanvas Whether the editor canvas has no content.
+ * @param {string}  props.upsellLink    The link to the upsell page.
  * @returns {JSX.Element} The Content Planner section in the sidebar.
  */
 export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, upsellLink } ) => {
 	const [ isApproveModalOpen, , , openApproveModal, closeApproveModal ] = useToggleState( false );
 	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
+	const [ isContentOutlineModalOpen, , , openContentOutlineModal, closeContentOutlineModal ] = useToggleState( false );
+	const [ selectedSuggestion, setSelectedSuggestion ] = useState( null );
+
+	// Used for testing only, will be addressed in future iterations.
+	const isOutlineLoading = get( window, "contentPlanner.isOutlineLoading", false );
+
+	const handleSuggestionClick = useCallback( ( suggestion ) => {
+		setSelectedSuggestion( suggestion );
+		closeContentSuggestionModal();
+		setTimeout( openContentOutlineModal, 200 );
+	}, [ closeContentSuggestionModal, openContentOutlineModal ] );
+
+	const handleBackToSuggestions = useCallback( () => {
+		closeContentOutlineModal();
+		setTimeout( openContentSuggestionModal, 200 );
+	}, [ closeContentOutlineModal, openContentSuggestionModal ] );
 
 	return <Root><div className="yst-p-4">
 		<Button variant="ai-secondary" onClick={ openApproveModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
@@ -33,7 +53,34 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 		<ContentSuggestionsModal
 			isOpen={ isContentSuggestionModalOpen }
 			onClose={ closeContentSuggestionModal }
+			onSuggestionClick={ handleSuggestionClick }
 			isPremium={ isPremium }
+		/>
+		<ContentOutlineModal
+			isOpen={ isContentOutlineModalOpen }
+			onClose={ closeContentOutlineModal }
+			isLoading={ isOutlineLoading }
+			onBack={ handleBackToSuggestions }
+			onAddOutline={ noop }
+			sparksLimit={ 10 }
+			sparksUsage={ 1 }
+			category="WordPress"
+			suggestion={ {
+				intent: selectedSuggestion ? selectedSuggestion.intent : "informational",
+				title: "The Ultimate Guide to Setting Up Your WordPress Blog",
+				description: selectedSuggestion ? selectedSuggestion.description : "This content is suggested because it addresses a common entry point for new users.",
+				focusKeyphrase: "Guide to set up WordPress blog",
+				metaDescription: "A comprehensive tutorial covering WordPress installation, theme selection, and essential plugins. In this article, we'll explore everything you need to know to get started and achieve success.",
+				structure: [
+					{ level: "H2", title: "Introduction" },
+					{ level: "H2", title: "Why This Matters" },
+					{ level: "H2", title: "Step-by-Step Guide" },
+					{ level: "H2", title: "Common Mistakes to Avoid" },
+					{ level: "H2", title: "Best Practices" },
+					{ level: "H2", title: "Conclusion" },
+					{ level: "FAQ", title: "FAQ" },
+				],
+			} }
 		/>
 	</div>
 	</Root>;

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -3,7 +3,7 @@ import { Button, Root, useToggleState } from "@yoast/ui-library";
 import { ApproveModal } from "./approve-modal";
 import { ContentSuggestionsModal } from "./content-suggestions-modal";
 import { ContentOutlineModal } from "./content-outline-modal";
-import { get, noop } from "lodash";
+import { noop } from "lodash";
 import { useCallback, useState } from "@wordpress/element";
 
 /**
@@ -21,9 +21,6 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 	const [ isContentSuggestionModalOpen, , , openContentSuggestionModal, closeContentSuggestionModal ] = useToggleState( false );
 	const [ isContentOutlineModalOpen, , , openContentOutlineModal, closeContentOutlineModal ] = useToggleState( false );
 	const [ selectedSuggestion, setSelectedSuggestion ] = useState( null );
-
-	// Used for testing only, will be addressed in future iterations.
-	const isOutlineLoading = get( window, "contentPlanner.isOutlineLoading", false );
 
 	const handleSuggestionClick = useCallback( ( suggestion ) => {
 		setSelectedSuggestion( suggestion );
@@ -59,7 +56,6 @@ export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, 
 		<ContentOutlineModal
 			isOpen={ isContentOutlineModalOpen }
 			onClose={ closeContentOutlineModal }
-			isLoading={ isOutlineLoading }
 			onBack={ handleBackToSuggestions }
 			onAddOutline={ noop }
 			sparksLimit={ 10 }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -6,7 +6,7 @@ import { UsageCounter } from "@yoast/ai-frontend";
 import { BookOpenIcon, StarIcon, MapIcon } from "@heroicons/react/outline";
 import { noop } from "lodash";
 import classNames from "classnames";
-import { useEffect } from "@wordpress/element";
+import { useCallback, useEffect } from "@wordpress/element";
 
 const intentBadge = {
 	informational: {
@@ -37,11 +37,12 @@ const intentBadge = {
  *
  * @returns {JSX.Element} The SuggestionButton component.
  */
-const SuggestionButton = ( { intent, title, description, onClick } ) => {
+const SuggestionButton = ( { intent, title, description, suggestion, onClick } ) => {
 	const svgAriaProps = useSvgAria();
 	const Icon = intentBadge[ intent ] ? intentBadge[ intent ].Icon : BookOpenIcon;
+	const handleClick = useCallback( () => onClick( suggestion ), [ onClick, suggestion ] );
 	return (
-		<button type="button" onClick={ onClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500">
+		<button type="button" onClick={ handleClick } className="yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500">
 			{ intentBadge[ intent ] ? (
 				<Badge className={ classNames( "yst-flex yst-items-center yst-gap-1 yst-w-fit yst-mb-2 yst-text-xs", intentBadge[ intent ].classes ) }>
 					<Icon className={ classNames( "yst-w-3 ", intentBadge[ intent ].classes ) } { ...svgAriaProps } /> { intentBadge[ intent ].label }
@@ -202,7 +203,8 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium, onSuggest
 										<SuggestionButton
 											key={ index }
 											{ ...suggestion }
-											onClick={ onSuggestionClick.bind( null, suggestion ) }
+											suggestion={ suggestion }
+											onClick={ onSuggestionClick }
 										/>
 									) ) }
 								</>

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -116,7 +116,7 @@ const LoadingModalContent = () => {
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
-export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
+export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium, onSuggestionClick = noop } ) => {
 	const suggestions = [
 		{
 			intent: "informational",
@@ -202,7 +202,7 @@ export const ContentSuggestionsModal = ( { isOpen, onClose, isPremium } ) => {
 										<SuggestionButton
 											key={ index }
 											{ ...suggestion }
-											onClick={ noop }
+											onClick={ onSuggestionClick.bind( null, suggestion ) }
 										/>
 									) ) }
 								</>

--- a/packages/js/tests/ai-content-planner/components/content-outline-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-outline-modal.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { ContentOutlineModal } from "../../../src/ai-content-planner/components/content-outline-modal";
 
 const mockUsageCounter = jest.fn( () => null );
@@ -28,7 +28,6 @@ const renderModal = ( props ) => render(
 	<ContentOutlineModal
 		isOpen={ true }
 		onClose={ jest.fn() }
-		isLoading={ false }
 		onBack={ jest.fn() }
 		onAddOutline={ jest.fn() }
 		suggestion={ defaultSuggestion }
@@ -36,9 +35,28 @@ const renderModal = ( props ) => render(
 	/>
 );
 
+/**
+ * Renders the modal and advances timers so the loading simulation completes.
+ *
+ * @param {Object} props Optional props to override defaults.
+ * @returns {Object} The render result.
+ */
+const renderLoadedModal = ( props ) => {
+	const result = renderModal( props );
+	act( () => {
+		jest.advanceTimersByTime( 5000 );
+	} );
+	return result;
+};
+
 describe( "ContentOutlineModal", () => {
 	beforeEach( () => {
 		mockUsageCounter.mockClear();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	describe( "visibility", () => {
@@ -102,7 +120,10 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "does not show the structure section when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.queryByRole( "listbox" ) ).not.toBeInTheDocument();
 		} );
 
@@ -111,13 +132,13 @@ describe( "ContentOutlineModal", () => {
 			expect( screen.getByRole( "note" ) ).toBeInTheDocument();
 		} );
 
-		it( "renders the structure list as a listbox", () => {
-			renderModal();
+		it( "renders the structure list as a listbox after loading", () => {
+			renderLoadedModal();
 			expect( screen.getByRole( "listbox", { name: "Blog post structure" } ) ).toBeInTheDocument();
 		} );
 
 		it( "renders structure rows as options with accessible labels", () => {
-			renderModal();
+			renderLoadedModal();
 			expect( screen.getByRole( "option", { name: "H2 Introduction" } ) ).toBeInTheDocument();
 			expect( screen.getByRole( "option", { name: "H2 Conclusion" } ) ).toBeInTheDocument();
 		} );
@@ -156,28 +177,28 @@ describe( "ContentOutlineModal", () => {
 	} );
 
 	describe( "content state", () => {
-		it( "shows the form field labels", () => {
-			renderModal();
+		it( "shows the form field labels after loading", () => {
+			renderLoadedModal();
 			expect( screen.getByText( "Focus Keyphrase" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Title" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Meta description" ) ).toBeInTheDocument();
 		} );
 
-		it( "shows the form field values", () => {
-			renderModal();
+		it( "shows the form field values after loading", () => {
+			renderLoadedModal();
 			expect( screen.getByText( defaultSuggestion.focusKeyphrase ) ).toBeInTheDocument();
 			expect( screen.getByText( defaultSuggestion.title ) ).toBeInTheDocument();
 			expect( screen.getByText( defaultSuggestion.metaDescription ) ).toBeInTheDocument();
 		} );
 
-		it( "shows the blog post structure section", () => {
-			renderModal();
+		it( "shows the blog post structure section after loading", () => {
+			renderLoadedModal();
 			expect( screen.getByText( "Blog post structure" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Drag to reorder" ) ).toBeInTheDocument();
 		} );
 
-		it( "renders all structure rows", () => {
-			renderModal();
+		it( "renders all structure rows after loading", () => {
+			renderLoadedModal();
 			expect( screen.getByText( "Introduction" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Why This Matters" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Step-by-Step Guide" ) ).toBeInTheDocument();
@@ -187,37 +208,55 @@ describe( "ContentOutlineModal", () => {
 
 	describe( "loading state", () => {
 		it( "shows the form field labels when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByText( "Focus Keyphrase" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Title" ) ).toBeInTheDocument();
 			expect( screen.getByText( "Meta description" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the form field values when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.queryByText( defaultSuggestion.focusKeyphrase ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( defaultSuggestion.metaDescription ) ).not.toBeInTheDocument();
 		} );
 
 		it( "does not show the blog post structure section when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.queryByText( "Blog post structure" ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( "Drag to reorder" ) ).not.toBeInTheDocument();
 		} );
 
 		it( "still shows the intent callout when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByText( "Why this content?" ) ).toBeInTheDocument();
 			expect( screen.getByText( defaultSuggestion.description ) ).toBeInTheDocument();
 		} );
 
 		it( "still shows the instruction text when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByText( "Review and customize your content outline before adding it to your post" ) ).toBeInTheDocument();
 		} );
 
 		it( "shows the footer buttons when loading", () => {
-			renderModal( { isLoading: true } );
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.getByRole( "button", { name: /Content suggestions/i } ) ).toBeInTheDocument();
 			expect( screen.getByRole( "button", { name: /Add outline to post/i } ) ).toBeInTheDocument();
 		} );
@@ -228,7 +267,6 @@ describe( "ContentOutlineModal", () => {
 			renderModal( { category: "WordPress" } );
 			expect( screen.getByRole( "switch", { name: "Suggest category" } ) ).toBeInTheDocument();
 			expect( screen.getByText( "Adds post to an existing category, when applicable." ) ).toBeInTheDocument();
-			expect( screen.getByText( "WordPress" ) ).toBeInTheDocument();
 		} );
 
 		it( "does not show the suggest category section when category is not provided", () => {
@@ -237,14 +275,17 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "hides the category badge when the toggle is turned off", () => {
-			renderModal( { category: "WordPress" } );
+			renderLoadedModal( { category: "WordPress" } );
 			expect( screen.getByText( "WordPress" ) ).toBeInTheDocument();
 			fireEvent.click( screen.getByRole( "switch", { name: "Suggest category" } ) );
 			expect( screen.queryByText( "WordPress" ) ).not.toBeInTheDocument();
 		} );
 
 		it( "does not show the category badge value when loading", () => {
-			renderModal( { category: "WordPress", isLoading: true } );
+			renderModal( { category: "WordPress" } );
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
 			expect( screen.queryByText( "WordPress" ) ).not.toBeInTheDocument();
 		} );
 	} );
@@ -267,9 +308,8 @@ describe( "ContentOutlineModal", () => {
 
 	describe( "keyboard reordering", () => {
 		it( "moves a row up with Alt+ArrowUp", () => {
-			renderModal();
+			renderLoadedModal();
 			const options = screen.getAllByRole( "option" );
-			// "Why This Matters" is at index 1
 			fireEvent.keyDown( options[ 1 ], { key: "ArrowUp", altKey: true } );
 			const updatedOptions = screen.getAllByRole( "option" );
 			expect( updatedOptions[ 0 ] ).toHaveAttribute( "aria-label", "H2 Why This Matters" );
@@ -277,9 +317,8 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "moves a row down with Alt+ArrowDown", () => {
-			renderModal();
+			renderLoadedModal();
 			const options = screen.getAllByRole( "option" );
-			// "Introduction" is at index 0
 			fireEvent.keyDown( options[ 0 ], { key: "ArrowDown", altKey: true } );
 			const updatedOptions = screen.getAllByRole( "option" );
 			expect( updatedOptions[ 0 ] ).toHaveAttribute( "aria-label", "H2 Why This Matters" );
@@ -287,7 +326,7 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "does not move the first row up", () => {
-			renderModal();
+			renderLoadedModal();
 			const options = screen.getAllByRole( "option" );
 			fireEvent.keyDown( options[ 0 ], { key: "ArrowUp", altKey: true } );
 			const updatedOptions = screen.getAllByRole( "option" );
@@ -295,7 +334,7 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "does not move the last row down", () => {
-			renderModal();
+			renderLoadedModal();
 			const options = screen.getAllByRole( "option" );
 			fireEvent.keyDown( options[ 3 ], { key: "ArrowDown", altKey: true } );
 			const updatedOptions = screen.getAllByRole( "option" );
@@ -303,7 +342,7 @@ describe( "ContentOutlineModal", () => {
 		} );
 
 		it( "does not move without the Alt key", () => {
-			renderModal();
+			renderLoadedModal();
 			const options = screen.getAllByRole( "option" );
 			fireEvent.keyDown( options[ 1 ], { key: "ArrowUp", altKey: false } );
 			const updatedOptions = screen.getAllByRole( "option" );

--- a/packages/js/tests/ai-content-planner/components/content-outline-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-outline-modal.test.js
@@ -1,0 +1,313 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ContentOutlineModal } from "../../../src/ai-content-planner/components/content-outline-modal";
+
+const mockUsageCounter = jest.fn( () => null );
+jest.mock( "@yoast/ai-frontend", () => ( {
+	UsageCounter: ( props ) => mockUsageCounter( props ),
+} ) );
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn( () => false ),
+} ) );
+
+const defaultSuggestion = {
+	intent: "informational",
+	title: "The Ultimate Guide to Setting Up Your WordPress Blog",
+	description: "This content is suggested because it addresses a common entry point for new users.",
+	focusKeyphrase: "Guide to set up WordPress blog",
+	metaDescription: "A comprehensive tutorial covering WordPress installation, theme selection, and essential plugins.",
+	structure: [
+		{ level: "H2", title: "Introduction" },
+		{ level: "H2", title: "Why This Matters" },
+		{ level: "H2", title: "Step-by-Step Guide" },
+		{ level: "H2", title: "Conclusion" },
+	],
+};
+
+const renderModal = ( props ) => render(
+	<ContentOutlineModal
+		isOpen={ true }
+		onClose={ jest.fn() }
+		isLoading={ false }
+		onBack={ jest.fn() }
+		onAddOutline={ jest.fn() }
+		suggestion={ defaultSuggestion }
+		{ ...props }
+	/>
+);
+
+describe( "ContentOutlineModal", () => {
+	beforeEach( () => {
+		mockUsageCounter.mockClear();
+	} );
+
+	describe( "visibility", () => {
+		it( "renders the modal when isOpen is true", () => {
+			renderModal( { isOpen: true } );
+			expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not render the modal when isOpen is false", () => {
+			renderModal( { isOpen: false } );
+			expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "calls onClose when the modal close button is clicked", () => {
+			const onClose = jest.fn();
+			renderModal( { onClose } );
+			fireEvent.click( screen.getByRole( "button", { name: /close/i } ) );
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( "header", () => {
+		it( "shows the 'Content outline' title", () => {
+			renderModal();
+			expect( screen.getByText( "Content outline" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the 'Beta' badge", () => {
+			renderModal();
+			expect( screen.getByText( "Beta" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the UsageCounter when sparksLimit is provided", () => {
+			renderModal( { sparksLimit: 10, sparksUsage: 3 } );
+			expect( mockUsageCounter ).toHaveBeenCalledWith(
+				expect.objectContaining( { limit: 10, requests: 3 } )
+			);
+		} );
+
+		it( "does not show the UsageCounter when sparksLimit is not provided", () => {
+			mockUsageCounter.mockClear();
+			renderModal();
+			expect( mockUsageCounter ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( "accessibility", () => {
+		it( "has a descriptive close button label", () => {
+			renderModal();
+			expect( screen.getByRole( "button", { name: "Close content outline" } ) ).toBeInTheDocument();
+		} );
+
+		it( "has an accessible dialog name from the title", () => {
+			renderModal();
+			expect( screen.getByRole( "dialog", { name: "Content outline" } ) ).toBeInTheDocument();
+		} );
+
+		it( "has an accessible description for the modal", () => {
+			renderModal();
+			expect( screen.getByText( "Review and customize your content outline before adding it to your post" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not show the structure section when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.queryByRole( "listbox" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "renders the intent callout with role='note'", () => {
+			renderModal();
+			expect( screen.getByRole( "note" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the structure list as a listbox", () => {
+			renderModal();
+			expect( screen.getByRole( "listbox", { name: "Blog post structure" } ) ).toBeInTheDocument();
+		} );
+
+		it( "renders structure rows as options with accessible labels", () => {
+			renderModal();
+			expect( screen.getByRole( "option", { name: "H2 Introduction" } ) ).toBeInTheDocument();
+			expect( screen.getByRole( "option", { name: "H2 Conclusion" } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "intent callout", () => {
+		it( "shows the intent badge label", () => {
+			renderModal();
+			expect( screen.getByText( "Informational" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the 'Why this content?' text", () => {
+			renderModal();
+			expect( screen.getByText( "Why this content?" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the suggestion description", () => {
+			renderModal();
+			expect( screen.getByText( defaultSuggestion.description ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the correct badge for navigational intent", () => {
+			renderModal( { suggestion: { ...defaultSuggestion, intent: "navigational" } } );
+			expect( screen.getByText( "Navigational" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the correct badge for commercial intent", () => {
+			renderModal( { suggestion: { ...defaultSuggestion, intent: "commercial" } } );
+			expect( screen.getByText( "Commercial" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders an unknown intent as a badge with the raw value", () => {
+			renderModal( { suggestion: { ...defaultSuggestion, intent: "transactional" } } );
+			expect( screen.getByText( "transactional" ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "content state", () => {
+		it( "shows the form field labels", () => {
+			renderModal();
+			expect( screen.getByText( "Focus Keyphrase" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Title" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Meta description" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the form field values", () => {
+			renderModal();
+			expect( screen.getByText( defaultSuggestion.focusKeyphrase ) ).toBeInTheDocument();
+			expect( screen.getByText( defaultSuggestion.title ) ).toBeInTheDocument();
+			expect( screen.getByText( defaultSuggestion.metaDescription ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the blog post structure section", () => {
+			renderModal();
+			expect( screen.getByText( "Blog post structure" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Drag to reorder" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders all structure rows", () => {
+			renderModal();
+			expect( screen.getByText( "Introduction" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Why This Matters" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Step-by-Step Guide" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Conclusion" ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "loading state", () => {
+		it( "shows the form field labels when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.getByText( "Focus Keyphrase" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Title" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Meta description" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not show the form field values when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.queryByText( defaultSuggestion.focusKeyphrase ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( defaultSuggestion.metaDescription ) ).not.toBeInTheDocument();
+		} );
+
+		it( "does not show the blog post structure section when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.queryByText( "Blog post structure" ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( "Drag to reorder" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "still shows the intent callout when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.getByText( "Why this content?" ) ).toBeInTheDocument();
+			expect( screen.getByText( defaultSuggestion.description ) ).toBeInTheDocument();
+		} );
+
+		it( "still shows the instruction text when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.getByText( "Review and customize your content outline before adding it to your post" ) ).toBeInTheDocument();
+		} );
+
+		it( "shows the footer buttons when loading", () => {
+			renderModal( { isLoading: true } );
+			expect( screen.getByRole( "button", { name: /Content suggestions/i } ) ).toBeInTheDocument();
+			expect( screen.getByRole( "button", { name: /Add outline to post/i } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "category section", () => {
+		it( "shows the suggest category section when category is provided", () => {
+			renderModal( { category: "WordPress" } );
+			expect( screen.getByRole( "switch", { name: "Suggest category" } ) ).toBeInTheDocument();
+			expect( screen.getByText( "Adds post to an existing category, when applicable." ) ).toBeInTheDocument();
+			expect( screen.getByText( "WordPress" ) ).toBeInTheDocument();
+		} );
+
+		it( "does not show the suggest category section when category is not provided", () => {
+			renderModal();
+			expect( screen.queryByText( "Suggest category" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "hides the category badge when the toggle is turned off", () => {
+			renderModal( { category: "WordPress" } );
+			expect( screen.getByText( "WordPress" ) ).toBeInTheDocument();
+			fireEvent.click( screen.getByRole( "switch", { name: "Suggest category" } ) );
+			expect( screen.queryByText( "WordPress" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "does not show the category badge value when loading", () => {
+			renderModal( { category: "WordPress", isLoading: true } );
+			expect( screen.queryByText( "WordPress" ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( "footer actions", () => {
+		it( "calls onBack when the back button is clicked", () => {
+			const onBack = jest.fn();
+			renderModal( { onBack } );
+			fireEvent.click( screen.getByRole( "button", { name: /Content suggestions/i } ) );
+			expect( onBack ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "calls onAddOutline when the add button is clicked", () => {
+			const onAddOutline = jest.fn();
+			renderModal( { onAddOutline } );
+			fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
+			expect( onAddOutline ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( "keyboard reordering", () => {
+		it( "moves a row up with Alt+ArrowUp", () => {
+			renderModal();
+			const options = screen.getAllByRole( "option" );
+			// "Why This Matters" is at index 1
+			fireEvent.keyDown( options[ 1 ], { key: "ArrowUp", altKey: true } );
+			const updatedOptions = screen.getAllByRole( "option" );
+			expect( updatedOptions[ 0 ] ).toHaveAttribute( "aria-label", "H2 Why This Matters" );
+			expect( updatedOptions[ 1 ] ).toHaveAttribute( "aria-label", "H2 Introduction" );
+		} );
+
+		it( "moves a row down with Alt+ArrowDown", () => {
+			renderModal();
+			const options = screen.getAllByRole( "option" );
+			// "Introduction" is at index 0
+			fireEvent.keyDown( options[ 0 ], { key: "ArrowDown", altKey: true } );
+			const updatedOptions = screen.getAllByRole( "option" );
+			expect( updatedOptions[ 0 ] ).toHaveAttribute( "aria-label", "H2 Why This Matters" );
+			expect( updatedOptions[ 1 ] ).toHaveAttribute( "aria-label", "H2 Introduction" );
+		} );
+
+		it( "does not move the first row up", () => {
+			renderModal();
+			const options = screen.getAllByRole( "option" );
+			fireEvent.keyDown( options[ 0 ], { key: "ArrowUp", altKey: true } );
+			const updatedOptions = screen.getAllByRole( "option" );
+			expect( updatedOptions[ 0 ] ).toHaveAttribute( "aria-label", "H2 Introduction" );
+		} );
+
+		it( "does not move the last row down", () => {
+			renderModal();
+			const options = screen.getAllByRole( "option" );
+			fireEvent.keyDown( options[ 3 ], { key: "ArrowDown", altKey: true } );
+			const updatedOptions = screen.getAllByRole( "option" );
+			expect( updatedOptions[ 3 ] ).toHaveAttribute( "aria-label", "H2 Conclusion" );
+		} );
+
+		it( "does not move without the Alt key", () => {
+			renderModal();
+			const options = screen.getAllByRole( "option" );
+			fireEvent.keyDown( options[ 1 ], { key: "ArrowUp", altKey: false } );
+			const updatedOptions = screen.getAllByRole( "option" );
+			expect( updatedOptions[ 1 ] ).toHaveAttribute( "aria-label", "H2 Why This Matters" );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Context
This PR adds the **Content Outline Modal** component for the AI Content Planner feature. The modal appears after selecting a suggestion from the [content suggestions modal](https://github.com/Yoast/reserved-tasks/issues/1102) and displays the AI-generated outline (focus keyphrase, title, meta description, blog post structure) for the user to review before adding it to their post.

## Summary

This PR can be summarized in the following changelog entry:

* Adds content outline modal with loading state and suggested content for the AI Content Planner feature.

## Relevant technical choices
   
- **Native HTML5 drag-and-drop** for structure row reordering — no additional library needed. Uses `useCallback` for all handlers to comply with `react/jsx-no-bind` lint rule.
- **Keyboard reorder** via Alt+ArrowUp/Down on structure rows for screen reader and keyboard-only users.
- **Stable keys** for reorderable structure rows — uses `withIds()` helper to assign IDs at initialization time, avoiding index-based keys that break React reconciliation during reorder.
- **Sticky gradient fade** inside `Modal.Container.Content` with `pb-0` on the scroll container and `pb-6` on the content div, matching the pattern from the task-list children modal.
- **Loading state uses real elements** with skeleton values (not a full skeleton replacement), matching the [Figma design](https://www.figma.com/design/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?node-id=776-3389&t=9hXDoH6FugVofss1-0) where IntentCallout, labels, toggle, and footer remain visible.
- **Modal transitions** — 200ms setTimeout between closing one modal and opening the next, matching HeadlessUI's leave animation duration for smooth transitions.
 - **Accessibility improvements:**
     - `Modal.Title` (HeadlessUI Dialog.Title) for proper `aria-labelledby` association
     - `Modal.Description` for `aria-describedby` on instruction text
     - `closeButtonScreenReaderText` on Modal.Panel
     - `useSvgAria` hook on all SVG icons for consistent `role="img"` + `aria-hidden`
     - `role="listbox"` + `role="option"` with `aria-label` and `aria-roledescription` on structure rows
     - `role="note"` on IntentCallout

> [!NOTE]
> All changes to the content-planner-editor-item.js and content-suggestions-modal.js files are minimal. 

 **`content-suggestions-modal.js`** (6 lines changed):
   - Added `useCallback` import.
   - Added `suggestion` prop to `SuggestionButton` + `useCallback` handler to pass the clicked suggestion object up to the parent.
   - Added `onSuggestionClick = noop` prop to `ContentSuggestionsModal` (defaults to `noop`, fully backward-compatible — existing
   behavior unchanged if prop is not passed).
   - Wired `onSuggestionClick` instead of `noop` on the suggestion button click.

These changes are needed because without `onSuggestionClick`, there is no way for the parent to know which suggestion was clicked, and therefore the outline modal cannot open with the correct intent and description.

**`content-planner-editor-item.js`** (all additive, zero lines removed from the base):
   - Imported `ContentOutlineModal`, `get`, `noop`, `useCallback`, `useState`.
   - Added outline modal toggle state and selected suggestion state.
   - Added `isOutlineLoading` from `window.contentPlanner` for testing.
   - Added `handleSuggestionClick` (closes suggestions modal → opens outline modal with 200ms transition).
   - Added `handleBackToSuggestions` (closes outline modal → reopens suggestions modal with 200ms transition).
   - Passed `onSuggestionClick` to `ContentSuggestionsModal`.
   - Rendered `<ContentOutlineModal>` with dummy data. 
   
## Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

With Free and Premium active
### Content state

1. Edit a post in the block editor. Open the Yoast sidebar or the metabox.
2. Click "Get content suggestions" button.
3. Verify the Get content suggestions modal opens.
4. Click on the "Get content suggestions" button of the modal.
5. The Content suggestion modal will open with dummy data. 
6. Click any suggestion card (e.g. "Commercial" or "Informational").
7. Verify the **Content Outline** modal opens with a smooth transition (suggestions modal fades out, then outline modal fades in).
8. Verify the modal first shows a loading state (skeleton placeholders for form values) that smoothly transitions to the loaded content after ~3 seconds.
9 . Verify the loaded modal shows (check the figma [design](https://www.figma.com/design/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?node-id=776-3542&t=9hXDoH6FugVofss1-4)):
   -  Correct intent badge (matching what you clicked) (e.g. 
<img width="640" height="169" alt="image" src="https://github.com/user-attachments/assets/95533940-0974-4acd-a26b-f8fd928e3267" />)
   - "Suggest category" section with toggle pushed right within a narrow container, and "WordPress" badge below
   - Form fields: Focus Keyphrase, Title, Meta description
   - Blog post structure rows with drag handles
   - "Content suggestions" back button and "Add outline to post" button
   - Gradient fade at the bottom when content overflows (scroll-bar)
10. Test drag-and-drop: drag a structure row to a different position and verify it reorders.
11. Test keyboard reorder: focus a structure row and press Alt+ArrowUp / Alt+ArrowDown to move it.
12. Click "Content suggestions" button in the footer — verify it goes back to the suggestions modal.
13. Scroll the modal content — verify the gradient fade appears when there's overflow and disappears when scrolled to bottom.

### Loading state
The loading state is simulated internally, but it can also be triggered by following these instructions: 
1. Open the browser console and run: `window.contentPlanner = { isOutlineLoading: true }`
2. Click through to open the Content Outline modal (Get content suggestions → approve modal → select a suggestion).
3. Verify the loading state shows, matching the [design](https://www.figma.com/design/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?node-id=776-3389&t=9hXDoH6FugVofss1-4):
   - **Real elements:** IntentCallout with intent badge and description, instruction text, "Suggest category" toggle section, form field labels ("Focus Keyphrase", "Title", "Meta description"), footer buttons
   - **Skeleton placeholders:** Category badge value, form field input values (keyphrase and title as single skeleton bars, meta description as 3 skeleton lines)
   - **Hidden:** Blog post structure section should NOT appear during loading
4. Reset with: `window.contentPlanner = { isOutlineLoading: false }`
6. Reopen the modal and verify it now shows the full content state after the ~3 seconds loading simulation.

## Relevant test scenarios

- [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
- [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
- [ ] Changes should be tested with the browser console open
- [ ] Changes should be tested on different browsers
- [ ] Changes should be tested on multisite

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- New `ContentOutlineModal` component in `packages/js/src/ai-content-planner/components/`
- Minor changes to `ContentSuggestionsModal` (added `onSuggestionClick` prop, refactored `SuggestionButton`)
- Integration changes in `ContentPlannerEditorItem` (added outline modal state, wiring, and `window.contentPlanner.isOutlineLoading`)

## Other environments

- [ ] This PR also affects Shopify.
- [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [ ] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [ ] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation

- [x] No innovation project is applicable for this PR.

Fixes Yoast/reserved-tasks#1103