### PR TITLE
Fix schema timezone handling for datePublished and dateModified

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -49,11 +49,11 @@ class Article extends Abstract_Schema_Piece {
 				'@id'  => $this->helpers->schema->id->get_user_schema_id( $this->context->post->post_author, $this->context ),
 			],
 			'headline'         => $this->helpers->schema->html->smart_strip_tags( $this->helpers->post->get_post_title_with_fallback( $this->context->id ) ),
-			'datePublished'    => $this->helpers->date->format( $this->context->post->post_date_gmt ),
+			'datePublished'    => $this->helpers->date->format_with_site_timezone( $this->context->post->post_date_gmt ),
 		];
 
 		if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
-			$data['dateModified'] = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+			$data['dateModified'] = $this->helpers->date->format_with_site_timezone( $this->context->post->post_modified_gmt );
 		}
 
 		$data['mainEntityOfPage'] = [ '@id' => $this->context->main_schema_id ];

--- a/src/generators/schema/webpage.php
+++ b/src/generators/schema/webpage.php
@@ -51,10 +51,10 @@ class WebPage extends Abstract_Schema_Piece {
 		$data = $this->add_image( $data );
 
 		if ( $this->context->indexable->object_type === 'post' ) {
-			$data['datePublished'] = $this->helpers->date->format( $this->context->post->post_date_gmt );
+			$data['datePublished'] = $this->helpers->date->format_with_site_timezone( $this->context->post->post_date_gmt );
 
 			if ( \strtotime( $this->context->post->post_modified_gmt ) > \strtotime( $this->context->post->post_date_gmt ) ) {
-				$data['dateModified'] = $this->helpers->date->format( $this->context->post->post_modified_gmt );
+				$data['dateModified'] = $this->helpers->date->format_with_site_timezone( $this->context->post->post_modified_gmt );
 			}
 
 			if ( $this->context->indexable->object_sub_type === 'post' ) {

--- a/src/helpers/date-helper.php
+++ b/src/helpers/date-helper.php
@@ -39,13 +39,35 @@ class Date_Helper {
 			return $date;
 		}
 
-		$immutable_date = \date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
+		$immutable_date = $this->parse_gmt_date( $date );
 
 		if ( ! $immutable_date ) {
 			return $date;
 		}
 
 		return $immutable_date->format( $format );
+	}
+
+	/**
+	 * Formats a given GMT date string in the site timezone.
+	 *
+	 * @param string $date   String representing the date / time in GMT.
+	 * @param string $format The format that the passed date should be in.
+	 *
+	 * @return string The formatted date.
+	 */
+	public function format_with_site_timezone( $date, $format = \DATE_W3C ) {
+		if ( ! \is_string( $date ) ) {
+			return $date;
+		}
+
+		$immutable_date = $this->parse_gmt_date( $date );
+
+		if ( ! $immutable_date ) {
+			return $date;
+		}
+
+		return $immutable_date->setTimezone( \wp_timezone() )->format( $format );
 	}
 
 	/**
@@ -116,5 +138,16 @@ class Date_Helper {
 		} catch ( Exception $exception ) {
 			return false;
 		}
+	}
+
+	/**
+	 * Parses a datetime string stored in GMT.
+	 *
+	 * @param string $date String representing the date / time in GMT.
+	 *
+	 * @return \DateTimeImmutable|false The immutable datetime object or false on failure.
+	 */
+	private function parse_gmt_date( $date ) {
+		return \date_create_immutable_from_format( 'Y-m-d H:i:s', $date, new DateTimeZone( 'UTC' ) );
 	}
 }

--- a/tests/Unit/Generators/Schema/Article_Test.php
+++ b/tests/Unit/Generators/Schema/Article_Test.php
@@ -235,13 +235,13 @@ final class Article_Test extends TestCase {
 			->andReturn( 'the-title' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2345-12-12 12:12:12' )
 			->andReturn( '2345-12-12 12:12:12' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2345-12-12 23:23:23' )
 			->andReturn( '2345-12-12 23:23:23' );

--- a/tests/Unit/Generators/Schema/WebPage_Test.php
+++ b/tests/Unit/Generators/Schema/WebPage_Test.php
@@ -124,9 +124,11 @@ final class WebPage_Test extends TestCase {
 	 *
 	 * @param bool   $is_front_page                          Whether the current page is a front page.
 	 * @param string $schema_page_type                       The Schema page type.
-	 * @param int    $calls_to_format_with_post_date_gmt     The number of function calls to 'format' with
+	 * @param int    $calls_to_format_with_post_date_gmt     The number of function calls to
+	 *                                                       'format_with_site_timezone' with
 	 *                                                       'post_date_gmt' as argument.
-	 * @param int    $calls_to_format_with_post_modified_gmt The number of function calls to 'format' with
+	 * @param int    $calls_to_format_with_post_modified_gmt The number of function calls to
+	 *                                                       'format_with_site_timezone' with
 	 *                                                       'post_modified_gmt' as argument.
 	 * @param int    $calls_to_filter                        The number of calls to the
 	 *                                                       'wpseo_schema_webpage_potential_action_target' filter.
@@ -153,13 +155,13 @@ final class WebPage_Test extends TestCase {
 			->andReturn( $is_front_page );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->with( $this->meta_tags_context->post->post_date_gmt )
 			->times( $calls_to_format_with_post_date_gmt )
 			->andReturn( $this->meta_tags_context->post->post_date_gmt );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->with( $this->meta_tags_context->post->post_modified_gmt )
 			->times( $calls_to_format_with_post_modified_gmt )
 			->andReturn( $this->meta_tags_context->post->post_modified_gmt );

--- a/tests/Unit/Generators/Schema_Generator_Test.php
+++ b/tests/Unit/Generators/Schema_Generator_Test.php
@@ -447,13 +447,13 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:09' )
 			->andReturn( '2024-12-13 09:58:09' );
@@ -652,13 +652,13 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:09' )
 			->andReturn( '2024-12-13 09:58:09' );
@@ -723,13 +723,13 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:09' )
 			->andReturn( '2024-12-13 09:58:09' );
@@ -837,13 +837,13 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:09' )
 			->andReturn( '2024-12-13 09:58:09' );
@@ -940,13 +940,13 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnTrue();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:09' )
 			->andReturn( '2024-12-13 09:58:09' );
@@ -1164,7 +1164,7 @@ final class Schema_Generator_Test extends TestCase {
 			->andReturnFalse();
 
 		$this->date
-			->expects( 'format' )
+			->expects( 'format_with_site_timezone' )
 			->once()
 			->with( '2024-12-13 09:58:08' )
 			->andReturn( '2024-12-13 09:58:08' );

--- a/tests/Unit/Helpers/Date_Helper_Test.php
+++ b/tests/Unit/Helpers/Date_Helper_Test.php
@@ -50,6 +50,43 @@ final class Date_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests formatting a GMT date in the site timezone.
+	 *
+	 * @dataProvider format_with_site_timezone_provider
+	 * @covers       ::format_with_site_timezone
+	 *
+	 * @param string $date     The GMT date to format.
+	 * @param string $format   The format.
+	 * @param string $timezone The timezone to format the date in.
+	 * @param string $expected The expected value.
+	 *
+	 * @return void
+	 */
+	public function test_format_with_site_timezone( $date, $format, $timezone, $expected ) {
+		Monkey\Functions\expect( 'wp_timezone' )
+			->once()
+			->andReturn( new \DateTimeZone( $timezone ) );
+
+		$this->assertSame( $expected, $this->instance->format_with_site_timezone( $date, $format ) );
+	}
+
+	/**
+	 * Tests that invalid site timezone input is returned unchanged.
+	 *
+	 * @covers ::format_with_site_timezone
+	 *
+	 * @return void
+	 */
+	public function test_format_with_site_timezone_with_invalid_date() {
+		Monkey\Functions\expect( 'wp_timezone' )->never();
+
+		$this->assertSame(
+			'2020-12-31',
+			$this->instance->format_with_site_timezone( '2020-12-31' ),
+		);
+	}
+
+	/**
 	 * Provides data to the test_format.
 	 *
 	 * @return array The test data.
@@ -100,6 +137,40 @@ final class Date_Helper_Test extends TestCase {
 				'date'     => '2020-12-31',
 				'format'   => \DATE_W3C,
 				'expected' => '2020-12-31',
+			],
+		];
+	}
+
+	/**
+	 * Provides data to the test_format_with_site_timezone.
+	 *
+	 * @return array The test data.
+	 */
+	public static function format_with_site_timezone_provider() {
+		return [
+			'Test formatting in UTC' => [
+				'date'     => '2020-12-31 13:37:00',
+				'format'   => \DATE_W3C,
+				'timezone' => 'UTC',
+				'expected' => '2020-12-31T13:37:00+00:00',
+			],
+			'Test formatting in Europe/Amsterdam' => [
+				'date'     => '2026-04-01 07:10:34',
+				'format'   => \DATE_W3C,
+				'timezone' => 'Europe/Amsterdam',
+				'expected' => '2026-04-01T09:10:34+02:00',
+			],
+			'Test formatting in UTC+8:45' => [
+				'date'     => '2026-04-01 07:10:34',
+				'format'   => \DATE_W3C,
+				'timezone' => '+08:45',
+				'expected' => '2026-04-01T15:55:34+08:45',
+			],
+			'Test formatting in UTC-3:30' => [
+				'date'     => '2026-04-01 07:10:34',
+				'format'   => \DATE_W3C,
+				'timezone' => '-03:30',
+				'expected' => '2026-04-01T03:40:34-03:30',
 			],
 		];
 	}


### PR DESCRIPTION
#23153.

## Summary
- add a schema-specific date formatter that converts GMT post dates into the site timezone
- update schema Article and WebPage generators to use the site timezone for `datePublished` and `dateModified`
- add and update unit tests for the helper and schema generators

## Testing
- composer test -- --filter Date_Helper_Test
- composer test -- --filter Article_Test
- composer test -- --filter WebPage_Test
- composer test -- --filter Schema_Generator_Test

Props ravikhadka
