### PR TITLE
23181 fix product properties in schema aggregator output

### DIFF
--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -187,4 +187,26 @@ class Meta_Tags_Context_Memoizer {
 	public function clear_for_current_page() {
 		unset( $this->cache['current_page'] );
 	}
+
+	/**
+	 * Replaces the memoized current-page context and returns the previous value.
+	 *
+	 * Allows callers to temporarily redirect what `for_current_page()` resolves to
+	 * (e.g. while iterating over indexables in the schema aggregator) and then
+	 * restore the prior value.
+	 *
+	 * @param Meta_Tags_Context|null $context The context to install, or null to clear.
+	 *
+	 * @return Meta_Tags_Context|null The previously cached current-page context, or null if unset.
+	 */
+	public function swap_current_page( ?Meta_Tags_Context $context ): ?Meta_Tags_Context {
+		$previous = ( $this->cache['current_page'] ?? null );
+		if ( $context === null ) {
+			unset( $this->cache['current_page'] );
+		}
+		else {
+			$this->cache['current_page'] = $context;
+		}
+		return $previous;
+	}
 }

--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -189,24 +189,17 @@ class Meta_Tags_Context_Memoizer {
 	}
 
 	/**
-	 * Replaces the memoized current-page context and returns the previous value.
+	 * Installs a context as the memoized current-page context.
 	 *
-	 * Allows callers to temporarily redirect what `for_current_page()` resolves to
-	 * (e.g. while iterating over indexables in the schema aggregator) and then
-	 * restore the prior value.
+	 * Allows callers to redirect what `for_current_page()` resolves to (e.g. while
+	 * iterating over indexables in the schema aggregator). The matching teardown
+	 * is `clear_for_current_page()`.
 	 *
-	 * @param Meta_Tags_Context|null $context The context to install, or null to clear.
+	 * @param Meta_Tags_Context $context The context to install.
 	 *
-	 * @return Meta_Tags_Context|null The previously cached current-page context, or null if unset.
+	 * @return void
 	 */
-	public function swap_current_page( ?Meta_Tags_Context $context ): ?Meta_Tags_Context {
-		$previous = ( $this->cache['current_page'] ?? null );
-		if ( $context === null ) {
-			unset( $this->cache['current_page'] );
-		}
-		else {
-			$this->cache['current_page'] = $context;
-		}
-		return $previous;
+	public function set_for_current_page( Meta_Tags_Context $context ): void {
+		$this->cache['current_page'] = $context;
 	}
 }

--- a/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
@@ -2,6 +2,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Pieces;
 
+use Throwable;
 use Yoast\WP\SEO\Helpers\Indexable_Helper;
 use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Schema_Aggregator\Application\Enhancement\Schema_Enhancement_Factory;
@@ -12,11 +13,15 @@ use Yoast\WP\SEO\Schema_Aggregator\Domain\Schema_Piece_Repository_Interface;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Aggregator_Config;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Indexable_Repository\Indexable_Repository_Factory;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Meta_Tags_Context_Memoizer_Adapter;
+use YoastSEO_Vendor\Psr\Log\LoggerAwareInterface;
+use YoastSEO_Vendor\Psr\Log\LoggerAwareTrait;
+use YoastSEO_Vendor\Psr\Log\NullLogger;
 
 /**
  * The Schema_Piece repository.
  */
