### PR TITLE
1171 fixed existing posts categories

### DIFF
--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -24,7 +24,7 @@ class Post {
 	/**
 	 * The category.
 	 *
-	 * @var Category
+	 * @var Category|null
 	 */
 	private $category;
 
@@ -59,18 +59,18 @@ class Post {
 	/**
 	 * The constructor.
 	 *
-	 * @param string   $title                 The title.
-	 * @param string   $description           The description.
-	 * @param Category $category              The category.
-	 * @param string   $primary_focus_keyword The primary focus keyword.
-	 * @param int      $is_cornerstone        Whether the post is cornerstone content.
-	 * @param string   $last_modified         The last modified date.
-	 * @param ?string  $schema_article_type   The schema article type.
+	 * @param string    $title                 The title.
+	 * @param string    $description           The description.
+	 * @param ?Category $category              The category, or null if the post has no category.
+	 * @param string    $primary_focus_keyword The primary focus keyword.
+	 * @param int       $is_cornerstone        Whether the post is cornerstone content.
+	 * @param string    $last_modified         The last modified date.
+	 * @param ?string   $schema_article_type   The schema article type.
 	 */
 	public function __construct(
 		string $title,
 		string $description,
-		Category $category,
+		?Category $category,
 		string $primary_focus_keyword,
 		int $is_cornerstone,
 		string $last_modified,
@@ -94,7 +94,7 @@ class Post {
 		$data = [
 			'title'                 => $this->title,
 			'description'           => $this->description,
-			'category'              => $this->category->to_array(),
+			'category'              => isset( $this->category ) ? $this->category->to_array() : null,
 			'primary_focus_keyword' => $this->primary_focus_keyword,
 			'is_cornerstone'        => $this->is_cornerstone,
 			'last_modified'         => $this->last_modified,

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -4,11 +4,14 @@
 
 namespace Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content;
 
+use WP_Term;
+use WPSEO_Meta;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
 
 /**
  * Collects the most recent published posts from indexables.
@@ -40,12 +43,24 @@ class Recent_Content_Collector {
 	private $indexable_repository;
 
 	/**
+	 * The primary term repository.
+	 *
+	 * @var Primary_Term_Repository
+	 */
+	private $primary_term_repository;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param Indexable_Repository $indexable_repository The indexable repository.
+	 * @param Indexable_Repository    $indexable_repository    The indexable repository.
+	 * @param Primary_Term_Repository $primary_term_repository The primary term repository.
 	 */
-	public function __construct( Indexable_Repository $indexable_repository ) {
-		$this->indexable_repository = $indexable_repository;
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		Primary_Term_Repository $primary_term_repository
+	) {
+		$this->indexable_repository    = $indexable_repository;
+		$this->primary_term_repository = $primary_term_repository;
 	}
 
 	/**
@@ -96,7 +111,7 @@ class Recent_Content_Collector {
 				new Post(
 					( $indexable->breadcrumb_title ?? '' ),
 					( $indexable->description ?? '' ),
-					new Category( 'My placeholder', '1' ),
+					$this->get_primary_category( $indexable->object_id ?? 0 ),
 					( $indexable->primary_focus_keyword ?? '' ),
 					( $indexable->is_cornerstone ?? false ),
 					( $indexable->object_last_modified ?? '' ),
@@ -106,5 +121,42 @@ class Recent_Content_Collector {
 		}
 
 		return $post_list;
+	}
+
+	/**
+	 * Resolves the post's primary category into a Category value object.
+	 *
+	 * Looks up Yoast's explicit primary term first, then the `_yoast_wpseo_primary_category` post meta,
+	 * and finally falls back to the first category WordPress has assigned to the post.
+	 *
+	 * @param int $post_id The post id.
+	 *
+	 * @return Category|null The primary category, or null when the post has no category at all.
+	 */
+	private function get_primary_category( int $post_id ): ?Category {
+		$primary_term = $this->primary_term_repository->find_by_post_id_and_taxonomy( $post_id, 'category', false );
+
+		if ( $primary_term ) {
+			$term_id = $primary_term->term_id;
+		}
+		else {
+			$term_id = \get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'primary_category', true );
+		}
+
+		if ( empty( $term_id ) ) {
+			$category_ids = \wp_get_post_categories( $post_id );
+			$term_id      = ( $category_ids[0] ?? 0 );
+		}
+
+		if ( empty( $term_id ) ) {
+			return null;
+		}
+
+		$term = \get_term( (int) $term_id, 'category' );
+		if ( ! $term instanceof WP_Term ) {
+			return null;
+		}
+
+		return new Category( $term->name, $term->term_id );
 	}
 }

--- a/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
+++ b/src/ai/content-planner/infrastructure/recent-content/recent-content-collector.php
@@ -134,20 +134,24 @@ class Recent_Content_Collector {
 	 * @return Category|null The primary category, or null when the post has no category at all.
 	 */
 	private function get_primary_category( int $post_id ): ?Category {
+		// We try to find the primary term using the repository first, which uses indexables.
 		$primary_term = $this->primary_term_repository->find_by_post_id_and_taxonomy( $post_id, 'category', false );
 
 		if ( $primary_term ) {
 			$term_id = $primary_term->term_id;
 		}
+		// If the repository did not return a primary term, we try to find it using the post meta, which is how older versions of Yoast SEO stored the primary category.
 		else {
 			$term_id = \get_post_meta( $post_id, WPSEO_Meta::$meta_prefix . 'primary_category', true );
 		}
 
+		// No primary term has been set in Yoast SEO, so we fall back to the first category WordPress has assigned to the post, if any.
 		if ( empty( $term_id ) ) {
 			$category_ids = \wp_get_post_categories( $post_id );
 			$term_id      = ( $category_ids[0] ?? 0 );
 		}
 
+		// If there are no categories at all, we return null.
 		if ( empty( $term_id ) ) {
 			return null;
 		}

--- a/tests/Unit/AI/Content_Planner/Domain/Post/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/Constructor_Test.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post;
 
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
 
 /**
  * Tests the Post constructor.
@@ -28,5 +29,24 @@ final class Constructor_Test extends Abstract_Post {
 		$this->assertSame( 1, $this->getPropertyValue( $this->instance, 'is_cornerstone' ) );
 		$this->assertSame( '2024-01-15', $this->getPropertyValue( $this->instance, 'last_modified' ) );
 		$this->assertSame( 'BlogPosting', $this->getPropertyValue( $this->instance, 'schema_article_type' ) );
+	}
+
+	/**
+	 * Tests the constructor when the post has no category.
+	 *
+	 * @return void
+	 */
+	public function test_constructor_without_category() {
+		$post = new Post(
+			'My Post Title',
+			'A description of the post.',
+			null,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$this->assertNull( $this->getPropertyValue( $post, 'category' ) );
 	}
 }

--- a/tests/Unit/AI/Content_Planner/Domain/Post/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/To_Array_Test.php
@@ -70,4 +70,36 @@ final class To_Array_Test extends Abstract_Post {
 		$this->assertSame( $expected, $post->to_array() );
 		$this->assertArrayNotHasKey( 'schema_article_type', $post->to_array() );
 	}
+
+	/**
+	 * Tests the to_array method when the post has no category.
+	 *
+	 * The `category` key is always emitted (with a null value when absent) because the AI API
+	 * contract requires the key to be present even when it carries no value.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_without_category() {
+		$post = new Post(
+			'My Post Title',
+			'A description of the post.',
+			null,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$expected = [
+			'title'                 => 'My Post Title',
+			'description'           => 'A description of the post.',
+			'category'              => null,
+			'primary_focus_keyword' => 'focus keyword',
+			'is_cornerstone'        => 1,
+			'last_modified'         => '2024-01-15',
+			'schema_article_type'   => 'BlogPosting',
+		];
+
+		$this->assertSame( $expected, $post->to_array() );
+	}
 }

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Recent_Content/Recent_Content_Collector/Abstract_Recent_Content_Collector_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Recent_Content/Recent_Content_Collector/Abstract_Recent_Content_Collector_Test.php
@@ -1,0 +1,58 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
+
+use Mockery;
+use Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Repositories\Primary_Term_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Base class for Recent_Content_Collector tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Recent_Content_Collector_Test extends TestCase {
+
+	/**
+	 * The indexable repository mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Repository
+	 */
+	protected $indexable_repository;
+
+	/**
+	 * The primary term repository mock.
+	 *
+	 * @var Mockery\MockInterface|Primary_Term_Repository
+	 */
+	protected $primary_term_repository;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Recent_Content_Collector
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->indexable_repository    = Mockery::mock( Indexable_Repository::class );
+		$this->primary_term_repository = Mockery::mock( Primary_Term_Repository::class );
+
+		$this->instance = new Recent_Content_Collector(
+			$this->indexable_repository,
+			$this->primary_term_repository,
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Recent_Content/Recent_Content_Collector/Collect_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Recent_Content/Recent_Content_Collector/Collect_Test.php
@@ -1,0 +1,260 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use stdClass;
+use WP_Term;
+use WPSEO_Meta;
+
+/**
+ * Tests Recent_Content_Collector::collect for the primary-category resolution cases.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector::collect
+ */
+final class Collect_Test extends Abstract_Recent_Content_Collector_Test {
+
+	/**
+	 * Builds a plain object mirroring the Indexable fields the collector reads.
+	 *
+	 * @return stdClass
+	 */
+	private function build_indexable_stub(): stdClass {
+		$indexable                        = new stdClass();
+		$indexable->object_id             = 42;
+		$indexable->breadcrumb_title      = 'My Post Title';
+		$indexable->description           = 'A description of the post.';
+		$indexable->primary_focus_keyword = 'focus keyword';
+		$indexable->is_cornerstone        = false;
+		$indexable->object_last_modified  = '2024-01-15';
+		$indexable->schema_article_type   = 'NewsArticle';
+
+		return $indexable;
+	}
+
+	/**
+	 * Tests that a Category from the Primary_Term_Repository is included on the Post.
+	 *
+	 * @return void
+	 */
+	public function test_collect_builds_post_with_primary_term_from_repository() {
+		$indexable = $this->build_indexable_stub();
+
+		$primary_term          = new stdClass();
+		$primary_term->term_id = 7;
+
+		$term          = Mockery::mock( WP_Term::class );
+		$term->name    = 'Travel';
+		$term->term_id = 7;
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', 100, false )
+			->andReturn( [ $indexable ] );
+
+		$this->primary_term_repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 42, 'category', false )
+			->andReturn( $primary_term );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 7, 'category' )
+			->andReturn( $term );
+
+		$result = $this->instance->collect( 'post' );
+
+		$this->assertSame(
+			[
+				[
+					'title'                 => 'My Post Title',
+					'description'           => 'A description of the post.',
+					'category'              => [
+						'name' => 'Travel',
+						'id'   => 7,
+					],
+					'primary_focus_keyword' => 'focus keyword',
+					'is_cornerstone'        => 0,
+					'last_modified'         => '2024-01-15',
+					'schema_article_type'   => 'NewsArticle',
+				],
+			],
+			$result->to_array(),
+		);
+	}
+
+	/**
+	 * Tests that the post_meta fallback is used when the repository has no record.
+	 *
+	 * @return void
+	 */
+	public function test_collect_falls_back_to_post_meta_for_primary_category() {
+		$indexable = $this->build_indexable_stub();
+
+		$term          = Mockery::mock( WP_Term::class );
+		$term->name    = 'News';
+		$term->term_id = 3;
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->andReturn( [ $indexable ] );
+
+		$this->primary_term_repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 42, 'category', false )
+			->andReturn( null );
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 42, WPSEO_Meta::$meta_prefix . 'primary_category', true )
+			->andReturn( '3' );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 3, 'category' )
+			->andReturn( $term );
+
+		$result = $this->instance->collect( 'post' );
+
+		$posts = $result->to_array();
+		$this->assertSame(
+			[
+				'name' => 'News',
+				'id'   => 3,
+			],
+			$posts[0]['category'],
+		);
+	}
+
+	/**
+	 * Tests that when no explicit primary is set, the first WP-assigned category is used.
+	 *
+	 * @return void
+	 */
+	public function test_collect_falls_back_to_first_wp_assigned_category() {
+		$indexable = $this->build_indexable_stub();
+
+		$term          = Mockery::mock( WP_Term::class );
+		$term->name    = 'General';
+		$term->term_id = 11;
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->andReturn( [ $indexable ] );
+
+		$this->primary_term_repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 42, 'category', false )
+			->andReturn( null );
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 42, WPSEO_Meta::$meta_prefix . 'primary_category', true )
+			->andReturn( '' );
+
+		Functions\expect( 'wp_get_post_categories' )
+			->once()
+			->with( 42 )
+			->andReturn( [ 11, 22 ] );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 11, 'category' )
+			->andReturn( $term );
+
+		$result = $this->instance->collect( 'post' );
+
+		$posts = $result->to_array();
+		$this->assertSame(
+			[
+				'name' => 'General',
+				'id'   => 11,
+			],
+			$posts[0]['category'],
+		);
+	}
+
+	/**
+	 * Tests that a Post with no category at all emits `category: null`.
+	 *
+	 * @return void
+	 */
+	public function test_collect_emits_null_category_when_post_has_no_category_at_all() {
+		$indexable = $this->build_indexable_stub();
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->andReturn( [ $indexable ] );
+
+		$this->primary_term_repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 42, 'category', false )
+			->andReturn( null );
+
+		Functions\expect( 'get_post_meta' )
+			->once()
+			->with( 42, WPSEO_Meta::$meta_prefix . 'primary_category', true )
+			->andReturn( '' );
+
+		Functions\expect( 'wp_get_post_categories' )
+			->once()
+			->with( 42 )
+			->andReturn( [] );
+
+		Functions\expect( 'get_term' )->never();
+
+		$result = $this->instance->collect( 'post' );
+
+		$posts = $result->to_array();
+		$this->assertArrayHasKey( 'category', $posts[0] );
+		$this->assertNull( $posts[0]['category'] );
+	}
+
+	/**
+	 * Tests that a stale primary term id (term no longer exists) yields no category on the Post.
+	 *
+	 * @return void
+	 */
+	public function test_collect_emits_post_without_category_when_term_is_missing() {
+		$indexable = $this->build_indexable_stub();
+
+		$primary_term          = new stdClass();
+		$primary_term->term_id = 99;
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->andReturn( [ $indexable ] );
+
+		$this->primary_term_repository
+			->expects( 'find_by_post_id_and_taxonomy' )
+			->once()
+			->with( 42, 'category', false )
+			->andReturn( $primary_term );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 99, 'category' )
+			->andReturn( null );
+
+		$result = $this->instance->collect( 'post' );
+
+		$posts = $result->to_array();
+		$this->assertArrayHasKey( 'category', $posts[0] );
+		$this->assertNull( $posts[0]['category'] );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the posts' categories sent to `content-planner/next-post-suggestion` were always empty.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have categories assigned to your existing posts
* Create a new post and click on `Get content suggestions`
* Select one of the suggestion
  * Make sure the suggested category is an existing one

#### Alternative way to check this
* Install and activate[ Log HTTP Requests](https://wordpress.org/plugins/log-http-requests/) plugin
* Take note of the category associated to one of your first 100 posts, together with its id
* Create a new post and click on `Get content suggestions`
* Go to `Tools` -> `Log HTTP Requests`
* Look for a request to `https://ai-staging.yoa.st/api/v1/content-planner/next-post-suggestions`
* Click on it and copy the `body` 
  * In the `posts` array, look for the post you noted down
    * Confirm the category is correct
 
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1171
