### PR TITLE
Remove logo and intro from Elementor and Classic editor

### DIFF
--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -14,12 +14,14 @@ import classNames from "classnames";
  *
  * @param {string} store The store to use. Defaults to {@code yoast-seo/editor}
  * @param {string} location Where the notice will be shown. Defaults to {@code sidebar}
+ * @param {boolean} inEditorIntro Whether rendered inside EditorIntro. Tightens margins.
  *
  * @returns {JSX.Element} The BlackFridayPromotion component.
  */
 export const BlackFridayPromotion = ( {
 	store = "yoast-seo/editor",
 	location = "sidebar",
+	inEditorIntro = false,
 } ) => {
 	const alertKey = "black-friday-promotion";
 	const isPremium = useSelect( select => select( store ).getIsPremium(), [ store ] );
@@ -27,6 +29,7 @@ export const BlackFridayPromotion = ( {
 	const promotionActive = useSelect( select => select( store ).isPromotionActive( alertKey ), [ store ] );
 	const isWooCommerceActive = useSelect( select => select( store ).getIsWooCommerceActive(), [ store ] );
 	const isAlertDismissed = useSelect( select => select( store ).isAlertDismissed( alertKey ), [ store ] );
+	const isElementorEditor = useSelect( select => select( store ).getIsElementorEditor(), [ store ] );
 
 	const onDismiss = useCallback( () => {
 		dispatch( store ).dismissAlert( alertKey );
@@ -47,7 +50,13 @@ export const BlackFridayPromotion = ( {
 			<div
 				className={
 					classNames(
-						"yst-mx-0 yst-border yst-rounded-lg yst-p-4 yst-max-w-md yst-mt-3 yst-relative yst-shadow-sm",
+						inEditorIntro
+							? "yst-mx-0 yst-mt-3"
+							: [
+								location === "sidebar" && ! isElementorEditor ? "yst-mx-0" : "yst-mx-4",
+								"yst-mt-6",
+							],
+						"yst-border yst-rounded-lg yst-p-4 yst-max-w-md yst-relative yst-shadow-sm",
 						isWooCommerceActive ? "yst-border-woo-light" : "yst-border-primary-200" ) }
 			>
 				<Badge size="small"className="yst-text-[10px] yst-bg-black yst-text-amber-300 yst-absolute yst--top-2">
@@ -94,4 +103,5 @@ export const BlackFridayPromotion = ( {
 BlackFridayPromotion.propTypes = {
 	store: PropTypes.string,
 	location: PropTypes.oneOf( [ "sidebar", "metabox" ] ),
+	inEditorIntro: PropTypes.bool,
 };

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -14,7 +14,7 @@ import classNames from "classnames";
  *
  * @param {string} store The store to use. Defaults to {@code yoast-seo/editor}
  * @param {string} location Where the notice will be shown. Defaults to {@code sidebar}
- * @param {boolean} inEditorIntro Whether rendered inside EditorIntro. Tightens margins.
+ * @param {boolean} [inEditorIntro=false] Whether rendered inside EditorIntro. Tightens margins.
  *
  * @returns {JSX.Element} The BlackFridayPromotion component.
  */

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -64,7 +64,7 @@ export default function MetaboxFill( { settings } ) {
 						key="editor-intro"
 						renderPriority={ 1 }
 					>
-						<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }>
+						<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isPost }>
 							<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
 						</EditorIntro>
 					</SidebarItem>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -65,7 +65,7 @@ export default function MetaboxFill( { settings } ) {
 						renderPriority={ 1 }
 					>
 						<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isPost }>
-							<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
+							<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } inEditorIntro={ true } />
 						</EditorIntro>
 					</SidebarItem>
 				) : (

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -59,14 +59,23 @@ export default function MetaboxFill( { settings } ) {
 				>
 					<Warning />
 				</SidebarItem>
-				<SidebarItem
-					key="editor-intro"
-					renderPriority={ 1 }
-				>
-					<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }>
+				{ isBlockEditorActive ? (
+					<SidebarItem
+						key="editor-intro"
+						renderPriority={ 1 }
+					>
+						<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }>
+							<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
+						</EditorIntro>
+					</SidebarItem>
+				) : (
+					<SidebarItem
+						key="time-constrained-notification"
+						renderPriority={ 1 }
+					>
 						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
-					</EditorIntro>
-				</SidebarItem>
+					</SidebarItem>
+				) }
 				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>
 					<ContentPlannerEditorItem location="metabox" />
 				</SidebarItem> }

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -62,7 +62,7 @@ export default function SidebarFill( { settings } ) {
 					renderPriority={ 1 }
 				>
 					<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }>
-						{ FirstEligibleNotification && <FirstEligibleNotification /> }
+						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
 					</EditorIntro>
 				</SidebarItem>
 				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>

--- a/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
+++ b/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
@@ -10,9 +10,10 @@ const OutboundLink = makeOutboundLink();
 
 /**
  * The Trustpilot review notification.
+ * @param {Object} props The component props forwarded to the underlying notification (e.g. inEditorIntro).
  * @returns {JSX.Element|null} The notification or null.
  */
-export const TrustpilotReviewNotification = () => {
+export const TrustpilotReviewNotification = ( props ) => {
 	const { shouldShow, dismiss } = useTrustpilotReviewNotification();
 	const { locationContext } = useRootContext();
 	const trustpilotLink = useSelect( ( select ) => select( STORE_NAME ).selectLink( "https://yoa.st/trustpilot-review", { context: locationContext } ), [ locationContext ] );
@@ -26,6 +27,7 @@ export const TrustpilotReviewNotification = () => {
 			hasIcon={ false }
 			isAlertDismissed={ ! shouldShow }
 			onDismissed={ dismiss }
+			{ ...props }
 		>
 			{ __( "Happy with the plugin?", "wordpress-seo" ) }
 			{ " " }

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import withPersistentDismiss from "./withPersistentDismiss";
@@ -9,9 +10,11 @@ import withPersistentDismiss from "./withPersistentDismiss";
  * @param {JSX.Element|null} image The image or null if no image.
  * @param {boolean} isAlertDismissed Whether or not the notification is dismissed.
  * @param {Function} onDismissed The dismissal prop to be renamed for Notification component.
+ * @param {boolean} inEditorIntro Whether rendered inside EditorIntro. Adds a small top margin under the logo.
  *
  * @returns {Component} The composed Notification component.
  */
+/* eslint-disable-next-line complexity */
 export const PersistentDismissableNotification = ( {
 	children,
 	id,
@@ -20,9 +23,10 @@ export const PersistentDismissableNotification = ( {
 	image: Image = null,
 	isAlertDismissed,
 	onDismissed,
+	inEditorIntro = false,
 } ) => {
 	return isAlertDismissed ? null : (
-		<div id={ id } className="notice-yoast yoast is-dismissible yoast-webinar-dashboard yoast-general-page-notices yst-mt-3">
+		<div id={ id } className={ classNames( "notice-yoast yoast is-dismissible yoast-webinar-dashboard yoast-general-page-notices", inEditorIntro && "yst-mt-3" ) }>
 			<div className="notice-yoast__container">
 				<div>
 					<div className="notice-yoast__header">
@@ -55,6 +59,7 @@ PersistentDismissableNotification.propTypes = {
 	image: PropTypes.elementType,
 	isAlertDismissed: PropTypes.bool.isRequired,
 	onDismissed: PropTypes.func.isRequired,
+	inEditorIntro: PropTypes.bool,
 };
 
 export default withPersistentDismiss( PersistentDismissableNotification );

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -10,7 +10,7 @@ import withPersistentDismiss from "./withPersistentDismiss";
  * @param {JSX.Element|null} image The image or null if no image.
  * @param {boolean} isAlertDismissed Whether or not the notification is dismissed.
  * @param {Function} onDismissed The dismissal prop to be renamed for Notification component.
- * @param {boolean} inEditorIntro Whether rendered inside EditorIntro. Adds a small top margin under the logo.
+ * @param {boolean} [inEditorIntro=false] Whether rendered inside EditorIntro. Adds a small top margin under the logo.
  *
  * @returns {Component} The composed Notification component.
  */

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -21,7 +21,6 @@ import AdvancedSettings from "../../../containers/AdvancedSettings";
 import SEMrushRelatedKeyphrases from "../../../containers/SEMrushRelatedKeyphrases";
 import WincherSEOPerformanceModal from "../../../containers/WincherSEOPerformanceModal";
 import KeywordUpsell from "../../../components/modals/KeywordUpsell";
-import { EditorIntro } from "../../../components/EditorIntro";
 
 /* eslint-disable complexity */
 /**
@@ -52,16 +51,13 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 	return (
 		<>
 			<Fill name="YoastElementor">
-				<SidebarItem
-					key="editor-intro"
-					renderPriority={ 0 }
-				>
-					<EditorIntro withPromptForContentSuggestions={ false }>
-						{ FirstEligibleNotification && <FirstEligibleNotification /> }
-					</EditorIntro>
-				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
+					{ FirstEligibleNotification && (
+						<div className="yst-inline-block yst-px-1.5">
+							<FirstEligibleNotification />
+						</div>
+					) }
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/hooks/use-first-eligible-notification.js
+++ b/packages/js/src/hooks/use-first-eligible-notification.js
@@ -39,11 +39,11 @@ export const useFirstEligibleNotification = ( { webinarIntroUrl } ) => {
 		},
 		{
 			getIsEligible: shouldShowWebinarPromotionNotificationInSidebar,
-			component: () => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } />,
+			component: ( props ) => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } { ...props } />,
 		},
 		{
 			getIsEligible: () => true,
-			component: () => <BlackFridayPromotion />,
+			component: ( props ) => <BlackFridayPromotion { ...props } />,
 		},
 	] );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Fixes the regression from https://github.com/Yoast/wordpress-seo/pull/23074, as per the conclusion [here](https://yoast.slack.com/archives/C03KU0EHCNQ/p1776774506533899?thread_ts=1776770409.340649&cid=C03KU0EHCNQ).

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hide the Yoast logo and discovery copy from the Elementor sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to the Elementor editor and confirm that the Yoast SEO tab in the sidebar doesn't include the Yoast logo or the discovery copy:

<img width="368" height="282" alt="image" src="https://github.com/user-attachments/assets/9fdb12a8-824b-4ddc-9e8f-8d229382aaf9" />

* Without this PR, this was what was happening:
<img width="374" height="261" alt="image" src="https://github.com/user-attachments/assets/db67870a-90be-4034-8746-4198270ac058" />

* Verify the same in the metabox of the classic editor
* Also verify that the logo and copy still exist in the sidebar and metabox of the block editor.
  * The copy is **Optimize your content for discovery or get new content suggestions** when AI features are enabled and we're on a post 
  * The copy is `Optimize your content for discovery` when AI features are disabled or we're not on a post

**Test ads**:
* Deactivate Premium
* Webinar ad: Change the user meta `_yoast_alerts_dismissed` to: `a:1:{s:26:"webinar-promo-notification";b:0;}`
* Check the webinar ad is between the yoast logo and copy.
<img width="322" height="480" alt="image" src="https://github.com/user-attachments/assets/028c3e8b-aff0-49b5-b042-de0778061195" />

* In elementor confirm that the webinar ad in the block editor looks exactly how it looks in production too
* Trigger the Black Friday ad by changing the date in `src/promotions/domain/black-friday-promotion.php`, change only the year in the second date to 2027:
```php
new Time_Interval( \gmmktime( 10, 00, 00, 3, 20, 2025 ), \gmmktime( 10, 00, 00, 3, 30, 2027 ) ),                           
```
* Check the ad appears in the editor intro (Yoast logo and intro copy). Check both metabox and sidebar
<img width="332" height="400" alt="image" src="https://github.com/user-attachments/assets/bed4e995-5366-439f-802c-52fd7929bcbd" />

* In elementor and classic editor confirm that the Black Friday ad in the block editor looks exactly how it looks in production too
* Remove the BF change you did in the code
* In a post have good SEO score and check the `Show Yoast SEO some love` notice. Confirm that it appears in the editor intro (Yoast logo and intro copy). Check only the sidebar
<img width="328" height="202" alt="image" src="https://github.com/user-attachments/assets/90afd548-0ecd-4862-85e2-5da1a8a73d20" />

* In elementor confirm that the notice in the block editor looks exactly how it looks in production too


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