-class Schema_Piece_Repository implements Schema_Piece_Repository_Interface {
+class Schema_Piece_Repository implements Schema_Piece_Repository_Interface, LoggerAwareInterface {
+	use LoggerAwareTrait;
 
 	/**
 	 * The meta tags context memoizer.
@@ -104,6 +109,7 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface {
 		$this->indexable_repository_factory = $indexable_repository_factory;
 		$this->global_state_adapter         = $global_state_adapter;
 		$this->external_repositories        = $external_repositories;
+		$this->logger                       = new NullLogger();
 	}
 
 	/**
@@ -143,6 +149,15 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface {
 					}
 					$schema_pieces[] = $schema_piece;
 				}
+			} catch ( Throwable $e ) {
+				$this->logger->warning( 'Schema aggregation failed for indexable #{indexable_id} ({object_type}/{object_sub_type}): {message}',
+					[
+						'indexable_id' => $indexable->id,
+						'object_type' => $indexable->object_type,
+						'object_sub_type' => $indexable->object_sub_type,
+						'message' => $e->getMessage()
+					]
+				);
 			} finally {
 				$this->global_state_adapter->reset_global_state();
 			}

--- a/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
@@ -150,12 +150,13 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface, Logg
 					$schema_pieces[] = $schema_piece;
 				}
 			} catch ( Throwable $e ) {
-				$this->logger->warning( 'Schema aggregation failed for indexable #{indexable_id} ({object_type}/{object_sub_type}): {message}',
+				$this->logger->warning(
+					'Schema aggregation failed for indexable #{indexable_id} ({object_type}/{object_sub_type}): {message}',
 					[
-						'indexable_id' => $indexable->id,
-						'object_type' => $indexable->object_type,
+						'indexable_id'    => $indexable->id,
+						'object_type'     => $indexable->object_type,
 						'object_sub_type' => $indexable->object_sub_type,
-						'message' => $e->getMessage()
+						'message'         => $e->getMessage(),
 					]
 				);
 			} finally {

--- a/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
@@ -157,7 +157,7 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface, Logg
 						'object_type'     => $indexable->object_type,
 						'object_sub_type' => $indexable->object_sub_type,
 						'message'         => $e->getMessage(),
-					]
+					],
 				);
 			} finally {
 				$this->global_state_adapter->reset_global_state();

--- a/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
@@ -131,8 +131,15 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface {
 			$context_array = $this->adapter->meta_tags_context_to_array( $context );
 			$pieces_data   = $context_array['@graph'];
 
-			// Collect external schema pieces from all supporting repositories.
-			$pieces_data = $this->collect_external_schema( $pieces_data, $post_type, $indexable->object_id );
+			// Make for_current_page() resolve to the indexable being processed, so
+			// external schema generators (e.g. WPSEO_WooCommerce_Schema) read the
+			// correct per-product canonical / main_schema_id instead of a stale one.
+			$previous_current_page = $this->memoizer->swap_current_page( $context );
+			try {
+				$pieces_data = $this->collect_external_schema( $pieces_data, $post_type, $indexable->object_id );
+			} finally {
+				$this->memoizer->swap_current_page( $previous_current_page );
+			}
 
 			foreach ( $pieces_data as $piece_data ) {
 				$schema_piece = new Schema_Piece( $piece_data, $piece_data['@type'] );

--- a/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/schema-piece-repository.php
@@ -125,32 +125,27 @@ class Schema_Piece_Repository implements Schema_Piece_Repository_Interface {
 				continue;
 			}
 
-			$this->global_state_adapter->set_global_state( $indexable );
-			$page_type     = $this->indexable_helper->get_page_type_for_indexable( $indexable );
-			$context       = $this->memoizer->get( $indexable, $page_type );
-			$context_array = $this->adapter->meta_tags_context_to_array( $context );
-			$pieces_data   = $context_array['@graph'];
+			$page_type = $this->indexable_helper->get_page_type_for_indexable( $indexable );
+			$context   = $this->memoizer->get( $indexable, $page_type );
 
-			// Make for_current_page() resolve to the indexable being processed, so
-			// external schema generators (e.g. WPSEO_WooCommerce_Schema) read the
-			// correct per-product canonical / main_schema_id instead of a stale one.
-			$previous_current_page = $this->memoizer->swap_current_page( $context );
+			$this->global_state_adapter->set_global_state( $indexable, $context );
 			try {
+				$context_array = $this->adapter->meta_tags_context_to_array( $context );
+				$pieces_data   = $context_array['@graph'];
+
 				$pieces_data = $this->collect_external_schema( $pieces_data, $post_type, $indexable->object_id );
-			} finally {
-				$this->memoizer->swap_current_page( $previous_current_page );
-			}
 
-			foreach ( $pieces_data as $piece_data ) {
-				$schema_piece = new Schema_Piece( $piece_data, $piece_data['@type'] );
-				$enhancer     = $this->enhancement_factory->get_enhancer( $this->get_all_schema_types( $context_array['@graph'] ) );
-				if ( $enhancer !== null ) {
-					$schema_piece = $enhancer->enhance( $schema_piece, $indexable );
+				foreach ( $pieces_data as $piece_data ) {
+					$schema_piece = new Schema_Piece( $piece_data, $piece_data['@type'] );
+					$enhancer     = $this->enhancement_factory->get_enhancer( $this->get_all_schema_types( $context_array['@graph'] ) );
+					if ( $enhancer !== null ) {
+						$schema_piece = $enhancer->enhance( $schema_piece, $indexable );
+					}
+					$schema_pieces[] = $schema_piece;
 				}
-				$schema_pieces[] = $schema_piece;
+			} finally {
+				$this->global_state_adapter->reset_global_state();
 			}
-
-			$this->global_state_adapter->reset_global_state();
 		}
 
 		return new Schema_Piece_Collection( $schema_pieces );

--- a/src/schema-aggregator/infrastructure/schema-pieces/wordpress-global-state-adapter.php
+++ b/src/schema-aggregator/infrastructure/schema-pieces/wordpress-global-state-adapter.php
@@ -3,11 +3,20 @@
 namespace Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Pieces;
 
 use WP_Post;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Models\Indexable;
 /**
  * Helper class to set and reset WordPress global state.
  */
 class WordPress_Global_State_Adapter {
+
+	/**
+	 * The meta tags context memoizer.
+	 *
+	 * @var Meta_Tags_Context_Memoizer
+	 */
+	private $memoizer;
 
 	/**
 	 * Previous global $post
@@ -38,16 +47,28 @@ class WordPress_Global_State_Adapter {
 	private $previous_query_flags;
 
 	/**
+	 * Constructor.
+	 *
+	 * @param Meta_Tags_Context_Memoizer $memoizer The meta tags context memoizer.
+	 */
+	public function __construct( Meta_Tags_Context_Memoizer $memoizer ) {
+		$this->memoizer = $memoizer;
+	}
+
+	/**
 	 * Set WordPress global state
 	 *
-	 * Helper method to set $post and $wp_query globals based on the given indexable.
+	 * Helper method to set $post and $wp_query globals based on the given indexable, and
+	 * prime the memoizer's current_page slot with the indexable's context so external schema
+	 * generators (e.g. WPSEO_WooCommerce_Schema) read the correct per-indexable values.
 	 * This is critical to ensure that schema pieces relying on global state function correctly.
 	 *
-	 * @param Indexable $indexable The indexable to set the global state for.
+	 * @param Indexable         $indexable The indexable to set the global state for.
+	 * @param Meta_Tags_Context $context   The indexable's context, installed as the current_page slot.
 	 *
 	 * @return void
 	 */
-	public function set_global_state( Indexable $indexable ): void {
+	public function set_global_state( Indexable $indexable, Meta_Tags_Context $context ): void {
 		global $post, $wp_query;
 		$this->previous_post              = $post;
 		$this->previous_queried_object    = ( $wp_query->queried_object ?? null );
@@ -77,6 +98,11 @@ class WordPress_Global_State_Adapter {
 		}
 
 		\setup_postdata( $post );
+
+		// Make for_current_page() resolve to the indexable being processed, so external schema
+		// generators (e.g. WPSEO_WooCommerce_Schema) read the correct per-indexable canonical /
+		// main_schema_id. reset_global_state() clears this slot at the end of the iteration.
+		$this->memoizer->set_for_current_page( $context );
 	}
 
 	/**
@@ -102,5 +128,9 @@ class WordPress_Global_State_Adapter {
 			$wp_query->is_page           = $this->previous_query_flags['is_page'];
 			$wp_query->is_singular       = $this->previous_query_flags['is_singular'];
 		}
+
+		// Drop the per-iteration current_page context primed by Schema_Piece_Repository::get(),
+		// so the next iteration re-resolves cleanly.
+		$this->memoizer->clear_for_current_page();
 	}
 }

--- a/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
+++ b/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
@@ -388,68 +388,49 @@ final class Meta_Tags_Context_Memoizer_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that swap_current_page returns null when no current_page context was cached.
+	 * Tests that set_for_current_page installs the given context as the current_page cache entry.
 	 *
-	 * @covers ::swap_current_page
+	 * @covers ::set_for_current_page
 	 *
 	 * @return void
 	 */
-	public function test_swap_current_page_returns_null_when_empty() {
+	public function test_set_for_current_page_installs_context() {
 		$new_context = new Meta_Tags_Context_Mock();
 
-		$previous = $this->instance->swap_current_page( $new_context );
+		$this->instance->set_for_current_page( $new_context );
 
-		$this->assertNull( $previous );
 		$this->assertSame( $new_context, $this->instance->get_cache()['current_page'] );
 	}
 
 	/**
-	 * Tests that swap_current_page returns the previously cached current_page context and installs the new one.
+	 * Tests that set_for_current_page overwrites a previously cached current_page context.
 	 *
-	 * @covers ::swap_current_page
+	 * @covers ::set_for_current_page
 	 *
 	 * @return void
 	 */
-	public function test_swap_current_page_returns_previous_context() {
+	public function test_set_for_current_page_overwrites_existing_context() {
 		$old_context = new Meta_Tags_Context_Mock();
 		$new_context = new Meta_Tags_Context_Mock();
 		$this->instance->set_cache( 'current_page', $old_context );
 
-		$previous = $this->instance->swap_current_page( $new_context );
+		$this->instance->set_for_current_page( $new_context );
 
-		$this->assertSame( $old_context, $previous );
 		$this->assertSame( $new_context, $this->instance->get_cache()['current_page'] );
 	}
 
 	/**
-	 * Tests that swap_current_page with null clears the current_page cache and returns the previous value.
+	 * Tests that set_for_current_page does not affect cache entries keyed by indexable id.
 	 *
-	 * @covers ::swap_current_page
-	 *
-	 * @return void
-	 */
-	public function test_swap_current_page_with_null_clears_cache() {
-		$old_context = new Meta_Tags_Context_Mock();
-		$this->instance->set_cache( 'current_page', $old_context );
-
-		$previous = $this->instance->swap_current_page( null );
-
-		$this->assertSame( $old_context, $previous );
-		$this->assertArrayNotHasKey( 'current_page', $this->instance->get_cache() );
-	}
-
-	/**
-	 * Tests that swap_current_page does not affect cache entries keyed by indexable id.
-	 *
-	 * @covers ::swap_current_page
+	 * @covers ::set_for_current_page
 	 *
 	 * @return void
 	 */
-	public function test_swap_current_page_leaves_indexable_cache_intact() {
+	public function test_set_for_current_page_leaves_indexable_cache_intact() {
 		$indexable_context = new Meta_Tags_Context_Mock();
 		$this->instance->set_cache( $this->indexable->id, $indexable_context );
 
-		$this->instance->swap_current_page( new Meta_Tags_Context_Mock() );
+		$this->instance->set_for_current_page( new Meta_Tags_Context_Mock() );
 
 		$this->assertSame( $indexable_context, $this->instance->get_cache()[ $this->indexable->id ] );
 	}

--- a/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
+++ b/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
@@ -388,6 +388,73 @@ final class Meta_Tags_Context_Memoizer_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that swap_current_page returns null when no current_page context was cached.
+	 *
+	 * @covers ::swap_current_page
+	 *
+	 * @return void
+	 */
+	public function test_swap_current_page_returns_null_when_empty() {
+		$new_context = new Meta_Tags_Context_Mock();
+
+		$previous = $this->instance->swap_current_page( $new_context );
+
+		$this->assertNull( $previous );
+		$this->assertSame( $new_context, $this->instance->get_cache()['current_page'] );
+	}
+
+	/**
+	 * Tests that swap_current_page returns the previously cached current_page context and installs the new one.
+	 *
+	 * @covers ::swap_current_page
+	 *
+	 * @return void
+	 */
+	public function test_swap_current_page_returns_previous_context() {
+		$old_context = new Meta_Tags_Context_Mock();
+		$new_context = new Meta_Tags_Context_Mock();
+		$this->instance->set_cache( 'current_page', $old_context );
+
+		$previous = $this->instance->swap_current_page( $new_context );
+
+		$this->assertSame( $old_context, $previous );
+		$this->assertSame( $new_context, $this->instance->get_cache()['current_page'] );
+	}
+
+	/**
+	 * Tests that swap_current_page with null clears the current_page cache and returns the previous value.
+	 *
+	 * @covers ::swap_current_page
+	 *
+	 * @return void
+	 */
+	public function test_swap_current_page_with_null_clears_cache() {
+		$old_context = new Meta_Tags_Context_Mock();
+		$this->instance->set_cache( 'current_page', $old_context );
+
+		$previous = $this->instance->swap_current_page( null );
+
+		$this->assertSame( $old_context, $previous );
+		$this->assertArrayNotHasKey( 'current_page', $this->instance->get_cache() );
+	}
+
+	/**
+	 * Tests that swap_current_page does not affect cache entries keyed by indexable id.
+	 *
+	 * @covers ::swap_current_page
+	 *
+	 * @return void
+	 */
+	public function test_swap_current_page_leaves_indexable_cache_intact() {
+		$indexable_context = new Meta_Tags_Context_Mock();
+		$this->instance->set_cache( $this->indexable->id, $indexable_context );
+
+		$this->instance->swap_current_page( new Meta_Tags_Context_Mock() );
+
+		$this->assertSame( $indexable_context, $this->instance->get_cache()[ $this->indexable->id ] );
+	}
+
+	/**
 	 * Mocks the get method for use in other methods.
 	 *
 	 * @return void

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Abstract_WordPress_Global_State_Adapter_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Abstract_WordPress_Global_State_Adapter_Test.php
@@ -3,6 +3,9 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Schema_Aggregator\Infrastructure\Schema_Pieces;
 
+use Mockery;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Memoizers\Meta_Tags_Context_Memoizer;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Pieces\WordPress_Global_State_Adapter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -23,6 +26,20 @@ abstract class Abstract_WordPress_Global_State_Adapter_Test extends TestCase {
 	protected $instance;
 
 	/**
+	 * Holds the meta tags context memoizer mock.
+	 *
+	 * @var Mockery\MockInterface|Meta_Tags_Context_Memoizer
+	 */
+	protected $memoizer;
+
+	/**
+	 * Holds a meta tags context mock used as the second argument of set_global_state.
+	 *
+	 * @var Mockery\MockInterface|Meta_Tags_Context
+	 */
+	protected $context;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -30,6 +47,14 @@ abstract class Abstract_WordPress_Global_State_Adapter_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new WordPress_Global_State_Adapter();
+		$this->context = Mockery::mock( Meta_Tags_Context::class );
+
+		$this->memoizer = Mockery::mock( Meta_Tags_Context_Memoizer::class );
+		// Default lenient expectations: most globals-focused tests don't care about the
+		// memoizer interactions. The dedicated tests that do care override these with `expects`.
+		$this->memoizer->shouldReceive( 'set_for_current_page' )->byDefault();
+		$this->memoizer->shouldReceive( 'clear_for_current_page' )->byDefault();
+
+		$this->instance = new WordPress_Global_State_Adapter( $this->memoizer );
 	}
 }

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
@@ -8,6 +8,7 @@ use RuntimeException;
 use Yoast\WP\SEO\Context\Meta_Tags_Context;
 use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Indexable_Repository\Indexable_Repository_Interface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use YoastSEO_Vendor\Psr\Log\LoggerInterface;
 
 /**
  * Tests that get() primes the memoizer's current_page cache with the per-indexable context

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
@@ -103,12 +103,13 @@ final class Get_Sets_Current_Page_Context_Test extends Abstract_Schema_Piece_Rep
 	}
 
 	/**
-	 * Tests that reset_global_state still runs when collect() throws — the iteration body
-	 * is wrapped in try/finally to guarantee teardown (which clears the memoizer slot).
+	 * Tests that a throwable raised inside the iteration is caught, logged via the PSR-3 logger
+	 * with structured context, and the iteration is unwound cleanly (reset_global_state runs).
+	 * The exception is swallowed — get() returns normally so other indexables can still be processed.
 	 *
 	 * @return void
 	 */
-	public function test_reset_global_state_runs_when_collect_throws(): void {
+	public function test_throwable_in_iteration_is_caught_logged_and_reset_runs(): void {
 		$indexable = $this->make_product_indexable( 9 );
 		$context   = Mockery::mock( Meta_Tags_Context::class );
 
@@ -117,7 +118,21 @@ final class Get_Sets_Current_Page_Context_Test extends Abstract_Schema_Piece_Rep
 		$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable, $context )->ordered();
 		$this->external_repository->expects( 'collect' )->with( 9 )->ordered()->andThrow( new RuntimeException( 'boom' ) );
 
-		$this->expectException( RuntimeException::class );
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->expects( 'warning' )
+			->once()
+			->with(
+				'Schema aggregation failed for indexable #{indexable_id} ({object_type}/{object_sub_type}): {message}',
+				[
+					'indexable_id'    => 9,
+					'object_type'     => 'post',
+					'object_sub_type' => 'product',
+					'message'         => 'boom',
+				]
+			);
+		$this->instance->setLogger( $logger );
+
+		// Should not throw — exception is caught and only logged.
 		$this->instance->get( 1, 10, 'product' );
 	}
 }

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
@@ -128,7 +128,7 @@ final class Get_Sets_Current_Page_Context_Test extends Abstract_Schema_Piece_Rep
 					'object_type'     => 'post',
 					'object_sub_type' => 'product',
 					'message'         => 'boom',
-				]
+				],
 			);
 		$this->instance->setLogger( $logger );
 

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Sets_Current_Page_Context_Test.php
@@ -11,7 +11,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 
 /**
  * Tests that get() primes the memoizer's current_page cache with the per-indexable context
- * around the external collect() call, and restores it afterwards (even on exception).
+ * before the external collect() call, and that reset_global_state() runs even when collect throws.
  *
  * @group schema-aggregator
  *
@@ -19,7 +19,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Repository_Test {
+final class Get_Sets_Current_Page_Context_Test extends Abstract_Schema_Piece_Repository_Test {
 
 	/**
 	 * Builds an indexable with a product sub-type and the given id.
@@ -38,7 +38,7 @@ final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Re
 	}
 
 	/**
-	 * Stubs every collaborator that is not relevant to the swap behaviour, leaving the
+	 * Stubs every collaborator that is not relevant to the prime behaviour, leaving the
 	 * indexable iteration as the only orchestration the test inspects.
 	 *
 	 * @param array<Indexable_Mock>    $indexables    The indexables to feed into the loop.
@@ -57,14 +57,12 @@ final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Re
 		$this->config->shouldReceive( 'get_allowed_post_types' )->andReturn( [ 'product' ] );
 
 		foreach ( $indexables as $indexable ) {
-			$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable );
-			if ( $expects_reset ) {
-				$this->global_state_adapter->expects( 'reset_global_state' );
-			}
-
 			$this->indexable_helper->expects( 'get_page_type_for_indexable' )->with( $indexable )->andReturn( 'Product' );
 			$this->memoizer->expects( 'get' )->with( $indexable, 'Product' )->andReturn( $contexts[ $indexable->id ] );
 			$this->adapter->expects( 'meta_tags_context_to_array' )->with( $contexts[ $indexable->id ] )->andReturn( [ '@graph' => [] ] );
+			if ( $expects_reset ) {
+				$this->global_state_adapter->expects( 'reset_global_state' );
+			}
 		}
 
 		$this->external_repository->shouldReceive( 'supports' )->with( 'product' )->andReturnTrue();
@@ -72,12 +70,12 @@ final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Re
 	}
 
 	/**
-	 * Tests that for each indexable, the memoizer's current_page cache is swapped to the
-	 * indexable's own context before collect() is called and restored afterwards.
+	 * Tests that for each indexable, set_global_state is called with the indexable and its
+	 * own context (so the adapter primes the memoizer's current_page slot) before collect().
 	 *
 	 * @return void
 	 */
-	public function test_swap_is_invoked_around_each_external_collect_call(): void {
+	public function test_set_global_state_is_called_with_per_indexable_context(): void {
 		$indexable_a = $this->make_product_indexable( 1 );
 		$indexable_b = $this->make_product_indexable( 2 );
 
@@ -92,54 +90,31 @@ final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Re
 			],
 		);
 
-		// Iteration 1: prime with context_a (no previous), collect, restore null.
-		$this->memoizer->expects( 'swap_current_page' )->with( $context_a )->ordered()->andReturnNull();
+		// Iteration 1: set_global_state primes with context_a, then collect.
+		$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable_a, $context_a )->ordered();
 		$this->external_repository->expects( 'collect' )->with( 1 )->ordered()->andReturn( [] );
