### PR TITLE
Fix AI generator callback URLs becoming stale after site URL change #23127

### DIFF
--- a/src/ai-authorization/application/token-manager.php
+++ b/src/ai-authorization/application/token-manager.php
@@ -202,16 +202,22 @@ class Token_Manager implements Token_Manager_Interface {
 		$code_verifier = $this->code_verifier->generate( $user->user_email );
 		$this->code_verifier_repository->store_code_verifier( $user->ID, $code_verifier->get_code(), $code_verifier->get_created_at() );
 
+		$callback_url         = $this->urls->get_callback_url();
+		$refresh_callback_url = $this->urls->get_refresh_callback_url();
+
 		$request_body = [
 			'service'              => 'openai',
 			'code_challenge'       => \hash( 'sha256', $code_verifier->get_code() ),
 			'license_site_url'     => WPSEO_Utils::get_home_url(),
 			'user_id'              => (string) $user->ID,
-			'callback_url'         => $this->urls->get_callback_url(),
-			'refresh_callback_url' => $this->urls->get_refresh_callback_url(),
+			'callback_url'         => $callback_url,
+			'refresh_callback_url' => $refresh_callback_url,
 		];
 
 		$this->request_handler->handle( new Request( '/token/request', $request_body ) );
+
+		// Store a per-user hash of the callback URL to detect future site URL changes.
+		$this->user_helper->update_meta( $user->ID, '_yoast_wpseo_ai_generator_callback_url_hash', \md5( $callback_url ) );
 
 		// The callback saves the metadata. Because that is in another session, we need to delete the current cache here. Or we may get the old token.
 		\wp_cache_delete( $user->ID, 'user_meta' );
@@ -306,6 +312,12 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws RuntimeException Unable to retrieve the access or refresh token.
 	 */
 	public function get_or_request_access_token( WP_User $user ): string {
+		// If the site URL has changed since callback URLs were registered, delete stale tokens.
+		if ( $this->have_callback_urls_changed( $user ) ) {
+			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt' );
+			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+		}
+
 		$access_jwt = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt', true );
 		if ( ! \is_string( $access_jwt ) || $access_jwt === '' ) {
 			$this->token_request( $user );
@@ -330,4 +342,30 @@ class Token_Manager implements Token_Manager_Interface {
 	}
 
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+
+	/**
+	 * Checks whether the callback URLs have changed since the last token request.
+	 *
+	 * Detects site URL changes (e.g., migrating from a staging URL to a production domain)
+	 * that would leave stale callback URLs registered with the Yoast AI service.
+	 * Uses a per-user hash so each user independently detects the change and re-registers.
+	 * The hash is immune to wp search-replace operations.
+	 *
+	 * When no hash is stored (first run after upgrade), returns true to force a fresh
+	 * token_request(). This ensures existing sites with stale callback URLs self-heal
+	 * without manual intervention.
+	 *
+	 * @param WP_User $user The current user.
+	 *
+	 * @return bool Whether the callback URLs may have changed.
+	 */
+	private function have_callback_urls_changed( WP_User $user ): bool {
+		$registered_hash = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_callback_url_hash', true );
+
+		if ( ! \is_string( $registered_hash ) || $registered_hash === '' ) {
+			return true;
+		}
+
+		return $registered_hash !== \md5( $this->urls->get_callback_url() );
+	}
 }

--- a/src/ai/authorization/application/token-manager.php
+++ b/src/ai/authorization/application/token-manager.php
@@ -218,8 +218,8 @@ class Token_Manager implements Token_Manager_Interface {
 
 		$this->request_handler->handle( new Request( '/token/request', $request_body ) );
 
-		// Store a hash of the callback URL to detect future site URL changes.
-		\update_option( 'yoast_ai_generator_callback_url_hash', \md5( $callback_url ), true );
+		// Store a per-user hash of the callback URL to detect future site URL changes.
+		$this->user_helper->update_meta( $user->ID, '_yoast_wpseo_ai_generator_callback_url_hash', \md5( $callback_url ) );
 
 		// The callback saves the metadata. Because that is in another session, we need to delete the current cache here. Or we may get the old token.
 		\wp_cache_delete( $user->ID, 'user_meta' );
@@ -315,7 +315,7 @@ class Token_Manager implements Token_Manager_Interface {
 	 */
 	public function get_or_request_access_token( WP_User $user ): string {
 		// If the site URL has changed since callback URLs were registered, delete stale tokens.
-		if ( $this->have_callback_urls_changed() ) {
+		if ( $this->have_callback_urls_changed( $user ) ) {
 			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt' );
 			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
 		}
@@ -350,18 +350,21 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * Detects site URL changes (e.g., migrating from a staging URL to a production domain)
 	 * that would leave stale callback URLs registered with the Yoast AI service.
-	 * Uses a hash so the stored value is immune to wp search-replace operations.
+	 * Uses a per-user hash so each user independently detects the change and re-registers.
+	 * The hash is immune to wp search-replace operations.
 	 *
 	 * When no hash is stored (first run after upgrade), returns true to force a fresh
 	 * token_request(). This ensures existing sites with stale callback URLs self-heal
 	 * without manual intervention.
 	 *
+	 * @param WP_User $user The current user.
+	 *
 	 * @return bool Whether the callback URLs may have changed.
 	 */
-	private function have_callback_urls_changed(): bool {
-		$registered_hash = \get_option( 'yoast_ai_generator_callback_url_hash', '' );
+	private function have_callback_urls_changed( WP_User $user ): bool {
+		$registered_hash = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_callback_url_hash', true );
 
-		if ( $registered_hash === '' ) {
+		if ( ! \is_string( $registered_hash ) || $registered_hash === '' ) {
 			return true;
 		}
 

--- a/src/ai/authorization/application/token-manager.php
+++ b/src/ai/authorization/application/token-manager.php
@@ -204,16 +204,22 @@ class Token_Manager implements Token_Manager_Interface {
 		$code_verifier = $this->code_verifier->generate( $user->user_email );
 		$this->code_verifier_repository->store_code_verifier( $user->ID, $code_verifier->get_code(), $code_verifier->get_created_at() );
 
+		$callback_url         = $this->urls->get_callback_url();
+		$refresh_callback_url = $this->urls->get_refresh_callback_url();
+
 		$request_body = [
 			'service'              => 'openai',
 			'code_challenge'       => \hash( 'sha256', $code_verifier->get_code() ),
 			'license_site_url'     => WPSEO_Utils::get_home_url(),
 			'user_id'              => (string) $user->ID,
-			'callback_url'         => $this->urls->get_callback_url(),
-			'refresh_callback_url' => $this->urls->get_refresh_callback_url(),
+			'callback_url'         => $callback_url,
+			'refresh_callback_url' => $refresh_callback_url,
 		];
 
 		$this->request_handler->handle( new Request( '/token/request', $request_body ) );
+
+		// Store a hash of the callback URL to detect future site URL changes.
+		\update_option( 'yoast_ai_generator_callback_url_hash', \md5( $callback_url ), true );
 
 		// The callback saves the metadata. Because that is in another session, we need to delete the current cache here. Or we may get the old token.
 		\wp_cache_delete( $user->ID, 'user_meta' );
@@ -308,6 +314,12 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws RuntimeException Unable to retrieve the access or refresh token.
 	 */
 	public function get_or_request_access_token( WP_User $user ): string {
+		// If the site URL has changed since callback URLs were registered, delete stale tokens.
+		if ( $this->have_callback_urls_changed() ) {
+			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt' );
+			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+		}
+
 		$access_jwt = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt', true );
 		if ( ! \is_string( $access_jwt ) || $access_jwt === '' ) {
 			$this->token_request( $user );
@@ -332,4 +344,27 @@ class Token_Manager implements Token_Manager_Interface {
 	}
 
 	// phpcs:enable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
+
+	/**
+	 * Checks whether the callback URLs have changed since the last token request.
+	 *
+	 * Detects site URL changes (e.g., migrating from a staging URL to a production domain)
+	 * that would leave stale callback URLs registered with the Yoast AI service.
+	 * Uses a hash so the stored value is immune to wp search-replace operations.
+	 *
+	 * When no hash is stored (first run after upgrade), returns true to force a fresh
+	 * token_request(). This ensures existing sites with stale callback URLs self-heal
+	 * without manual intervention.
+	 *
+	 * @return bool Whether the callback URLs may have changed.
+	 */
+	private function have_callback_urls_changed(): bool {
+		$registered_hash = \get_option( 'yoast_ai_generator_callback_url_hash', '' );
+
+		if ( $registered_hash === '' ) {
+			return true;
+		}
+
+		return $registered_hash !== \md5( $this->urls->get_callback_url() );
+	}
 }

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
@@ -113,6 +113,15 @@ abstract class Abstract_Token_Manager_Test extends TestCase {
 		$this->urls                     = Mockery::mock( WordPress_URLs::class );
 		$this->url_helper               = Mockery::mock( Url_Helper::class );
 
+		// Default: have_callback_urls_changed() returns false by providing a matching hash.
+		$default_callback_url = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', '' )
+			->andReturn( \md5( $default_callback_url ) )
+			->byDefault();
+		Monkey\Functions\expect( 'update_option' )->byDefault();
+		$this->urls->shouldReceive( 'get_callback_url' )->andReturn( $default_callback_url )->byDefault();
+
 		$this->instance = new Token_Manager( $this->access_token_repository, $this->code_verifier, $this->consent_handler, $this->refresh_token_repository, $this->user_helper, $this->request_handler, $this->code_verifier_repository, $this->urls );
 	}
 

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
@@ -113,13 +113,13 @@ abstract class Abstract_Token_Manager_Test extends TestCase {
 		$this->urls                     = Mockery::mock( WordPress_URLs::class );
 		$this->url_helper               = Mockery::mock( Url_Helper::class );
 
-		// Default: have_callback_urls_changed() returns false by providing a matching hash.
+		// Default: have_callback_urls_changed() returns false by providing a matching per-user hash.
 		$default_callback_url = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
-		Monkey\Functions\expect( 'get_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', '' )
+		$this->user_helper->shouldReceive( 'get_meta' )
+			->with( Mockery::any(), '_yoast_wpseo_ai_generator_callback_url_hash', true )
 			->andReturn( \md5( $default_callback_url ) )
 			->byDefault();
-		Monkey\Functions\stubs( [ 'update_option' ] );
+		$this->user_helper->shouldReceive( 'update_meta' )->zeroOrMoreTimes()->byDefault();
 		$this->urls->shouldReceive( 'get_callback_url' )->andReturn( $default_callback_url )->byDefault();
 		$this->urls->shouldReceive( 'get_refresh_callback_url' )->andReturn( 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback' )->byDefault();
 

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Abstract_Token_Manager_Test.php
@@ -119,8 +119,9 @@ abstract class Abstract_Token_Manager_Test extends TestCase {
 			->with( 'yoast_ai_generator_callback_url_hash', '' )
 			->andReturn( \md5( $default_callback_url ) )
 			->byDefault();
-		Monkey\Functions\expect( 'update_option' )->byDefault();
+		Monkey\Functions\stubs( [ 'update_option' ] );
 		$this->urls->shouldReceive( 'get_callback_url' )->andReturn( $default_callback_url )->byDefault();
+		$this->urls->shouldReceive( 'get_refresh_callback_url' )->andReturn( 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback' )->byDefault();
 
 		$this->instance = new Token_Manager( $this->access_token_repository, $this->code_verifier, $this->consent_handler, $this->refresh_token_repository, $this->user_helper, $this->request_handler, $this->code_verifier_repository, $this->urls );
 	}

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -108,10 +108,13 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// The new callback URL hash should be stored.
-		Monkey\Functions\expect( 'update_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', \md5( $new_callback_url ), true )
-			->once();
+		// Capture the update_option call to verify the hash is stored.
+		$stored_option = [];
+		Monkey\Functions\when( 'update_option' )->alias(
+			static function () use ( &$stored_option ) {
+				$stored_option = \func_get_args();
+			}
+		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
@@ -126,6 +129,8 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$result = $this->instance->get_or_request_access_token( $user );
 
 		$this->assertEquals( $new_access_jwt, $result );
+		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
+		$this->assertEquals( \md5( $new_callback_url ), $stored_option[1] );
 	}
 
 	/**
@@ -136,9 +141,6 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 	public function test_matching_callback_url_hash_does_not_invalidate_tokens() {
 		$user     = Mockery::mock( WP_User::class );
 		$user->ID = 123;
-
-		$callback_url  = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
-		$callback_hash = \md5( $callback_url );
 
 		// Create a non-expired JWT token.
 		$future_exp = ( \time() + 3600 );
@@ -250,10 +252,13 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// The new callback URL hash should be stored.
-		Monkey\Functions\expect( 'update_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', \md5( $new_callback_url ), true )
-			->once();
+		// Capture the update_option call to verify the hash is stored.
+		$stored_option = [];
+		Monkey\Functions\when( 'update_option' )->alias(
+			static function () use ( &$stored_option ) {
+				$stored_option = \func_get_args();
+			}
+		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
@@ -268,6 +273,8 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$result = $this->instance->get_or_request_access_token( $user );
 
 		$this->assertEquals( $new_access_jwt, $result );
+		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
+		$this->assertEquals( \md5( $new_callback_url ), $stored_option[1] );
 	}
 
 	/**
@@ -329,15 +336,21 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// Verify the hash is stored after successful token request.
-		Monkey\Functions\expect( 'update_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', \md5( $callback_url ), true )
-			->once();
+		// Capture the update_option call to verify the hash is stored.
+		$stored_option = [];
+		Monkey\Functions\when( 'update_option' )->alias(
+			static function () use ( &$stored_option ) {
+				$stored_option = \func_get_args();
+			}
+		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
 			->once();
 
 		$this->instance->token_request( $user );
+
+		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
+		$this->assertEquals( \md5( $callback_url ), $stored_option[1] );
 	}
 }

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -40,10 +40,10 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$code              = 'test-code-verifier';
 		$created_at        = 1_640_995_200;
 
-		// The stored hash differs from the current callback URL hash.
-		Monkey\Functions\expect( 'get_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', '' )
-			->once()
+		// The stored per-user hash differs from the current callback URL hash.
+		$this->user_helper
+			->shouldReceive( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', true )
 			->andReturn( $old_callback_hash );
 
 		$this->urls
@@ -108,13 +108,11 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// Capture the update_option call to verify the hash is stored.
-		$stored_option = [];
-		Monkey\Functions\when( 'update_option' )->alias(
-			static function () use ( &$stored_option ) {
-				$stored_option = \func_get_args();
-			},
-		);
+		// The new callback URL hash should be stored per-user.
+		$this->user_helper
+			->expects( 'update_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', \md5( $new_callback_url ) )
+			->once();
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
@@ -129,8 +127,6 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$result = $this->instance->get_or_request_access_token( $user );
 
 		$this->assertEquals( $new_access_jwt, $result );
-		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
-		$this->assertEquals( \md5( $new_callback_url ), $stored_option[1] );
 	}
 
 	/**
@@ -184,10 +180,10 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$code             = 'test-code-verifier';
 		$created_at       = 1_640_995_200;
 
-		// No stored hash — return empty to trigger re-request.
-		Monkey\Functions\expect( 'get_option' )
-			->with( 'yoast_ai_generator_callback_url_hash', '' )
-			->once()
+		// No stored per-user hash — return empty to trigger re-request.
+		$this->user_helper
+			->shouldReceive( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', true )
 			->andReturn( '' );
 
 		// Stale tokens should be deleted.
@@ -252,13 +248,11 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// Capture the update_option call to verify the hash is stored.
-		$stored_option = [];
-		Monkey\Functions\when( 'update_option' )->alias(
-			static function () use ( &$stored_option ) {
-				$stored_option = \func_get_args();
-			},
-		);
+		// The new callback URL hash should be stored per-user.
+		$this->user_helper
+			->expects( 'update_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', \md5( $new_callback_url ) )
+			->once();
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
@@ -273,12 +267,10 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$result = $this->instance->get_or_request_access_token( $user );
 
 		$this->assertEquals( $new_access_jwt, $result );
-		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
-		$this->assertEquals( \md5( $new_callback_url ), $stored_option[1] );
 	}
 
 	/**
-	 * Tests that token_request stores the callback URL hash.
+	 * Tests that token_request stores the callback URL hash per-user.
 	 *
 	 * @return void
 	 */
@@ -336,21 +328,16 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->expects( 'handle' )
 			->once();
 
-		// Capture the update_option call to verify the hash is stored.
-		$stored_option = [];
-		Monkey\Functions\when( 'update_option' )->alias(
-			static function () use ( &$stored_option ) {
-				$stored_option = \func_get_args();
-			},
-		);
+		// Verify the per-user hash is stored after successful token request.
+		$this->user_helper
+			->expects( 'update_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', \md5( $callback_url ) )
+			->once();
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
 			->with( 123, 'user_meta' )
 			->once();
 
 		$this->instance->token_request( $user );
-
-		$this->assertEquals( 'yoast_ai_generator_callback_url_hash', $stored_option[0] );
-		$this->assertEquals( \md5( $callback_url ), $stored_option[1] );
 	}
 }

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -1,0 +1,343 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Reason: Used for legitimate JWT testing, not obfuscation.
+namespace Yoast\WP\SEO\Tests\Unit\AI\Authorization\Application\Token_Manager;
+
+use Brain\Monkey;
+use Mockery;
+use WP_User;
+use Yoast\WP\SEO\AI\Authorization\Domain\Code_Verifier;
+
+/**
+ * Class Callback_Url_Change_Test.
+ *
+ * Tests that stale AI generator callback URLs are detected and tokens are
+ * re-registered when the site URL changes (e.g., migrating from a staging
+ * URL to a production domain).
+ *
+ * @group ai-authorization
+ * @covers \Yoast\WP\SEO\AI\Authorization\Application\Token_Manager::get_or_request_access_token
+ * @covers \Yoast\WP\SEO\AI\Authorization\Application\Token_Manager::token_request
+ */
+final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
+
+	/**
+	 * Tests that tokens are deleted and re-requested when the callback URL hash has changed.
+	 *
+	 * @return void
+	 */
+	public function test_stale_callback_url_triggers_token_re_request() {
+		$user             = Mockery::mock( WP_User::class );
+		$user->ID         = 123;
+		$user->user_email = 'test@example.com';
+
+		$new_access_jwt       = 'new-access-token';
+		$new_callback_url     = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		$old_callback_hash    = \md5( 'https://old-staging.example.com/wp-json/yoast/v1/ai_generator/callback' );
+		$code_verifier        = Mockery::mock( Code_Verifier::class );
+		$code                 = 'test-code-verifier';
+		$created_at           = 1_640_995_200;
+
+		// The stored hash differs from the current callback URL hash.
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', '' )
+			->once()
+			->andReturn( $old_callback_hash );
+
+		$this->urls
+			->shouldReceive( 'get_callback_url' )
+			->andReturn( $new_callback_url );
+
+		$this->urls
+			->expects( 'get_refresh_callback_url' )
+			->once()
+			->andReturn( 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback' );
+
+		// Stale tokens should be deleted.
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_access_jwt' )
+			->once();
+
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_refresh_jwt' )
+			->once();
+
+		// After deletion, get_meta returns empty — triggers token_request.
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_access_jwt', true )
+			->once()
+			->andReturn( '' );
+
+		// token_request flow.
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_consent', true )
+			->once()
+			->andReturn( '1' );
+
+		$this->code_verifier
+			->expects( 'generate' )
+			->with( 'test@example.com' )
+			->once()
+			->andReturn( $code_verifier );
+
+		$code_verifier
+			->expects( 'get_code' )
+			->twice()
+			->andReturn( $code );
+
+		$code_verifier
+			->expects( 'get_created_at' )
+			->once()
+			->andReturn( $created_at );
+
+		$this->code_verifier_repository
+			->expects( 'store_code_verifier' )
+			->with( 123, $code, $created_at )
+			->once();
+
+		// Mock YoastSEO function for WPSEO_Utils::get_home_url().
+		$this->WPSEO_Utils_get_home_url();
+
+		$this->request_handler
+			->expects( 'handle' )
+			->once();
+
+		// The new callback URL hash should be stored.
+		Monkey\Functions\expect( 'update_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', \md5( $new_callback_url ), true )
+			->once();
+
+		Monkey\Functions\expect( 'wp_cache_delete' )
+			->with( 123, 'user_meta' )
+			->once();
+
+		$this->access_token_repository
+			->expects( 'get_token' )
+			->with( 123 )
+			->once()
+			->andReturn( $new_access_jwt );
+
+		$result = $this->instance->get_or_request_access_token( $user );
+
+		$this->assertEquals( $new_access_jwt, $result );
+	}
+
+	/**
+	 * Tests that no action is taken when the callback URL hash matches (URL has not changed).
+	 *
+	 * @return void
+	 */
+	public function test_matching_callback_url_hash_does_not_invalidate_tokens() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 123;
+
+		$callback_url  = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		$callback_hash = \md5( $callback_url );
+
+		// Create a non-expired JWT token.
+		$future_exp = ( \time() + 3600 );
+		$payload    = \base64_encode( \json_encode( [ 'exp' => $future_exp ] ) );
+		$access_jwt = "header.{$payload}.signature";
+
+		// The stored hash matches the current callback URL hash — setUp defaults handle this.
+
+		// delete_meta should NOT be called — tokens are valid.
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->never();
+
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_access_jwt', true )
+			->once()
+			->andReturn( $access_jwt );
+
+		$result = $this->instance->get_or_request_access_token( $user );
+
+		$this->assertEquals( $access_jwt, $result );
+	}
+
+	/**
+	 * Tests that tokens are invalidated when no hash is stored (first run after upgrade).
+	 *
+	 * This forces a fresh token_request() on first use after upgrading, ensuring
+	 * existing sites with stale callback URLs self-heal without manual intervention.
+	 *
+	 * @return void
+	 */
+	public function test_empty_stored_hash_forces_token_re_request() {
+		$user             = Mockery::mock( WP_User::class );
+		$user->ID         = 123;
+		$user->user_email = 'test@example.com';
+
+		$new_access_jwt   = 'new-access-token';
+		$new_callback_url = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		$code_verifier    = Mockery::mock( Code_Verifier::class );
+		$code             = 'test-code-verifier';
+		$created_at       = 1_640_995_200;
+
+		// No stored hash — return empty to trigger re-request.
+		Monkey\Functions\expect( 'get_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', '' )
+			->once()
+			->andReturn( '' );
+
+		// Stale tokens should be deleted.
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_access_jwt' )
+			->once();
+
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_refresh_jwt' )
+			->once();
+
+		// After deletion, get_meta returns empty — triggers token_request.
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_generator_access_jwt', true )
+			->once()
+			->andReturn( '' );
+
+		// token_request flow.
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_consent', true )
+			->once()
+			->andReturn( '1' );
+
+		$this->code_verifier
+			->expects( 'generate' )
+			->with( 'test@example.com' )
+			->once()
+			->andReturn( $code_verifier );
+
+		$code_verifier
+			->expects( 'get_code' )
+			->twice()
+			->andReturn( $code );
+
+		$code_verifier
+			->expects( 'get_created_at' )
+			->once()
+			->andReturn( $created_at );
+
+		$this->code_verifier_repository
+			->expects( 'store_code_verifier' )
+			->with( 123, $code, $created_at )
+			->once();
+
+		$this->urls
+			->shouldReceive( 'get_callback_url' )
+			->andReturn( $new_callback_url );
+
+		$this->urls
+			->expects( 'get_refresh_callback_url' )
+			->once()
+			->andReturn( 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback' );
+
+		// Mock YoastSEO function for WPSEO_Utils::get_home_url().
+		$this->WPSEO_Utils_get_home_url();
+
+		$this->request_handler
+			->expects( 'handle' )
+			->once();
+
+		// The new callback URL hash should be stored.
+		Monkey\Functions\expect( 'update_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', \md5( $new_callback_url ), true )
+			->once();
+
+		Monkey\Functions\expect( 'wp_cache_delete' )
+			->with( 123, 'user_meta' )
+			->once();
+
+		$this->access_token_repository
+			->expects( 'get_token' )
+			->with( 123 )
+			->once()
+			->andReturn( $new_access_jwt );
+
+		$result = $this->instance->get_or_request_access_token( $user );
+
+		$this->assertEquals( $new_access_jwt, $result );
+	}
+
+	/**
+	 * Tests that token_request stores the callback URL hash.
+	 *
+	 * @return void
+	 */
+	public function test_token_request_stores_callback_url_hash() {
+		$user             = Mockery::mock( WP_User::class );
+		$user->ID         = 123;
+		$user->user_email = 'test@example.com';
+
+		$callback_url         = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		$refresh_callback_url = 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback';
+		$code_verifier        = Mockery::mock( Code_Verifier::class );
+		$code                 = 'test-code-verifier';
+		$created_at           = 1_640_995_200;
+
+		$this->user_helper
+			->expects( 'get_meta' )
+			->with( 123, '_yoast_wpseo_ai_consent', true )
+			->once()
+			->andReturn( '1' );
+
+		$this->code_verifier
+			->expects( 'generate' )
+			->with( 'test@example.com' )
+			->once()
+			->andReturn( $code_verifier );
+
+		$code_verifier
+			->expects( 'get_code' )
+			->twice()
+			->andReturn( $code );
+
+		$code_verifier
+			->expects( 'get_created_at' )
+			->once()
+			->andReturn( $created_at );
+
+		$this->code_verifier_repository
+			->expects( 'store_code_verifier' )
+			->with( 123, $code, $created_at )
+			->once();
+
+		$this->urls
+			->shouldReceive( 'get_callback_url' )
+			->andReturn( $callback_url );
+
+		$this->urls
+			->expects( 'get_refresh_callback_url' )
+			->once()
+			->andReturn( $refresh_callback_url );
+
+		// Mock YoastSEO function for WPSEO_Utils::get_home_url().
+		$this->WPSEO_Utils_get_home_url();
+
+		$this->request_handler
+			->expects( 'handle' )
+			->once();
+
+		// Verify the hash is stored after successful token request.
+		Monkey\Functions\expect( 'update_option' )
+			->with( 'yoast_ai_generator_callback_url_hash', \md5( $callback_url ), true )
+			->once();
+
+		Monkey\Functions\expect( 'wp_cache_delete' )
+			->with( 123, 'user_meta' )
+			->once();
+
+		$this->instance->token_request( $user );
+	}
+}

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -33,12 +33,12 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		$user->ID         = 123;
 		$user->user_email = 'test@example.com';
 
-		$new_access_jwt       = 'new-access-token';
-		$new_callback_url     = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
-		$old_callback_hash    = \md5( 'https://old-staging.example.com/wp-json/yoast/v1/ai_generator/callback' );
-		$code_verifier        = Mockery::mock( Code_Verifier::class );
-		$code                 = 'test-code-verifier';
-		$created_at           = 1_640_995_200;
+		$new_access_jwt    = 'new-access-token';
+		$new_callback_url  = 'https://example.com/wp-json/yoast/v1/ai_generator/callback';
+		$old_callback_hash = \md5( 'https://old-staging.example.com/wp-json/yoast/v1/ai_generator/callback' );
+		$code_verifier     = Mockery::mock( Code_Verifier::class );
+		$code              = 'test-code-verifier';
+		$created_at        = 1_640_995_200;
 
 		// The stored hash differs from the current callback URL hash.
 		Monkey\Functions\expect( 'get_option' )

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -113,7 +113,7 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		Monkey\Functions\when( 'update_option' )->alias(
 			static function () use ( &$stored_option ) {
 				$stored_option = \func_get_args();
-			}
+			},
 		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
@@ -257,7 +257,7 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		Monkey\Functions\when( 'update_option' )->alias(
 			static function () use ( &$stored_option ) {
 				$stored_option = \func_get_args();
-			}
+			},
 		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )
@@ -341,7 +341,7 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 		Monkey\Functions\when( 'update_option' )->alias(
 			static function () use ( &$stored_option ) {
 				$stored_option = \func_get_args();
-			}
+			},
 		);
 
 		Monkey\Functions\expect( 'wp_cache_delete' )

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Get_Or_Request_Access_Token_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Get_Or_Request_Access_Token_Test.php
@@ -101,16 +101,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->with( 123, $code, $created_at )
 			->once();
 
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
-
 		$this->request_handler
 			->expects( 'handle' )
 			->once();
@@ -181,17 +171,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->with( 123, $code, $created_at )
 			->once();
 
-		// Mock URLs.
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
-
 		$this->request_handler
 			->expects( 'handle' )
 			->once();
@@ -261,16 +240,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->expects( 'store_code_verifier' )
 			->with( 123, $code, $created_at )
 			->once();
-
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
 
 		$this->request_handler
 			->expects( 'handle' )
@@ -450,16 +419,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->with( 123, $code, $created_at )
 			->once();
 
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
-
 		$this->request_handler
 			->expects( 'handle' )
 			->once();
@@ -597,16 +556,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->with( 123, $code, $created_at )
 			->once();
 
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
-
 		$this->request_handler
 			->expects( 'handle' )
 			->once()
@@ -668,16 +617,6 @@ final class Get_Or_Request_Access_Token_Test extends Abstract_Token_Manager_Test
 			->expects( 'store_code_verifier' )
 			->with( 123, $code, $created_at )
 			->once();
-
-		$this->urls
-			->expects( 'get_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/callback' );
-
-		$this->urls
-			->expects( 'get_refresh_callback_url' )
-			->once()
-			->andReturn( 'https://example.com/refresh-callback' );
 
 		$this->request_handler
 			->expects( 'handle' )


### PR DESCRIPTION
## Context

When a WordPress site is provisioned at a temporary/staging URL (common with Bluehost, Kinsta, WP Engine, and many other managed hosts) and the user later points a real domain to the site, the AI Generator's "Generate with AI" feature fails silently. The `callback_url` and `refresh_callback_url` are sent to Yoast's API only during `token_request()`, but `token_refresh()` never re-sends them. The API continues using the original (stale) staging URLs for all subsequent token delivery callbacks, which fail due to DNS/TLS mismatches.

This is not host-specific — any site that changes its URL after first using the AI Generator is affected. Yoast SEO does hook into `update_option_home` (via `Indexable_HomeUrl_Watcher`), but this only fires when the `home` option is updated through WordPress's `update_option()` API. If hosting providers change site URLs using `wp search-replace` or direct MySQL updates, those hooks do not fire, so Yoast never detects the change.

See #23127 for full reproduction steps and technical analysis.

<img width="1614" height="769" alt="AI Generator error showing callback to stale staging URL eqo.cfk.mybluehost.me failing with TLS certificate mismatch" src="https://github.com/user-attachments/assets/f516c7ac-bfb3-4f97-a9f5-62ee729cddd2" />

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the AI Generator's "Generate with AI" feature failed after a site's domain was changed, because stale callback URLs remained registered with the Yoast API from the original domain.

## Relevant technical choices:

* **Self-healing detection via hash comparison:** On each call to `get_or_request_access_token()`, the current callback URL is compared (via md5 hash) against a stored hash from the last successful `token_request()`. If they differ, stale tokens are deleted and a fresh `token_request()` re-registers the correct URLs.
* **md5 hash instead of storing the URL directly:** `wp search-replace` would update a stored URL in lockstep with the site URL, masking the change. A hash is immune to this because search-replace won't find the old domain string inside a hex digest.
* **First run after upgrade forces re-request:** When no stored hash exists (first use after upgrading to this version), `have_callback_urls_changed()` returns `true`, forcing a one-time fresh `token_request()`. This is an intentional tradeoff — it ensures all existing affected sites self-heal on their next "Generate with AI" click without any manual intervention (no SQL, no CLI, no user action). The cost is one extra `token_request()` per user on their first use after the upgrade. Subsequent uses are unaffected because the hash is stored after the first successful request.
* **Standalone WordPress option (`get_option`/`update_option`)** instead of `Options_Helper` via DI: The compiled DI container (`src/generated/container.php`) hardcodes the `Token_Manager` constructor signature. Adding a new constructor parameter would require recompiling the container. Using `get_option`/`update_option` directly avoids this and keeps the change minimal. The Yoast team may prefer to refactor this to use `Options_Helper` with a recompiled container in a follow-up — the runtime behavior is identical either way.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Set up a WordPress site at a temporary URL (or use an existing site and note its current URL)
2. Install and activate Yoast SEO and Yoast SEO Premium
3. Create a post, add a focus keyphrase, and click "Generate with AI" — confirm it works
4. Change the site URL (via Settings > General, `wp option update home`, or `wp search-replace`)
5. Edit a post and click "Generate with AI" again
6. **Expected:** The feature should work — the plugin detects the URL change, clears stale tokens, and re-registers with the correct callback URLs
7. Click "Generate with AI" a third time to confirm subsequent requests also work without re-requesting tokens

To verify the self-healing on upgrade (simulating an existing affected site):

1. On a site where "Generate with AI" is currently failing due to a prior domain change
2. Upload and activate this patched version of the plugin
3. Click "Generate with AI"
4. **Expected:** It works on the first click — no manual database cleanup needed

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* **AI Generator token authorization flow** — `Token_Manager::get_or_request_access_token()` now checks for URL changes before proceeding. This is the entry point for all AI Generator features (suggestions, usage).
* **First use after upgrade** — Every user's first "Generate with AI" click after upgrading will trigger a fresh `token_request()` regardless of whether their URL actually changed. This is by design to catch existing stale sites but should be verified to not cause issues at scale.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23127
