### PR TITLE
Set the WordPress tested up to version to 7.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 Yoast SEO
 =========
 Requires at least: 6.8
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 
 Changelog

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://yoa.st/1up
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
 Tags: SEO, XML sitemap, Content analysis, Readability, Schema
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 27.2
 Requires PHP: 7.4
 

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -40,7 +40,7 @@ if ( ! \defined( 'WPSEO_BASENAME' ) ) {
 \define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 \define( 'YOAST_SEO_PHP_REQUIRED', '7.4' );
-\define( 'YOAST_SEO_WP_TESTED', '6.9.4' );
+\define( 'YOAST_SEO_WP_TESTED', '7.0' );
 \define( 'YOAST_SEO_WP_REQUIRED', '6.8' );
 
 if ( ! \defined( 'WPSEO_NAMESPACES' ) ) {

--- a/wp-seo-main.php
+++ b/wp-seo-main.php
@@ -35,7 +35,7 @@ define( 'YOAST_VENDOR_DEFINE_PREFIX', 'YOASTSEO_VENDOR__' );
 define( 'YOAST_VENDOR_PREFIX_DIRECTORY', 'vendor_prefixed' );
 
 define( 'YOAST_SEO_PHP_REQUIRED', '7.4' );
-define( 'YOAST_SEO_WP_TESTED', '6.9.4' );
+define( 'YOAST_SEO_WP_TESTED', '7.0' );
 define( 'YOAST_SEO_WP_REQUIRED', '6.8' );
 
 if ( ! defined( 'WPSEO_NAMESPACES' ) ) {


### PR DESCRIPTION
## Context

Bump the WordPress tested up to version to 7.0 for the upcoming WordPress 7.0 release.

## Summary

This PR can be summarized in the following changelog entry:

* Sets the _WordPress tested up to_ version to 7.0.

## Relevant technical choices:

*

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* NA

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes https://github.com/Yoast/wordpress-seo/issues/23093