-		$this->memoizer->expects( 'swap_current_page' )->with( null )->ordered()->andReturnNull();
 
-		// Iteration 2: prime with context_b (previous is null because we restored above), collect, restore null.
-		$this->memoizer->expects( 'swap_current_page' )->with( $context_b )->ordered()->andReturnNull();
+		// Iteration 2: set_global_state primes with context_b, then collect.
+		$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable_b, $context_b )->ordered();
 		$this->external_repository->expects( 'collect' )->with( 2 )->ordered()->andReturn( [] );
-		$this->memoizer->expects( 'swap_current_page' )->with( null )->ordered()->andReturnNull();
 
 		$this->instance->get( 1, 10, 'product' );
 	}
 
 	/**
-	 * Tests that whatever swap_current_page returned before collect() is the value passed back
-	 * after collect() — i.e. an existing current_page cache entry is preserved across the loop.
+	 * Tests that reset_global_state still runs when collect() throws — the iteration body
+	 * is wrapped in try/finally to guarantee teardown (which clears the memoizer slot).
 	 *
 	 * @return void
 	 */
-	public function test_swap_restores_the_previously_cached_current_page(): void {
-		$indexable = $this->make_product_indexable( 7 );
-		$context   = Mockery::mock( Meta_Tags_Context::class );
-		$previous  = Mockery::mock( Meta_Tags_Context::class );
-
-		$this->stub_iteration( [ $indexable ], [ 7 => $context ] );
-
-		$this->memoizer->expects( 'swap_current_page' )->with( $context )->ordered()->andReturn( $previous );
-		$this->external_repository->expects( 'collect' )->with( 7 )->ordered()->andReturn( [] );
-		$this->memoizer->expects( 'swap_current_page' )->with( $previous )->ordered()->andReturnNull();
-
-		$this->instance->get( 1, 10, 'product' );
-	}
-
-	/**
-	 * Tests that the previous current_page context is restored even when collect() throws.
-	 *
-	 * @return void
-	 */
-	public function test_swap_restores_when_collect_throws(): void {
+	public function test_reset_global_state_runs_when_collect_throws(): void {
 		$indexable = $this->make_product_indexable( 9 );
 		$context   = Mockery::mock( Meta_Tags_Context::class );
-		$previous  = Mockery::mock( Meta_Tags_Context::class );
 
-		$this->stub_iteration( [ $indexable ], [ 9 => $context ], false );
+		$this->stub_iteration( [ $indexable ], [ 9 => $context ] );
 
-		$this->memoizer->expects( 'swap_current_page' )->with( $context )->ordered()->andReturn( $previous );
+		$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable, $context )->ordered();
 		$this->external_repository->expects( 'collect' )->with( 9 )->ordered()->andThrow( new RuntimeException( 'boom' ) );
-		$this->memoizer->expects( 'swap_current_page' )->with( $previous )->ordered()->andReturnNull();
 
 		$this->expectException( RuntimeException::class );
 		$this->instance->get( 1, 10, 'product' );

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Swaps_Current_Page_Context_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Swaps_Current_Page_Context_Test.php
@@ -1,0 +1,147 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Schema_Aggregator\Infrastructure\Schema_Pieces\Schema_Piece_Repository;
+
+use Mockery;
+use RuntimeException;
+use Yoast\WP\SEO\Context\Meta_Tags_Context;
+use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Indexable_Repository\Indexable_Repository_Interface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+
+/**
+ * Tests that get() primes the memoizer's current_page cache with the per-indexable context
+ * around the external collect() call, and restores it afterwards (even on exception).
+ *
+ * @group schema-aggregator
+ *
+ * @covers Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Pieces\Schema_Piece_Repository::get
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Swaps_Current_Page_Context_Test extends Abstract_Schema_Piece_Repository_Test {
+
+	/**
+	 * Builds an indexable with a product sub-type and the given id.
+	 *
+	 * @param int $id The indexable id (used as both id and object_id).
+	 *
+	 * @return Indexable_Mock
+	 */
+	private function make_product_indexable( int $id ): Indexable_Mock {
+		$indexable                  = new Indexable_Mock();
+		$indexable->id              = $id;
+		$indexable->object_id       = $id;
+		$indexable->object_type     = 'post';
+		$indexable->object_sub_type = 'product';
+		return $indexable;
+	}
+
+	/**
+	 * Stubs every collaborator that is not relevant to the swap behaviour, leaving the
+	 * indexable iteration as the only orchestration the test inspects.
+	 *
+	 * @param array<Indexable_Mock>    $indexables    The indexables to feed into the loop.
+	 * @param array<Meta_Tags_Context> $contexts      The contexts to return from the memoizer, keyed by indexable id.
+	 * @param bool                     $expects_reset Whether each iteration is expected to reach reset_global_state.
+	 *
+	 * @return void
+	 */
+	private function stub_iteration( array $indexables, array $contexts, bool $expects_reset = true ): void {
+		$this->indexable_helper->expects( 'should_index_indexables' )->once()->andReturnTrue();
+
+		$indexable_repository = Mockery::mock( Indexable_Repository_Interface::class );
+		$indexable_repository->expects( 'get' )->once()->andReturn( $indexables );
+		$this->indexable_repository_factory->expects( 'get_repository' )->once()->with( true )->andReturn( $indexable_repository );
+
+		$this->config->shouldReceive( 'get_allowed_post_types' )->andReturn( [ 'product' ] );
+
+		foreach ( $indexables as $indexable ) {
+			$this->global_state_adapter->expects( 'set_global_state' )->with( $indexable );
+			if ( $expects_reset ) {
+				$this->global_state_adapter->expects( 'reset_global_state' );
+			}
+
+			$this->indexable_helper->expects( 'get_page_type_for_indexable' )->with( $indexable )->andReturn( 'Product' );
+			$this->memoizer->expects( 'get' )->with( $indexable, 'Product' )->andReturn( $contexts[ $indexable->id ] );
+			$this->adapter->expects( 'meta_tags_context_to_array' )->with( $contexts[ $indexable->id ] )->andReturn( [ '@graph' => [] ] );
+		}
+
+		$this->external_repository->shouldReceive( 'supports' )->with( 'product' )->andReturnTrue();
+		$this->enhancement_factory->shouldReceive( 'get_enhancer' )->andReturnNull();
+	}
+
+	/**
+	 * Tests that for each indexable, the memoizer's current_page cache is swapped to the
+	 * indexable's own context before collect() is called and restored afterwards.
+	 *
+	 * @return void
+	 */
+	public function test_swap_is_invoked_around_each_external_collect_call(): void {
+		$indexable_a = $this->make_product_indexable( 1 );
+		$indexable_b = $this->make_product_indexable( 2 );
+
+		$context_a = Mockery::mock( Meta_Tags_Context::class );
+		$context_b = Mockery::mock( Meta_Tags_Context::class );
+
+		$this->stub_iteration(
+			[ $indexable_a, $indexable_b ],
+			[
+				1 => $context_a,
+				2 => $context_b,
+			],
+		);
+
+		// Iteration 1: prime with context_a (no previous), collect, restore null.
+		$this->memoizer->expects( 'swap_current_page' )->with( $context_a )->ordered()->andReturnNull();
+		$this->external_repository->expects( 'collect' )->with( 1 )->ordered()->andReturn( [] );
+		$this->memoizer->expects( 'swap_current_page' )->with( null )->ordered()->andReturnNull();
+
+		// Iteration 2: prime with context_b (previous is null because we restored above), collect, restore null.
+		$this->memoizer->expects( 'swap_current_page' )->with( $context_b )->ordered()->andReturnNull();
+		$this->external_repository->expects( 'collect' )->with( 2 )->ordered()->andReturn( [] );
+		$this->memoizer->expects( 'swap_current_page' )->with( null )->ordered()->andReturnNull();
+
+		$this->instance->get( 1, 10, 'product' );
+	}
+
+	/**
+	 * Tests that whatever swap_current_page returned before collect() is the value passed back
+	 * after collect() — i.e. an existing current_page cache entry is preserved across the loop.
+	 *
+	 * @return void
+	 */
+	public function test_swap_restores_the_previously_cached_current_page(): void {
+		$indexable = $this->make_product_indexable( 7 );
+		$context   = Mockery::mock( Meta_Tags_Context::class );
+		$previous  = Mockery::mock( Meta_Tags_Context::class );
+
+		$this->stub_iteration( [ $indexable ], [ 7 => $context ] );
+
+		$this->memoizer->expects( 'swap_current_page' )->with( $context )->ordered()->andReturn( $previous );
+		$this->external_repository->expects( 'collect' )->with( 7 )->ordered()->andReturn( [] );
+		$this->memoizer->expects( 'swap_current_page' )->with( $previous )->ordered()->andReturnNull();
+
+		$this->instance->get( 1, 10, 'product' );
+	}
+
+	/**
+	 * Tests that the previous current_page context is restored even when collect() throws.
+	 *
+	 * @return void
+	 */
+	public function test_swap_restores_when_collect_throws(): void {
+		$indexable = $this->make_product_indexable( 9 );
+		$context   = Mockery::mock( Meta_Tags_Context::class );
+		$previous  = Mockery::mock( Meta_Tags_Context::class );
+
+		$this->stub_iteration( [ $indexable ], [ 9 => $context ], false );
+
+		$this->memoizer->expects( 'swap_current_page' )->with( $context )->ordered()->andReturn( $previous );
+		$this->external_repository->expects( 'collect' )->with( 9 )->ordered()->andThrow( new RuntimeException( 'boom' ) );
+		$this->memoizer->expects( 'swap_current_page' )->with( $previous )->ordered()->andReturnNull();
+
+		$this->expectException( RuntimeException::class );
+		$this->instance->get( 1, 10, 'product' );
+	}
+}

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/WordPress_Global_State_Adapter_Reset_Global_State_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/WordPress_Global_State_Adapter_Reset_Global_State_Test.php
@@ -55,7 +55,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $new_post, $post );
 
