### PR TITLE
1131 next post create endpoint for sending the 1st request to ai api for generating post suggestions

### DIFF
--- a/src/ai/authorization/application/token-manager.php
+++ b/src/ai/authorization/application/token-manager.php
@@ -128,8 +128,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param string $user_id The user ID.
 	 *
-	 * @return void
-	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
 	 * @throws Not_Found_Exception Not_Found_Exception.
@@ -138,6 +136,7 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Service_Unavailable_Exception Service_Unavailable_Exception.
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws RuntimeException Unable to retrieve the access token.
+	 * @return void
 	 */
 	public function token_invalidate( string $user_id ): void {
 		try {
@@ -165,9 +164,19 @@ class Token_Manager implements Token_Manager_Interface {
 			// If the credentials in our request were already invalid, our job is done and we continue to remove the tokens client-side.
 		}
 
-		// Delete the stored JWT tokens.
-		$this->user_helper->delete_meta( $user_id, '_yoast_wpseo_ai_generator_access_jwt' );
-		$this->user_helper->delete_meta( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' );
+		$this->clear_tokens( $user_id );
+	}
+
+	/**
+	 * Clears the user meta tokens for a specific user.
+	 *
+	 * @param string $user_id The user id to delete this for.
+	 *
+	 * @return void
+	 */
+	public function clear_tokens( string $user_id ): void {
+		$this->access_token_repository->delete_token( $user_id );
+		$this->refresh_token_repository->delete_token( $user_id );
 	}
 
 	/**
@@ -178,8 +187,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
-	 * @return void
-	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -189,6 +196,7 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Service_Unavailable_Exception Service_Unavailable_Exception.
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
+	 * @return void
 	 */
 	public function token_request( WP_User $user ): void {
 		// Ensure the user has given consent.
@@ -227,8 +235,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
-	 * @return void
-	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -239,6 +245,7 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
 	 * @throws RuntimeException Unable to retrieve the refresh token.
+	 * @return void
 	 */
 	public function token_refresh( WP_User $user ): void {
 		$refresh_jwt = $this->refresh_token_repository->get_token( $user->ID );
@@ -294,8 +301,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
-	 * @return string The access token.
-	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -306,6 +311,7 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
 	 * @throws RuntimeException Unable to retrieve the access or refresh token.
+	 * @return string The access token.
 	 */
 	public function get_or_request_access_token( WP_User $user ): string {
 		$access_jwt = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt', true );

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -3,7 +3,6 @@
 
 namespace Yoast\WP\SEO\AI\Content_Planner\Application;
 
-use WPSEO_Utils;
 use Yoast\WP\SEO\AI\Authorization\Application\Token_Manager;
 use Yoast\WP\SEO\AI\Consent\Application\Consent_Handler;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
@@ -11,16 +10,8 @@ use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
 use Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
 use Yoast\WP\SEO\AI\HTTP_Request\Application\Request_Handler;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Bad_Request_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Forbidden_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Internal_Server_Error_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Not_Found_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Payment_Required_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Request_Timeout_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Service_Unavailable_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Too_Many_Requests_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Unauthorized_Exception;
-use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\WP_Request_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Request;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Response;
 use Yoast\WP\SEO\Helpers\User_Helper;
@@ -31,29 +22,39 @@ use Yoast\WP\SEO\Helpers\User_Helper;
 class Content_Suggestion_Command_Handler {
 
 	/**
-	 * @var Recent_Content_Collector The recent content collector.
+	 * The recent content collector.
+	 *
+	 * @var Recent_Content_Collector
 	 */
-	private Recent_Content_Collector $recent_content_collector;
+	private $recent_content_collector;
 
 	/**
-	 * @var Token_Manager The token manager.
+	 * The token manager.
+	 *
+	 * @var Token_Manager
 	 */
-	private Token_Manager $token_manager;
+	private $token_manager;
 
 	/**
-	 * @var Request_Handler The request handler.
+	 * The request handler.
+	 *
+	 * @var Request_Handler
 	 */
-	private Request_Handler $request_handler;
+	private $request_handler;
 
 	/**
-	 * @var User_Helper The user helper.
+	 * The user helper.
+	 *
+	 * @var User_Helper
 	 */
-	private User_Helper $user_helper;
+	private $user_helper;
 
 	/**
-	 * @var Consent_Handler The consent handler.
+	 * The consent handler.
+	 *
+	 * @var Consent_Handler
 	 */
-	private Consent_Handler $consent_handler;
+	private $consent_handler;
 
 	/**
 	 * The constructor.
@@ -79,31 +80,38 @@ class Content_Suggestion_Command_Handler {
 	}
 
 	/**
+	 * Handles the content suggestion command by collecting recent content and requesting suggestions from the AI API.
 	 *
-	 * @throws Bad_Request_Exception
-	 * @throws Forbidden_Exception
-	 * @throws Internal_Server_Error_Exception
-	 * @throws Not_Found_Exception
-	 * @throws Payment_Required_Exception
-	 * @throws Request_Timeout_Exception
-	 * @throws Service_Unavailable_Exception
-	 * @throws Too_Many_Requests_Exception
-	 * @throws Unauthorized_Exception
-	 * @throws WP_Request_Exception
-	 * @return Content_Suggestion_List A list of content suggestions
+	 * @param Content_Suggestion_Command $command               The content suggestion command.
+	 * @param bool                       $retry_on_unauthorized Whether to retry on unauthorized response.
+	 *
+	 * @throws Unauthorized_Exception When the API returns an unauthorized response and retry is exhausted.
+	 * @throws Forbidden_Exception    When consent has been revoked.
+	 *
+	 * @return Content_Suggestion_List A list of content suggestions.
 	 */
 	public function handle(
 		Content_Suggestion_Command $command,
 		bool $retry_on_unauthorized = true
 	): Content_Suggestion_List {
 		$recent_content = $this->recent_content_collector->collect( $command->get_post_type() );
+		$about_page     = $this->recent_content_collector->collect_about_page( $command->get_post_type() );
 		$token          = $this->token_manager->get_or_request_access_token( $command->get_user() );
-		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Reason: We don't want the debug/pretty possibility.
-		$recent_content  = WPSEO_Utils::format_json_encode( $recent_content->to_array() );
-		$request_body    = [
-			'language' => $command->get_language(),
-			'content'  => $recent_content,
+		$recent_content = $recent_content->to_array();
+
+		$content = [
+			'posts' => $recent_content,
 		];
+		if ( $about_page ) {
+			$content['about_page'] = $about_page;
+		}
+		$request_body = [
+			'subject' => [
+				'language' => $command->get_language(),
+				'content'  => $content,
+			],
+		];
+
 		$request_headers = [
 			'Authorization' => "Bearer $token",
 			'X-Yst-Cohort'  => $command->get_editor(),
@@ -134,6 +142,13 @@ class Content_Suggestion_Command_Handler {
 		return $this->build_suggestions_array( $response );
 	}
 
+	/**
+	 * Builds a list of content suggestions from the API response.
+	 *
+	 * @param Response $response The API response.
+	 *
+	 * @return Content_Suggestion_List The list of content suggestions.
+	 */
 	public function build_suggestions_array( Response $response ): Content_Suggestion_List {
 		$content_suggestion_list = new Content_Suggestion_List();
 		$json                    = \json_decode( $response->get_body() );

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -152,10 +152,12 @@ class Content_Suggestion_Command_Handler {
 	public function build_suggestions_array( Response $response ): Content_Suggestion_List {
 		$content_suggestion_list = new Content_Suggestion_List();
 		$json                    = \json_decode( $response->get_body() );
+
 		if ( $json === null || ! isset( $json->choices ) ) {
 			return $content_suggestion_list;
 		}
 		foreach ( $json->choices as $suggestion ) {
+
 			$content_suggestion_list->add_suggestion(
 				new Content_Suggestion(
 					$suggestion->title,
@@ -163,7 +165,7 @@ class Content_Suggestion_Command_Handler {
 					$suggestion->explanation,
 					$suggestion->keyphrase,
 					$suggestion->meta_description,
-					new Category( $suggestion->category->title, $suggestion->category->id ),
+					( isset( $suggestion->category->title ) ? new Category( $suggestion->category->title, $suggestion->category->id ) : null ),
 				),
 			);
 		}

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -158,7 +158,7 @@ class Content_Suggestion_Command_Handler {
 		}
 		foreach ( $json->choices as $suggestion ) {
 
-			$content_suggestion_list->add_suggestion(
+			$content_suggestion_list->add(
 				new Content_Suggestion(
 					$suggestion->title,
 					$suggestion->intent,

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -1,0 +1,158 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Application;
+
+use WPSEO_Utils;
+use Yoast\WP\SEO\AI\Authorization\Application\Token_Manager;
+use Yoast\WP\SEO\AI\Consent\Application\Consent_Handler;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
+use Yoast\WP\SEO\AI\HTTP_Request\Application\Request_Handler;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Bad_Request_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Forbidden_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Internal_Server_Error_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Not_Found_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Payment_Required_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Request_Timeout_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Service_Unavailable_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Too_Many_Requests_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Unauthorized_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\WP_Request_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Request;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Response;
+use Yoast\WP\SEO\Helpers\User_Helper;
+
+/**
+ * Handles the content suggestion command.
+ */
+class Content_Suggestion_Command_Handler {
+
+	/**
+	 * @var Recent_Content_Collector The recent content collector.
+	 */
+	private Recent_Content_Collector $recent_content_collector;
+
+	/**
+	 * @var Token_Manager The token manager.
+	 */
+	private Token_Manager $token_manager;
+
+	/**
+	 * @var Request_Handler The request handler.
+	 */
+	private Request_Handler $request_handler;
+
+	/**
+	 * @var User_Helper The user helper.
+	 */
+	private User_Helper $user_helper;
+
+	/**
+	 * @var Consent_Handler The consent handler.
+	 */
+	private Consent_Handler $consent_handler;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Recent_Content_Collector $recent_content_collector The recent content collector.
+	 * @param Token_Manager            $token_manager            The token manager.
+	 * @param Request_Handler          $request_handler          The request handler.
+	 * @param User_Helper              $user_helper              The user helper.
+	 * @param Consent_Handler          $consent_handler          The consent handler.
+	 */
+	public function __construct(
+		Recent_Content_Collector $recent_content_collector,
+		Token_Manager $token_manager,
+		Request_Handler $request_handler,
+		User_Helper $user_helper,
+		Consent_Handler $consent_handler
+	) {
+		$this->recent_content_collector = $recent_content_collector;
+		$this->token_manager            = $token_manager;
+		$this->request_handler          = $request_handler;
+		$this->user_helper              = $user_helper;
+		$this->consent_handler          = $consent_handler;
+	}
+
+	/**
+	 *
+	 * @throws Bad_Request_Exception
+	 * @throws Forbidden_Exception
+	 * @throws Internal_Server_Error_Exception
+	 * @throws Not_Found_Exception
+	 * @throws Payment_Required_Exception
+	 * @throws Request_Timeout_Exception
+	 * @throws Service_Unavailable_Exception
+	 * @throws Too_Many_Requests_Exception
+	 * @throws Unauthorized_Exception
+	 * @throws WP_Request_Exception
+	 * @return Content_Suggestion_List A list of content suggestions
+	 */
+	public function handle(
+		Content_Suggestion_Command $command,
+		bool $retry_on_unauthorized = true
+	): Content_Suggestion_List {
+		$recent_content = $this->recent_content_collector->collect( $command->get_post_type() );
+		$token          = $this->token_manager->get_or_request_access_token( $command->get_user() );
+		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Reason: We don't want the debug/pretty possibility.
+		$recent_content  = WPSEO_Utils::format_json_encode( $recent_content->to_array() );
+		$request_body    = [
+			'language' => $command->get_language(),
+			'content'  => $recent_content,
+		];
+		$request_headers = [
+			'Authorization' => "Bearer $token",
+			'X-Yst-Cohort'  => $command->get_editor(),
+		];
+
+		try {
+
+			$response = $this->request_handler->handle( new Request( '/content-planner/next-post-suggestions', $request_body, $request_headers ) );
+		} catch ( Unauthorized_Exception $exception ) {
+			// Delete the stored JWT tokens, as they appear to be no longer valid.
+			$this->user_helper->delete_meta( $command->get_user()->ID, '_yoast_wpseo_ai_generator_access_jwt' );
+			$this->user_helper->delete_meta( $command->get_user()->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+
+			if ( ! $retry_on_unauthorized ) {
+				throw $exception;
+			}
+
+			// Try again once more by fetching a new set of tokens and trying the suggestions endpoint again.
+			return $this->handle( $command, false );
+		} catch ( Forbidden_Exception $exception ) {
+			// Follow the API in the consent being revoked (Use case: user sent an e-mail to revoke?).
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- false positive.
+			$this->consent_handler->revoke_consent( $command->get_user()->ID );
+			throw new Forbidden_Exception( 'CONSENT_REVOKED', $exception->getCode() );
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		return $this->build_suggestions_array( $response );
+	}
+
+	public function build_suggestions_array( Response $response ): Content_Suggestion_List {
+		$content_suggestion_list = new Content_Suggestion_List();
+		$json                    = \json_decode( $response->get_body() );
+		if ( $json === null || ! isset( $json->choices ) ) {
+			return $content_suggestion_list;
+		}
+		foreach ( $json->choices as $suggestion ) {
+			$content_suggestion_list->add_suggestion(
+				new Content_Suggestion(
+					$suggestion->title,
+					$suggestion->intent,
+					$suggestion->explanation,
+					$suggestion->keyphrase,
+					$suggestion->meta_description,
+					new Category( $suggestion->category->title, $suggestion->category->id ),
+				),
+			);
+		}
+
+		return $content_suggestion_list;
+	}
+}

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -14,7 +14,6 @@ use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Forbidden_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Unauthorized_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Request;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Response;
-use Yoast\WP\SEO\Helpers\User_Helper;
 
 /**
  * Handles the content suggestion command.
@@ -43,13 +42,6 @@ class Content_Suggestion_Command_Handler {
 	private $request_handler;
 
 	/**
-	 * The user helper.
-	 *
-	 * @var User_Helper
-	 */
-	private $user_helper;
-
-	/**
 	 * The consent handler.
 	 *
 	 * @var Consent_Handler
@@ -62,20 +54,17 @@ class Content_Suggestion_Command_Handler {
 	 * @param Recent_Content_Collector $recent_content_collector The recent content collector.
 	 * @param Token_Manager            $token_manager            The token manager.
 	 * @param Request_Handler          $request_handler          The request handler.
-	 * @param User_Helper              $user_helper              The user helper.
 	 * @param Consent_Handler          $consent_handler          The consent handler.
 	 */
 	public function __construct(
 		Recent_Content_Collector $recent_content_collector,
 		Token_Manager $token_manager,
 		Request_Handler $request_handler,
-		User_Helper $user_helper,
 		Consent_Handler $consent_handler
 	) {
 		$this->recent_content_collector = $recent_content_collector;
 		$this->token_manager            = $token_manager;
 		$this->request_handler          = $request_handler;
-		$this->user_helper              = $user_helper;
 		$this->consent_handler          = $consent_handler;
 	}
 
@@ -122,8 +111,7 @@ class Content_Suggestion_Command_Handler {
 			$response = $this->request_handler->handle( new Request( '/content-planner/next-post-suggestions', $request_body, $request_headers ) );
 		} catch ( Unauthorized_Exception $exception ) {
 			// Delete the stored JWT tokens, as they appear to be no longer valid.
-			$this->user_helper->delete_meta( $command->get_user()->ID, '_yoast_wpseo_ai_generator_access_jwt' );
-			$this->user_helper->delete_meta( $command->get_user()->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+			$this->token_manager->clear_tokens( $command->get_user() );
 
 			if ( ! $retry_on_unauthorized ) {
 				throw $exception;

--- a/src/ai/content-planner/application/content-suggestion-command.php
+++ b/src/ai/content-planner/application/content-suggestion-command.php
@@ -1,0 +1,83 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Application;
+
+use WP_User;
+
+/**
+ * Command for requesting content suggestions.
+ */
+class Content_Suggestion_Command {
+
+	/**
+	 * @var WP_User The user.
+	 */
+	private WP_User $user;
+
+	/**
+	 * @var string The post type.
+	 */
+	private string $post_type;
+
+	/**
+	 * @var string The language.
+	 */
+	private string $language;
+
+	/**
+	 * @var string The editor.
+	 */
+	private string $editor;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param WP_User $user      The user.
+	 * @param string  $post_type The post type.
+	 * @param string  $language  The language.
+	 * @param string  $editor    The editor.
+	 */
+	public function __construct( WP_User $user, string $post_type, string $language, string $editor ) {
+		$this->user      = $user;
+		$this->post_type = $post_type;
+		$this->language  = $language;
+		$this->editor    = $editor;
+	}
+
+	/**
+	 * Returns the user.
+	 *
+	 * @return WP_User The user.
+	 */
+	public function get_user(): WP_User {
+		return $this->user;
+	}
+
+	/**
+	 * Returns the post type.
+	 *
+	 * @return string The post type.
+	 */
+	public function get_post_type(): string {
+		return $this->post_type;
+	}
+
+	/**
+	 * Returns the language.
+	 *
+	 * @return string The language.
+	 */
+	public function get_language(): string {
+		return $this->language;
+	}
+
+	/**
+	 * Returns the editor.
+	 *
+	 * @return string The editor.
+	 */
+	public function get_editor(): string {
+		return $this->editor;
+	}
+}

--- a/src/ai/content-planner/application/content-suggestion-command.php
+++ b/src/ai/content-planner/application/content-suggestion-command.php
@@ -11,24 +11,32 @@ use WP_User;
 class Content_Suggestion_Command {
 
 	/**
-	 * @var WP_User The user.
+	 * The user.
+	 *
+	 * @var WP_User
 	 */
-	private WP_User $user;
+	private $user;
 
 	/**
-	 * @var string The post type.
+	 * The post type.
+	 *
+	 * @var string
 	 */
-	private string $post_type;
+	private $post_type;
 
 	/**
-	 * @var string The language.
+	 * The language.
+	 *
+	 * @var string
 	 */
-	private string $language;
+	private $language;
 
 	/**
-	 * @var string The editor.
+	 * The editor.
+	 *
+	 * @var string
 	 */
-	private string $editor;
+	private $editor;
 
 	/**
 	 * The constructor.

--- a/src/ai/content-planner/domain/category.php
+++ b/src/ai/content-planner/domain/category.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 
 /**
@@ -8,24 +8,28 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Category {
 
 	/**
-	 * @var string The title.
+	 * The name.
+	 *
+	 * @var string
 	 */
-	private string $title;
+	private $name;
 
 	/**
-	 * @var string The ID.
+	 * The ID.
+	 *
+	 * @var string
 	 */
-	private string $id;
+	private $id;
 
 	/**
 	 * The constructor.
 	 *
-	 * @param string $title The category title.
-	 * @param string $id    The category ID.
+	 * @param string $name The category title.
+	 * @param string $id   The category ID.
 	 */
-	public function __construct( string $title, string $id ) {
-		$this->title = $title;
-		$this->id    = $id;
+	public function __construct( string $name, string $id ) {
+		$this->name = $name;
+		$this->id   = $id;
 	}
 
 	/**
@@ -35,8 +39,8 @@ class Category {
 	 */
 	public function to_array(): array {
 		return [
-			'title' => $this->title,
-			'id'    => $this->id,
+			'name' => $this->name,
+			'id'   => $this->id,
 		];
 	}
 }

--- a/src/ai/content-planner/domain/category.php
+++ b/src/ai/content-planner/domain/category.php
@@ -17,7 +17,7 @@ class Category {
 	/**
 	 * The ID.
 	 *
-	 * @var string
+	 * @var int
 	 */
 	private $id;
 
@@ -25,9 +25,9 @@ class Category {
 	 * The constructor.
 	 *
 	 * @param string $name The category title.
-	 * @param string $id   The category ID.
+	 * @param int    $id   The category ID.
 	 */
-	public function __construct( string $name, string $id ) {
+	public function __construct( string $name, int $id ) {
 		$this->name = $name;
 		$this->id   = $id;
 	}

--- a/src/ai/content-planner/domain/category.php
+++ b/src/ai/content-planner/domain/category.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * Value object for a Post Category.
+ */
+class Category {
+
+	/**
+	 * @var string The title.
+	 */
+	private string $title;
+
+	/**
+	 * @var string The ID.
+	 */
+	private string $id;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string $title The category title.
+	 * @param string $id    The category ID.
+	 */
+	public function __construct( string $title, string $id ) {
+		$this->title = $title;
+		$this->id    = $id;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<string,int>
+	 */
+	public function to_array(): array {
+		return [
+			'title' => $this->title,
+			'id'    => $this->id,
+		];
+	}
+}

--- a/src/ai/content-planner/domain/content-suggestion-list.php
+++ b/src/ai/content-planner/domain/content-suggestion-list.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * List of content suggestions.
+ */
+class Content_Suggestion_List {
+
+	/**
+	 * @var array<Content_Suggestion> The suggestions.
+	 */
+	private array $content_suggestions = [];
+
+	/**
+	 * Adds a content suggestion to the list.
+	 *
+	 * @param Content_Suggestion $content_suggestion A content suggestion.
+	 *
+	 * @return void
+	 */
+	public function add_suggestion( Content_Suggestion $content_suggestion ): void {
+		$this->content_suggestions[] = $content_suggestion;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<array<string, string|bool|array<string, int>>> The suggestions as an array.
+	 */
+	public function to_array(): array {
+		$result = [];
+		foreach ( $this->content_suggestions as $suggestion ) {
+			$result[] = $suggestion->to_array();
+		}
+
+		return $result;
+	}
+}

--- a/src/ai/content-planner/domain/content-suggestion-list.php
+++ b/src/ai/content-planner/domain/content-suggestion-list.php
@@ -21,7 +21,7 @@ class Content_Suggestion_List {
 	 *
 	 * @return void
 	 */
-	public function add_suggestion( Content_Suggestion $content_suggestion ): void {
+	public function add( Content_Suggestion $content_suggestion ): void {
 		$this->content_suggestions[] = $content_suggestion;
 	}
 

--- a/src/ai/content-planner/domain/content-suggestion-list.php
+++ b/src/ai/content-planner/domain/content-suggestion-list.php
@@ -36,6 +36,6 @@ class Content_Suggestion_List {
 			$result[] = $suggestion->to_array();
 		}
 
-		return $result;
+		return [ 'suggestions' => $result ];
 	}
 }

--- a/src/ai/content-planner/domain/content-suggestion-list.php
+++ b/src/ai/content-planner/domain/content-suggestion-list.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 
 /**
@@ -8,9 +8,11 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Content_Suggestion_List {
 
 	/**
-	 * @var array<Content_Suggestion> The suggestions.
+	 * The suggestions.
+	 *
+	 * @var array<Content_Suggestion>
 	 */
-	private array $content_suggestions = [];
+	private $content_suggestions = [];
 
 	/**
 	 * Adds a content suggestion to the list.

--- a/src/ai/content-planner/domain/content-suggestion.php
+++ b/src/ai/content-planner/domain/content-suggestion.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 
 /**
@@ -8,34 +8,46 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Content_Suggestion {
 
 	/**
-	 * @var string The title.
+	 * The title.
+	 *
+	 * @var string
 	 */
-	private string $title;
+	private $title;
 
 	/**
-	 * @var string The intent.
+	 * The intent.
+	 *
+	 * @var string
 	 */
-	private string $intent;
+	private $intent;
 
 	/**
-	 * @var string The explanation.
+	 * The explanation.
+	 *
+	 * @var string
 	 */
-	private string $explanation;
+	private $explanation;
 
 	/**
-	 * @var string The keyphrase.
+	 * The keyphrase.
+	 *
+	 * @var string
 	 */
-	private string $keyphrase;
+	private $keyphrase;
 
 	/**
-	 * @var string The meta description.
+	 * The meta description.
+	 *
+	 * @var string
 	 */
-	private string $meta_description;
+	private $meta_description;
 
 	/**
-	 * @var Category The category.
+	 * The category.
+	 *
+	 * @var Category
 	 */
-	private Category $category;
+	private $category;
 
 	/**
 	 * The constructor.

--- a/src/ai/content-planner/domain/content-suggestion.php
+++ b/src/ai/content-planner/domain/content-suggestion.php
@@ -65,7 +65,7 @@ class Content_Suggestion {
 		string $explanation,
 		string $keyphrase,
 		string $meta_description,
-		Category $category
+		?Category $category
 	) {
 		$this->title            = $title;
 		$this->intent           = $intent;
@@ -81,13 +81,17 @@ class Content_Suggestion {
 	 * @return array<string, string|array<string, int>> The content suggestion as an array.
 	 */
 	public function to_array(): array {
-		return [
+		$data = [
 			'title'            => $this->title,
 			'intent'           => $this->intent,
 			'explanation'      => $this->explanation,
 			'keyphrase'        => $this->keyphrase,
 			'meta_description' => $this->meta_description,
-			'category'         => $this->category->to_array(),
 		];
+		if ( isset( $this->category ) ) {
+			$data['category'] = $this->category->to_array();
+		}
+
+		return $data;
 	}
 }

--- a/src/ai/content-planner/domain/content-suggestion.php
+++ b/src/ai/content-planner/domain/content-suggestion.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * Value object for a content suggestion.
+ */
+class Content_Suggestion {
+
+	/**
+	 * @var string The title.
+	 */
+	private string $title;
+
+	/**
+	 * @var string The intent.
+	 */
+	private string $intent;
+
+	/**
+	 * @var string The explanation.
+	 */
+	private string $explanation;
+
+	/**
+	 * @var string The keyphrase.
+	 */
+	private string $keyphrase;
+
+	/**
+	 * @var string The meta description.
+	 */
+	private string $meta_description;
+
+	/**
+	 * @var Category The category.
+	 */
+	private Category $category;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string   $title            The title.
+	 * @param string   $intent           The intent.
+	 * @param string   $explanation      The explanation.
+	 * @param string   $keyphrase        The keyphrase.
+	 * @param string   $meta_description The meta description.
+	 * @param Category $category         The category.
+	 */
+	public function __construct(
+		string $title,
+		string $intent,
+		string $explanation,
+		string $keyphrase,
+		string $meta_description,
+		Category $category
+	) {
+		$this->title            = $title;
+		$this->intent           = $intent;
+		$this->explanation      = $explanation;
+		$this->keyphrase        = $keyphrase;
+		$this->meta_description = $meta_description;
+		$this->category         = $category;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<string, string|array<string, int>> The content suggestion as an array.
+	 */
+	public function to_array(): array {
+		return [
+			'title'            => $this->title,
+			'intent'           => $this->intent,
+			'explanation'      => $this->explanation,
+			'keyphrase'        => $this->keyphrase,
+			'meta_description' => $this->meta_description,
+			'category'         => $this->category->to_array(),
+		];
+	}
+}

--- a/src/ai/content-planner/domain/post-list.php
+++ b/src/ai/content-planner/domain/post-list.php
@@ -21,7 +21,7 @@ class Post_List {
 	 *
 	 * @return void
 	 */
-	public function add_post( Post $post ): void {
+	public function add( Post $post ): void {
 		$this->posts[] = $post;
 	}
 

--- a/src/ai/content-planner/domain/post-list.php
+++ b/src/ai/content-planner/domain/post-list.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 
 /**
@@ -8,9 +8,11 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Post_List {
 
 	/**
-	 * @var array<Post> The posts.
+	 * The posts.
+	 *
+	 * @var array<Post>
 	 */
-	private array $posts = [];
+	private $posts = [];
 
 	/**
 	 * Adds a post to the list.

--- a/src/ai/content-planner/domain/post-list.php
+++ b/src/ai/content-planner/domain/post-list.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * List of posts.
+ */
+class Post_List {
+
+	/**
+	 * @var array<Post> The posts.
+	 */
+	private array $posts = [];
+
+	/**
+	 * Adds a post to the list.
+	 *
+	 * @param Post $post A post.
+	 *
+	 * @return void
+	 */
+	public function add_post( Post $post ): void {
+		$this->posts[] = $post;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<array<string, string|bool|array<string, int>>> The posts as an array.
+	 */
+	public function to_array(): array {
+		$result = [];
+		foreach ( $this->posts as $post ) {
+			$result[] = $post->to_array();
+		}
+
+		return $result;
+	}
+}

--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -63,18 +63,18 @@ class Post {
 	 * @param string   $description           The description.
 	 * @param Category $category              The category.
 	 * @param string   $primary_focus_keyword The primary focus keyword.
-	 * @param bool     $is_cornerstone        Whether the post is cornerstone content.
+	 * @param int      $is_cornerstone        Whether the post is cornerstone content.
 	 * @param string   $last_modified         The last modified date.
-	 * @param string   $schema_article_type   The schema article type.
+	 * @param ?string  $schema_article_type   The schema article type.
 	 */
 	public function __construct(
 		string $title,
 		string $description,
 		Category $category,
 		string $primary_focus_keyword,
-		bool $is_cornerstone,
+		int $is_cornerstone,
 		string $last_modified,
-		string $schema_article_type
+		?string $schema_article_type
 	) {
 		$this->title                 = $title;
 		$this->description           = $description;
@@ -91,14 +91,18 @@ class Post {
 	 * @return array<string, string|bool|array<string, int>> The post as an array.
 	 */
 	public function to_array(): array {
-		return [
+		$data = [
 			'title'                 => $this->title,
 			'description'           => $this->description,
 			'category'              => $this->category->to_array(),
 			'primary_focus_keyword' => $this->primary_focus_keyword,
 			'is_cornerstone'        => $this->is_cornerstone,
 			'last_modified'         => $this->last_modified,
-			'schema_article_type'   => $this->schema_article_type,
 		];
+		if ( isset( $this->schema_article_type ) ) {
+			$data['schema_article_type'] = $this->schema_article_type;
+		}
+
+		return $data;
 	}
 }

--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -1,6 +1,5 @@
 <?php
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
-
 namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 
 /**
@@ -9,39 +8,53 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Post {
 
 	/**
-	 * @var string The title.
+	 * The title.
+	 *
+	 * @var string
 	 */
-	private string $title;
+	private $title;
 
 	/**
-	 * @var string The description.
+	 * The description.
+	 *
+	 * @var string
 	 */
-	private string $description;
+	private $description;
 
 	/**
-	 * @var Category The category.
+	 * The category.
+	 *
+	 * @var Category
 	 */
-	private Category $category;
+	private $category;
 
 	/**
-	 * @var string The primary focus keyword.
+	 * The primary focus keyword.
+	 *
+	 * @var string
 	 */
-	private string $primary_focus_keyword;
+	private $primary_focus_keyword;
 
 	/**
-	 * @var bool Whether the post is cornerstone content.
+	 * Whether the post is cornerstone content.
+	 *
+	 * @var bool
 	 */
-	private bool $is_cornerstone;
+	private $is_cornerstone;
 
 	/**
-	 * @var string The last modified date.
+	 * The last modified date.
+	 *
+	 * @var string
 	 */
-	private string $last_modified;
+	private $last_modified;
 
 	/**
-	 * @var string The schema article type.
+	 * The schema article type.
+	 *
+	 * @var string
 	 */
-	private string $schema_article_type;
+	private $schema_article_type;
 
 	/**
 	 * The constructor.

--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -1,0 +1,91 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * Value object for a Post.
+ */
+class Post {
+
+	/**
+	 * @var string The title.
+	 */
+	private string $title;
+
+	/**
+	 * @var string The description.
+	 */
+	private string $description;
+
+	/**
+	 * @var Category The category.
+	 */
+	private Category $category;
+
+	/**
+	 * @var string The primary focus keyword.
+	 */
+	private string $primary_focus_keyword;
+
+	/**
+	 * @var bool Whether the post is cornerstone content.
+	 */
+	private bool $is_cornerstone;
+
+	/**
+	 * @var string The last modified date.
+	 */
+	private string $last_modified;
+
+	/**
+	 * @var string The schema article type.
+	 */
+	private string $schema_article_type;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string   $title                 The title.
+	 * @param string   $description           The description.
+	 * @param Category $category              The category.
+	 * @param string   $primary_focus_keyword The primary focus keyword.
+	 * @param bool     $is_cornerstone        Whether the post is cornerstone content.
+	 * @param string   $last_modified         The last modified date.
+	 * @param string   $schema_article_type   The schema article type.
+	 */
+	public function __construct(
+		string $title,
+		string $description,
+		Category $category,
+		string $primary_focus_keyword,
+		bool $is_cornerstone,
+		string $last_modified,
+		string $schema_article_type
+	) {
+		$this->title                 = $title;
+		$this->description           = $description;
+		$this->category              = $category;
+		$this->primary_focus_keyword = $primary_focus_keyword;
+		$this->is_cornerstone        = $is_cornerstone;
+		$this->last_modified         = $last_modified;
+		$this->schema_article_type   = $schema_article_type;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<string, string|bool|array<string, int>> The post as an array.
+	 */
+	public function to_array(): array {
+		return [
+			'title'                 => $this->title,
+			'description'           => $this->description,
+			'category'              => $this->category->to_array(),
+			'primary_focus_keyword' => $this->primary_focus_keyword,
+			'is_cornerstone'        => $this->is_cornerstone,
+			'last_modified'         => $this->last_modified,
+			'schema_article_type'   => $this->schema_article_type,
+		];
+	}
+}

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -19,6 +19,18 @@ class Recent_Content_Collector {
 	 * The maximum number of posts to collect.
 	 */
 	private const LIMIT = 100;
+	/**
+	 * The valid schema types that we want to send to the API. Otherwise this field is omitted.
+	 */
+	public const         VALID_SCHEMA_TYPES = [
+		'SocialMediaPosting',
+		'NewsArticle',
+		'AdvertiserContentArticle',
+		'SatiricalArticle',
+		'ScholarlyArticle',
+		'TechArticle',
+		'Report',
+	];
 
 	/**
 	 * The indexable repository.
@@ -50,6 +62,26 @@ class Recent_Content_Collector {
 	}
 
 	/**
+	 * Collects the most recent indexed about page.
+	 *
+	 * @param string $post_type The post type to collect.
+	 *
+	 * @return array<string>|false The about page needed information.
+	 */
+	public function collect_about_page( string $post_type ) {
+		$indexable = $this->indexable_repository->get_most_recent_about_page( $post_type );
+
+		if ( $indexable ) {
+			return [
+				'title'       => ( $indexable->breadcrumb_title ?? '' ),
+				'description' => ( $indexable->description ?? '' ),
+			];
+		}
+
+		return false;
+	}
+
+	/**
 	 * Maps indexable results to a Post_List.
 	 *
 	 * @param Indexable[] $indexables The indexable results.
@@ -64,11 +96,11 @@ class Recent_Content_Collector {
 				new Post(
 					( $indexable->breadcrumb_title ?? '' ),
 					( $indexable->description ?? '' ),
-					new Category( '', '' ),
+					new Category( 'My placeholder', '1' ),
 					( $indexable->primary_focus_keyword ?? '' ),
 					( $indexable->is_cornerstone ?? false ),
 					( $indexable->object_last_modified ?? '' ),
-					( $indexable->schema_article_type ?? '' ),
+					( \in_array( $indexable->schema_article_type, self::VALID_SCHEMA_TYPES, true ) ? $indexable->schema_article_type : null ),
 				),
 			);
 		}

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -1,0 +1,75 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+use Yoast\WP\SEO\Models\Indexable;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+
+/**
+ * Collects the most recent published posts from indexables.
+ */
+class Recent_Content_Collector {
+
+	/**
+	 * The maximum number of posts to collect.
+	 */
+	private const LIMIT = 100;
+
+	/**
+	 * @var Indexable_Repository The indexable repository.
+	 */
+	private Indexable_Repository $indexable_repository;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Indexable_Repository $indexable_repository The indexable repository.
+	 */
+	public function __construct( Indexable_Repository $indexable_repository ) {
+		$this->indexable_repository = $indexable_repository;
+	}
+
+	/**
+	 * Collects the 100 most recent published, indexed posts.
+	 *
+	 * @param string $post_type The post type to collect.
+	 *
+	 * @return Post_List The list of recent posts.
+	 */
+	public function collect( string $post_type ): Post_List {
+		$results = $this->indexable_repository->get_recently_modified_posts( $post_type, self::LIMIT, false );
+
+		return $this->map_to_post_list( $results );
+	}
+
+	/**
+	 * Maps indexable results to a Post_List.
+	 *
+	 * @param Indexable[] $indexables The indexable results.
+	 *
+	 * @return Post_List The mapped post list.
+	 */
+	private function map_to_post_list( array $indexables ): Post_List {
+		$post_list = new Post_List();
+
+		foreach ( $indexables as $indexable ) {
+			$post_list->add_post(
+				new Post(
+					( $indexable->breadcrumb_title ?? '' ),
+					( $indexable->description ?? '' ),
+					new Category( '', '' ),
+					( $indexable->primary_focus_keyword ?? '' ),
+					( $indexable->is_cornerstone ?? false ),
+					( $indexable->object_last_modified ?? '' ),
+					( $indexable->schema_article_type ?? '' ),
+				),
+			);
+		}
+
+		return $post_list;
+	}
+}

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -92,7 +92,7 @@ class Recent_Content_Collector {
 		$post_list = new Post_List();
 
 		foreach ( $indexables as $indexable ) {
-			$post_list->add_post(
+			$post_list->add(
 				new Post(
 					( $indexable->breadcrumb_title ?? '' ),
 					( $indexable->description ?? '' ),

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -1,5 +1,6 @@
 <?php
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 
 namespace Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content;
 
@@ -20,9 +21,11 @@ class Recent_Content_Collector {
 	private const LIMIT = 100;
 
 	/**
-	 * @var Indexable_Repository The indexable repository.
+	 * The indexable repository.
+	 *
+	 * @var Indexable_Repository
 	 */
-	private Indexable_Repository $indexable_repository;
+	private $indexable_repository;
 
 	/**
 	 * The constructor.

--- a/src/ai/content-planner/user-interface/content-planner-route.php
+++ b/src/ai/content-planner/user-interface/content-planner-route.php
@@ -1,0 +1,159 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\AI\Content_Planner\User_Interface;
+
+use RuntimeException;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command_Handler;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Payment_Required_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Remote_Request_Exception;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Too_Many_Requests_Exception;
+use Yoast\WP\SEO\Conditionals\AI_Conditional;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Routes\Route_Interface;
+
+/**
+ * Registers a route to get content suggestions from the AI API.
+ *
+ * @makePublic
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+class Content_Planner_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The namespace for this route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_NAMESPACE = Main::API_V1_NAMESPACE;
+
+	/**
+	 * The prefix for this route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_PREFIX = '/ai_content_planner/get_suggestions';
+
+	/**
+	 * The command handler instance.
+	 *
+	 * @var Content_Suggestion_Command_Handler
+	 */
+	private $command_handler;
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array<string> The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ AI_Conditional::class ];
+	}
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Content_Suggestion_Command_Handler $command_handler The command handler instance.
+	 */
+	public function __construct( Content_Suggestion_Command_Handler $command_handler ) {
+		$this->command_handler = $command_handler;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			self::ROUTE_NAMESPACE,
+			self::ROUTE_PREFIX,
+			[
+				'methods'             => 'GET',
+				'args'                => [
+					'post_type' => [
+						'required'    => true,
+						'type'        => 'string',
+						'description' => 'The post type to get content suggestions for.',
+					],
+					'language'  => [
+						'required'    => true,
+						'type'        => 'string',
+						'description' => 'The language the content is written in.',
+					],
+					'editor'    => [
+						'required'    => true,
+						'type'        => 'string',
+						'enum'        => [
+							'classic',
+							'elementor',
+							'gutenberg',
+						],
+						'description' => 'The current editor.',
+					],
+				],
+				'callback'            => [ $this, 'get_suggestions' ],
+				'permission_callback' => [ $this, 'check_permissions' ],
+			],
+		);
+	}
+
+	/**
+	 * Runs the callback to get AI-generated content suggestions.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The response of the get_suggestions action.
+	 */
+	public function get_suggestions( WP_REST_Request $request ): WP_REST_Response {
+		try {
+			$user = \wp_get_current_user();
+
+			$command = new Content_Suggestion_Command(
+				$user,
+				$request->get_param( 'post_type' ),
+				$request->get_param( 'language' ),
+				$request->get_param( 'editor' ),
+			);
+			$data    = $this->command_handler->handle( $command );
+		} catch ( Remote_Request_Exception $e ) {
+			$message = [
+				'message'         => $e->getMessage(),
+				'errorIdentifier' => $e->get_error_identifier(),
+			];
+			if ( $e instanceof Payment_Required_Exception || $e instanceof Too_Many_Requests_Exception ) {
+				$message['missingLicenses'] = $e->get_missing_licenses();
+			}
+			return new WP_REST_Response(
+				$message,
+				$e->getCode(),
+			);
+		} catch ( RuntimeException $e ) {
+			return new WP_REST_Response( 'Failed to get content suggestions.', 500 );
+		}
+
+		return new WP_REST_Response( $data->to_array() );
+	}
+
+	/**
+	 * Checks if the user is logged in and can edit posts.
+	 *
+	 * @return bool Whether the user is logged in and can edit posts.
+	 */
+	public function check_permissions(): bool {
+		return true;
+		$user = \wp_get_current_user();
+		if ( $user === null || $user->ID < 1 ) {
+			return false;
+		}
+
+		return \user_can( $user, 'edit_posts' );
+	}
+}

--- a/src/ai/content-planner/user-interface/content-planner-route.php
+++ b/src/ai/content-planner/user-interface/content-planner-route.php
@@ -12,7 +12,6 @@ use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Payment_Required_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Remote_Request_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Too_Many_Requests_Exception;
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
 
@@ -24,8 +23,6 @@ use Yoast\WP\SEO\Routes\Route_Interface;
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
 class Content_Planner_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 * The namespace for this route.

--- a/src/ai/content-planner/user-interface/content-planner-route.php
+++ b/src/ai/content-planner/user-interface/content-planner-route.php
@@ -148,7 +148,6 @@ class Content_Planner_Route implements Route_Interface {
 	 * @return bool Whether the user is logged in and can edit posts.
 	 */
 	public function check_permissions(): bool {
-		return true;
 		$user = \wp_get_current_user();
 		if ( $user === null || $user->ID < 1 ) {
 			return false;

--- a/src/repositories/indexable-repository.php
+++ b/src/repositories/indexable-repository.php
@@ -538,6 +538,24 @@ class Indexable_Repository {
 	}
 
 	/**
+	 * Returns the most recently modified about page based on schema_page_type.
+	 *
+	 * @param string $post_type The post type.
+	 *
+	 * @return Indexable|false The about page if its there.
+	 */
+	public function get_most_recent_about_page( $post_type ) {
+		$query = $this->query()
+			->where( 'object_type', 'post' )
+			->where( 'object_sub_type', $post_type )
+			->where( 'schema_page_type', 'AboutPage' )
+			->where_raw( '( is_public IS NULL OR is_public = 1 )' )
+			->order_by_desc( 'object_last_modified' );
+
+		return $query->find_one();
+	}
+
+	/**
 	 * Returns the most recently modified posts with keywords of a post type.
 	 *
 	 * @param string      $post_type  The post type.

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Token_Invalidate_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Token_Invalidate_Test.php
@@ -48,15 +48,15 @@ final class Token_Invalidate_Test extends Abstract_Token_Manager_Test {
 			)
 			->once();
 
-		// Mock user meta deletion.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Mock token deletion.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
 		$this->instance->token_invalidate( $user_id );
@@ -91,15 +91,15 @@ final class Token_Invalidate_Test extends Abstract_Token_Manager_Test {
 			)
 			->once();
 
-		// Mock user meta deletion.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Mock token deletion.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
 		$this->instance->token_invalidate( $user_id );
@@ -136,15 +136,15 @@ final class Token_Invalidate_Test extends Abstract_Token_Manager_Test {
 			->once()
 			->andThrow( new Unauthorized_Exception( 'Unauthorized', 401 ) );
 
-		// Mock user meta deletion should still happen.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Mock token deletion should still happen.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
 		$this->instance->token_invalidate( $user_id );
@@ -181,15 +181,15 @@ final class Token_Invalidate_Test extends Abstract_Token_Manager_Test {
 			->once()
 			->andThrow( new Forbidden_Exception( 'Forbidden', 403 ) );
 
-		// Mock user meta deletion should still happen.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Mock token deletion should still happen.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( $user_id )
 			->once();
 
 		$this->instance->token_invalidate( $user_id );

--- a/tests/Unit/AI/Content_Planner/Domain/Category/Abstract_Category.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Category/Abstract_Category.php
@@ -1,0 +1,34 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Category;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Category tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Category extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Category
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->instance = new Category( 'Tech', 5 );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Category/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Category/Constructor_Test.php
@@ -1,0 +1,25 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Category;
+
+/**
+ * Tests the Category constructor.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Category::__construct
+ */
+final class Constructor_Test extends Abstract_Category {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertSame( 'Tech', $this->getPropertyValue( $this->instance, 'name' ) );
+		$this->assertSame( 5, $this->getPropertyValue( $this->instance, 'id' ) );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Category/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Category/To_Array_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Category;
+
+/**
+ * Tests the Category's to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Category::to_array
+ */
+final class To_Array_Test extends Abstract_Category {
+
+	/**
+	 * Tests the to_array method.
+	 *
+	 * @return void
+	 */
+	public function test_to_array() {
+		$expected = [
+			'name' => 'Tech',
+			'id'   => 5,
+		];
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Abstract_Content_Suggestion.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Abstract_Content_Suggestion.php
@@ -1,0 +1,50 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Content_Suggestion tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Content_Suggestion extends TestCase {
+
+	/**
+	 * The category instance.
+	 *
+	 * @var Category
+	 */
+	protected $category;
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Content_Suggestion
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->category = new Category( 'Tech', 5 );
+		$this->instance = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			$this->category,
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Constructor_Test.php
@@ -1,0 +1,31 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+
+/**
+ * Tests the Content_Suggestion constructor.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion::__construct
+ */
+final class Constructor_Test extends Abstract_Content_Suggestion {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertSame( 'How to use AI', $this->getPropertyValue( $this->instance, 'title' ) );
+		$this->assertSame( 'informational', $this->getPropertyValue( $this->instance, 'intent' ) );
+		$this->assertSame( 'This article explains AI usage.', $this->getPropertyValue( $this->instance, 'explanation' ) );
+		$this->assertSame( 'AI usage', $this->getPropertyValue( $this->instance, 'keyphrase' ) );
+		$this->assertSame( 'Learn how to use AI effectively.', $this->getPropertyValue( $this->instance, 'meta_description' ) );
+		$this->assertInstanceOf( Category::class, $this->getPropertyValue( $this->instance, 'category' ) );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/Constructor_Test.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion;
 
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
 
 /**
  * Tests the Content_Suggestion constructor.
@@ -27,5 +28,23 @@ final class Constructor_Test extends Abstract_Content_Suggestion {
 		$this->assertSame( 'AI usage', $this->getPropertyValue( $this->instance, 'keyphrase' ) );
 		$this->assertSame( 'Learn how to use AI effectively.', $this->getPropertyValue( $this->instance, 'meta_description' ) );
 		$this->assertInstanceOf( Category::class, $this->getPropertyValue( $this->instance, 'category' ) );
+	}
+
+	/**
+	 * Tests the constructor without a category.
+	 *
+	 * @return void
+	 */
+	public function test_constructor_without_category() {
+		$instance = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			null,
+		);
+
+		$this->assertNull( $this->getPropertyValue( $instance, 'category' ) );
 	}
 }

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/To_Array_Test.php
@@ -1,0 +1,36 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion;
+
+/**
+ * Tests the Content_Suggestion's to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion::to_array
+ */
+final class To_Array_Test extends Abstract_Content_Suggestion {
+
+	/**
+	 * Tests the to_array method.
+	 *
+	 * @return void
+	 */
+	public function test_to_array() {
+		$expected = [
+			'title'            => 'How to use AI',
+			'intent'           => 'informational',
+			'explanation'      => 'This article explains AI usage.',
+			'keyphrase'        => 'AI usage',
+			'meta_description' => 'Learn how to use AI effectively.',
+			'category'         => [
+				'name' => 'Tech',
+				'id'   => 5,
+			],
+		];
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion/To_Array_Test.php
@@ -4,6 +4,8 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion;
 
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+
 /**
  * Tests the Content_Suggestion's to_array method.
  *
@@ -32,5 +34,31 @@ final class To_Array_Test extends Abstract_Content_Suggestion {
 		];
 
 		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+
+	/**
+	 * Tests the to_array method without a category.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_without_category() {
+		$instance = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			null,
+		);
+
+		$expected = [
+			'title'            => 'How to use AI',
+			'intent'           => 'informational',
+			'explanation'      => 'This article explains AI usage.',
+			'keyphrase'        => 'AI usage',
+			'meta_description' => 'Learn how to use AI effectively.',
+		];
+
+		$this->assertSame( $expected, $instance->to_array() );
 	}
 }

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Abstract_Content_Suggestion_List.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Abstract_Content_Suggestion_List.php
@@ -1,0 +1,34 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Content_Suggestion_List tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Content_Suggestion_List extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Content_Suggestion_List
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->instance = new Content_Suggestion_List();
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Add_Suggestion_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Add_Suggestion_Test.php
@@ -1,0 +1,42 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+
+/**
+ * Tests the Content_Suggestion_List's add_suggestion method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List::add_suggestion
+ */
+final class Add_Suggestion_Test extends Abstract_Content_Suggestion_List {
+
+	/**
+	 * Tests the add_suggestion method.
+	 *
+	 * @return void
+	 */
+	public function test_add_suggestion() {
+		$category   = new Category( 'Tech', 5 );
+		$suggestion = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			$category,
+		);
+
+		$this->instance->add_suggestion( $suggestion );
+
+		$suggestions = $this->getPropertyValue( $this->instance, 'content_suggestions' );
+
+		$this->assertArrayHasKey( 0, $suggestions );
+		$this->assertInstanceOf( Content_Suggestion::class, $suggestions[0] );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Add_Suggestion_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/Add_Suggestion_Test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
  *
  * @group ai-content-planner
  *
- * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List::add_suggestion
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List::add
  */
 final class Add_Suggestion_Test extends Abstract_Content_Suggestion_List {
 
@@ -32,7 +32,7 @@ final class Add_Suggestion_Test extends Abstract_Content_Suggestion_List {
 			$category,
 		);
 
-		$this->instance->add_suggestion( $suggestion );
+		$this->instance->add( $suggestion );
 
 		$suggestions = $this->getPropertyValue( $this->instance, 'content_suggestions' );
 

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
@@ -41,7 +41,7 @@ final class To_Array_Test extends Abstract_Content_Suggestion_List {
 			$category,
 		);
 
-		$this->instance->add_suggestion( $suggestion );
+		$this->instance->add( $suggestion );
 
 		$expected = [
 			'suggestions' => [

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
@@ -1,0 +1,62 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+
+/**
+ * Tests the Content_Suggestion_List's to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List::to_array
+ */
+final class To_Array_Test extends Abstract_Content_Suggestion_List {
+
+	/**
+	 * Tests the to_array method returns an empty array when no suggestions are added.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_empty() {
+		$this->assertSame( [], $this->instance->to_array() );
+	}
+
+	/**
+	 * Tests the to_array method returns the correct array when suggestions are added.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_with_suggestions() {
+		$category   = new Category( 'Tech', 5 );
+		$suggestion = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			$category,
+		);
+
+		$this->instance->add_suggestion( $suggestion );
+
+		$expected = [
+			[
+				'title'            => 'How to use AI',
+				'intent'           => 'informational',
+				'explanation'      => 'This article explains AI usage.',
+				'keyphrase'        => 'AI usage',
+				'meta_description' => 'Learn how to use AI effectively.',
+				'category'         => [
+					'name' => 'Tech',
+					'id'   => 5,
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_List/To_Array_Test.php
@@ -22,7 +22,7 @@ final class To_Array_Test extends Abstract_Content_Suggestion_List {
 	 * @return void
 	 */
 	public function test_to_array_empty() {
-		$this->assertSame( [], $this->instance->to_array() );
+		$this->assertSame( [ 'suggestions' => [] ], $this->instance->to_array() );
 	}
 
 	/**
@@ -44,15 +44,17 @@ final class To_Array_Test extends Abstract_Content_Suggestion_List {
 		$this->instance->add_suggestion( $suggestion );
 
 		$expected = [
-			[
-				'title'            => 'How to use AI',
-				'intent'           => 'informational',
-				'explanation'      => 'This article explains AI usage.',
-				'keyphrase'        => 'AI usage',
-				'meta_description' => 'Learn how to use AI effectively.',
-				'category'         => [
-					'name' => 'Tech',
-					'id'   => 5,
+			'suggestions' => [
+				[
+					'title'            => 'How to use AI',
+					'intent'           => 'informational',
+					'explanation'      => 'This article explains AI usage.',
+					'keyphrase'        => 'AI usage',
+					'meta_description' => 'Learn how to use AI effectively.',
+					'category'         => [
+						'name' => 'Tech',
+						'id'   => 5,
+					],
 				],
 			],
 		];

--- a/tests/Unit/AI/Content_Planner/Domain/Post/Abstract_Post.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/Abstract_Post.php
@@ -1,0 +1,51 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Post tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Post extends TestCase {
+
+	/**
+	 * The category instance.
+	 *
+	 * @var Category
+	 */
+	protected $category;
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Post
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->category = new Category( 'Tech', 5 );
+		$this->instance = new Post(
+			'My Post Title',
+			'A description of the post.',
+			$this->category,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Post/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/Constructor_Test.php
@@ -1,0 +1,32 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+
+/**
+ * Tests the Post constructor.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post::__construct
+ */
+final class Constructor_Test extends Abstract_Post {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertSame( 'My Post Title', $this->getPropertyValue( $this->instance, 'title' ) );
+		$this->assertSame( 'A description of the post.', $this->getPropertyValue( $this->instance, 'description' ) );
+		$this->assertInstanceOf( Category::class, $this->getPropertyValue( $this->instance, 'category' ) );
+		$this->assertSame( 'focus keyword', $this->getPropertyValue( $this->instance, 'primary_focus_keyword' ) );
+		$this->assertSame( 1, $this->getPropertyValue( $this->instance, 'is_cornerstone' ) );
+		$this->assertSame( '2024-01-15', $this->getPropertyValue( $this->instance, 'last_modified' ) );
+		$this->assertSame( 'BlogPosting', $this->getPropertyValue( $this->instance, 'schema_article_type' ) );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Post/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/To_Array_Test.php
@@ -1,0 +1,73 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+
+/**
+ * Tests the Post's to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post::to_array
+ */
+final class To_Array_Test extends Abstract_Post {
+
+	/**
+	 * Tests the to_array method with schema_article_type set.
+	 *
+	 * @return void
+	 */
+	public function test_to_array() {
+		$expected = [
+			'title'                 => 'My Post Title',
+			'description'           => 'A description of the post.',
+			'category'              => [
+				'name' => 'Tech',
+				'id'   => 5,
+			],
+			'primary_focus_keyword' => 'focus keyword',
+			'is_cornerstone'        => 1,
+			'last_modified'         => '2024-01-15',
+			'schema_article_type'   => 'BlogPosting',
+		];
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+
+	/**
+	 * Tests the to_array method without schema_article_type.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_without_schema_article_type() {
+		$category = new Category( 'Tech', 5 );
+		$post     = new Post(
+			'My Post Title',
+			'A description of the post.',
+			$category,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			null,
+		);
+
+		$expected = [
+			'title'                 => 'My Post Title',
+			'description'           => 'A description of the post.',
+			'category'              => [
+				'name' => 'Tech',
+				'id'   => 5,
+			],
+			'primary_focus_keyword' => 'focus keyword',
+			'is_cornerstone'        => 1,
+			'last_modified'         => '2024-01-15',
+		];
+
+		$this->assertSame( $expected, $post->to_array() );
+		$this->assertArrayNotHasKey( 'schema_article_type', $post->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Post_List/Abstract_Post_List.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post_List/Abstract_Post_List.php
@@ -1,0 +1,34 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Post_List tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Post_List extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Post_List
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->instance = new Post_List();
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Post_List/Add_Post_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post_List/Add_Post_Test.php
@@ -1,0 +1,43 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+
+/**
+ * Tests the Post_List's add_post method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List::add_post
+ */
+final class Add_Post_Test extends Abstract_Post_List {
+
+	/**
+	 * Tests the add_post method.
+	 *
+	 * @return void
+	 */
+	public function test_add_post() {
+		$category = new Category( 'Tech', 5 );
+		$post     = new Post(
+			'My Post Title',
+			'A description of the post.',
+			$category,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$this->instance->add_post( $post );
+
+		$posts = $this->getPropertyValue( $this->instance, 'posts' );
+
+		$this->assertArrayHasKey( 0, $posts );
+		$this->assertInstanceOf( Post::class, $posts[0] );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Post_List/Add_Post_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post_List/Add_Post_Test.php
@@ -12,7 +12,7 @@ use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
  *
  * @group ai-content-planner
  *
- * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List::add_post
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List::add
  */
 final class Add_Post_Test extends Abstract_Post_List {
 
@@ -33,7 +33,7 @@ final class Add_Post_Test extends Abstract_Post_List {
 			'BlogPosting',
 		);
 
-		$this->instance->add_post( $post );
+		$this->instance->add( $post );
 
 		$posts = $this->getPropertyValue( $this->instance, 'posts' );
 

--- a/tests/Unit/AI/Content_Planner/Domain/Post_List/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post_List/To_Array_Test.php
@@ -42,7 +42,7 @@ final class To_Array_Test extends Abstract_Post_List {
 			'BlogPosting',
 		);
 
-		$this->instance->add_post( $post );
+		$this->instance->add( $post );
 
 		$expected = [
 			[

--- a/tests/Unit/AI/Content_Planner/Domain/Post_List/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post_List/To_Array_Test.php
@@ -1,0 +1,64 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post_List;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+
+/**
+ * Tests the Post_List's to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List::to_array
+ */
+final class To_Array_Test extends Abstract_Post_List {
+
+	/**
+	 * Tests the to_array method returns an empty array when no posts are added.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_empty() {
+		$this->assertSame( [], $this->instance->to_array() );
+	}
+
+	/**
+	 * Tests the to_array method returns the correct array when posts are added.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_with_posts() {
+		$category = new Category( 'Tech', 5 );
+		$post     = new Post(
+			'My Post Title',
+			'A description of the post.',
+			$category,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$this->instance->add_post( $post );
+
+		$expected = [
+			[
+				'title'                 => 'My Post Title',
+				'description'           => 'A description of the post.',
+				'category'              => [
+					'name' => 'Tech',
+					'id'   => 5,
+				],
+				'primary_focus_keyword' => 'focus keyword',
+				'is_cornerstone'        => 1,
+				'last_modified'         => '2024-01-15',
+				'schema_article_type'   => 'BlogPosting',
+			],
+		];
+
+		$this->assertSame( $expected, $this->instance->to_array() );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to add an endpoint to call that new content planner AI endpoint.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an endpoint to be able to request content suggestions.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* If this PR is tested before the UI is done run the following test actions. Otherwise test the UI connection PR since that tests this PR.
* Make sure you can run API requests in Postman. by copying you cookie and nonce. and have a live link/actual site ready to go so you can have a API callback.
* Open your site and make sure you have 5 posts that have some actual content in the title and meta description. These are the most important fields. For example copy paste it from 5 yoast.com posts.
* Send a GET request to `/wp-json/yoast/v1/ai_content_planner/get_suggestions?post_type=post&language=en-US&editor=classic`
* Make sure that in the response you see the following structure
```json
{
    "suggestions": [
        {
            "title": "The Beginner's Guide to SEO: Strategies for Success",
            "intent": "informational",
            "explanation": "This post will serve as a foundational resource for newcomers to SEO, filling a gap for beginners looking for a systematic introduction, which is currently underdeveloped on the site.",
            "keyphrase": "beginner's guide to SEO",
            "meta_description": "Discover essential strategies for SEO success with our comprehensive beginner's guide. Learn the foundational concepts and best practices to start optimizing your website today."
        },
]
}
```


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
