### PR TITLE
Fix grammar typo in UI library button size docs

### DIFF
--- a/packages/ui-library/src/elements/button/docs/sizes.md
+++ b/packages/ui-library/src/elements/button/docs/sizes.md
@@ -1,7 +1,7 @@
 The aforementioned button variants can be used in four different sizes:
 
 1. **Extra large**<br>
-The extra large button size is often used ads and upsells that require significant user attention. It can also be useful for touch interfaces, where extra large buttons are easier to tap.
+The extra large button size is often used for ads and upsells that require significant user attention. It can also be useful for touch interfaces, where extra large buttons are easier to tap.
 
 2. **Large**<br>
 The large button size is used next to form input fields, by default it has the same height.


### PR DESCRIPTION
## Description

There is a grammar typo in the UI library button size documentation.

File:
`packages/ui-library/src/elements/button/docs/sizes.md`

Current text:
`The extra large button size is often used ads and upsells that require significant user attention.`

Expected text:
`The extra large button size is often used for ads and upsells that require significant user attention.`

## Impact

This is a documentation-only issue. There is no functional impact, but the typo makes the sentence incorrect and less polished.

## Proposed fix

Add the missing word `for` in the "Extra large" button size description.

Props: ravikhadka