@@ -104,7 +104,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $new_post, $wp_query->queried_object );
 
@@ -150,7 +150,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( 123, $wp_query->queried_object_id );
 
@@ -196,7 +196,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertTrue( $wp_query->is_single );
 		$this->assertTrue( $wp_query->is_singular );
@@ -246,7 +246,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_page );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertFalse( $wp_query->is_single );
 		$this->assertTrue( $wp_query->is_singular );
@@ -296,7 +296,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $new_post, $post );
 		$this->assertSame( $new_post, $wp_query->queried_object );
@@ -343,7 +343,7 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$wp_query = null;
 
@@ -389,10 +389,54 @@ final class WordPress_Global_State_Adapter_Reset_Global_State_Test extends Abstr
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		Functions\expect( 'wp_reset_postdata' )
 			->once();
+
+		$this->instance->reset_global_state();
+	}
+
+	/**
+	 * Tests that reset_global_state clears the memoizer's current_page cache.
+	 *
+	 * @return void
+	 */
+	public function test_reset_global_state_clears_memoizer_current_page() {
+		global $post, $wp_query;
+
+		$post     = null;
+		$wp_query = (object) [
+			'queried_object'    => null,
+			'queried_object_id' => null,
+			'is_single'         => false,
+			'is_singular'       => false,
+			'is_page'           => false,
+		];
+
+		$indexable                  = new Indexable_Mock();
+		$indexable->object_id       = 123;
+		$indexable->object_sub_type = 'post';
+
+		$new_post            = Mockery::mock( WP_Post::class )->makePartial();
+		$new_post->ID        = 123;
+		$new_post->post_type = 'post';
+
+		Functions\expect( 'get_post' )
+			->twice()
+			->with( 123 )
+			->andReturn( $new_post );
+
+		Functions\expect( 'setup_postdata' )
+			->once()
+			->with( $new_post );
+
+		$this->instance->set_global_state( $indexable, $this->context );
+
+		Functions\expect( 'wp_reset_postdata' )
+			->once();
+
+		$this->memoizer->expects( 'clear_for_current_page' )->once();
 
 		$this->instance->reset_global_state();
 	}

