### PR TITLE
1164 minor discrepancies in the intent banners and badges

### DIFF
--- a/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
+++ b/packages/js/src/ai-content-planner/components/content-suggestions-modal.js
@@ -30,7 +30,7 @@ const SuggestionButton = ( { suggestion, onClick } ) => {
 	const handleClick = useCallback( () => onClick( suggestion ), [ onClick, suggestion ] );
 	return (
 		<button type="button" onClick={ handleClick } className="yst-group yst-text-start yst-w-full yst-rounded-md yst-border yst-border-slate-200 yst-mb-4 yst-p-4 yst-shadow-sm yst-transition-colors hover:yst-bg-slate-50 hover:yst-border-slate-300 focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500">
-			<IntentBadge intent={ intent } className="yst-mb-2 yst-text-xs" />
+			<IntentBadge intent={ intent } className="yst-mb-2 yst-text-xs" cursor="pointer" />
 			<div className="yst-font-medium yst-text-sm yst-mb-2 yst-text-slate-800 group-hover:yst-underline">{ title }</div>
 			<p className="yst-text-slate-600">{ explanation }</p>
 		</button>

--- a/packages/js/src/ai-content-planner/components/intent-badge.js
+++ b/packages/js/src/ai-content-planner/components/intent-badge.js
@@ -27,9 +27,9 @@ export const intentBadgeProps = {
 		tooltip: __( "The user wants to find a specific page or site.", "wordpress-seo" ),
 	},
 	commercial: {
-		classes: "yst-bg-yellow-200 yst-text-yellow-900",
-		calloutClasses: "yst-bg-yellow-50 yst-border-yellow-200",
-		calloutTextClasses: "yst-text-yellow-900",
+		classes: "yst-bg-amber-200 yst-text-amber-900",
+		calloutClasses: "yst-bg-amber-50 yst-border-amber-200",
+		calloutTextClasses: "yst-text-amber-900",
 		Icon: StarIcon,
 		label: __( "Commercial", "wordpress-seo" ),
 		tooltip: __( "The user wants to investigate brands or services.", "wordpress-seo" ),

--- a/packages/js/src/ai-content-planner/components/intent-badge.js
+++ b/packages/js/src/ai-content-planner/components/intent-badge.js
@@ -1,8 +1,8 @@
 import { __ } from "@wordpress/i18n";
 import { BookOpenIcon, StarIcon, MapIcon, ShoppingCartIcon } from "@heroicons/react/outline";
 import classNames from "classnames";
-import { Badge, Tooltip, useSvgAria } from "@yoast/ui-library";
-import { useCallback, useId, useState } from "@wordpress/element";
+import { Badge, TooltipContainer, TooltipTrigger, TooltipWithContext, useSvgAria } from "@yoast/ui-library";
+import { useId } from "@wordpress/element";
 
 /**
  * Mapping from intent type to badge styling, icon, tooltip and callout colors.
@@ -51,16 +51,14 @@ export const intentBadgeProps = {
  * @param {string} props.intent The intent type (e.g. "informational").
  * @param {string} [props.className] Additional class names to apply to the badge.
  * @param {string} [props.tooltipPosition] Position of the tooltip. Defaults to "top-right".
- * @param {"default"|"pointer"} [props.cursor] Cursor style for the badge. Defaults to "default"; use "pointer" when the badge sits inside a clickable parent.
+ * @param {"default"|"pointer"} [props.cursor] Cursor style for the badge. Defaults to "default";
+ *     use "pointer" when the badge sits inside a clickable parent.
  *
  * @returns {JSX.Element|null} The IntentBadge component.
  */
 export const IntentBadge = ( { intent, className, tooltipPosition = "top-right", cursor = "default" } ) => {
 	const badge = intentBadgeProps[ intent ];
 	const svgAriaProps = useSvgAria();
-	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
-	const handleMouseEnter = useCallback( () => setIsTooltipVisible( true ), [] );
-	const handleMouseLeave = useCallback( () => setIsTooltipVisible( false ), [] );
 	const uniqueId = useId();
 	const tooltipId = `intent-tooltip-${ intent }-${ uniqueId }`;
 
@@ -71,14 +69,15 @@ export const IntentBadge = ( { intent, className, tooltipPosition = "top-right",
 	const { Icon } = badge;
 	const cursorClass = cursor === "pointer" ? "yst-cursor-pointer" : "yst-cursor-default";
 	return (
-		<Badge
-			className={ classNames( "yst-relative yst-flex yst-items-center yst-gap-1 yst-w-fit", cursorClass, badge.classes, className ) }
-			aria-describedby={ isTooltipVisible ? tooltipId : null }
-			onMouseEnter={ handleMouseEnter }
-			onMouseLeave={ handleMouseLeave }
-		>
-			<Icon className={ classNames( "yst-w-3", badge.classes ) } { ...svgAriaProps } /> { badge.label }
-			{ isTooltipVisible && <Tooltip id={ tooltipId } className="yst-max-w-48 yst-z-50 yst-text-center" position={ tooltipPosition }>{ badge.tooltip }</Tooltip> }
-		</Badge>
+		<TooltipContainer>
+			<TooltipTrigger as="span" ariaDescribedby={ tooltipId } className="yst-inline-flex yst-w-fit">
+				<Badge className={ classNames( "yst-relative yst-flex yst-items-center yst-gap-1 yst-w-fit", cursorClass, badge.classes, className ) }>
+					<Icon className={ classNames( "yst-w-3", badge.classes ) } { ...svgAriaProps } /> { badge.label }
+				</Badge>
+			</TooltipTrigger>
+			<TooltipWithContext id={ tooltipId } className="yst-max-w-48 yst-z-50 yst-text-center" position={ tooltipPosition }>
+				{ badge.tooltip }
+			</TooltipWithContext>
+		</TooltipContainer>
 	);
 };

--- a/packages/js/src/ai-content-planner/components/intent-badge.js
+++ b/packages/js/src/ai-content-planner/components/intent-badge.js
@@ -51,10 +51,11 @@ export const intentBadgeProps = {
  * @param {string} props.intent The intent type (e.g. "informational").
  * @param {string} [props.className] Additional class names to apply to the badge.
  * @param {string} [props.tooltipPosition] Position of the tooltip. Defaults to "top-right".
+ * @param {"default"|"pointer"} [props.cursor] Cursor style for the badge. Defaults to "default"; use "pointer" when the badge sits inside a clickable parent.
  *
  * @returns {JSX.Element|null} The IntentBadge component.
  */
-export const IntentBadge = ( { intent, className, tooltipPosition = "top-right" } ) => {
+export const IntentBadge = ( { intent, className, tooltipPosition = "top-right", cursor = "default" } ) => {
 	const badge = intentBadgeProps[ intent ];
 	const svgAriaProps = useSvgAria();
 	const [ isTooltipVisible, setIsTooltipVisible ] = useState( false );
@@ -68,9 +69,10 @@ export const IntentBadge = ( { intent, className, tooltipPosition = "top-right" 
 	}
 
 	const { Icon } = badge;
+	const cursorClass = cursor === "pointer" ? "yst-cursor-pointer" : "yst-cursor-default";
 	return (
 		<Badge
-			className={ classNames( "yst-relative yst-flex yst-items-center yst-gap-1 yst-w-fit yst-cursor-default", badge.classes, className ) }
+			className={ classNames( "yst-relative yst-flex yst-items-center yst-gap-1 yst-w-fit", cursorClass, badge.classes, className ) }
 			aria-describedby={ isTooltipVisible ? tooltipId : null }
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }

--- a/packages/js/tests/ai-content-planner/components/intent-badge.test.js
+++ b/packages/js/tests/ai-content-planner/components/intent-badge.test.js
@@ -81,4 +81,20 @@ describe( "IntentBadge", () => {
 			expect( firstId ).not.toEqual( secondId );
 		} );
 	} );
+
+	describe( "cursor", () => {
+		it( "applies the default cursor class when no cursor prop is provided", () => {
+			render( <IntentBadge intent="informational" /> );
+			const badge = getBadge( "Informational" );
+			expect( badge ).toHaveClass( "yst-cursor-default" );
+			expect( badge ).not.toHaveClass( "yst-cursor-pointer" );
+		} );
+
+		it( "applies the pointer cursor class when cursor=\"pointer\" is provided", () => {
+			render( <IntentBadge intent="informational" cursor="pointer" /> );
+			const badge = getBadge( "Informational" );
+			expect( badge ).toHaveClass( "yst-cursor-pointer" );
+			expect( badge ).not.toHaveClass( "yst-cursor-default" );
+		} );
+	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/intent-badge.test.js
+++ b/packages/js/tests/ai-content-planner/components/intent-badge.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { IntentBadge } from "../../../src/ai-content-planner/components/intent-badge";
 
 /**
@@ -8,6 +8,14 @@ import { IntentBadge } from "../../../src/ai-content-planner/components/intent-b
  * @returns {HTMLElement} The badge element (span.yst-badge).
  */
 const getBadge = ( label ) => screen.getByText( label ).closest( ".yst-badge" );
+
+/**
+ * Finds the tooltip trigger element wrapping the given IntentBadge.
+ *
+ * @param {string} label The visible label text (e.g. "Informational").
+ * @returns {HTMLElement} The trigger element (span.yst-tooltip-trigger).
+ */
+const getTrigger = ( label ) => screen.getByText( label ).closest( ".yst-tooltip-trigger" );
 
 describe( "IntentBadge", () => {
 	describe( "label rendering", () => {
@@ -27,44 +35,22 @@ describe( "IntentBadge", () => {
 		} );
 	} );
 
-	describe( "tooltip behavior", () => {
+	describe( "tooltip content and wiring", () => {
 		it.each( [
 			[ "informational", "Informational", "The user wants to find an answer to a specific question." ],
 			[ "navigational", "Navigational", "The user wants to find a specific page or site." ],
 			[ "commercial", "Commercial", "The user wants to investigate brands or services." ],
 			[ "transactional", "Transactional", "The user wants to complete an action (conversion)." ],
-		] )( "shows the %s tooltip text on mouse enter", ( intent, label, expectedTooltip ) => {
+		] )( "renders the %s tooltip text", ( intent, label, expectedTooltip ) => {
 			render( <IntentBadge intent={ intent } /> );
-			fireEvent.mouseEnter( getBadge( label ) );
-			expect( screen.getByRole( "tooltip" ) ).toHaveTextContent( expectedTooltip );
+			expect( screen.getByRole( "tooltip", { hidden: true } ) ).toHaveTextContent( expectedTooltip );
 		} );
 
-		it( "hides the tooltip on mouse leave", () => {
+		it( "wires aria-describedby on the trigger to the tooltip id", () => {
 			render( <IntentBadge intent="informational" /> );
-			const badge = getBadge( "Informational" );
-			fireEvent.mouseEnter( badge );
-			expect( screen.getByRole( "tooltip" ) ).toBeInTheDocument();
-			fireEvent.mouseLeave( badge );
-			expect( screen.queryByRole( "tooltip" ) ).not.toBeInTheDocument();
-		} );
-
-		it( "does not render a tooltip initially", () => {
-			render( <IntentBadge intent="informational" /> );
-			expect( screen.queryByRole( "tooltip" ) ).not.toBeInTheDocument();
-		} );
-
-		it( "does not set aria-describedby when the tooltip is hidden", () => {
-			render( <IntentBadge intent="informational" /> );
-			expect( getBadge( "Informational" ) ).not.toHaveAttribute( "aria-describedby" );
-		} );
-
-		it( "sets aria-describedby pointing to the tooltip id when the tooltip is visible", () => {
-			render( <IntentBadge intent="informational" /> );
-			const badge = getBadge( "Informational" );
-			fireEvent.mouseEnter( badge );
-			const describedBy = badge.getAttribute( "aria-describedby" );
+			const describedBy = getTrigger( "Informational" ).getAttribute( "aria-describedby" );
 			expect( describedBy ).toMatch( /^intent-tooltip-informational-/ );
-			expect( screen.getByRole( "tooltip" ) ).toHaveAttribute( "id", describedBy );
+			expect( screen.getByRole( "tooltip", { hidden: true } ) ).toHaveAttribute( "id", describedBy );
 		} );
 
 		it( "generates unique tooltip ids for multiple instances of the same intent", () => {
@@ -72,13 +58,8 @@ describe( "IntentBadge", () => {
 				<IntentBadge intent="informational" />
 				<IntentBadge intent="informational" />
 			</> );
-			const badges = screen.getAllByText( "Informational" ).map( ( el ) => el.closest( ".yst-badge" ) );
-			fireEvent.mouseEnter( badges[ 0 ] );
-			const firstId = badges[ 0 ].getAttribute( "aria-describedby" );
-			fireEvent.mouseLeave( badges[ 0 ] );
-			fireEvent.mouseEnter( badges[ 1 ] );
-			const secondId = badges[ 1 ].getAttribute( "aria-describedby" );
-			expect( firstId ).not.toEqual( secondId );
+			const triggers = screen.getAllByText( "Informational" ).map( ( el ) => el.closest( ".yst-tooltip-trigger" ) );
+			expect( triggers[ 0 ].getAttribute( "aria-describedby" ) ).not.toEqual( triggers[ 1 ].getAttribute( "aria-describedby" ) );
 		} );
 	} );
 

--- a/packages/ui-library/src/elements/tooltip/style.css
+++ b/packages/ui-library/src/elements/tooltip/style.css
@@ -30,7 +30,7 @@
 			}
 		}
 
-		.yst-tooltip--top {
+		.yst-tooltip.yst-tooltip--top {
 			@apply yst--translate-x-1/2
 			rtl:yst-translate-x-1/2
 			yst--translate-y-full
@@ -56,7 +56,7 @@
 			}
 		}
 
-		.yst-tooltip--top-left {
+		.yst-tooltip.yst-tooltip--top-left {
 			@apply yst--translate-y-full
 			yst-end-0
 			yst-top-0
@@ -76,7 +76,7 @@
 			}
 		}
 
-		.yst-tooltip--top-right {
+		.yst-tooltip.yst-tooltip--top-right {
 			@apply yst--translate-y-full
 			yst-start-0
 			yst-top-0
@@ -96,7 +96,7 @@
 			}
 		}
 
-		.yst-tooltip--bottom {
+		.yst-tooltip.yst-tooltip--bottom {
 			@apply yst--translate-x-1/2
 			rtl:yst-translate-x-1/2
 			yst--translate-y-0
@@ -121,7 +121,7 @@
 			}
 		}
 
-		.yst-tooltip--bottom-left {
+		.yst-tooltip.yst-tooltip--bottom-left {
 			@apply yst-end-0
 			yst-top-full
 			yst-mt-3
@@ -139,7 +139,7 @@
 			}
 		}
 
-		.yst-tooltip--bottom-right {
+		.yst-tooltip.yst-tooltip--bottom-right {
 			@apply yst-start-0
 			yst-top-full
 			yst-mt-3
@@ -157,7 +157,7 @@
 			}
 		}
 
-		.yst-tooltip--right {
+		.yst-tooltip.yst-tooltip--right {
 			@apply yst--translate-x-0
 			yst--translate-y-1/2
 			yst-start-full
@@ -177,7 +177,7 @@
 			}
 		}
 
-		.yst-tooltip--left {
+		.yst-tooltip.yst-tooltip--left {
 			@apply yst--translate-y-1/2
 			yst-end-full
 			yst-top-1/2


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Follows up https://github.com/Yoast/wordpress-seo/pull/23152, where we noticed some minor discrepancies in the intent banners and badges and we split it in a new task.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes some discrepancies in the intent banners and badges.
* [@yoast/ui-library 0.1.0 other] Improves the tooltip arrow styling to avoid conflicting style sheets. 

## Relevant technical choices:

* Aside from the visual discrepancies, we also take care of feedback from Copilot in [the followed-up PR](https://github.com/Yoast/wordpress-seo/pull/23152), the most important of which is the switch to the `TooltipContainer` way of adding tooltips.
* Added enforcment to the tooltip arrow styling in the ui library after conflicting styling from the `@yoast/ai-frontend` package.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Confirm that the `Commercial` intent and its badge have the same styling with the designs (namely, their colors)
<img width="786" height="160" alt="image" src="https://github.com/user-attachments/assets/bf2d2fa2-db8b-4991-ae68-84065e3646a3" />
<img width="252" height="97" alt="image" src="https://github.com/user-attachments/assets/fa39559a-b14c-4c36-ba38-ab1030e1219b" />

* Confirm that the cursor when the badge is hovered (and the tooltip is shown) is:
  * the pointer cursor when on the suggestions modal (because it's part of a clickable button)
  * the default cursor when on the outline modal (because it's part of a non-clickable button)
* Confirm that the tooltip of badges when on the suggestions modal is the same with the designs and not like reported [here](https://github.com/Yoast/wordpress-seo/pull/23152#pullrequestreview-4145542266).
* Also a quick regression test of the tooltips, as per the test instructions of [this PR](https://github.com/Yoast/wordpress-seo/pull/23152).


For devs:
* Smoke test Tooltip in UI library storybook.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
