### PR TITLE
Connect inline banner to the content suggestions modal flow

### DIFF
--- a/packages/js/src/ai-content-planner/block.js
+++ b/packages/js/src/ai-content-planner/block.js
@@ -4,6 +4,7 @@ import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
 import block from "./block.json";
 import { InlineBanner } from "./components/inline-banner";
+import { FEATURE_MODAL_STORE } from "./constants";
 
 const INJECTED_STYLE_ID = "yoast-seo-tailwind-css";
 
@@ -22,10 +23,15 @@ const Edit = ( { clientId } ) => {
 	const ref = useRef( null );
 	const isPremium = useSelect( select => select( "yoast-seo/editor" ).getIsPremium(), [] );
 	const { removeBlock } = useDispatch( "core/block-editor" );
+	const { openModal } = useDispatch( FEATURE_MODAL_STORE );
 
 	const handleDismiss = useCallback( () => {
 		removeBlock( clientId );
 	}, [ removeBlock, clientId ] );
+
+	const handleClick = useCallback( () => {
+		openModal( true );
+	}, [ openModal ] );
 
 	useEffect( () => {
 		// Inject the Tailwind stylesheet into the editor iframe if needed.
@@ -49,6 +55,7 @@ const Edit = ( { clientId } ) => {
 			<InlineBanner
 				isPremium={ isPremium }
 				onDismiss={ handleDismiss }
+				onClick={ handleClick }
 			/>
 		</div>
 	);

--- a/packages/js/src/ai-content-planner/block.js
+++ b/packages/js/src/ai-content-planner/block.js
@@ -4,7 +4,7 @@ import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
 import block from "./block.json";
 import { InlineBanner } from "./components/inline-banner";
-import { FEATURE_MODAL_STORE } from "./constants";
+import { CONTENT_PLANNER_STORE } from "./constants";
 
 const INJECTED_STYLE_ID = "yoast-seo-tailwind-css";
 
@@ -23,7 +23,7 @@ const Edit = ( { clientId } ) => {
 	const ref = useRef( null );
 	const isPremium = useSelect( select => select( "yoast-seo/editor" ).getIsPremium(), [] );
 	const { removeBlock } = useDispatch( "core/block-editor" );
-	const { openModal } = useDispatch( FEATURE_MODAL_STORE );
+	const { openModal } = useDispatch( CONTENT_PLANNER_STORE );
 
 	const handleDismiss = useCallback( () => {
 		removeBlock( clientId );

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -5,11 +5,11 @@ import { OneSparkNote } from "./one-spark-note";
 /**
  * Get the content of the modal based on whether the canvas is empty or not.
  *
- * @param {boolean} isEmptyCanvas Whether the post has content or not.
+ * @param {boolean} isEmptyPost Whether the post has content or not.
  * @returns {object} The content of the modal.
  */
-const getModalContent = ( isEmptyCanvas ) => {
-	if ( isEmptyCanvas ) {
+const getModalContent = ( isEmptyPost ) => {
+	if ( isEmptyPost ) {
 		return {
 			title: __( "Looking for inspiration?", "wordpress-seo" ),
 			description: __( "Yoast identifies content gaps in your site structure and recommends topics that strengthen your topical authority.", "wordpress-seo" ),
@@ -34,15 +34,15 @@ const getModalContent = ( isEmptyCanvas ) => {
 /**
  * The modal that is shown when the user clicks the "Get content suggestions" button.
  *
- * @param {boolean} isEmptyCanvas Whether the post has content or not.
+ * @param {boolean} isEmptyPost Whether the post has content or not.
  * @param {boolean} isPremium Whether the user has a premium subscription or not.
  * @param {boolean} isUpsell Whether the modal is shown as an upsell or not.
  * @param {function} onClick The function to call when the user clicks the "Get content suggestions" button.
  * @param {string} upsellLink The link to the upsell page.
  * @returns {JSX.Element} The ApproveModal content.
  */
-export const ApproveModal = ( { isEmptyCanvas, isPremium, isUpsell, onClick, upsellLink } ) => {
-	const { title, description } = getModalContent( isEmptyCanvas );
+export const ApproveModal = ( { isEmptyPost, isPremium, isUpsell, onClick, upsellLink } ) => {
+	const { title, description } = getModalContent( isEmptyPost );
 	const svgAriaProps = useSvgAria();
 
 	return (

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -1,38 +1,27 @@
 import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
-import { Button, Root, useToggleState } from "@yoast/ui-library";
-import { FeatureModal } from "./feature-modal";
+import { useDispatch } from "@wordpress/data";
+import { Button, Root } from "@yoast/ui-library";
+import { FEATURE_MODAL_STORE } from "../constants";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
  *
- * @param {Object}  props               The component props.
- * @param {string}  props.location      The location where the editor item is rendered. Can be "sidebar" or "metabox".
- * @param {boolean} props.isPremium     Whether the user has a premium add-on activated.
- * @param {boolean} props.isEmptyCanvas Whether the editor canvas has no content.
- * @param {boolean} props.isUpsell     Whether to show the upsell variant of the modal.
- * @param {string}  props.upsellLink   The link to the upsell page for the content planner feature.
+ * @param {Object}  props           The component props.
+ * @param {string}  props.location  The location where the editor item is rendered. Can be "sidebar" or "metabox".
  * @returns {JSX.Element} The Content Planner section in the sidebar.
  */
-export const ContentPlannerEditorItem = ( { location, isPremium, isEmptyCanvas, isUpsell, upsellLink } ) => {
-	const [ isFeatureModalOpen, , , openFeatureModal, closeFeatureModal ] = useToggleState( false );
+export const ContentPlannerEditorItem = ( { location } ) => {
+	const { openModal } = useDispatch( FEATURE_MODAL_STORE );
 
-	// Temporary: will be wired to handleApplyOutline (store-based outline application) once the blocks PR is merged.
-	const handleAddOutline = useCallback( () => {}, [] );
+	const handleClick = useCallback( () => {
+		openModal( false );
+	}, [ openModal ] );
 
 	return <Root><div className="yst-p-4">
-		<Button variant="ai-secondary" onClick={ openFeatureModal } className={ location === "sidebar" ? "yst-w-full" : "" }>
+		<Button variant="ai-secondary" onClick={ handleClick } className={ location === "sidebar" ? "yst-w-full" : "" }>
 			{ __( "Get content suggestions", "wordpress-seo" ) }
 		</Button>
-		<FeatureModal
-			isOpen={ isFeatureModalOpen }
-			onClose={ closeFeatureModal }
-			isEmptyCanvas={ isEmptyCanvas }
-			isPremium={ isPremium }
-			isUpsell={ isUpsell }
-			upsellLink={ upsellLink }
-			onAddOutline={ handleAddOutline }
-		/>
 	</div>
 	</Root>;
 };

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -1,19 +1,16 @@
 import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
-import { useDispatch } from "@wordpress/data";
 import { Button, Root } from "@yoast/ui-library";
-import { FEATURE_MODAL_STORE } from "../constants";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
  *
- * @param {Object}  props           The component props.
- * @param {string}  props.location  The location where the editor item is rendered. Can be "sidebar" or "metabox".
+ * @param {Object}   props           The component props.
+ * @param {string}   props.location  The location where the editor item is rendered. Can be "sidebar" or "metabox".
+ * @param {Function} props.openModal The function to open the content planner modal.
  * @returns {JSX.Element} The Content Planner section in the sidebar.
  */
-export const ContentPlannerEditorItem = ( { location } ) => {
-	const { openModal } = useDispatch( FEATURE_MODAL_STORE );
-
+export const ContentPlannerEditorItem = ( { location, openModal } ) => {
 	const handleClick = useCallback( () => {
 		openModal( false );
 	}, [ openModal ] );

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -26,24 +26,6 @@ const getPanelStyles = ( status ) => ( {
 } );
 
 /**
- * Returns the enter transition props for the suggestions panel.
- * Applies a cross-fade when coming from the approve modal, instant otherwise.
- *
- * @param {boolean} fromApproveModal Whether the suggestions are entering from the approve modal.
- * @returns {Object} The enter, enterFrom, and enterTo transition class strings.
- */
-const getSuggestionsEnterTransition = ( fromApproveModal ) => {
-	if ( fromApproveModal ) {
-		return {
-			enter: "yst-transition-opacity yst-duration-300 yst-delay-300",
-			enterFrom: "yst-opacity-0",
-			enterTo: "yst-opacity-100",
-		};
-	}
-	return { enter: "", enterFrom: "", enterTo: "" };
-};
-
-/**
  * Renders the suggestions modal, with a cross-fade transition when coming from
  * the approve modal and an instant render otherwise.
  *
@@ -57,14 +39,13 @@ const getSuggestionsEnterTransition = ( fromApproveModal ) => {
  */
 const SuggestionsPanel = ( { isVisible, cameFromApproveModal, status, isPremium, onSuggestionClick } ) => {
 	if ( cameFromApproveModal ) {
-		const transition = getSuggestionsEnterTransition( true );
 		return (
 			<Transition
 				as={ Fragment }
 				show={ isVisible }
-				enter={ transition.enter }
-				enterFrom={ transition.enterFrom }
-				enterTo={ transition.enterTo }
+				enter="yst-transition-opacity yst-duration-300 yst-delay-300"
+				enterFrom="yst-opacity-0"
+				enterTo="yst-opacity-100"
 			>
 				<div>
 					<ContentSuggestionsModal

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -9,8 +9,7 @@ import { Transition } from "@headlessui/react";
 import { noop } from "lodash";
 import { buildBlocksFromOutline } from "../helpers/build-blocks-from-outline";
 import { applyPostMetaFromOutline } from "../helpers/apply-post-meta-from-outline";
-import { STORE_NAME } from "../store";
-import { FEATURE_MODAL_STATUS } from "../constants";
+import { FEATURE_MODAL_STATUS, CONTENT_PLANNER_STORE } from "../constants";
 
 const HIDDEN_STYLE = { display: "none" };
 
@@ -121,7 +120,7 @@ export const FeatureModal = ( {
 	const [ hasVisitedReplace, setHasVisitedReplace ] = useState( false );
 	const editedOutlineRef = useRef( null );
 	const { resetBlocks } = useDispatch( "core/block-editor" );
-	const { getContentOutline } = useDispatch( STORE_NAME );
+	const { getContentOutline } = useDispatch( CONTENT_PLANNER_STORE );
 
 	const handleGetSuggestionsClick = useCallback( () => {
 		setCameFromApproveModal( true );
@@ -144,7 +143,7 @@ export const FeatureModal = ( {
 		// receive the edited outline so the API can return content notes that match
 		// the user's edits. At that point the notesByHeading lookup below can be removed.
 		await getContentOutline( selectedSuggestion );
-		const apiOutline = select( STORE_NAME ).selectContentOutline();
+		const apiOutline = select( CONTENT_PLANNER_STORE ).selectContentOutline();
 
 		// Build metadata from the user's edits in the modal.
 		const metaOutline = editedOutline

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -215,7 +215,7 @@ export const FeatureModal = ( {
 			setHasVisitedReplace( false );
 			return;
 		}
-		setCameFromApproveModal( initialStatus === FEATURE_MODAL_STATUS.contentSuggestionsLoading );
+		setCameFromApproveModal( false );
 		setStatus( initialStatus );
 	}, [ isOpen, initialStatus ] );
 

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -14,12 +14,12 @@ const HIDDEN_STYLE = { display: "none" };
  * Returns the appropriate handler for adding an outline to the post.
  * When the canvas is empty, skips the replace confirmation and applies directly.
  *
- * @param {boolean}  isEmptyCanvas Whether the post has content or not.
+ * @param {boolean}  isEmptyPost Whether the post is empty or not.
  * @param {Function} onConfirm     The handler that applies the outline directly.
  * @param {Function} onRequest     The handler that shows the replace confirmation first.
  * @returns {Function} The appropriate outline handler.
  */
-const getOutlineHandler = ( isEmptyCanvas, onConfirm, onRequest ) => isEmptyCanvas ? onConfirm : onRequest;
+const getOutlineHandler = ( isEmptyPost, onConfirm, onRequest ) => isEmptyPost ? onConfirm : onRequest;
 
 /**
  * Returns the display styles for the outline and confirmation panels.
@@ -103,7 +103,7 @@ const SuggestionsPanel = ( { isVisible, cameFromApproveModal, status, isPremium,
  *
  * @param {boolean}       isOpen                    Whether the modal is open or not.
  * @param {function}      onClose                   The function to call when the modal is closed.
- * @param {boolean}       isEmptyCanvas             Whether the post has content or not.
+ * @param {boolean}       isEmptyPost             Whether the post has content or not.
  * @param {boolean}       isPremium                 Whether the user has a premium subscription or not.
  * @param {boolean}       isUpsell                  Whether the modal is shown as an upsell or not.
  * @param {string}        upsellLink                The link to the upsell page.
@@ -115,7 +115,7 @@ const SuggestionsPanel = ( { isVisible, cameFromApproveModal, status, isPremium,
 export const FeatureModal = ( {
 	isOpen,
 	onClose,
-	isEmptyCanvas,
+	isEmptyPost,
 	isPremium,
 	isUpsell,
 	upsellLink,
@@ -200,7 +200,7 @@ export const FeatureModal = ( {
 				>
 					<div className="yst-w-96 yst-flex yst-items-center yst-justify-center yst-mx-auto">
 						<ApproveModal
-							isEmptyCanvas={ isEmptyCanvas }
+							isEmptyPost={ isEmptyPost }
 							isPremium={ isPremium }
 							isUpsell={ isUpsell }
 							onClick={ handleGetSuggestionsClick }
@@ -226,7 +226,7 @@ export const FeatureModal = ( {
 						<ContentOutlineModal
 							isActive={ status === FEATURE_MODAL_STATUS.contentOutline }
 							onBack={ handleBackToSuggestions }
-							onAddOutline={ getOutlineHandler( isEmptyCanvas, handleConfirmReplace, handleRequestAddOutline ) }
+							onAddOutline={ getOutlineHandler( isEmptyPost, handleConfirmReplace, handleRequestAddOutline ) }
 							sparksLimit={ 10 }
 							sparksUsage={ 1 }
 							category="WordPress"

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -11,6 +11,17 @@ import { FEATURE_MODAL_STATUS } from "../constants";
 const HIDDEN_STYLE = { display: "none" };
 
 /**
+ * Returns the appropriate handler for adding an outline to the post.
+ * When the canvas is empty, skips the replace confirmation and applies directly.
+ *
+ * @param {boolean}  isEmptyCanvas Whether the post has content or not.
+ * @param {Function} onConfirm     The handler that applies the outline directly.
+ * @param {Function} onRequest     The handler that shows the replace confirmation first.
+ * @returns {Function} The appropriate outline handler.
+ */
+const getOutlineHandler = ( isEmptyCanvas, onConfirm, onRequest ) => isEmptyCanvas ? onConfirm : onRequest;
+
+/**
  * Returns the display styles for the outline and confirmation panels.
  * Both are kept mounted and toggled via display:none to avoid layout flash.
  *
@@ -90,17 +101,27 @@ const SuggestionsPanel = ( { isVisible, cameFromApproveModal, status, isPremium,
  * The modal that orchestrates the flow between the approve, content suggestions,
  * content outline, and replace content confirmation views.
  *
- * @param {boolean}  isOpen        Whether the modal is open or not.
- * @param {function} onClose       The function to call when the modal is closed.
- * @param {boolean}  isEmptyCanvas Whether the post has content or not.
- * @param {boolean}  isPremium     Whether the user has a premium subscription or not.
- * @param {boolean}  isUpsell      Whether the modal is shown as an upsell or not.
- * @param {string}   upsellLink    The link to the upsell page.
- * @param {function} onAddOutline  The function to call when the user adds the outline to the post.
+ * @param {boolean}       isOpen                    Whether the modal is open or not.
+ * @param {function}      onClose                   The function to call when the modal is closed.
+ * @param {boolean}       isEmptyCanvas             Whether the post has content or not.
+ * @param {boolean}       isPremium                 Whether the user has a premium subscription or not.
+ * @param {boolean}       isUpsell                  Whether the modal is shown as an upsell or not.
+ * @param {string}        upsellLink                The link to the upsell page.
+ * @param {function}      onAddOutline              The function to call when the user adds the outline to the post.
+ * @param {string|null}   initialStatus             The status to start at when the modal opens. Defaults to null (starts at idle/ApproveModal).
  * @returns {JSX.Element} The Content Planner Feature Modal.
  */
 
-export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUpsell, upsellLink, onAddOutline = noop } ) => {
+export const FeatureModal = ( {
+	isOpen,
+	onClose,
+	isEmptyCanvas,
+	isPremium,
+	isUpsell,
+	upsellLink,
+	onAddOutline = noop,
+	initialStatus = null,
+} ) => {
 	const [ status, setStatus ] = useState( null );
 	const [ selectedSuggestion, setSelectedSuggestion ] = useState( null );
 	const [ cameFromApproveModal, setCameFromApproveModal ] = useState( false );
@@ -149,12 +170,15 @@ export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUps
 
 	useEffect( () => {
 		if ( ! isOpen ) {
-			setStatus( FEATURE_MODAL_STATUS.idle );
+			setStatus( null );
 			setCameFromApproveModal( false );
 			setSelectedSuggestion( null );
 			setHasVisitedReplace( false );
+			return;
 		}
-	}, [ isOpen ] );
+		setCameFromApproveModal( initialStatus === FEATURE_MODAL_STATUS.contentSuggestionsLoading );
+		setStatus( initialStatus );
+	}, [ isOpen, initialStatus ] );
 
 	const isSuggestionsVisible =
 		status === FEATURE_MODAL_STATUS.contentSuggestionsSuccess ||
@@ -202,7 +226,7 @@ export const FeatureModal = ( { isOpen, onClose, isEmptyCanvas, isPremium, isUps
 						<ContentOutlineModal
 							isActive={ status === FEATURE_MODAL_STATUS.contentOutline }
 							onBack={ handleBackToSuggestions }
-							onAddOutline={ handleRequestAddOutline }
+							onAddOutline={ getOutlineHandler( isEmptyCanvas, handleConfirmReplace, handleRequestAddOutline ) }
 							sparksLimit={ 10 }
 							sparksUsage={ 1 }
 							category="WordPress"

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -10,9 +10,10 @@ import { OneSparkNote } from "./one-spark-note";
  * @param {object}    props     The block props passed by Gutenberg.
  * @param {boolean}  props.isPremium Whether the user has a premium add-on activated.
  * @param {Function} props.onDismiss The function to call when the banner is dismissed.
+ * @param {Function} props.onClick   The function to call when the "Get content suggestions" button is clicked.
  * @returns {JSX.Element} The inline banner with the button.
  */
-export const InlineBanner = ( { isPremium, onDismiss } ) => {
+export const InlineBanner = ( { isPremium, onDismiss, onClick } ) => {
 	const ariaProps = useSvgAria();
 	return <Root><div className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg yst-max-w">
 		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1">
@@ -31,7 +32,7 @@ export const InlineBanner = ( { isPremium, onDismiss } ) => {
 				<OneSparkNote />
 				<span aria-hidden="true">·</span>
 			</>  }
-			<Button variant="ai-primary">
+			<Button variant="ai-primary" onClick={ onClick }>
 				{ __( "Get content suggestions", "wordpress-seo" ) }
 			</Button>
 		</div>

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -1,4 +1,11 @@
 /**
+ * The store name for the content planner UI state.
+ *
+ * @type {string}
+ */
+export const STORE_NAME = "yoast-seo/content-planner";
+
+/**
  * The possible statuses for the FeatureModal flow.
  *
  * @type {Object<string, string>}

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -3,7 +3,7 @@
  *
  * @type {string}
  */
-export const FEATURE_MODAL_STORE = "yoast-seo/content-planner";
+export const CONTENT_PLANNER_STORE = "yoast-seo/content-planner";
 
 /**
  * The possible statuses for the FeatureModal flow.

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -3,7 +3,7 @@
  *
  * @type {string}
  */
-export const STORE_NAME = "yoast-seo/content-planner";
+export const FEATURE_MODAL_STORE = "yoast-seo/content-planner";
 
 /**
  * The possible statuses for the FeatureModal flow.

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -1,5 +1,5 @@
 /**
- * The store name for the content planner UI state.
+ * The store name for the content planner feature.
  *
  * @type {string}
  */

--- a/packages/js/src/ai-content-planner/containers/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/containers/content-planner-editor-item.js
@@ -1,3 +1,13 @@
+import { compose } from "@wordpress/compose";
+import { withDispatch } from "@wordpress/data";
 import { ContentPlannerEditorItem } from "../components/content-planner-editor-item";
+import { CONTENT_PLANNER_STORE } from "../constants";
 
-export default ContentPlannerEditorItem;
+export default compose( [
+	withDispatch( ( dispatch ) => {
+		const { openModal } = dispatch( CONTENT_PLANNER_STORE );
+		return {
+			openModal,
+		};
+	} ),
+] )( ContentPlannerEditorItem );

--- a/packages/js/src/ai-content-planner/containers/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/containers/content-planner-editor-item.js
@@ -1,16 +1,3 @@
-import { compose } from "@wordpress/compose";
-import { withSelect } from "@wordpress/data";
-import { count } from "@wordpress/wordcount";
 import { ContentPlannerEditorItem } from "../components/content-planner-editor-item";
 
-export default compose( [
-	withSelect( select => {
-		const content = select( "core/editor" ).getEditedPostContent();
-
-		return {
-			isPremium: select( "yoast-seo/editor" ).getIsPremium(),
-			isEmptyCanvas: count( content, "words", {} ) === 0,
-			upsellLink: select( "yoast-seo/editor" ).selectLink( "https://yoa.st/content-planner-approve-modal" ),
-		};
-	} ),
-] )( ContentPlannerEditorItem );
+export default ContentPlannerEditorItem;

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -5,7 +5,7 @@ import { count } from "@wordpress/wordcount";
 import { registerPlugin } from "@wordpress/plugins";
 import { registerStore } from "./store";
 import { FeatureModal } from "./components/feature-modal";
-import { FEATURE_MODAL_STORE, FEATURE_MODAL_STATUS } from "./constants";
+import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS } from "./constants";
 import "./block";
 
 /**
@@ -71,8 +71,8 @@ export const ContentPlannerEditorPlugin = () => {
 			isNewPost: select( "core/editor" ).isEditedPostNew(),
 			postType: select( "core/editor" ).getCurrentPostType(),
 			blocks: select( "core/block-editor" ).getBlocks(),
-			isModalOpen: select( FEATURE_MODAL_STORE ).selectIsModalOpen(),
-			skipApprove: select( FEATURE_MODAL_STORE ).selectShouldSkipApprove(),
+			isModalOpen: select( CONTENT_PLANNER_STORE ).selectIsModalOpen(),
+			skipApprove: select( CONTENT_PLANNER_STORE ).selectShouldSkipApprove(),
 			isPremium: select( "yoast-seo/editor" ).getIsPremium(),
 			isEmptyPost: count( content, "words", {} ) === 0,
 			upsellLink: select( "yoast-seo/editor" ).selectLink( "https://yoa.st/content-planner-approve-modal" ),
@@ -80,7 +80,7 @@ export const ContentPlannerEditorPlugin = () => {
 	}, [] );
 
 	const { insertBlock, removeBlock } = useDispatch( "core/block-editor" );
-	const { closeModal } = useDispatch( FEATURE_MODAL_STORE );
+	const { closeModal } = useDispatch( CONTENT_PLANNER_STORE );
 
 	useEffect( () => {
 		if ( hasInserted.current || ! isNewPost || postType !== "post" ) {

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -1,8 +1,11 @@
 import { createBlock } from "@wordpress/blocks";
-import { useSelect, useDispatch } from "@wordpress/data";
-import { useEffect, useRef } from "@wordpress/element";
+import { useSelect, useDispatch, select as wpSelect } from "@wordpress/data";
+import { useEffect, useRef, useCallback } from "@wordpress/element";
+import { count } from "@wordpress/wordcount";
 import { registerPlugin } from "@wordpress/plugins";
 import { registerStore } from "./store";
+import { FeatureModal } from "./components/feature-modal";
+import { FEATURE_MODAL_STORE, FEATURE_MODAL_STATUS } from "./constants";
 import "./block";
 
 /**
@@ -39,24 +42,45 @@ export function insertBannerAfterFirstParagraph( blocks, insertBlock ) {
 }
 
 /**
+ * Removes the Content Planner Banner block from the editor if present.
+ *
+ * @param {Function} removeBlock The block editor removeBlock dispatch function.
+ * @returns {void}
+ */
+function removeBannerBlock( removeBlock ) {
+	const blocks = wpSelect( "core/block-editor" ).getBlocks();
+	const banner = blocks.find( b => b.name === "yoast/content-planner-banner" );
+	if ( banner ) {
+		removeBlock( banner.clientId );
+	}
+}
+
+/**
  * Editor plugin that auto-inserts the Content Planner Banner block
- * after the first paragraph on new posts.
+ * after the first paragraph on new posts and renders the shared
+ * FeatureModal controlled by the content planner store.
  *
- * Also ensures a paragraph block exists when the canvas is empty,
- * so the banner has a block to follow.
- *
- * @returns {null} Renders nothing.
+ * @returns {JSX.Element|null} The FeatureModal when open, otherwise null.
  */
 export const ContentPlannerEditorPlugin = () => {
 	const hasInserted = useRef( false );
 
-	const { isNewPost, postType, blocks } = useSelect( select => ( {
-		isNewPost: select( "core/editor" ).isEditedPostNew(),
-		postType: select( "core/editor" ).getCurrentPostType(),
-		blocks: select( "core/block-editor" ).getBlocks(),
-	} ), [] );
+	const { isNewPost, postType, blocks, isModalOpen, skipApprove, isPremium, isEmptyCanvas, upsellLink } = useSelect( select => {
+		const content = select( "core/editor" ).getEditedPostContent();
+		return {
+			isNewPost: select( "core/editor" ).isEditedPostNew(),
+			postType: select( "core/editor" ).getCurrentPostType(),
+			blocks: select( "core/block-editor" ).getBlocks(),
+			isModalOpen: select( FEATURE_MODAL_STORE ).selectIsModalOpen(),
+			skipApprove: select( FEATURE_MODAL_STORE ).selectShouldSkipApprove(),
+			isPremium: select( "yoast-seo/editor" ).getIsPremium(),
+			isEmptyCanvas: count( content, "words", {} ) === 0,
+			upsellLink: select( "yoast-seo/editor" ).selectLink( "https://yoa.st/content-planner-approve-modal" ),
+		};
+	}, [] );
 
-	const { insertBlock } = useDispatch( "core/block-editor" );
+	const { insertBlock, removeBlock } = useDispatch( "core/block-editor" );
+	const { closeModal } = useDispatch( FEATURE_MODAL_STORE );
 
 	useEffect( () => {
 		if ( hasInserted.current || ! isNewPost || postType !== "post" ) {
@@ -66,7 +90,26 @@ export const ContentPlannerEditorPlugin = () => {
 		hasInserted.current = insertBannerAfterFirstParagraph( blocks, insertBlock );
 	}, [ blocks, isNewPost, postType, insertBlock ] );
 
-	return null;
+	const handleClose = useCallback( () => {
+		closeModal();
+	}, [ closeModal ] );
+
+	// Temporary: will be wired to handleApplyOutline (store-based outline application) once the blocks PR is merged.
+	const handleAddOutline = useCallback( () => {
+		removeBannerBlock( removeBlock );
+	}, [ removeBlock ] );
+
+	return (
+		<FeatureModal
+			isOpen={ isModalOpen }
+			onClose={ handleClose }
+			isEmptyCanvas={ isEmptyCanvas }
+			isPremium={ isPremium }
+			upsellLink={ upsellLink }
+			onAddOutline={ handleAddOutline }
+			initialStatus={ skipApprove ? FEATURE_MODAL_STATUS.contentSuggestionsLoading : null }
+		/>
+	);
 };
 
 /**

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -7,13 +7,11 @@ import { useBlockProps } from "@wordpress/block-editor";
 import { __ } from "@wordpress/i18n";
 import { FeatureModal } from "./components/feature-modal";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS } from "./constants";
-import { modalStore } from "./store/modal";
 import "./block";
 import { store } from "./store";
 import { ContentSuggestionBlock } from "./components/content-suggestion-block";
 
 register( store );
-register( modalStore );
 
 /**
  * Inserts a Content Planner Banner block after the first paragraph in the editor.

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -7,12 +7,13 @@ import { useBlockProps } from "@wordpress/block-editor";
 import { __ } from "@wordpress/i18n";
 import { FeatureModal } from "./components/feature-modal";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS } from "./constants";
-import { registerModalStore } from "./store/modal";
+import { modalStore } from "./store/modal";
 import "./block";
 import { store } from "./store";
 import { ContentSuggestionBlock } from "./components/content-suggestion-block";
 
 register( store );
+register( modalStore );
 
 /**
  * Inserts a Content Planner Banner block after the first paragraph in the editor.
@@ -178,6 +179,5 @@ registerBlockType( "yoast-seo/content-suggestion", {
  * @returns {void}
  */
 export default function initContentPlanner() {
-	registerModalStore();
 	registerPlugin( "yoast-content-planner", { render: ContentPlannerEditorPlugin } );
 }

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -2,6 +2,7 @@ import { createBlock } from "@wordpress/blocks";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useEffect, useRef } from "@wordpress/element";
 import { registerPlugin } from "@wordpress/plugins";
+import { registerStore } from "./store";
 import "./block";
 
 /**
@@ -77,5 +78,6 @@ export const ContentPlannerEditorPlugin = () => {
  * @returns {void}
  */
 export default function initContentPlanner() {
+	registerStore();
 	registerPlugin( "yoast-content-planner", { render: ContentPlannerEditorPlugin } );
 }

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -65,7 +65,7 @@ function removeBannerBlock( removeBlock ) {
 export const ContentPlannerEditorPlugin = () => {
 	const hasInserted = useRef( false );
 
-	const { isNewPost, postType, blocks, isModalOpen, skipApprove, isPremium, isEmptyCanvas, upsellLink } = useSelect( select => {
+	const { isNewPost, postType, blocks, isModalOpen, skipApprove, isPremium, isEmptyPost, upsellLink } = useSelect( select => {
 		const content = select( "core/editor" ).getEditedPostContent();
 		return {
 			isNewPost: select( "core/editor" ).isEditedPostNew(),
@@ -74,7 +74,7 @@ export const ContentPlannerEditorPlugin = () => {
 			isModalOpen: select( FEATURE_MODAL_STORE ).selectIsModalOpen(),
 			skipApprove: select( FEATURE_MODAL_STORE ).selectShouldSkipApprove(),
 			isPremium: select( "yoast-seo/editor" ).getIsPremium(),
-			isEmptyCanvas: count( content, "words", {} ) === 0,
+			isEmptyPost: count( content, "words", {} ) === 0,
 			upsellLink: select( "yoast-seo/editor" ).selectLink( "https://yoa.st/content-planner-approve-modal" ),
 		};
 	}, [] );
@@ -103,7 +103,7 @@ export const ContentPlannerEditorPlugin = () => {
 		<FeatureModal
 			isOpen={ isModalOpen }
 			onClose={ handleClose }
-			isEmptyCanvas={ isEmptyCanvas }
+			isEmptyPost={ isEmptyPost }
 			isPremium={ isPremium }
 			upsellLink={ upsellLink }
 			onAddOutline={ handleAddOutline }

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -1,5 +1,5 @@
 import { createReduxStore, register } from "@wordpress/data";
-import { STORE_NAME } from "../constants";
+import { FEATURE_MODAL_STORE } from "../constants";
 
 const OPEN_MODAL = "OPEN_MODAL";
 const CLOSE_MODAL = "CLOSE_MODAL";
@@ -70,7 +70,7 @@ const selectors = {
 	},
 };
 
-const store = createReduxStore( STORE_NAME, {
+const store = createReduxStore( FEATURE_MODAL_STORE, {
 	reducer,
 	actions,
 	selectors,

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -24,8 +24,6 @@ import {
 	getInitialModalState,
 } from "./modal";
 
-export { CONTENT_PLANNER_STORE as STORE_NAME };
-
 export const store = createReduxStore( CONTENT_PLANNER_STORE, {
 	actions: {
 		...contentSuggestionsActions,

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -70,7 +70,7 @@ const selectors = {
 	},
 };
 
-const store = createReduxStore( FEATURE_MODAL_STORE, {
+export const store = createReduxStore( FEATURE_MODAL_STORE, {
 	reducer,
 	actions,
 	selectors,

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -1,5 +1,5 @@
 import { createReduxStore, register } from "@wordpress/data";
-import { FEATURE_MODAL_STORE } from "../constants";
+import { CONTENT_PLANNER_STORE } from "../constants";
 
 const OPEN_MODAL = "OPEN_MODAL";
 const CLOSE_MODAL = "CLOSE_MODAL";
@@ -70,7 +70,7 @@ const selectors = {
 	},
 };
 
-export const store = createReduxStore( FEATURE_MODAL_STORE, {
+export const store = createReduxStore( CONTENT_PLANNER_STORE, {
 	reducer,
 	actions,
 	selectors,

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -1,0 +1,86 @@
+import { createReduxStore, register } from "@wordpress/data";
+import { STORE_NAME } from "../constants";
+
+const OPEN_MODAL = "OPEN_MODAL";
+const CLOSE_MODAL = "CLOSE_MODAL";
+
+const DEFAULT_STATE = {
+	isOpen: false,
+	skipApprove: false,
+};
+
+/**
+ * Reducer for the content planner modal UI state.
+ *
+ * @param {Object} state  The current state.
+ * @param {Object} action The dispatched action.
+ * @returns {Object} The new state.
+ */
+const reducer = ( state = DEFAULT_STATE, action ) => {
+	switch ( action.type ) {
+		case OPEN_MODAL:
+			return { ...state, isOpen: true, skipApprove: Boolean( action.skipApprove ) };
+		case CLOSE_MODAL:
+			return { ...DEFAULT_STATE };
+		default:
+			return state;
+	}
+};
+
+const actions = {
+	/**
+	 * Opens the content planner modal.
+	 *
+	 * @param {boolean} [skipApprove=false] Whether to skip the approve modal step.
+	 * @returns {Object} The action object.
+	 */
+	openModal( skipApprove = false ) {
+		return { type: OPEN_MODAL, skipApprove };
+	},
+
+	/**
+	 * Closes the content planner modal and resets state.
+	 *
+	 * @returns {Object} The action object.
+	 */
+	closeModal() {
+		return { type: CLOSE_MODAL };
+	},
+};
+
+const selectors = {
+	/**
+	 * Returns whether the modal is open.
+	 *
+	 * @param {Object} state The store state.
+	 * @returns {boolean} Whether the modal is open.
+	 */
+	selectIsModalOpen( state ) {
+		return state.isOpen;
+	},
+
+	/**
+	 * Returns whether the approve modal step should be skipped.
+	 *
+	 * @param {Object} state The store state.
+	 * @returns {boolean} Whether to skip the approve modal.
+	 */
+	selectShouldSkipApprove( state ) {
+		return state.skipApprove;
+	},
+};
+
+const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+/**
+ * Registers the content planner store to WP data's default registry.
+ *
+ * @returns {void}
+ */
+export const registerStore = () => {
+	register( store );
+};

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -1,4 +1,5 @@
 import { combineReducers, createReduxStore } from "@wordpress/data";
+import { CONTENT_PLANNER_STORE } from "../constants";
 import {
 	CONTENT_SUGGESTIONS_NAME,
 	contentSuggestionsActions,
@@ -15,17 +16,26 @@ import {
 	contentOutlineSelectors,
 	getInitialContentOutlineState,
 } from "./content-outline";
+import {
+	MODAL_NAME,
+	modalActions,
+	modalReducer,
+	modalSelectors,
+	getInitialModalState,
+} from "./modal";
 
-export const STORE_NAME = "yoast-seo/post-planner";
+export { CONTENT_PLANNER_STORE as STORE_NAME };
 
-export const store = createReduxStore( STORE_NAME, {
+export const store = createReduxStore( CONTENT_PLANNER_STORE, {
 	actions: {
 		...contentSuggestionsActions,
 		...contentOutlineActions,
+		...modalActions,
 	},
 	selectors: {
 		...contentSuggestionsSelectors,
 		...contentOutlineSelectors,
+		...modalSelectors,
 	},
 	controls: {
 		...contentSuggestionsControls,
@@ -34,9 +44,11 @@ export const store = createReduxStore( STORE_NAME, {
 	initialState: {
 		[ CONTENT_SUGGESTIONS_NAME ]: getInitialContentSuggestionsState(),
 		[ CONTENT_OUTLINE_NAME ]: getInitialContentOutlineState(),
+		[ MODAL_NAME ]: getInitialModalState(),
 	},
 	reducer: combineReducers( {
 		[ CONTENT_SUGGESTIONS_NAME ]: contentSuggestionsReducer,
 		[ CONTENT_OUTLINE_NAME ]: contentOutlineReducer,
+		[ MODAL_NAME ]: modalReducer,
 	} ),
 } );

--- a/packages/js/src/ai-content-planner/store/modal.js
+++ b/packages/js/src/ai-content-planner/store/modal.js
@@ -1,5 +1,6 @@
-import { createReduxStore } from "@wordpress/data";
-import { CONTENT_PLANNER_STORE } from "../constants";
+import { get } from "lodash";
+
+export const MODAL_NAME = "modal";
 
 const OPEN_MODAL = "OPEN_MODAL";
 const CLOSE_MODAL = "CLOSE_MODAL";
@@ -10,13 +11,20 @@ const DEFAULT_STATE = {
 };
 
 /**
+ * Returns the initial modal state.
+ *
+ * @returns {Object} The initial state.
+ */
+export const getInitialModalState = () => ( { ...DEFAULT_STATE } );
+
+/**
  * Reducer for the content planner modal UI state.
  *
  * @param {Object} state  The current state.
  * @param {Object} action The dispatched action.
  * @returns {Object} The new state.
  */
-const reducer = ( state = DEFAULT_STATE, action ) => {
+export const modalReducer = ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {
 		case OPEN_MODAL:
 			return { ...state, isOpen: true, skipApprove: Boolean( action.skipApprove ) };
@@ -27,7 +35,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 	}
 };
 
-const actions = {
+export const modalActions = {
 	/**
 	 * Opens the content planner modal.
 	 *
@@ -48,7 +56,7 @@ const actions = {
 	},
 };
 
-const selectors = {
+export const modalSelectors = {
 	/**
 	 * Returns whether the modal is open.
 	 *
@@ -56,7 +64,7 @@ const selectors = {
 	 * @returns {boolean} Whether the modal is open.
 	 */
 	selectIsModalOpen( state ) {
-		return state.isOpen;
+		return get( state, [ MODAL_NAME, "isOpen" ], false );
 	},
 
 	/**
@@ -66,12 +74,6 @@ const selectors = {
 	 * @returns {boolean} Whether to skip the approve modal.
 	 */
 	selectShouldSkipApprove( state ) {
-		return state.skipApprove;
+		return get( state, [ MODAL_NAME, "skipApprove" ], false );
 	},
 };
-
-export const modalStore = createReduxStore( CONTENT_PLANNER_STORE, {
-	reducer,
-	actions,
-	selectors,
-} );

--- a/packages/js/src/ai-content-planner/store/modal.js
+++ b/packages/js/src/ai-content-planner/store/modal.js
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from "@wordpress/data";
+import { createReduxStore } from "@wordpress/data";
 import { CONTENT_PLANNER_STORE } from "../constants";
 
 const OPEN_MODAL = "OPEN_MODAL";
@@ -75,12 +75,3 @@ export const modalStore = createReduxStore( CONTENT_PLANNER_STORE, {
 	actions,
 	selectors,
 } );
-
-/**
- * Registers the content planner modal store to WP data's default registry.
- *
- * @returns {void}
- */
-export const registerModalStore = () => {
-	register( modalStore );
-};

--- a/packages/js/tests/ai-content-planner/components/approve-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/approve-modal.test.js
@@ -6,7 +6,7 @@ const renderApproveModal = ( { onClose = jest.fn(), ...props } = {} ) => render(
 	<Modal isOpen={ true } onClose={ onClose }>
 		<div>
 			<ApproveModal
-				isEmptyCanvas={ true }
+				isEmptyPost={ true }
 				isPremium={ false }
 				isUpsell={ false }
 				onClick={ jest.fn() }
@@ -28,24 +28,24 @@ describe( "ApproveModal", () => {
 
 	describe( "empty canvas content", () => {
 		it( "shows the inspiration title when the canvas is empty", () => {
-			renderApproveModal( { isEmptyCanvas: true } );
+			renderApproveModal( { isEmptyPost: true } );
 			expect( screen.getByText( "Looking for inspiration?" ) ).toBeInTheDocument();
 		} );
 
 		it( "shows the ai-primary button variant when the canvas is empty and not an upsell", () => {
-			renderApproveModal( { isEmptyCanvas: true, isUpsell: false } );
+			renderApproveModal( { isEmptyPost: true, isUpsell: false } );
 			expect( screen.getByRole( "button", { name: "Get content suggestions" } ) ).toHaveClass( "yst-button--ai-primary" );
 		} );
 	} );
 
 	describe( "non-empty canvas content", () => {
 		it( "shows the 'Get content suggestions' title when the canvas has content", () => {
-			renderApproveModal( { isEmptyCanvas: false } );
+			renderApproveModal( { isEmptyPost: false } );
 			expect( screen.getByRole( "heading", { name: "Get content suggestions" } ) ).toBeInTheDocument();
 		} );
 
 		it( "shows a note that content will be replaced when the canvas has content", () => {
-			renderApproveModal( { isEmptyCanvas: false } );
+			renderApproveModal( { isEmptyPost: false } );
 			expect( screen.getByText( /Note: Applying a content suggestion will replace/ ) ).toBeInTheDocument();
 		} );
 	} );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -63,7 +63,7 @@ describe( "FeatureModal", () => {
 	} );
 
 	it( "transitions to the replace content confirmation when 'Add outline to post' is clicked", () => {
-		renderModal();
+		renderModal( { isEmptyCanvas: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -84,7 +84,7 @@ describe( "FeatureModal", () => {
 	} );
 
 	it( "returns to the content outline when cancel is clicked on the replace confirmation", () => {
-		renderModal();
+		renderModal( { isEmptyCanvas: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -110,7 +110,7 @@ describe( "FeatureModal", () => {
 	it( "calls onAddOutline and onClose when replace is confirmed", () => {
 		const onAddOutline = jest.fn();
 		const onClose = jest.fn();
-		renderModal( { onAddOutline, onClose } );
+		renderModal( { onAddOutline, onClose, isEmptyCanvas: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -129,5 +129,54 @@ describe( "FeatureModal", () => {
 		fireEvent.click( screen.getByRole( "button", { name: "Replace content" } ) );
 		expect( onAddOutline ).toHaveBeenCalledTimes( 1 );
 		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "skips the approve modal when initialStatus is content-suggestions-loading", () => {
+		renderModal( { initialStatus: "content-suggestions-loading" } );
+		// Should go straight to content suggestions, no approve modal.
+		expect( screen.queryByText( "Looking for inspiration?" ) ).not.toBeInTheDocument();
+		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
+	} );
+
+	it( "skips replace confirmation and applies outline directly when isEmptyCanvas is true", () => {
+		const onAddOutline = jest.fn();
+		const onClose = jest.fn();
+		renderModal( { onAddOutline, onClose, isEmptyCanvas: true } );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		fireEvent.click( screen.getByText( "How to train your dog" ) );
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
+		// Should directly apply without showing replace confirmation.
+		expect( screen.queryByText( "Replace existing content with this outline?" ) ).not.toBeInTheDocument();
+		expect( onAddOutline ).toHaveBeenCalledTimes( 1 );
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "shows replace confirmation when isEmptyCanvas is false", () => {
+		renderModal( { isEmptyCanvas: false } );
+		act( () => {
+			jest.advanceTimersByTime( 300 );
+		} );
+		fireEvent.click( screen.getByRole( "button", { name: "Get content suggestions" } ) );
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		fireEvent.click( screen.getByText( "How to train your dog" ) );
+		act( () => {
+			jest.advanceTimersByTime( 5000 );
+		} );
+		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
+		act( () => {
+			jest.advanceTimersByTime( 600 );
+		} );
+		expect( screen.getByText( "Replace existing content with this outline?" ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -13,7 +13,7 @@ const renderModal = ( props ) => render(
 	<FeatureModal
 		isOpen={ true }
 		onClose={ jest.fn() }
-		isEmptyCanvas={ true }
+		isEmptyPost={ true }
 		isPremium={ false }
 		isUpsell={ false }
 		{ ...props }
@@ -63,7 +63,7 @@ describe( "FeatureModal", () => {
 	} );
 
 	it( "transitions to the replace content confirmation when 'Add outline to post' is clicked", () => {
-		renderModal( { isEmptyCanvas: false } );
+		renderModal( { isEmptyPost: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -84,7 +84,7 @@ describe( "FeatureModal", () => {
 	} );
 
 	it( "returns to the content outline when cancel is clicked on the replace confirmation", () => {
-		renderModal( { isEmptyCanvas: false } );
+		renderModal( { isEmptyPost: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -110,7 +110,7 @@ describe( "FeatureModal", () => {
 	it( "calls onAddOutline and onClose when replace is confirmed", () => {
 		const onAddOutline = jest.fn();
 		const onClose = jest.fn();
-		renderModal( { onAddOutline, onClose, isEmptyCanvas: false } );
+		renderModal( { onAddOutline, onClose, isEmptyPost: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -138,10 +138,10 @@ describe( "FeatureModal", () => {
 		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
 	} );
 
-	it( "skips replace confirmation and applies outline directly when isEmptyCanvas is true", () => {
+	it( "skips replace confirmation and applies outline directly when isEmptyPost is true", () => {
 		const onAddOutline = jest.fn();
 		const onClose = jest.fn();
-		renderModal( { onAddOutline, onClose, isEmptyCanvas: true } );
+		renderModal( { onAddOutline, onClose, isEmptyPost: true } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );
@@ -160,8 +160,8 @@ describe( "FeatureModal", () => {
 		expect( onClose ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( "shows replace confirmation when isEmptyCanvas is false", () => {
-		renderModal( { isEmptyCanvas: false } );
+	it( "shows replace confirmation when isEmptyPost is false", () => {
+		renderModal( { isEmptyPost: false } );
 		act( () => {
 			jest.advanceTimersByTime( 300 );
 		} );

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -42,10 +42,6 @@ jest.mock( "../../src/ai-content-planner/components/feature-modal", () => ( {
 	FeatureModal: ( props ) => props.isOpen ? <div data-testid="feature-modal" /> : null,
 } ) );
 
-jest.mock( "../../src/ai-content-planner/store/modal", () => ( {
-	modalStore: {},
-} ) );
-
 jest.mock( "../../src/ai-content-planner/components/content-suggestion-block", () => ( {
 	ContentSuggestionBlock: () => null,
 } ) );

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -43,7 +43,7 @@ jest.mock( "../../src/ai-content-planner/components/feature-modal", () => ( {
 } ) );
 
 jest.mock( "../../src/ai-content-planner/store/modal", () => ( {
-	registerModalStore: jest.fn(),
+	modalStore: {},
 } ) );
 
 jest.mock( "../../src/ai-content-planner/components/content-suggestion-block", () => ( {

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -6,6 +6,9 @@ import { insertBannerAfterFirstParagraph, ContentPlannerEditorPlugin } from "../
 jest.mock( "@wordpress/data", () => ( {
 	useSelect: jest.fn(),
 	useDispatch: jest.fn(),
+	select: jest.fn( () => ( {
+		getBlocks: () => [],
+	} ) ),
 } ) );
 
 jest.mock( "@wordpress/blocks", () => ( {
@@ -21,8 +24,20 @@ jest.mock( "@wordpress/plugins", () => ( {
 	registerPlugin: jest.fn(),
 } ) );
 
+jest.mock( "@wordpress/wordcount", () => ( {
+	count: jest.fn( () => 0 ),
+} ) );
+
 jest.mock( "../../src/ai-content-planner/components/inline-banner", () => ( {
 	InlineBanner: () => null,
+} ) );
+
+jest.mock( "../../src/ai-content-planner/components/feature-modal", () => ( {
+	FeatureModal: ( props ) => props.isOpen ? <div data-testid="feature-modal" /> : null,
+} ) );
+
+jest.mock( "../../src/ai-content-planner/store", () => ( {
+	registerStore: jest.fn(),
 } ) );
 
 describe( "insertBannerAfterFirstParagraph", () => {
@@ -75,23 +90,42 @@ describe( "insertBannerAfterFirstParagraph", () => {
 
 describe( "ContentPlannerEditorPlugin", () => {
 	let mockInsertBlock;
+	let mockRemoveBlock;
+	let mockCloseModal;
+
+	const defaultSelectOptions = {
+		isNewPost: true,
+		postType: "post",
+		blocks: [],
+		isModalOpen: false,
+		skipApprove: false,
+		isPremium: false,
+	};
 
 	/**
 	 * Mocks the useSelect hook with store-based selectors.
-	 * @param {Object} options The mock options.
-	 * @param {boolean} [options.isNewPost=true] Whether the post is new.
-	 * @param {string} [options.postType="post"] The post type.
-	 * @param {Array} [options.blocks=[]] The editor blocks.
+	 *
+	 * @param {Object} options The mock options, merged with defaults.
 	 * @returns {void}
 	 */
-	const mockSelect = ( { isNewPost = true, postType = "post", blocks = [] } = {} ) => {
+	const mockSelect = ( options = {} ) => {
+		const opts = { ...defaultSelectOptions, ...options };
 		const stores = {
 			"core/editor": {
-				isEditedPostNew: () => isNewPost,
-				getCurrentPostType: () => postType,
+				isEditedPostNew: () => opts.isNewPost,
+				getCurrentPostType: () => opts.postType,
+				getEditedPostContent: () => "",
 			},
 			"core/block-editor": {
-				getBlocks: () => blocks,
+				getBlocks: () => opts.blocks,
+			},
+			"yoast-seo/content-planner": {
+				selectIsModalOpen: () => opts.isModalOpen,
+				selectShouldSkipApprove: () => opts.skipApprove,
+			},
+			"yoast-seo/editor": {
+				getIsPremium: () => opts.isPremium,
+				selectLink: () => "https://example.com/upsell",
 			},
 		};
 		useSelect.mockImplementation( ( selector ) => selector( ( storeName ) => stores[ storeName ] ) );
@@ -99,17 +133,33 @@ describe( "ContentPlannerEditorPlugin", () => {
 
 	beforeEach( () => {
 		mockInsertBlock = jest.fn();
-		useDispatch.mockImplementation( () => ( { insertBlock: mockInsertBlock } ) );
+		mockRemoveBlock = jest.fn();
+		mockCloseModal = jest.fn();
+		useDispatch.mockImplementation( ( storeName ) => {
+			if ( storeName === "core/block-editor" ) {
+				return { insertBlock: mockInsertBlock, removeBlock: mockRemoveBlock };
+			}
+			if ( storeName === "yoast-seo/content-planner" ) {
+				return { closeModal: mockCloseModal };
+			}
+			return {};
+		} );
 	} );
 
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
 
-	test( "should render nothing", () => {
-		mockSelect();
-		const { container } = render( <ContentPlannerEditorPlugin /> );
-		expect( container.innerHTML ).toBe( "" );
+	test( "should not render the feature modal when the store says it is closed", () => {
+		mockSelect( { isModalOpen: false } );
+		const { queryByTestId } = render( <ContentPlannerEditorPlugin /> );
+		expect( queryByTestId( "feature-modal" ) ).not.toBeInTheDocument();
+	} );
+
+	test( "should render the feature modal when the store says it is open", () => {
+		mockSelect( { isModalOpen: true } );
+		const { getByTestId } = render( <ContentPlannerEditorPlugin /> );
+		expect( getByTestId( "feature-modal" ) ).toBeInTheDocument();
 	} );
 
 	test( "should insert a paragraph block when canvas is empty on a new post", () => {

--- a/packages/js/tests/ai-content-planner/store/index.test.js
+++ b/packages/js/tests/ai-content-planner/store/index.test.js
@@ -1,0 +1,66 @@
+import { createReduxStore, createRegistry } from "@wordpress/data";
+import { FEATURE_MODAL_STORE } from "../../../src/ai-content-planner/constants";
+
+describe( "content planner store", () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+		const store = createReduxStore( FEATURE_MODAL_STORE, {
+			reducer( state = { isOpen: false, skipApprove: false }, action ) {
+				switch ( action.type ) {
+					case "OPEN_MODAL":
+						return { ...state, isOpen: true, skipApprove: Boolean( action.skipApprove ) };
+					case "CLOSE_MODAL":
+						return { isOpen: false, skipApprove: false };
+					default:
+						return state;
+				}
+			},
+			actions: {
+				openModal( skipApprove = false ) {
+					return { type: "OPEN_MODAL", skipApprove };
+				},
+				closeModal() {
+					return { type: "CLOSE_MODAL" };
+				},
+			},
+			selectors: {
+				selectIsModalOpen( state ) {
+					return state.isOpen;
+				},
+				selectShouldSkipApprove( state ) {
+					return state.skipApprove;
+				},
+			},
+		} );
+		registry.register( store );
+	} );
+
+	it( "has modal closed by default", () => {
+		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( false );
+	} );
+
+	it( "has skipApprove false by default", () => {
+		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+	} );
+
+	it( "opens the modal without skipping approve", () => {
+		registry.dispatch( FEATURE_MODAL_STORE ).openModal( false );
+		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( true );
+		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+	} );
+
+	it( "opens the modal with skipApprove true", () => {
+		registry.dispatch( FEATURE_MODAL_STORE ).openModal( true );
+		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( true );
+		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( true );
+	} );
+
+	it( "closes the modal and resets state", () => {
+		registry.dispatch( FEATURE_MODAL_STORE ).openModal( true );
+		registry.dispatch( FEATURE_MODAL_STORE ).closeModal();
+		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( false );
+		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/store/index.test.js
+++ b/packages/js/tests/ai-content-planner/store/index.test.js
@@ -1,5 +1,5 @@
 import { createRegistry } from "@wordpress/data";
-import { modalStore as store } from "../../../src/ai-content-planner/store/modal";
+import { store } from "../../../src/ai-content-planner/store";
 import { CONTENT_PLANNER_STORE } from "../../../src/ai-content-planner/constants";
 
 describe( "content planner store", () => {

--- a/packages/js/tests/ai-content-planner/store/index.test.js
+++ b/packages/js/tests/ai-content-planner/store/index.test.js
@@ -1,6 +1,6 @@
 import { createRegistry } from "@wordpress/data";
 import { store } from "../../../src/ai-content-planner/store";
-import { FEATURE_MODAL_STORE } from "../../../src/ai-content-planner/constants";
+import { CONTENT_PLANNER_STORE } from "../../../src/ai-content-planner/constants";
 
 describe( "content planner store", () => {
 	let registry;
@@ -11,29 +11,29 @@ describe( "content planner store", () => {
 	} );
 
 	it( "has modal closed by default", () => {
-		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( false );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectIsModalOpen() ).toBe( false );
 	} );
 
 	it( "has skipApprove false by default", () => {
-		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectShouldSkipApprove() ).toBe( false );
 	} );
 
 	it( "opens the modal without skipping approve", () => {
-		registry.dispatch( FEATURE_MODAL_STORE ).openModal( false );
-		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( true );
-		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+		registry.dispatch( CONTENT_PLANNER_STORE ).openModal( false );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectIsModalOpen() ).toBe( true );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectShouldSkipApprove() ).toBe( false );
 	} );
 
 	it( "opens the modal with skipApprove true", () => {
-		registry.dispatch( FEATURE_MODAL_STORE ).openModal( true );
-		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( true );
-		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( true );
+		registry.dispatch( CONTENT_PLANNER_STORE ).openModal( true );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectIsModalOpen() ).toBe( true );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectShouldSkipApprove() ).toBe( true );
 	} );
 
 	it( "closes the modal and resets state", () => {
-		registry.dispatch( FEATURE_MODAL_STORE ).openModal( true );
-		registry.dispatch( FEATURE_MODAL_STORE ).closeModal();
-		expect( registry.select( FEATURE_MODAL_STORE ).selectIsModalOpen() ).toBe( false );
-		expect( registry.select( FEATURE_MODAL_STORE ).selectShouldSkipApprove() ).toBe( false );
+		registry.dispatch( CONTENT_PLANNER_STORE ).openModal( true );
+		registry.dispatch( CONTENT_PLANNER_STORE ).closeModal();
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectIsModalOpen() ).toBe( false );
+		expect( registry.select( CONTENT_PLANNER_STORE ).selectShouldSkipApprove() ).toBe( false );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/store/index.test.js
+++ b/packages/js/tests/ai-content-planner/store/index.test.js
@@ -1,4 +1,5 @@
-import { createReduxStore, createRegistry } from "@wordpress/data";
+import { createRegistry } from "@wordpress/data";
+import { store } from "../../../src/ai-content-planner/store";
 import { FEATURE_MODAL_STORE } from "../../../src/ai-content-planner/constants";
 
 describe( "content planner store", () => {
@@ -6,34 +7,6 @@ describe( "content planner store", () => {
 
 	beforeEach( () => {
 		registry = createRegistry();
-		const store = createReduxStore( FEATURE_MODAL_STORE, {
-			reducer( state = { isOpen: false, skipApprove: false }, action ) {
-				switch ( action.type ) {
-					case "OPEN_MODAL":
-						return { ...state, isOpen: true, skipApprove: Boolean( action.skipApprove ) };
-					case "CLOSE_MODAL":
-						return { isOpen: false, skipApprove: false };
-					default:
-						return state;
-				}
-			},
-			actions: {
-				openModal( skipApprove = false ) {
-					return { type: "OPEN_MODAL", skipApprove };
-				},
-				closeModal() {
-					return { type: "CLOSE_MODAL" };
-				},
-			},
-			selectors: {
-				selectIsModalOpen( state ) {
-					return state.isOpen;
-				},
-				selectShouldSkipApprove( state ) {
-					return state.skipApprove;
-				},
-			},
-		} );
 		registry.register( store );
 	} );
 


### PR DESCRIPTION
## Context
The inline outline banner (`yoast/content-planner-banner` block) auto-inserts on new empty posts with a "Get content suggestions" button that was not wired to any action. This PR connects that button to the existing `FeatureModal` flow (Suggestions → Outline → Add blocks) as per de [design](https://www.figma.com/proto/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?page-id=0%3A1&node-id=128-844&p=f&viewport=-1685%2C83%2C0.81&t=77ctLIxQ8dGAeU1Z-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=128%3A844), creating a shared modal architecture controlled via a WordPress data store that works across the block editor iframe boundary.

## Summary

- Connects the inline banner to the content suggestions modal flow.

## Relevant technical choices
- **WordPress data store for cross-iframe communication:** The block editor renders blocks inside an iframe, but `@wordpress/data` stores are shared across the iframe boundary. A lightweight store was chosen over DOM events or React context, which don't cross the iframe.
- **Single shared `FeatureModal` instance:** Both the sidebar button and inline banner dispatch to the same store, which the `ContentPlannerEditorPlugin` subscribes to. This prevents two modal instances from opening simultaneously.
- **`getOutlineHandler` helper:** Extracted to a standalone function to keep the `FeatureModal` component's cyclomatic complexity within the ESLint maximum of 6.
- **`isEmptyCanvas` renamed to `isEmptyPost`:** Renamed across all components and tests to align with the existing `isNewPost` naming convention. The prop is used to skip the replace confirmation when the post is empty — semantically correct since the banner only appears on empty posts.
- **`onAddOutline` is still a stub:** The actual block insertion logic will come from PR #23117. Currently, `onAddOutline` only removes the banner block from the editor.

## Test instructions for the acceptance test before the PR gets merged
1. Go to **Posts > Add New** to create a new post.
2. Verify the inline banner appears below the first paragraph placeholder with the text "Stuck on what to write next?" and a "Get content suggestions" button.
3. Click the **"Get content suggestions"** button on the inline banner.
4. Verify the modal opens directly to the **content suggestions loading** view (skeleton loaders), **without** showing the "Looking for inspiration?" approve screen first.
5. Wait for suggestions to load, then click on a suggestion.
6. Verify the **Content outline** modal appears.
7. Click **"Add outline to post"**.
8. Verify the modal closes directly — **no** "Replace existing content?" confirmation is shown.
9. Verify the inline banner block is removed from the editor.
10. Create another new post. This time, open the **Yoast SEO sidebar** or metabox and click the **"Get content suggestions"** button there.
11. Verify the modal opens with the **"Looking for inspiration?"** approve screen first (the existing flow is unchanged).
12. Click through: approve → suggestions → outline.
13. Close the modal without applying the outline — verify the inline banner remains visible in the editor.
14. Dismiss the inline banner via the **X** button — verify the block is removed.

## Relevant test scenarios
- [x] Changes should be tested with the browser console open
- [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)

The inline banner only appears in the Block Editor. Verify the sidebar button still works correctly in both Block Editor and Elementor.

## Test instructions for QA when the code is in the RC
- [x] QA should use the same steps as above.

## Impact check
- Content Planner feature (inline banner, feature modal, sidebar button)
- Block editor integration (`ContentPlannerEditorPlugin`)
- `@wordpress/data` store registration

## Other environments
- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation
- [ ] I have written documentation for this change.

## Quality assurance
- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [x] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation
- [ ] No innovation project is applicable for this PR.
- [x] This PR falls under an innovation project. I have attached the innovation label.
- [x] I have added my hours to the WBSO document.

Fixes https://github.com/Yoast/reserved-tasks/issues/1147