--- a/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/WordPress_Global_State_Adapter_Set_Global_State_Test.php
+++ b/tests/Unit/Schema_Aggregator/Infrastructure/Schema_Pieces/WordPress_Global_State_Adapter_Set_Global_State_Test.php
@@ -56,7 +56,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $mock_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $mock_post, $post );
 		$this->assertSame( $mock_post, $wp_query->queried_object );
@@ -111,7 +111,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $mock_page );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $mock_page, $post );
 		$this->assertSame( $mock_page, $wp_query->queried_object );
@@ -164,7 +164,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $previous_post, $this->getPropertyValue( $this->instance, 'previous_post' ) );
 	}
@@ -206,7 +206,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( $previous_queried_object, $this->getPropertyValue( $this->instance, 'previous_queried_object' ) );
 	}
@@ -244,7 +244,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertSame( 456, $this->getPropertyValue( $this->instance, 'previous_queried_object_id' ) );
 	}
@@ -282,7 +282,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertNull( $this->getPropertyValue( $this->instance, 'previous_post' ) );
 		$this->assertNull( $this->getPropertyValue( $this->instance, 'previous_queried_object' ) );
@@ -318,7 +318,7 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$this->assertNull( $this->getPropertyValue( $this->instance, 'previous_post' ) );
 		$this->assertNull( $this->getPropertyValue( $this->instance, 'previous_queried_object' ) );
