### PR TITLE
docs: fix 'Indexable_Presention' -> 'Indexable_Presentation' in docblock

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -472,7 +472,7 @@ class Front_End_Integration implements Integration_Interface {
 		/**
 		 * Filter 'wpseo_frontend_presentation' - Allow filtering the presentation used to output our meta values.
 		 *
-		 * @param Indexable_Presention $presentation The indexable presentation.
+		 * @param Indexable_Presentation $presentation The indexable presentation.
 		 * @param Meta_Tags_Context    $context      The meta tags context for the current page.
 		 */
 		$presentation = \apply_filters( 'wpseo_frontend_presentation', $context->presentation, $context );


### PR DESCRIPTION
## Summary

\`src/integrations/front-end-integration.php\` line 475 documents the \`wpseo_frontend_presentation\` filter's first argument as \`Indexable_Presention\`, which is a typo — the real class is \`Indexable_Presentation\` (see \`src/presentations/indexable-presentation.php\`).

Before:
\`\`\`
* @param Indexable_Presention \$presentation The indexable presentation.
\`\`\`

After:
\`\`\`
* @param Indexable_Presentation \$presentation The indexable presentation.
\`\`\`

This is inside a docblock describing a \`apply_filters\` hook, so the fix makes the IDE/type-hinting and filter reference docs correct without changing runtime behavior.

Closes #23147


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves documentation in a docblock. Props to [@MukundaKatta](https://github.com/MukundaKatta).

## Testing

PHPDoc-only change; no code path altered. Verified the referenced class \`Indexable_Presentation\` exists in \`src/presentations/indexable-presentation.php\`.