### PR TITLE
1138 connect the spark counter data and update the upsell ads

### DIFF
--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -242,7 +242,7 @@ export const ContentOutlineModal = ( { status, isPremium, onBackToSuggestions, o
 
 
 	return (
-		<Modal.Panel className="yst-p-0 yst-max-w-2xl" hasCloseButton={ false }>
+		<Modal.Panel className="yst-p-0 yst-max-w-2xl yst-overflow-visible yst-relative" hasCloseButton={ false }>
 			<Modal.CloseButton ref={ closeButtonRef } screenReaderText={ __( "Close content outline", "wordpress-seo" ) } />
 			<Modal.Container>
 				<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">

--- a/packages/js/src/ai-content-planner/components/content-outline-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-outline-modal.js
@@ -242,7 +242,7 @@ export const ContentOutlineModal = ( { status, isPremium, onBackToSuggestions, o
 
 
 	return (
-		<Modal.Panel className="yst-p-0 yst-max-w-2xl yst-overflow-visible yst-relative" hasCloseButton={ false }>
+		<Modal.Panel className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
 			<Modal.CloseButton ref={ closeButtonRef } screenReaderText={ __( "Close content outline", "wordpress-seo" ) } />
 			<Modal.Container>
 				<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
@@ -251,6 +251,7 @@ export const ContentOutlineModal = ( { status, isPremium, onBackToSuggestions, o
 					<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
 					{ sparksLimit && (
 						<UsageCounter
+							className="yst-relative"
 							limit={ sparksLimit }
 							requests={ sparksUsage }
 							mentionBetaInTooltip={ isPremium }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Badge, Modal, SkeletonLoader, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
@@ -89,6 +90,7 @@ const LoadingModalContent = () => {
  * @param {boolean} props.skipTransitions Whether to skip transition animations.
  * @param {number} props.usageCount The number of times the user has used the content suggestions feature.
  * @param {number} props.usageCountLimit The maximum number of times the user can use the content suggestions feature before hitting a limit.
+ * @param {string} props.usageCountStatus The status of the usage count (e.g. "approaching", "reached").
  *
  * @returns {JSX.Element} The ContentSuggestionsModal component.
  */
@@ -100,6 +102,7 @@ export const ContentSuggestionsModal = ( {
 	skipTransitions = false,
 	usageCount,
 	usageCountLimit,
+	usageCountStatus,
 } ) => {
 	const svgAriaProps = useSvgAria();
 	const closeButtonRef = useRef( null );
@@ -125,6 +128,7 @@ export const ContentSuggestionsModal = ( {
 						requests={ usageCount }
 						mentionBetaInTooltip={ isPremium }
 						mentionResetInTooltip={ isPremium }
+						isSkeleton={ status === ASYNC_ACTION_STATUS.loading || usageCountStatus === ASYNC_ACTION_STATUS.loading }
 					/>
 				</Modal.Container.Header>
 				<Modal.Container.Content className="yst-overflow-y-auto yst-p-6 yst-m-0">

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -110,7 +110,7 @@ export const ContentSuggestionsModal = ( {
 
 	return (
 		<Modal.Panel
-			className="yst-p-0 yst-max-w-2xl yst-overflow-visible yst-relative"
+			className="yst-p-0 yst-max-w-2xl yst-overflow-visible"
 			hasCloseButton={ false }
 		>
 			<Modal.CloseButton ref={ closeButtonRef } screenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) } />
@@ -120,6 +120,7 @@ export const ContentSuggestionsModal = ( {
 					<Modal.Title size="2" className="yst-flex-grow">{ __( "Content suggestions", "wordpress-seo" ) }</Modal.Title>
 					<Badge size="small">{ __( "Beta", "wordpress-seo" ) }</Badge>
 					<UsageCounter
+						className="yst-relative"
 						limit={ usageCountLimit }
 						requests={ usageCount }
 						mentionBetaInTooltip={ isPremium }

--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -110,7 +110,7 @@ export const ContentSuggestionsModal = ( {
 
 	return (
 		<Modal.Panel
-			className="yst-p-0 yst-max-w-2xl"
+			className="yst-p-0 yst-max-w-2xl yst-overflow-visible yst-relative"
 			hasCloseButton={ false }
 		>
 			<Modal.CloseButton ref={ closeButtonRef } screenReaderText={ __( "Close content suggestions modal", "wordpress-seo" ) } />

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -1,12 +1,14 @@
 import { Modal } from "@yoast/ui-library";
 import { Fragment, useState, useEffect, useCallback, useRef } from "@wordpress/element";
-import { useSelect } from "@wordpress/data";
+import { useSelect, useDispatch } from "@wordpress/data";
 import { ApproveModal } from "./approve-modal";
 import ContentSuggestionsModal from "../containers/content-suggestions-modal";
 import ContentOutlineModal  from "../containers/content-outline-modal";
 import { ReplaceContentModal } from "./replace-content-modal";
 import { Transition } from "@headlessui/react";
 import { FEATURE_MODAL_STATUS, CONTENT_PLANNER_STORE } from "../constants";
+import { STORE_NAME_AI } from "../../ai-generator/constants";
+import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { useFetchContentSuggestions, useFetchContentOutline, useApplyOutline } from "../hooks";
 
 const HIDDEN_STYLE = { display: "none" };
@@ -29,9 +31,8 @@ const getPanelStyles = ( status ) => ( {
  *
  * @param {boolean}  isVisible            Whether the suggestions should be shown.
  * @param {boolean}  cameFromApproveModal Whether transitioning from the approve modal.
- * @param {string}   status           The current modal status.
- * @param {boolean}  isPremium        Whether the user has a premium subscription.
- * @param {Function} onSuggestionClick Callback when a suggestion is clicked.
+ * @param {string}   status               The current modal status.
+ * @param {Function} onSuggestionClick    Callback when a suggestion is clicked.
  *
  * @returns {JSX.Element|null} The suggestions panel.
  */
@@ -76,6 +77,8 @@ const SuggestionsPanel = ( { isVisible, cameFromApproveModal, status, onSuggesti
  * @param {boolean}       isPremium                       Whether the user has a premium subscription or not.
  * @param {boolean}       isUpsell                        Whether the modal is shown as an upsell or not.
  * @param {string}        upsellLink                      The link to the upsell page.
+ * @param {string}        status                          The current modal status from the store.
+ * @param {function}      setStatus                       Dispatch function to update the modal status.
  * @returns {JSX.Element} The Content Planner Feature Modal.
  */
 
@@ -89,10 +92,22 @@ export const FeatureModal = ( {
 	status,
 	setStatus,
 } ) => {
-	const selectedSuggestion = useSelect( ( select ) => select( CONTENT_PLANNER_STORE ).selectSuggestion(), [] );
+	const { selectedSuggestion, suggestionsStatus } = useSelect( ( select ) => {
+		const store = select( CONTENT_PLANNER_STORE );
+		return {
+			selectedSuggestion: store.selectSuggestion(),
+			suggestionsStatus: store.selectSuggestionsStatus(),
+		};
+	}, [] );
+
+	const usageCountEndpoint = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCountEndpoint(), [] );
+
+	const { fetchUsageCount, addUsageCount } = useDispatch( STORE_NAME_AI );
+
 	const [ cameFromApproveModal, setCameFromApproveModal ] = useState( false );
 	const [ hasVisitedReplace, setHasVisitedReplace ] = useState( false );
 	const editedOutlineRef = useRef( null );
+	const prevSuggestionsStatus = useRef( suggestionsStatus );
 
 	const fetchContentSuggestions = useFetchContentSuggestions();
 	const fetchContentOutline = useFetchContentOutline();
@@ -144,17 +159,29 @@ export const FeatureModal = ( {
 	}, [ handleApplyOutline ] );
 
 	useEffect( () => {
+		if ( isOpen && usageCountEndpoint ) {
+			fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
+		}
+	}, [ isOpen, usageCountEndpoint, fetchUsageCount ] );
+
+	useEffect( () => {
+		if ( prevSuggestionsStatus.current !== ASYNC_ACTION_STATUS.success &&
+			suggestionsStatus === ASYNC_ACTION_STATUS.success ) {
+			addUsageCount();
+		}
+		prevSuggestionsStatus.current = suggestionsStatus;
+	}, [ suggestionsStatus, addUsageCount ] );
+
+	useEffect( () => {
 		if ( ! isOpen ) {
 			setCameFromApproveModal( true );
 			setHasVisitedReplace( false );
-			return;
 		}
 	}, [ isOpen ] );
 
 	useEffect( () => {
 		if ( status === FEATURE_MODAL_STATUS.idle ) {
 			setCameFromApproveModal( true );
-			return;
 		}
 	}, [ status ] );
 

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -87,7 +87,6 @@ export const FeatureModal = ( {
 	upsellLink,
 	status,
 	setStatus,
-	selectedSuggestion,
 } ) => {
 	const [ cameFromApproveModal, setCameFromApproveModal ] = useState( false );
 	const [ hasVisitedReplace, setHasVisitedReplace ] = useState( false );
@@ -185,12 +184,7 @@ export const FeatureModal = ( {
 					cameFromApproveModal={ cameFromApproveModal }
 					onSuggestionClick={ handleSuggestionClick }
 				/>
-				{ /*
-				 * Once the replace confirmation has been visited, keep both outline and
-				 * confirmation panels mounted and toggle via display:none to avoid a
-				 * one-frame empty container between panel swaps.
-				 */ }
-				{ selectedSuggestion && (
+				{ status === FEATURE_MODAL_STATUS.contentOutline && (
 					<div style={ outlineStyle }>
 						<ContentOutlineModal
 							onApplyOutline={ handleOnApplyOutline }

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -1,14 +1,11 @@
 import { Modal } from "@yoast/ui-library";
 import { Fragment, useState, useEffect, useCallback, useRef } from "@wordpress/element";
-import { useSelect, useDispatch } from "@wordpress/data";
 import { ApproveModal } from "./approve-modal";
 import ContentSuggestionsModal from "../containers/content-suggestions-modal";
 import ContentOutlineModal  from "../containers/content-outline-modal";
 import { ReplaceContentModal } from "./replace-content-modal";
 import { Transition } from "@headlessui/react";
-import { FEATURE_MODAL_STATUS, CONTENT_PLANNER_STORE } from "../constants";
-import { STORE_NAME_AI } from "../../ai-generator/constants";
-import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+import { FEATURE_MODAL_STATUS } from "../constants";
 import { useFetchContentSuggestions, useFetchContentOutline, useApplyOutline } from "../hooks";
 
 const HIDDEN_STYLE = { display: "none" };
@@ -91,23 +88,11 @@ export const FeatureModal = ( {
 	upsellLink,
 	status,
 	setStatus,
+	selectedSuggestion,
 } ) => {
-	const { selectedSuggestion, suggestionsStatus } = useSelect( ( select ) => {
-		const store = select( CONTENT_PLANNER_STORE );
-		return {
-			selectedSuggestion: store.selectSuggestion(),
-			suggestionsStatus: store.selectSuggestionsStatus(),
-		};
-	}, [] );
-
-	const usageCountEndpoint = useSelect( ( select ) => select( STORE_NAME_AI ).selectUsageCountEndpoint(), [] );
-
-	const { fetchUsageCount, addUsageCount } = useDispatch( STORE_NAME_AI );
-
 	const [ cameFromApproveModal, setCameFromApproveModal ] = useState( false );
 	const [ hasVisitedReplace, setHasVisitedReplace ] = useState( false );
 	const editedOutlineRef = useRef( null );
-	const prevSuggestionsStatus = useRef( suggestionsStatus );
 
 	const fetchContentSuggestions = useFetchContentSuggestions();
 	const fetchContentOutline = useFetchContentOutline();
@@ -157,20 +142,6 @@ export const FeatureModal = ( {
 	const handleConfirmReplace = useCallback( () => {
 		handleApplyOutline();
 	}, [ handleApplyOutline ] );
-
-	useEffect( () => {
-		if ( isOpen && usageCountEndpoint ) {
-			fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
-		}
-	}, [ isOpen, usageCountEndpoint, fetchUsageCount ] );
-
-	useEffect( () => {
-		if ( prevSuggestionsStatus.current !== ASYNC_ACTION_STATUS.success &&
-			suggestionsStatus === ASYNC_ACTION_STATUS.success ) {
-			addUsageCount();
-		}
-		prevSuggestionsStatus.current = suggestionsStatus;
-	}, [ suggestionsStatus, addUsageCount ] );
 
 	useEffect( () => {
 		if ( ! isOpen ) {

--- a/packages/js/src/ai-content-planner/containers/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/containers/content-suggestions-modal.js
@@ -17,6 +17,7 @@ export default compose( [
 		const {
 			selectUsageCount,
 			selectUsageCountLimit,
+			selectUsageCountStatus,
 		} = select( STORE_NAME_AI );
 
 		return {
@@ -25,6 +26,7 @@ export default compose( [
 			usageCount: selectUsageCount(),
 			usageCountLimit: selectUsageCountLimit(),
 			status: selectSuggestionsStatus(),
+			isUsageCountLoading: selectUsageCountStatus(),
 		};
 	} ),
 ] )( ContentSuggestionsModal );

--- a/packages/js/src/ai-content-planner/containers/feature-modal.js
+++ b/packages/js/src/ai-content-planner/containers/feature-modal.js
@@ -7,7 +7,7 @@ import { STORE_NAME_AI } from "../../ai-generator/constants";
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { selectFeatureModalStatus, selectIsModalOpen, selectSuggestion } = select( CONTENT_PLANNER_STORE );
+		const { selectFeatureModalStatus, selectIsModalOpen } = select( CONTENT_PLANNER_STORE );
 		const content = select( "core/editor" ).getEditedPostContent();
 		const { getIsPremium, selectLink } = select( "yoast-seo/editor" );
 		const { isUsageCountLimitReached } = select( STORE_NAME_AI );
@@ -19,7 +19,6 @@ export default compose( [
 			status: selectFeatureModalStatus(),
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
 			isUpsell: isUsageCountLimitReached(),
-			selectedSuggestion: selectSuggestion(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/ai-content-planner/containers/feature-modal.js
+++ b/packages/js/src/ai-content-planner/containers/feature-modal.js
@@ -7,7 +7,7 @@ import { STORE_NAME_AI } from "../../ai-generator/constants";
 
 export default compose( [
 	withSelect( ( select ) => {
-const { selectFeatureModalStatus, selectIsModalOpen, selectSuggestion } = select( CONTENT_PLANNER_STORE );
+		const { selectFeatureModalStatus, selectIsModalOpen, selectSuggestion } = select( CONTENT_PLANNER_STORE );
 		const content = select( "core/editor" ).getEditedPostContent();
 		const { getIsPremium, selectLink } = select( "yoast-seo/editor" );
 		const { isUsageCountLimitReached } = select( STORE_NAME_AI );

--- a/packages/js/src/ai-content-planner/containers/feature-modal.js
+++ b/packages/js/src/ai-content-planner/containers/feature-modal.js
@@ -7,7 +7,7 @@ import { STORE_NAME_AI } from "../../ai-generator/constants";
 
 export default compose( [
 	withSelect( ( select ) => {
-		const { selectFeatureModalStatus, selectIsModalOpen } = select( CONTENT_PLANNER_STORE );
+const { selectFeatureModalStatus, selectIsModalOpen, selectSuggestion } = select( CONTENT_PLANNER_STORE );
 		const content = select( "core/editor" ).getEditedPostContent();
 		const { getIsPremium, selectLink } = select( "yoast-seo/editor" );
 		const { isUsageCountLimitReached } = select( STORE_NAME_AI );
@@ -19,6 +19,7 @@ export default compose( [
 			status: selectFeatureModalStatus(),
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
 			isUpsell: isUsageCountLimitReached(),
+			selectedSuggestion: selectSuggestion(),
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -1,6 +1,8 @@
-import { useCallback } from "@wordpress/element";
+import { useCallback, useEffect, useRef } from "@wordpress/element";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { CONTENT_PLANNER_STORE } from "../constants";
+import { STORE_NAME_AI } from "../../ai-generator/constants";
+import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { removesLocaleVariantSuffixes } from "../../shared-admin/helpers";
 
 /**
@@ -8,23 +10,40 @@ import { removesLocaleVariantSuffixes } from "../../shared-admin/helpers";
  *
  * Reads the required parameters from the store and dispatches the
  * fetchContentPlannerSuggestions action when invoked.
+ * Also handles usage count fetching and incrementing on success.
  *
  * @returns {Function} Callback to trigger the content suggestions fetch.
  */
 export const useFetchContentSuggestions = () => {
-	const { endpoint, postType, contentLocale, editorApiValue } = useSelect( ( select ) => {
+	const { endpoint, postType, contentLocale, editorApiValue, usageCountEndpoint, suggestionsStatus } = useSelect( ( select ) => {
 		return {
 			endpoint: select( CONTENT_PLANNER_STORE ).selectContentSuggestionsEndpoint(),
 			postType: select( "yoast-seo/editor" ).getPostType(),
 			contentLocale: select( "yoast-seo/editor" ).getContentLocale(),
 			editorApiValue: select( "yoast-seo/editor" ).getEditorTypeApiValue(),
+			usageCountEndpoint: select( STORE_NAME_AI ).selectUsageCountEndpoint(),
+			suggestionsStatus: select( CONTENT_PLANNER_STORE ).selectSuggestionsStatus(),
 		};
 	}, [] );
 
 	const { fetchContentPlannerSuggestions } = useDispatch( CONTENT_PLANNER_STORE );
+	const { fetchUsageCount, addUsageCount } = useDispatch( STORE_NAME_AI );
+
+	const prevSuggestionsStatus = useRef( suggestionsStatus );
+
+	useEffect( () => {
+		if ( prevSuggestionsStatus.current !== ASYNC_ACTION_STATUS.success &&
+			suggestionsStatus === ASYNC_ACTION_STATUS.success ) {
+			addUsageCount();
+		}
+		prevSuggestionsStatus.current = suggestionsStatus;
+	}, [ suggestionsStatus, addUsageCount ] );
 
 	return useCallback( () => {
 		const language = removesLocaleVariantSuffixes( contentLocale ).replace( "_", "-" );
 		fetchContentPlannerSuggestions( { endpoint, postType, language, editor: editorApiValue } );
-	}, [ endpoint, postType, contentLocale, editorApiValue, fetchContentPlannerSuggestions ] );
+		if ( usageCountEndpoint ) {
+			fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
+		}
+	}, [ endpoint, postType, contentLocale, editorApiValue, fetchContentPlannerSuggestions, usageCountEndpoint, fetchUsageCount ] );
 };

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useRef } from "@wordpress/element";
+import { useCallback } from "@wordpress/element";
 import { useSelect, useDispatch } from "@wordpress/data";
-import { CONTENT_PLANNER_STORE } from "../constants";
+import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS } from "../constants";
 import { STORE_NAME_AI } from "../../ai-generator/constants";
-import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { removesLocaleVariantSuffixes } from "../../shared-admin/helpers";
 
 /**
@@ -15,35 +14,46 @@ import { removesLocaleVariantSuffixes } from "../../shared-admin/helpers";
  * @returns {Function} Callback to trigger the content suggestions fetch.
  */
 export const useFetchContentSuggestions = () => {
-	const { endpoint, postType, contentLocale, editorApiValue, usageCountEndpoint, suggestionsStatus } = useSelect( ( select ) => {
+	const { endpoint, postType, contentLocale, editorApiValue, isUsageCountLimitReached, usageCountEndpoint } = useSelect( ( select ) => {
 		return {
 			endpoint: select( CONTENT_PLANNER_STORE ).selectContentSuggestionsEndpoint(),
 			postType: select( "yoast-seo/editor" ).getPostType(),
 			contentLocale: select( "yoast-seo/editor" ).getContentLocale(),
 			editorApiValue: select( "yoast-seo/editor" ).getEditorTypeApiValue(),
 			usageCountEndpoint: select( STORE_NAME_AI ).selectUsageCountEndpoint(),
-			suggestionsStatus: select( CONTENT_PLANNER_STORE ).selectSuggestionsStatus(),
+			isUsageCountLimitReached: select( STORE_NAME_AI ).isUsageCountLimitReached(),
 		};
 	}, [] );
 
-	const { fetchContentPlannerSuggestions } = useDispatch( CONTENT_PLANNER_STORE );
+	const { fetchContentPlannerSuggestions, setFeatureModalStatus } = useDispatch( CONTENT_PLANNER_STORE );
 	const { fetchUsageCount, addUsageCount } = useDispatch( STORE_NAME_AI );
 
-	const prevSuggestionsStatus = useRef( suggestionsStatus );
-
-	useEffect( () => {
-		if ( prevSuggestionsStatus.current !== ASYNC_ACTION_STATUS.success &&
-			suggestionsStatus === ASYNC_ACTION_STATUS.success ) {
-			addUsageCount();
+	// eslint-disable-next-line complexity
+	return useCallback( async() => {
+		// Before fetching usgage count, check if it's already known that the limit has been reached to avoid unnecessary API calls.
+		if ( isUsageCountLimitReached ) {
+			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
+			return;
 		}
-		prevSuggestionsStatus.current = suggestionsStatus;
-	}, [ suggestionsStatus, addUsageCount ] );
+		// Getting the usage count.
+		const { payload } = await fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
+		const sparksLimitReached = ( payload?.errorCode === 429 && payload?.errorIdentifier === "USAGE_LIMIT_REACHED" ) || payload.count >= payload.limit;
 
-	return useCallback( () => {
+		if ( sparksLimitReached ) {
+			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
+			return;
+		}
 		const language = removesLocaleVariantSuffixes( contentLocale ).replace( "_", "-" );
 		fetchContentPlannerSuggestions( { endpoint, postType, language, editor: editorApiValue } );
-		if ( usageCountEndpoint ) {
-			fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
-		}
-	}, [ endpoint, postType, contentLocale, editorApiValue, fetchContentPlannerSuggestions, usageCountEndpoint, fetchUsageCount ] );
+		addUsageCount();
+	}, [ endpoint,
+		postType,
+		contentLocale,
+		editorApiValue,
+		isUsageCountLimitReached,
+		usageCountEndpoint,
+		fetchContentPlannerSuggestions,
+		addUsageCount,
+		fetchUsageCount,
+		setFeatureModalStatus ] );
 };

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -30,7 +30,7 @@ export const useFetchContentSuggestions = () => {
 
 	// eslint-disable-next-line complexity
 	return useCallback( async() => {
-		// Before fetching usgage count, check if it's already known that the limit has been reached to avoid unnecessary API calls.
+		// Before fetching usage count, check if it's already known that the limit has been reached to avoid unnecessary API calls.
 		if ( isUsageCountLimitReached ) {
 			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
 			return;

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { useSelect, select } from "@wordpress/data";
+import { useSelect, useDispatch, select } from "@wordpress/data";
 import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
 import { useFetchContentSuggestions } from "../../../src/ai-content-planner/hooks/use-fetch-content-suggestions";
 
@@ -9,8 +9,9 @@ jest.mock( "@yoast/ai-frontend", () => ( {
 
 jest.mock( "@wordpress/data", () => {
 	const useSelectMock = jest.fn();
+	const useDispatchMock = jest.fn();
 	return {
-		useDispatch: jest.fn(),
+		useDispatch: useDispatchMock,
 		useSelect: useSelectMock,
 		withSelect: ( mapSelectToProps ) => ( Component ) => {
 			const React = require( "react" );
@@ -20,6 +21,28 @@ jest.mock( "@wordpress/data", () => {
 			};
 			WithSelectComponent.displayName = `WithSelect(${ Component.displayName || Component.name || "Component" })`;
 			return WithSelectComponent;
+		},
+		withDispatch: ( mapDispatchToProps ) => ( Component ) => {
+			const React = require( "react" );
+			const WithDispatchComponent = ( ownProps ) => {
+				const dispatchFn = ( storeName ) => {
+					if ( storeName === "core/block-editor" ) {
+						return { resetBlocks: jest.fn() };
+					}
+					if ( storeName === "yoast-seo/content-planner" ) {
+						return {
+							getContentOutline: jest.fn().mockResolvedValue( undefined ),
+							fetchContentPlannerSuggestions: jest.fn(),
+							setFeatureModalStatus: jest.fn(),
+						};
+					}
+					return {};
+				};
+				const dispatchProps = mapDispatchToProps( dispatchFn );
+				return React.createElement( Component, Object.assign( {}, ownProps, dispatchProps ) );
+			};
+			WithDispatchComponent.displayName = `WithDispatch(${ Component.displayName || Component.name || "Component" })`;
+			return WithDispatchComponent;
 		},
 		combineReducers: ( reducers ) => ( state = {}, action ) => Object.keys( reducers ).reduce(
 			( nextState, key ) => ( { ...nextState, [ key ]: reducers[ key ]( state[ key ], action ) } ),
@@ -56,9 +79,27 @@ jest.mock( "../../../src/ai-content-planner/hooks/use-fetch-content-suggestions"
 const mockResetBlocks = jest.fn();
 const mockGetContentOutline = jest.fn().mockResolvedValue( undefined );
 const mockFetchContentPlannerSuggestions = jest.fn();
+const mockFetchUsageCount = jest.fn().mockResolvedValue( {} );
+const mockAddUsageCount = jest.fn();
 
 const setupMocks = () => {
 	useFetchContentSuggestions.mockReturnValue( mockFetchContentPlannerSuggestions );
+	useDispatch.mockImplementation( ( storeName ) => {
+		if ( storeName === "yoast-seo/ai-generator" ) {
+			return {
+				fetchUsageCount: mockFetchUsageCount,
+				addUsageCount: mockAddUsageCount,
+			};
+		}
+		if ( storeName === "yoast-seo/content-planner" ) {
+			return {
+				fetchContentPlannerSuggestions: jest.fn(),
+				fetchContentOutline: jest.fn(),
+				setFeatureModalStatus: jest.fn(),
+			};
+		}
+		return {};
+	} );
 	useSelect.mockImplementation( ( selector ) => {
 		if ( typeof selector !== "function" ) {
 			return {};
@@ -66,22 +107,31 @@ const setupMocks = () => {
 		const mockSelectFn = ( storeName ) => {
 			if ( storeName === "yoast-seo/content-planner" ) {
 				return {
+					selectSuggestion: () => null,
 					selectSuggestions: () => [
 						{ intent: "informational", title: "How to train your dog", explanation: "Tips on dog training." },
 					],
 					selectContentOutline: () => ( { sections: [], faqContentNotes: [] } ),
 					selectSuggestionsStatus: () => "success",
+					selectContentOutlineStatus: () => "idle",
+					selectContentSuggestionsEndpoint: () => "/yoast/v1/content_planner/suggestions",
+					selectContentOutlineEndpoint: () => "/yoast/v1/content_planner/outline",
 				};
 			}
 			if ( storeName === "yoast-seo/editor" ) {
 				return {
 					getIsPremium: () => false,
+					getPostType: () => "post",
+					getContentLocale: () => "en_US",
+					getEditorTypeApiValue: () => "gutenberg",
 				};
 			}
 			if ( storeName === "yoast-seo/ai-generator" ) {
 				return {
 					selectUsageCount: () => 1,
 					selectUsageCountLimit: () => 10,
+					selectUsageCountEndpoint: () => "/yoast/v1/ai_generator/get_usage",
+					isUsageCountLimitReached: () => false,
 				};
 			}
 			return {};
@@ -91,13 +141,15 @@ const setupMocks = () => {
 	select.mockReturnValue( { selectContentOutline: jest.fn().mockReturnValue( { sections: [], faqContentNotes: [] } ) } );
 };
 
-const createModalElement = ( props ) => (
+const createModalElement = ( { initialStatus = "idle", ...props } = {} ) => (
 	<FeatureModal
 		isOpen={ true }
 		onClose={ jest.fn() }
 		isEmptyPost={ true }
 		isPremium={ false }
 		isUpsell={ false }
+		status={ initialStatus }
+		setStatus={ jest.fn() }
 		resetBlocks={ mockResetBlocks }
 		getContentOutline={ mockGetContentOutline }
 		{ ...props }
@@ -262,5 +314,75 @@ describe( "FeatureModal", () => {
 		// Should go straight to content suggestions, no approve modal.
 		expect( screen.queryByText( "Looking for inspiration?" ) ).not.toBeInTheDocument();
 		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
+	} );
+
+	it( "fetches usage count when the modal opens", () => {
+		renderModal( { isOpen: true } );
+		expect( mockFetchUsageCount ).toHaveBeenCalledWith( {
+			endpoint: "/yoast/v1/ai_generator/get_usage",
+			isWooProductEntity: false,
+		} );
+	} );
+
+	it( "does not fetch usage count when the modal is closed", () => {
+		renderModal( { isOpen: false } );
+		expect( mockFetchUsageCount ).not.toHaveBeenCalled();
+	} );
+
+	it( "calls addUsageCount when suggestions status transitions to success", () => {
+		// Start with suggestionsStatus as "idle" so the ref initializes to "idle".
+		const mockSelectWithIdle = ( selector ) => {
+			if ( typeof selector !== "function" ) {
+				return {};
+			}
+			return selector( ( storeName ) => {
+				if ( storeName === "yoast-seo/content-planner" ) {
+					return {
+						selectSuggestion: () => null,
+						selectSuggestions: () => [],
+						selectContentOutline: () => ( { sections: [], faqContentNotes: [] } ),
+						selectSuggestionsStatus: () => "idle",
+						selectContentOutlineStatus: () => "idle",
+						selectContentSuggestionsEndpoint: () => "",
+						selectContentOutlineEndpoint: () => "",
+					};
+				}
+				if ( storeName === "yoast-seo/editor" ) {
+					return {
+						getIsPremium: () => false,
+						getPostType: () => "post",
+						getContentLocale: () => "en_US",
+						getEditorTypeApiValue: () => "gutenberg",
+					};
+				}
+				if ( storeName === "yoast-seo/ai-generator" ) {
+					return {
+						selectUsageCount: () => 0,
+						selectUsageCountLimit: () => 10,
+						selectUsageCountEndpoint: () => "/yoast/v1/ai_generator/get_usage",
+						isUsageCountLimitReached: () => false,
+					};
+				}
+				return {};
+			} );
+		};
+
+		// Render with suggestions status "idle".
+		useSelect.mockImplementation( mockSelectWithIdle );
+		const { rerender } = renderModal();
+		expect( mockAddUsageCount ).not.toHaveBeenCalled();
+
+		// Now transition suggestions status to "success".
+		setupMocks();
+		rerender( createModalElement() );
+
+		expect( mockAddUsageCount ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "does not call addUsageCount when suggestions status is already success on mount", () => {
+		// Default setupMocks returns suggestionsStatus "success", so the ref initializes to "success".
+		renderModal();
+		// addUsageCount should NOT be called because there was no transition.
+		expect( mockAddUsageCount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import { useSelect, useDispatch, select, useDispatch } from "@wordpress/data";
+import { useSelect, useDispatch, select } from "@wordpress/data";
 import { FeatureModal } from "../../../src/ai-content-planner/components/feature-modal";
 import { useFetchContentSuggestions } from "../../../src/ai-content-planner/hooks/use-fetch-content-suggestions";
 import { useFetchContentOutline } from "../../../src/ai-content-planner/hooks/use-fetch-content-outline";
@@ -211,7 +211,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { status: "content-outline" } );
+		renderModal( { status: "content-outline", selectedSuggestion: mockSuggestion } );
 		expect( screen.getByText( "Content outline" ) ).toBeInTheDocument();
 	} );
 
@@ -222,7 +222,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { isEmptyPost: false, status: "content-outline", setStatus } );
+		renderModal( { isEmptyPost: false, status: "content-outline", setStatus, selectedSuggestion: mockSuggestion } );
 		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		expect( setStatus ).toHaveBeenCalledWith( "replace-content" );
 	} );
@@ -233,7 +233,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { isEmptyPost: true, status: "content-outline" } );
+		renderModal( { isEmptyPost: true, status: "content-outline", selectedSuggestion: mockSuggestion } );
 		await act( async() => {
 			fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		} );
@@ -249,8 +249,8 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		// Render with non-empty post at content-outline status
-		renderModal( { isEmptyPost: false, status: "content-outline", setStatus } );
+		// Render with non-empty post at content-outline status.
+		renderModal( { isEmptyPost: false, status: "content-outline", setStatus, selectedSuggestion: mockSuggestion } );
 		// Click Add outline to post → triggers setHasVisitedReplace=true and setStatus("replace-content")
 		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		// Both setStatus calls happen: once with "replace-content", then Cancel would call "content-outline"
@@ -263,7 +263,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { isEmptyPost: true, status: "content-outline" } );
+		renderModal( { isEmptyPost: true, status: "content-outline", selectedSuggestion: mockSuggestion } );
 		await act( async() => {
 			fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		} );
@@ -275,75 +275,5 @@ describe( "FeatureModal", () => {
 		renderModal( { status: "content-suggestions" } );
 		expect( screen.queryByText( "Looking for inspiration?" ) ).not.toBeInTheDocument();
 		expect( screen.getByText( "Content suggestions" ) ).toBeInTheDocument();
-	} );
-
-	it( "fetches usage count when the modal opens", () => {
-		renderModal( { isOpen: true } );
-		expect( mockFetchUsageCount ).toHaveBeenCalledWith( {
-			endpoint: "/yoast/v1/ai_generator/get_usage",
-			isWooProductEntity: false,
-		} );
-	} );
-
-	it( "does not fetch usage count when the modal is closed", () => {
-		renderModal( { isOpen: false } );
-		expect( mockFetchUsageCount ).not.toHaveBeenCalled();
-	} );
-
-	it( "calls addUsageCount when suggestions status transitions to success", () => {
-		// Start with suggestionsStatus as "idle" so the ref initializes to "idle".
-		const mockSelectWithIdle = ( selector ) => {
-			if ( typeof selector !== "function" ) {
-				return {};
-			}
-			return selector( ( storeName ) => {
-				if ( storeName === "yoast-seo/content-planner" ) {
-					return {
-						selectSuggestion: () => null,
-						selectSuggestions: () => [],
-						selectContentOutline: () => ( { sections: [], faqContentNotes: [] } ),
-						selectSuggestionsStatus: () => "idle",
-						selectContentOutlineStatus: () => "idle",
-						selectContentSuggestionsEndpoint: () => "",
-						selectContentOutlineEndpoint: () => "",
-					};
-				}
-				if ( storeName === "yoast-seo/editor" ) {
-					return {
-						getIsPremium: () => false,
-						getPostType: () => "post",
-						getContentLocale: () => "en_US",
-						getEditorTypeApiValue: () => "gutenberg",
-					};
-				}
-				if ( storeName === "yoast-seo/ai-generator" ) {
-					return {
-						selectUsageCount: () => 0,
-						selectUsageCountLimit: () => 10,
-						selectUsageCountEndpoint: () => "/yoast/v1/ai_generator/get_usage",
-						isUsageCountLimitReached: () => false,
-					};
-				}
-				return {};
-			} );
-		};
-
-		// Render with suggestions status "idle".
-		useSelect.mockImplementation( mockSelectWithIdle );
-		const { rerender } = renderModal();
-		expect( mockAddUsageCount ).not.toHaveBeenCalled();
-
-		// Now transition suggestions status to "success".
-		setupMocks();
-		rerender( createModalElement() );
-
-		expect( mockAddUsageCount ).toHaveBeenCalledTimes( 1 );
-	} );
-
-	it( "does not call addUsageCount when suggestions status is already success on mount", () => {
-		// Default setupMocks returns suggestionsStatus "success", so the ref initializes to "success".
-		renderModal();
-		// addUsageCount should NOT be called because there was no transition.
-		expect( mockAddUsageCount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -109,6 +109,7 @@ const defaultStoreSelectors = {
 		selectUsageCount: () => 1,
 		selectUsageCountLimit: () => 10,
 		isUsageCountLimitReached: () => false,
+		selectUsageCountStatus: () => "idle",
 	},
 	"core/editor": {
 		getEditedPostContent: () => "",

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -81,7 +81,6 @@ const mockSuggestion = {
 	keyphrase: "dog training",
 	// eslint-disable-next-line camelcase
 	meta_description: "A guide to training your dog.",
-	structure: [ { level: "H2", title: "Introduction" } ],
 };
 
 const EMPTY_OUTLINE = [];
@@ -166,6 +165,20 @@ const createModalElement = ( { status = "idle", setStatus = mockSetStatus, ...pr
 const renderModal = ( props ) => render( createModalElement( props ) );
 
 describe( "FeatureModal", () => {
+	beforeAll( () => {
+		// Suppress the @testing-library/react v14 warning about the deprecated ReactDOMTestUtils.act.
+		jest.spyOn( console, "error" ).mockImplementation( ( message, ...args ) => {
+			if ( typeof message === "string" && message.includes( "ReactDOMTestUtils.act" ) ) {
+				return;
+			}
+			process.stderr.write( [ message, ...args ].join( " " ) + "\n" );
+		} );
+	} );
+
+	afterAll( () => {
+		console.error.mockRestore();
+	} );
+
 	beforeEach( () => {
 		setupMocks();
 	} );
@@ -212,7 +225,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { status: "content-outline", selectedSuggestion: mockSuggestion } );
+		renderModal( { status: "content-outline" } );
 		expect( screen.getByText( "Content outline" ) ).toBeInTheDocument();
 	} );
 
@@ -223,7 +236,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { isEmptyPost: false, status: "content-outline", setStatus, selectedSuggestion: mockSuggestion } );
+		renderModal( { isEmptyPost: false, status: "content-outline", setStatus } );
 		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		expect( setStatus ).toHaveBeenCalledWith( "replace-content" );
 	} );
@@ -234,7 +247,7 @@ describe( "FeatureModal", () => {
 				selectSuggestion: () => mockSuggestion,
 			},
 		} );
-		renderModal( { isEmptyPost: true, status: "content-outline", selectedSuggestion: mockSuggestion } );
+		renderModal( { isEmptyPost: true, status: "content-outline" } );
 		await act( async() => {
 			fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		} );
@@ -251,7 +264,7 @@ describe( "FeatureModal", () => {
 			},
 		} );
 		// Render with non-empty post at content-outline status.
-		renderModal( { isEmptyPost: false, status: "content-outline", setStatus, selectedSuggestion: mockSuggestion } );
+		renderModal( { isEmptyPost: false, status: "content-outline", setStatus } );
 		// Click Add outline to post → triggers setHasVisitedReplace=true and setStatus("replace-content")
 		fireEvent.click( screen.getByRole( "button", { name: /Add outline to post/i } ) );
 		// Both setStatus calls happen: once with "replace-content", then Cancel would call "content-outline"


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Adds real time info about your usage.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the usage of the free sparks tracked.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open the suggestions and take note of how many sparks you have used.
* Wait for the suggestions to pop up and make sure there is now 1 more used.
* Refresh the page and open the suggestions modal once more and make sure you see the +1 count from before to make sure it reads the api.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