@@ -359,11 +359,50 @@ final class WordPress_Global_State_Adapter_Set_Global_State_Test extends Abstrac
 			->once()
 			->with( $new_post );
 
-		$this->instance->set_global_state( $indexable );
+		$this->instance->set_global_state( $indexable, $this->context );
 
 		$previous_flags = $this->getPropertyValue( $this->instance, 'previous_query_flags' );
 		$this->assertTrue( $previous_flags['is_single'] );
 		$this->assertTrue( $previous_flags['is_singular'] );
 		$this->assertFalse( $previous_flags['is_page'] );
+	}
+
+	/**
+	 * Tests that set_global_state primes the memoizer's current_page slot with the given context.
+	 *
+	 * @return void
+	 */
+	public function test_set_global_state_primes_memoizer_current_page() {
+		global $post, $wp_query;
+
+		$post     = null;
+		$wp_query = (object) [
+			'queried_object'    => null,
+			'queried_object_id' => null,
+			'is_single'         => false,
+			'is_singular'       => false,
+			'is_page'           => false,
+		];
+
+		$indexable                  = new Indexable_Mock();
+		$indexable->object_id       = 123;
+		$indexable->object_sub_type = 'post';
+
+		$new_post            = Mockery::mock( WP_Post::class )->makePartial();
+		$new_post->ID        = 123;
+		$new_post->post_type = 'post';
+
+		Functions\expect( 'get_post' )
+			->twice()
+			->with( 123 )
+			->andReturn( $new_post );
+
+		Functions\expect( 'setup_postdata' )
+			->once()
+			->with( $new_post );
+
+		$this->memoizer->expects( 'set_for_current_page' )->once()->with( $this->context );
+
+		$this->instance->set_global_state( $indexable, $this->context );
 	}
 }

