### PR TITLE
Add filter to control wpseo_taxonomy_meta option autoload

### DIFF
--- a/inc/options/class-wpseo-taxonomy-meta.php
+++ b/inc/options/class-wpseo-taxonomy-meta.php
@@ -544,7 +544,18 @@ class WPSEO_Taxonomy_Meta extends WPSEO_Option {
 	 * @return void
 	 */
 	private static function save_tax_meta( $tax_meta ) {
-		update_option( self::$name, $tax_meta );
+		/**
+		 * Filter to control the autoload behavior of the wpseo_taxonomy_meta option.
+		 *
+		 * Sites with many taxonomy terms may have a large wpseo_taxonomy_meta option
+		 * that can negatively impact performance when autoloaded on every request.
+		 * Return false to disable autoloading.
+		 *
+		 * @param bool $autoload Whether to autoload the option. Default true.
+		 */
+		$autoload = (bool) apply_filters( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', true );
+
+		update_option( self::$name, $tax_meta, $autoload );
 	}
 
 	/**

--- a/tests/WP/Inc/Options/Taxonomy_Meta_Test.php
+++ b/tests/WP/Inc/Options/Taxonomy_Meta_Test.php
@@ -99,6 +99,99 @@ final class Taxonomy_Meta_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the taxonomy meta option is autoloaded by default.
+	 *
+	 * @covers WPSEO_Taxonomy_Meta::set_values
+	 *
+	 * @return void
+	 */
+	public function test_save_tax_meta_autoloads_by_default() {
+		$term = self::factory()->term->create_and_get( [ 'taxonomy' => 'category' ] );
+
+		WPSEO_Taxonomy_Meta::set_values(
+			$term->term_id,
+			'category',
+			[ 'wpseo_title' => 'Test title' ],
+		);
+
+		$this->assertSame( 'on', $this->get_autoload_value( 'wpseo_taxonomy_meta' ) );
+	}
+
+	/**
+	 * Tests that the taxonomy meta option autoload can be disabled via filter.
+	 *
+	 * @covers WPSEO_Taxonomy_Meta::set_values
+	 *
+	 * @return void
+	 */
+	public function test_save_tax_meta_respects_autoload_filter() {
+		\add_filter( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', '__return_false' );
+
+		$term = self::factory()->term->create_and_get( [ 'taxonomy' => 'category' ] );
+
+		WPSEO_Taxonomy_Meta::set_values(
+			$term->term_id,
+			'category',
+			[ 'wpseo_title' => 'Test title' ],
+		);
+
+		$this->assertSame( 'off', $this->get_autoload_value( 'wpseo_taxonomy_meta' ) );
+
+		\remove_filter( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', '__return_false' );
+	}
+
+	/**
+	 * Tests that removing the filter restores autoload to on.
+	 *
+	 * @covers WPSEO_Taxonomy_Meta::set_values
+	 *
+	 * @return void
+	 */
+	public function test_save_tax_meta_restores_autoload_when_filter_removed() {
+		// First, disable autoload via filter.
+		\add_filter( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', '__return_false' );
+
+		$term = self::factory()->term->create_and_get( [ 'taxonomy' => 'category' ] );
+
+		WPSEO_Taxonomy_Meta::set_values(
+			$term->term_id,
+			'category',
+			[ 'wpseo_title' => 'Test title' ],
+		);
+
+		$this->assertSame( 'off', $this->get_autoload_value( 'wpseo_taxonomy_meta' ) );
+
+		// Remove the filter and save again.
+		\remove_filter( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', '__return_false' );
+
+		WPSEO_Taxonomy_Meta::set_values(
+			$term->term_id,
+			'category',
+			[ 'wpseo_title' => 'Updated title' ],
+		);
+
+		$this->assertSame( 'on', $this->get_autoload_value( 'wpseo_taxonomy_meta' ) );
+	}
+
+	/**
+	 * Gets the autoload value for an option directly from the database.
+	 *
+	 * @param string $option_name The option name.
+	 *
+	 * @return string The autoload value ('on' or 'off').
+	 */
+	private function get_autoload_value( $option_name ) {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT autoload FROM {$wpdb->options} WHERE option_name = %s",
+				$option_name,
+			),
+		);
+	}
+
+	/**
 	 * Tests if data gets validated as expected.
 	 *
 	 * @covers WPSEO_Taxonomy_Meta::validate_term_meta_data


### PR DESCRIPTION
## Context

Sites with many taxonomy terms can have a very large `wpseo_taxonomy_meta` option (users report 340 KB+) that gets autoloaded on every single request, negatively impacting performance — especially on hosts with limited object caching or DB cache size constraints.

This follows the same pattern as Yoast/wordpress-seo-premium#4000 which introduced a similar filter for redirect options.

## Summary

This PR can be summarized in the following changelog entry:

* Introduces the `Yoast\WP\SEO\taxonomy_meta_option_autoload` filter, which can be used to override the default setting of having the `wpseo_taxonomy_meta` option autoloaded.

## Relevant technical choices:

* The default behavior remains unchanged (autoload = `true`) to avoid affecting existing sites.
* The filter is applied in `save_tax_meta()`, the central save path for taxonomy meta, which is called on every term save.
* Other `update_option` calls (import, upgrade, split term) don't pass an explicit autoload param and thus preserve whatever value is currently set in the DB — this is the correct behavior since WordPress 6.6+.
* The `$include_in_all = false` property already signals this option isn't expected on every request, making it a good candidate for optional autoload control.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Test 1: Verify default behavior (autoload on)**
1. Edit a taxonomy term (e.g., a category) and set an SEO title via Yoast.
2. Save the term.
3. Check the `wp_options` table: `SELECT autoload FROM wp_options WHERE option_name = 'wpseo_taxonomy_meta'` — should be `on`.
4. Verify with Query Monitor that `wpseo_taxonomy_meta` is not queried separately (it's part of the autoloaded options batch).

**Test 2: Test the filter (autoload off)**
1. Add the following snippet to `functions.php`:
   ```php
   add_filter( 'Yoast\WP\SEO\taxonomy_meta_option_autoload', '__return_false' );
   ```
2. Edit a taxonomy term and save.
3. Check the DB: autoload should now be `off`.
4. Verify with Query Monitor that `wpseo_taxonomy_meta` now appears as a separate query when viewing a taxonomy archive.

**Test 3: Test filter removal (restores autoload on)**
1. Remove the snippet from `functions.php`.
2. Edit a taxonomy term and save.
3. Check the DB: autoload should be back to `on`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Different taxonomy types should be tested to ensure the filter works for categories, tags, and custom taxonomies alike.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Taxonomy meta saving — the `save_tax_meta()` method in `WPSEO_Taxonomy_Meta`.
* No other functionality is affected. The option continues to work identically; only the DB-level autoload flag changes when the filter is used.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

The filter is documented via its PHPDoc block in the code.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23121