--- a/tests/WP/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Test.php
+++ b/tests/WP/Schema_Aggregator/Infrastructure/Schema_Pieces/Schema_Piece_Repository/Get_Test.php
@@ -87,7 +87,7 @@ final class Get_Test extends TestCase {
 		$indexable_repository           = new Indexable_Repository( $pure_indexable_repository );
 		$wordpress_query_repository     = new WordPress_Query_Repository( \YoastSEO()->classes->get( Indexable_Builder::class ), $pure_indexable_repository );
 		$indexable_repository_factory   = new Indexable_Repository_Factory( $indexable_repository, $wordpress_query_repository );
-		$wordpress_global_state_adapter = new WordPress_Global_State_Adapter();
+		$wordpress_global_state_adapter = new WordPress_Global_State_Adapter( $meta_tags_context_memoizer );
 		$edd_schema_piece_repository    = new Edd_Schema_Piece_Repository( new EDD_Conditional(), \YoastSEO()->classes->get( Meta_Surface::class ) );
 		$woo_schema_piece_repository    = new Woo_Schema_Piece_Repository( new WooCommerce_Conditional() );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The products that are rendered in the schemamap have incorrect `@id` values for `mainEntityOfPage` and `image` properties.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug in Schema aggregator where products Schema pieces had  incorrect `@id` values for `mainEntityOfPage` and `image` properties.

## Relevant technical choices:
* The root cause is that `Meta_Tags_Context_Memoizer::for_current_page()` caches the first call's result. `WPSEO_WooCommerce_Schema` relies on `for_current_page()` for canonical/main_schema_id (per-product values), so every product after the first reuses the first product's URL
* A new method `set_for_current_page` has then been introduced in the `Meta_Tags_Context_Memoizer` that allows to set the current page: this is used, together with `clear_for_current_page` by the `Global_State_Adapter` to fetch the needed data from the indexable that is currently being used by the aggregator main loop.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have WooCoomerce and Yoast WooCommerce SEO installed and activated
* Go to `Yoast SEO` -> `Settings` ->  `Site features` and turn on `Schema aggregation endpoint`
* Create at least two different products
* Visit `YOUR-BLOG-URL/wp-json/yoast/v1/schema-aggregator/get-schema/product`
  * Copy the output 
  * Paste it in `https://schema-visualizer.yoast.com/`
    * Use the validator to validate it
    * By using the visualization tool make sure that each `Product` piece is connected to its own `Image`, which is the same one referenced by the `WebPage` as `mainEntityOfPage`


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23181
