### PR TITLE
docs: introduce a contributor guide for humans and AI coding tools

### DIFF
--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -3,13 +3,14 @@ description: Yoast SEO contributor and agent instructions — always apply
 alwaysApply: true
 ---
 
-The canonical guidance for working in this repository is in the repo-root [`AGENTS.md`](../../AGENTS.md). Cursor should treat `AGENTS.md` as the source of truth for architecture, tooling, testing, code-style, and PR conventions.
+The canonical contributor guide for this repository is [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md). It covers architecture, tooling, workflows, testing, code style, commits, and PR conventions. [`AGENTS.md`](../../AGENTS.md) adds a short set of behaviours specific to AI coding agents on top. Cursor should treat `CONTRIBUTING.md` as the primary source of truth and `AGENTS.md` as the agent-behaviour delta.
 
-@AGENTS.md
+@../../.github/CONTRIBUTING.md
 
-Additional authoritative docs:
+@../../AGENTS.md
 
-- [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) — external-contributor guidelines and the pre-push checklist (tests, `composer check-branch-cs`, coverage).
+Additional authoritative doc:
+
 - [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — PR template and changelog conventions.
 
-If anything in this file contradicts `AGENTS.md` or `CONTRIBUTING.md`, prefer those.
+If anything in this file contradicts `CONTRIBUTING.md`, the PR template, or `AGENTS.md`, prefer those.

--- a/.cursor/rules/agents.mdc
+++ b/.cursor/rules/agents.mdc
@@ -1,0 +1,15 @@
+---
+description: Yoast SEO contributor and agent instructions — always apply
+alwaysApply: true
+---
+
+The canonical guidance for working in this repository is in the repo-root [`AGENTS.md`](../../AGENTS.md). Cursor should treat `AGENTS.md` as the source of truth for architecture, tooling, testing, code-style, and PR conventions.
+
+@AGENTS.md
+
+Additional authoritative docs:
+
+- [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) — external-contributor guidelines and the pre-push checklist (tests, `composer check-branch-cs`, coverage).
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — PR template and changelog conventions.
+
+If anything in this file contradicts `AGENTS.md` or `CONTRIBUTING.md`, prefer those.

--- a/.cursor/rules/create-pr.mdc
+++ b/.cursor/rules/create-pr.mdc
@@ -1,0 +1,14 @@
+---
+description: Yoast SEO — create a pull request workflow. Apply whenever the user asks to open, file, or update a pull request.
+alwaysApply: false
+---
+
+When the user asks to create, open, or update a pull request, follow the procedure in [`docs/workflows/create-pr.md`](../../docs/workflows/create-pr.md) exactly. That file is the canonical workflow shared across tools — do not reinvent it from context.
+
+@../../docs/workflows/create-pr.md
+
+The recipe's own references are:
+
+- [`AGENTS.md`](../../AGENTS.md) — conventions and architecture.
+- [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) — pre-push checks and coverage policy.
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) — changelog grammar, labels, bracket syntax, release-branch rules.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Community patches, localizations, bug reports, and contributions are very welcom
 3. Follow the [Yoast Coding Standards](https://github.com/Yoast/yoastcs) (a superset of the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)).
 4. Document any new functions, actions, and filters following the [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
 5. Write tests. We expect every PR that changes PHP behaviour to ship unit tests — see the commands in the checklist below.
-6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(dashboard): …`). Small, atomic commits are preferred.
+6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(dashboard): …`). **Prefer atomic commits whenever practical** — each commit should represent a single logical change that can be reviewed or reverted on its own. If your PR mixes unrelated changes (e.g. a bugfix plus a refactor plus a tooling tweak), split them into separate commits or ideally separate PRs. Combining closely coupled changes into one commit is fine when splitting would be artificial.
 7. Push your branch and open a pull request against `trunk`. **Use the pull request template** at [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) and fill in every section — even for small changes.
 
 #### Before you push or open/update a PR

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,60 +1,95 @@
 # Contribution Guidelines
-<img src="https://yoast-mercury.s3.amazonaws.com/uploads/2013/02/Yoast_Logo_Large_RGB.png" alt="Yoast logo" width="250px">
 
-Before filing a bug report or a feature request, be sure to read the contribution guidelines.
+Thanks for taking the time to contribute to Yoast SEO! Before filing a bug report, feature request, or pull request, please read the guidelines below.
 
 ## How to use GitHub
-We use GitHub exclusively for well-documented bugs, feature requests and code contributions. Communication is always done in English.
 
-To receive free support for WordPress SEO we have the following channels:
+We use GitHub exclusively for well-documented bugs, feature requests, and code contributions. Communication is always done in English.
+
+For support with Yoast SEO we have the following channels:
+
 * [Yoast Knowledge base](https://yoa.st/1y0)
 * [Support forums](https://wordpress.org/support/plugin/wordpress-seo) on WordPress.org
 
-If you have purchased one of [our premium plugins](https://yoa.st/1y1), we will give you personal support via email, please see your purchase email for details.
-
-
-Thanks for your understanding.
+If you have purchased one of [our premium plugins](https://yoa.st/1y1) you will receive personal support by email — see your purchase email for details.
 
 ## Security issues
-Please do not report security issues here. Instead, email them to security at yoast dot com so we can deal with them securely and quickly.
+
+Please do **not** report security issues on GitHub. Follow our [security program](https://yoast.com/security-program/) instead, or email the details to `security@yoast.com` so we can handle them quickly and responsibly.
 
 ## I have found a bug
+
 Before opening a new issue, please:
-* update to the newest versions of WordPress and the Yoast SEO plugins.
-* search for duplicate issues to prevent opening a duplicate issue. If there is already an open existing issue, please comment on that issue.
-* check our [knowledge base](https://yoa.st/1y0) for your issue. There are a lot of common errors documented there with possible solutions.
-* follow our _New issue_ template when creating a new issue.
-* check for [plugin and theme conflicts](https://yoa.st/1y2). Please report your findings in the issue.
-* check for [JavaScript errors with your browser's console](https://yoa.st/1y3). Please report your findings in the issue.
-* add as much information as possible. For example: add screenshots, relevant links, step by step guides etc.
+
+* update to the latest versions of WordPress and the Yoast SEO plugins.
+* search for duplicate issues to avoid filing the same report twice. If an open issue already exists, please comment on it.
+* check our [knowledge base](https://yoa.st/1y0) — many common errors are documented there with possible solutions.
+* pick the matching GitHub issue form (Bug report, Feature request, Design implementation, etc.) and fill in every section.
+* check for [plugin and theme conflicts](https://yoa.st/1y2) and include your findings.
+* check for [JavaScript errors in your browser's console](https://yoa.st/1y3) and include any output.
+* include as much information as possible — screenshots, relevant links, step-by-step reproductions, plugin/theme versions.
 
 ## I have a feature request
-Before opening a new issue, please:
-* search for duplicate issues to prevent opening a duplicate feature request. If there is already an open existing request, please leave a comment there.
-* add as much information as possible. For example: give us a clear explanation of why you think the feature request is something we should consider for the Yoast SEO plugins.
+
+Before opening a new issue:
+
+* search for duplicate issues to avoid filing the same request twice. If an open request already exists, please add your thoughts there.
+* pick the Feature request issue form and explain *why* you think this feature is worth considering.
 
 ## I want to create a patch
-Community made patches, localizations, bug reports and contributions are very welcome and help Yoast SEO remain the #1 SEO plugin for WordPress.
 
-When contributing please ensure you follow the guidelines below so that we can keep on top of things.
+Community patches, localizations, bug reports, and contributions are very welcome — they help Yoast SEO remain the #1 SEO plugin for WordPress.
 
-#### Submitting an issue you found
-Make sure your problem does not exist as a ticket already by searching through [the existing issues](https://github.com/Yoast/wordpress-seo/issues). If you cannot find anything which resembles your problem, please [create a new issue](https://github.com/Yoast/wordpress-seo/issues/new).
+### Supported environment
 
-#### Fixing an issue
+* PHP 7.4 or newer (8.x is supported too).
+* The latest two major WordPress versions are officially supported.
 
-* Fork the repository on GitHub (make sure to use the trunk branch, not main).
-* Make the changes to your forked repository.
-* Ensure you stick to the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and you properly document any new functions, actions and filters following the [documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
-* When committing, reference your issue and include a note about the fix.
-* Push the changes to your fork and submit a pull request to the 'trunk' branch of the Yoast SEO repository.
+### Opening a pull request
 
-We will review your pull request and merge when everything is in order. We will help you to make sure the code complies with the standards described above.
+1. Fork the repository and create your branch from `trunk`. `trunk` is the active development branch and the default branch on GitHub — every PR should target it unless a maintainer asks otherwise. Do **not** target `main`: that branch tracks the latest released version and is not where new work goes.
+2. Make your changes on your fork.
+3. Follow the [Yoast Coding Standards](https://github.com/Yoast/yoastcs) (a superset of the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)).
+4. Document any new functions, actions, and filters following the [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
+5. Write tests. We expect every PR that changes PHP behaviour to ship unit tests — see the commands in the checklist below.
+6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(dashboard): …`). Small, atomic commits are preferred.
+7. Push your branch and open a pull request against `trunk`. **Use the pull request template** at [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) and fill in every section — even for small changes.
 
-#### 'Patch welcome' issues
-Some issues are labeled 'patch-welcome'. This means we see the value in the particular enhancement being suggested but have decided for now not to prioritize it. If you however decide to write a patch for it, we'll gladly include it after some code review.
+#### Before you push or open/update a PR
 
-#### Additional Resources
+Run these checks locally and make sure each one is clean. CI will run the same checks — catching issues locally is faster and easier than fixing them afterwards on a review cycle.
+
+* `composer test` — the unit test suite must pass.
+* `composer test-wp-env` — the WordPress integration tests (Docker via `@wordpress/env`) must pass if your change touches code that has or needs WP integration coverage.
+* `composer check-branch-cs` — checks the Yoast coding-standard ruleset against the files you changed on this branch. It must report **no new errors or warnings** introduced by your branch. Use `composer fix-cs` to auto-fix what it can, and address the rest by hand.
+* `composer lint-branch` — PHP parse-error check on the files changed on this branch.
+* For changes under `packages/*` or `js/`: run `yarn lint` and the relevant package's `yarn test`.
+
+**Coverage:** every PR should *increase* test coverage, or at minimum keep it flat. In practice this means the code you add should come with tests that exercise it. CI reports the coverage delta on the PR — if coverage drops, explain in the PR description why it was not possible to add tests for the new code (for example: pure wiring code that can only be exercised through a full WordPress boot, or a third-party API call that is impractical to mock).
+
+If a check fails or you need to skip one (e.g. you can't run Docker locally for `test-wp-env`), say so explicitly in the PR description so reviewers know what still needs validating.
+
+### Changelog entry and label
+
+Every PR needs a **changelog entry** in the Summary section of the PR body and a **changelog label** on the PR itself:
+
+* Write one bullet describing the change in present tense, 3rd person singular, ending with a full stop. For bugfixes use the template `Fixes a bug where … (was …) when …`.
+* Attach one of: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
+* If the change also affects another Yoast repo or package, add an extra bullet prefixed with `[<repo-or-package>]`. The PR template explains this in more detail.
+
+The `community-patch` label is applied automatically to external contributions — you do not need to add it yourself. Milestones are set by the maintainer who merges your PR.
+
+### Issues labelled _patch welcome_
+
+Issues tagged with the `patch welcome` label are enhancements we see value in but have not prioritised. If you'd like to take one on, write a patch and we'll review it.
+
+### Submitting an issue you have found
+
+Make sure your problem doesn't already have a ticket by searching [the existing issues](https://github.com/Yoast/wordpress-seo/issues). If you can't find anything matching, please [open a new issue](https://github.com/Yoast/wordpress-seo/issues/new/choose).
+
+## Additional resources
+
+* [Yoast developer portal](https://developer.yoast.com/)
 * [Yoast SEO API](https://yoa.st/1y4)
-* [General GitHub Documentation](https://help.github.com/)
-* [GitHub Pull Request documentation](https://help.github.com/send-pull-requests/)
+* [General GitHub documentation](https://docs.github.com/)
+* [GitHub Pull Request documentation](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,7 +100,7 @@ The top-level folders you will touch (or explicitly avoid):
 | `lib/` | Low-level utilities (ORM, migrations). Touch only when needed. | Maintenance |
 | `src/generated/` | Compiled Symfony DI container. **Gitignored, not committed**; the release-build pipeline bundles it into the shipped artifact. | **Never hand-edit** — regenerate via `composer compile-di` |
 | `vendor/`, `vendor_prefixed/` | Composer dependencies (prefixed copies are scoped with `YoastSEO_Vendor`). | Never hand-edit |
-| `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
+| `build/`, `js/dist/`, `css/dist/`, `artifact/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
 | `wp-seo.php`, `wp-seo-main.php`, `index.php` | Plugin bootstrap. Change only when the bootstrap itself needs to change. | With care |
 
 ### Where to put new code

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,7 +98,7 @@ The top-level folders you will touch (or explicitly avoid):
 | `docs/` | Repo-local developer notes. | Yes |
 | `admin/`, `inc/` | Legacy non-namespaced PHP. | **Maintenance only** — see below |
 | `lib/` | Low-level utilities (ORM, migrations). Touch only when needed. | Maintenance |
-| `src/generated/` | Compiled Symfony DI container. | **Never hand-edit** — regenerate via `composer compile-di` |
+| `src/generated/` | Compiled Symfony DI container. **Gitignored, not committed**; the release-build pipeline bundles it into the shipped artifact. | **Never hand-edit** — regenerate via `composer compile-di` |
 | `vendor/`, `vendor_prefixed/` | Composer dependencies (prefixed copies are scoped with `YoastSEO_Vendor`). | Never hand-edit |
 | `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
 | `wp-seo.php`, `wp-seo-main.php`, `index.php` | Plugin bootstrap. Change only when the bootstrap itself needs to change. | With care |
@@ -140,8 +140,8 @@ The plugin uses a compiled Symfony DI container. Services are auto-wired from `s
   - You added a new class under `src/`.
   - You changed a constructor signature of an existing class.
   - You added/removed a service definition or tag in `config/dependency-injection/` (if applicable).
-- Commit the regenerated `src/generated/container.php` and `src/generated/container.php.meta`. The `post-autoload-dump` hook also runs this, so it usually happens automatically on `composer install` / `composer update`.
-- If CI complains about the container being out of sync, re-run `composer compile-di` and commit the result.
+- The regenerated files under `src/generated/` (`container.php`, `container.php.meta`) are **gitignored — do not commit them**. Every environment rebuilds its own container: `composer install` and `composer update` re-run `compile-di` via the `post-autoload-dump` hook, so local dev, CI, and the release build each regenerate it fresh. The compiled container *is* included in the shipped release artifact; it is just never part of the Git history.
+- If CI fails during DI compilation after your changes, check that your new or modified classes resolve correctly via auto-wiring (type-hinted constructor arguments, correct namespaces, etc.).
 
 ### PHP workflow
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Before opening a new issue, please:
 * pick the matching GitHub issue form (Bug report, Feature request, Design implementation, etc.) and fill in every section.
 * check for [plugin and theme conflicts](https://yoa.st/1y2) and include your findings.
 * check for [JavaScript errors in your browser's console](https://yoa.st/1y3) and include any output.
-* include as much information as possible — screenshots, relevant links, step-by-step reproductions, plugin/theme versions.
+* include everything needed to understand and reproduce the problem — screenshots, clear reproduction steps, plugin and theme versions, and any relevant logs — but stay focused. A tight, reproducible report is easier to triage than a long narrative with unrelated context or commentary.
 
 ## I have a feature request
 
@@ -65,6 +65,7 @@ If you are unsure whether a piece of code is safe to include, ask in the issue o
 5. Write tests. We expect every PR that changes PHP behaviour to ship unit tests — see the commands in the checklist below.
 6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(dashboard): …`). **Prefer atomic commits whenever practical** — each commit should represent a single logical change that can be reviewed or reverted on its own. If your PR mixes unrelated changes (e.g. a bugfix plus a refactor plus a tooling tweak), split them into separate commits or ideally separate PRs. Combining closely coupled changes into one commit is fine when splitting would be artificial.
 7. Push your branch and open a pull request against `trunk`. **Use the pull request template** at [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) and fill in every section — even for small changes.
+8. **Keep the PR description focused.** Fill every required section of the template with what the reviewer actually needs — no more. *Context* and *Relevant technical choices* are usually one or two clear sentences; *Test instructions* are concrete steps, not essays. Don't pad sections to look thorough; reviewers read every line, and padding makes the substance harder to find. Summarise — link to the epic, issue, or design doc instead of restating them.
 
 #### Before you push or open/update a PR
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -40,6 +40,17 @@ Before opening a new issue:
 
 Community patches, localizations, bug reports, and contributions are very welcome — they help Yoast SEO remain the #1 SEO plugin for WordPress.
 
+### License and copyright
+
+Yoast SEO is licensed under [GPL-2.0-or-later](../license.txt). By opening a pull request you confirm that your contribution is offered under the same license. Before contributing code, make sure that:
+
+- You wrote the code yourself, or you have the right to relicense it under GPL-2.0-or-later.
+- You have not copied code from sources whose license is incompatible with GPL-2.0-or-later (for example proprietary code, CC-licensed snippets that restrict commercial use, or GPL-3.0-only code).
+- If you have reused code from a GPL-2.0-compatible source (MIT, BSD, public domain, Apache-2.0 where compatible, etc.), you have preserved the original copyright notice and license header, and noted the provenance in the commit message.
+- You have not included code whose licensing status is unclear — including AI-generated code whose training or output terms you have not verified as compatible.
+
+If you are unsure whether a piece of code is safe to include, ask in the issue or PR before opening it for review.
+
 ### Supported environment
 
 * PHP 7.4 or newer (8.x is supported too).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -222,7 +222,7 @@ If a check fails or you need to skip one (e.g. you can't run Docker locally for 
 
 Every PR needs a **changelog entry** in the Summary section of the PR body and a **changelog label** on the PR itself:
 
-* Write one bullet describing the change in present tense, 3rd person singular, ending with a full stop. For bugfixes use the template `Fixes a bug where … (was …) when …`.
+* Write one bullet describing the change in present tense, 3rd person singular, ending with a full stop. For bugfixes, describe the incorrect behaviour followed by the condition that triggered it, in clear past tense, avoiding hypothetical or nested conditionals (e.g. `Fixes a bug where X happened when Y` or `Fixes a bug where X was caused by Y`). See [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) for the full grammar and examples.
 * Attach one of: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
 * If the change also affects another Yoast repo or package, add an extra bullet prefixed with `[<repo-or-package>]`. The PR template explains this in more detail.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -202,7 +202,7 @@ Each package under `packages/*` has its own `package.json` with local scripts; p
 5. Write tests. We expect every PR that changes PHP behaviour to ship unit tests — see the commands in the checklist below.
 6. Use the [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages (e.g. `fix: …`, `feat(dashboard): …`). **Prefer atomic commits whenever practical** — each commit should represent a single logical change that can be reviewed or reverted on its own. If your PR mixes unrelated changes (e.g. a bugfix plus a refactor plus a tooling tweak), split them into separate commits or ideally separate PRs. Combining closely coupled changes into one commit is fine when splitting would be artificial.
 7. Push your branch and open a pull request against `trunk`. **Use the pull request template** at [`.github/PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) and fill in every section — even for small changes.
-8. **Keep the PR description focused.** Fill every required section of the template with what the reviewer actually needs — no more. *Context* and *Relevant technical choices* are usually one or two clear sentences; *Test instructions* are concrete steps, not essays. Don't pad sections to look thorough; reviewers read every line, and padding makes the substance harder to find. Summarise — link to the epic, issue, or design doc instead of restating them.
+8. **Keep the PR description focused.** Fill every required section of the template — aim for what the reviewer actually needs. For *Context* and *Relevant technical choices*, brevity is welcome but not enforced. *Test instructions* should be concrete steps, not essays. Link to the epic, issue, or design doc rather than restating them.
 
 #### Before you push or open/update a PR
 
@@ -224,6 +224,7 @@ If a check fails or you need to skip one (e.g. you can't run Docker locally for 
 Every PR needs a **changelog entry** in the Summary section of the PR body and a **changelog label** on the PR itself:
 
 * Write one bullet describing the change in present tense, 3rd person singular, ending with a full stop. For bugfixes, describe the incorrect behaviour followed by the condition that triggered it, in clear past tense, avoiding hypothetical or nested conditionals (e.g. `Fixes a bug where X happened when Y` or `Fixes a bug where X was caused by Y`). See [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) for the full grammar and examples.
+* Keep each bullet to one short sentence. If you need commas, semicolons, or colons to chain clauses together, the extra context belongs in *Context* or *Relevant technical choices* — not in the bullet.
 * Attach one of: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
 * If the change also affects another Yoast repo or package, add an extra bullet prefixed with `[<repo-or-package>]`. The PR template explains this in more detail.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If you have purchased one of [our premium plugins](https://yoa.st/1y1) you will 
 
 ## Security issues
 
-Please do **not** report security issues on GitHub. Follow our [security program](https://yoast.com/security-program/) instead, or email the details to `security@yoast.com` so we can handle them quickly and responsibly.
+Please do **not** report security issues on GitHub. Follow our [security program](https://yoast.com/security-program/) instead — see [`yoast.com/security.txt`](https://yoast.com/security.txt) for the canonical contact details — so we can handle them quickly and responsibly.
 
 ## I have found a bug
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,31 @@ Thanks for taking the time to contribute to Yoast SEO! Before filing a bug repor
 
 This file is the canonical contributor guide for this repository. It is written for both humans and AI coding tools. The repo-root [`AGENTS.md`](../AGENTS.md) adds a small set of behaviours specific to AI agents on top of the rules here; the [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) carries the detailed changelog and label rules.
 
+## Contents
+
+- [How to use GitHub](#how-to-use-github)
+- [Security issues](#security-issues)
+- [I have found a bug](#i-have-found-a-bug)
+- [I have a feature request](#i-have-a-feature-request)
+- [I want to create a patch](#i-want-to-create-a-patch)
+  - [License and copyright](#license-and-copyright)
+  - [Supported environment](#supported-environment)
+  - [Repository layout](#repository-layout)
+  - [Where to put new code](#where-to-put-new-code)
+    - [Onion dependency rules](#onion-dependency-rules)
+    - [Legacy folders (`admin/`, `inc/`)](#legacy-folders-admin-inc)
+  - [Dependency injection](#dependency-injection)
+  - [PHP workflow](#php-workflow)
+  - [JavaScript workflow](#javascript-workflow)
+  - [Testing](#testing)
+  - [Code style](#code-style)
+  - [Opening a pull request](#opening-a-pull-request)
+    - [Before you push or open/update a PR](#before-you-push-or-openupdate-a-pr)
+  - [Changelog entry and label](#changelog-entry-and-label)
+  - [Issues labelled _patch welcome_](#issues-labelled-_patch-welcome_)
+  - [Submitting an issue you have found](#submitting-an-issue-you-have-found)
+- [Additional resources](#additional-resources)
+
 ## How to use GitHub
 
 We use GitHub exclusively for well-documented bugs, feature requests, and code contributions. Communication is always done in English.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for taking the time to contribute to Yoast SEO! Before filing a bug report, feature request, or pull request, please read the guidelines below.
 
+This file is the canonical contributor guide for this repository. It is written for both humans and AI coding tools. The repo-root [`AGENTS.md`](../AGENTS.md) adds a small set of behaviours specific to AI agents on top of the rules here; the [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md) carries the detailed changelog and label rules.
+
 ## How to use GitHub
 
 We use GitHub exclusively for well-documented bugs, feature requests, and code contributions. Communication is always done in English.
@@ -55,10 +57,120 @@ If you are unsure whether a piece of code is safe to include, ask in the issue o
 
 * PHP 7.4 or newer (8.x is supported too).
 * The latest two major WordPress versions are officially supported.
+* The plugin is a single PHP plugin plus a Yarn workspaces / Lerna monorepo of JS packages under `packages/*`.
+
+### Repository layout
+
+The top-level folders you will touch (or explicitly avoid):
+
+| Path | Purpose | Editable? |
+| --- | --- | --- |
+| `src/` | Namespaced PHP. All new backend work lives here. | Yes |
+| `packages/js/` | The primary JS bundle shipped with the plugin. | Yes |
+| `packages/*` | Shared JS/TS libraries (UI library, analysis engine, etc.). | Yes |
+| `tests/` | PHPUnit tests (unit + WP integration). | Yes |
+| `config/` | Grunt, webpack, php-scoper, wp-env, composer actions, build scripts. | Yes, with care |
+| `docs/` | Repo-local developer notes. | Yes |
+| `admin/`, `inc/` | Legacy non-namespaced PHP. | **Maintenance only** — see below |
+| `lib/` | Low-level utilities (ORM, migrations). Touch only when needed. | Maintenance |
+| `src/generated/` | Compiled Symfony DI container. | **Never hand-edit** — regenerate via `composer compile-di` |
+| `vendor/`, `vendor_prefixed/` | Composer dependencies (prefixed copies are scoped with `YoastSEO_Vendor`). | Never hand-edit |
+| `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
+| `wp-seo.php`, `wp-seo-main.php`, `index.php` | Plugin bootstrap. Change only when the bootstrap itself needs to change. | With care |
+
+### Where to put new code
+
+Two organisational patterns coexist inside `src/`:
+
+1. **Concept-based (older, still valid for extensions of existing features).** Code is grouped by its role in the plugin: `src/integrations/`, `src/conditionals/`, `src/generators/`, `src/actions/`, `src/presenters/`, `src/surfaces/`, `src/helpers/`, etc. When you are expanding a feature that already follows this layout — for example adding a new Schema piece, a new admin integration, or a new REST action — keep it in the matching folder and follow the surrounding patterns. See [`src/README.md`](../src/README.md) for a description of each concept folder.
+
+2. **Feature-folder with onion layers (preferred for new self-contained features).** A new feature gets its own directory under `src/` with four subfolders:
+
+   ```
+   src/<feature>/
+   ├── domain/          Pure business logic — no WordPress, no I/O.
+   ├── application/     Use cases, orchestration, DTOs, interfaces.
+   ├── infrastructure/  WordPress/DB/HTTP adapters; repository implementations.
+   └── user-interface/  Integrations, REST routes, WP-CLI, presenters.
+   ```
+
+   Live examples in the repo: `src/dashboard/`, `src/introductions/`, `src/llms-txt/`, `src/schema-aggregator/`, `src/ai-*/`.
+
+#### Onion dependency rules
+
+- Domain depends on **nothing** outside itself (no WP functions, no framework, no infrastructure).
+- Application depends on Domain only, and defines interfaces for anything it needs from Infrastructure.
+- Infrastructure and User-Interface depend on Application and Domain — never the other way round.
+- Cross-layer wiring happens through constructor injection via the Symfony DI container.
+
+#### Legacy folders (`admin/`, `inc/`)
+
+These contain pre-namespace, pre-onion code. Treat them as **maintenance-only**: fix bugs, keep them compatible, but do not add new features there. When a legacy class needs significant changes, consider whether the work justifies moving (or extracting a new service for) the affected responsibility into `src/`.
+
+### Dependency injection
+
+The plugin uses a compiled Symfony DI container. Services are auto-wired from `src/` based on their type hints.
+
+- **Run `composer compile-di` whenever a change would affect the container.** In practice this means:
+  - You added a new class under `src/`.
+  - You changed a constructor signature of an existing class.
+  - You added/removed a service definition or tag in `config/dependency-injection/` (if applicable).
+- Commit the regenerated `src/generated/container.php` and `src/generated/container.php.meta`. The `post-autoload-dump` hook also runs this, so it usually happens automatically on `composer install` / `composer update`.
+- If CI complains about the container being out of sync, re-run `composer compile-di` and commit the result.
+
+### PHP workflow
+
+All commands are run from the repo root.
+
+| Command | What it does |
+| --- | --- |
+| `composer install` | Install PHP dependencies (also compiles DI and prefixes vendor packages). |
+| `composer lint` | PHP parse-error check across the repo. |
+| `composer lint-branch` | Same, but only for files changed on the current branch. |
+| `composer check-cs` | Run phpcs with the Yoast ruleset (errors only). |
+| `composer check-branch-cs` | Run phpcs against the files changed on the current branch. |
+| `composer fix-cs` | Auto-fix fixable phpcs violations. |
+| `composer test` | Run PHPUnit unit tests (no WP, no coverage). |
+| `composer test-wp-env` | Run WP integration tests inside the `wp-env` Docker environment (preferred way to run integration tests locally). |
+| `composer coverage` / `coverage-wp-env` | Same, with coverage. |
+| `composer compile-di` | Rebuild the DI container. |
+| `composer generate-migration` | Scaffold a new DB migration under `src/config/migrations/`. |
+| `composer generate-unit-test` | Scaffold a unit-test file for a fully-qualified class name. |
+
+Coding standards are enforced by the Yoast Coding Standard (`yoast/yoastcs`) — a superset of WordPress Coding Standards — plus parallel-lint for syntax. Run `composer check-branch-cs` before opening a PR.
+
+### JavaScript workflow
+
+| Command | What it does |
+| --- | --- |
+| `yarn install` | Install JS dependencies for the whole workspace. |
+| `yarn start` | Webpack dev build with watch for the main JS bundle. |
+| `yarn build` | Run the `build` script of every workspace package. |
+| `yarn lint` | Lint every workspace package plus the repo-level tooling. |
+| `yarn test` | Run every workspace's `test` script (Jest). |
+| `grunt build` / `grunt build:dev` | Full plugin build (assets + images + i18n) via Grunt. |
+
+Each package under `packages/*` has its own `package.json` with local scripts; prefer running those directly when iterating on a single package.
+
+### Testing
+
+- **Every PR that changes PHP behaviour should ship unit tests.** Place them under `tests/Unit/…` mirroring the path of the class under test.
+- **Integration tests** (those that boot WordPress) live under `tests/WP/…` and run via `composer test-wp-env`, which starts an isolated WP in Docker through `@wordpress/env`.
+- Test one method per test class where practical; share setup via abstract base classes or traits (examples already exist under `tests/Unit`).
+- JS tests use Jest and live inside the relevant `packages/*/tests/` folder.
+- If you cannot run the integration tests in your environment, say so explicitly in the PR description rather than skipping them silently.
+
+### Code style
+
+- Follow the existing code. When two styles look plausible, match the file you are editing.
+- PHP: Yoast CS (`yoast/yoastcs`). Class files use **snake_case with underscores** (e.g. `Introductions_Collector`) — this is Yoast's convention even though it differs from PSR. Namespaces live under `Yoast\WP\SEO\…`.
+- JavaScript/TypeScript: the shared `@yoast/eslint-config`, plus per-package overrides where they exist.
+- Comments: document **why**, not **what**. End every inline comment with a full stop.
+- Don't add features, scaffolding, or abstractions the task doesn't need.
 
 ### Opening a pull request
 
-1. Fork the repository and create your branch from `trunk`. `trunk` is the active development branch and the default branch on GitHub — every PR should target it unless a maintainer asks otherwise. Do **not** target `main`: that branch tracks the latest released version and is not where new work goes.
+1. Fork the repository and create your branch from `trunk`. `trunk` is the active development branch and the default branch on GitHub — every PR should target it unless a maintainer asks otherwise. Do **not** target `main`: that branch tracks the latest released version and is not where new work goes. When the work tracks a GitHub issue, name your branch `<issue-number>-<short-description>` (e.g. `2056-paid-upgrades`).
 2. Make your changes on your fork.
 3. Follow the [Yoast Coding Standards](https://github.com/Yoast/yoastcs) (a superset of the [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)).
 4. Document any new functions, actions, and filters following the [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -213,6 +213,7 @@ Run these checks locally and make sure each one is clean. CI will run the same c
 * `composer check-branch-cs` — checks the Yoast coding-standard ruleset against the files you changed on this branch. It must report **no new errors or warnings** introduced by your branch. Use `composer fix-cs` to auto-fix what it can, and address the rest by hand.
 * `composer lint-branch` — PHP parse-error check on the files changed on this branch.
 * For changes under `packages/*` or `js/`: run `yarn lint` and the relevant package's `yarn test`.
+* If your change adds or edits any image or SVG (`.png`, `.jpg`, `.gif`, `.svg` — primarily under `images/` or `svn-assets/`): run `grunt build:images` (or plain `grunt build`, which includes it) and commit the resulting optimised files. The release pipeline re-runs `imagemin` during artifact creation, and the build fails if the committed images aren't already optimised.
 
 **Coverage:** every PR should *increase* test coverage, or at minimum keep it flat. In practice this means the code you add should come with tests that exercise it. CI reports the coverage delta on the PR — if coverage drops, explain in the PR description why it was not possible to add tests for the new code (for example: pure wiring code that can only be exercised through a full WordPress boot, or a third-party API call that is impractical to mock).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ What do we want to achieve with this PR? Why did we write this code?
 ## Summary
 
 <!--
+Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
 Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
 If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
 If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -85,7 +85,7 @@ This PR affects the following parts of the plugin, which may require extra testi
 * [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
 * [ ] I have written this PR in accordance with my team's definition of done.
 * [ ] I have checked that the base branch is correctly set.
-* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.
+* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.
 
 ## Innovation
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,8 @@ which type/editor/browser should be tested in particular, multisite with subfold
 ### Test instructions for QA when the code is in the RC
 <!--
 Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
-QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
+QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
+For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
 -->
 
 * [ ] QA should use the same steps as above.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 
 ### Safety
 
-- Flag any file under `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, or `node_modules/` appearing in the diff — these paths are generated or vendored and gitignored; they must not be committed.
+- Flag any file under `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `languages/`, or `node_modules/` appearing in the diff — these paths are generated or vendored and gitignored; they must not be committed.
 - Flag any committed secrets, credentials, or API keys.
 - Flag disabled CS checks, skipped tests, or bypassed CI gates without explanation.
 - Breaking changes to public extension points (filters, actions, surfaces, REST routes) must be called out in the PR body.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 - Every required section of the PR template must have content — no empty bullets.
 - At least one changelog bullet in the *Summary* section.
 - A `changelog:` label attached (`bugfix`, `enhancement`, `other`, `non-user-facing`). Milestones are set by the merger, not the author.
-- Bugfix entries follow `Fixes a bug where … (was …) when …` with past-tense inner verbs.
+- Bugfix entries: past tense, incorrect behaviour then triggering condition, no hypotheticals.
 - Multiple changelog bullets only when (a) the PR has two logically distinct changes, (b) types differ — then use `[repo type]` override on the divergent bullets, or (c) the change must land in multiple repos/packages, in which case each extra bullet is prefixed with `[<repo-or-package>]`.
 - Title under ~70 characters; Conventional Commits prefix where natural.
 - Prefer atomic commits: if the PR mixes unrelated changes in a single commit (e.g. bugfix + refactor + tooling), suggest splitting into separate commits (or separate PRs) when practical.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# GitHub Copilot review instructions
+
+Copilot is used in this repository primarily for **pull request reviews**.
+
+The authoritative guidance lives in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md), and [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md). If anything below contradicts those, prefer them.
+
+## Review priorities
+
+### PR hygiene
+
+- Every required section of the PR template must have content — no empty bullets.
+- At least one changelog bullet in the *Summary* section.
+- A `changelog:` label attached (`bugfix`, `enhancement`, `other`, `non-user-facing`). Milestones are set by the merger, not the author.
+- Bugfix entries follow `Fixes a bug where … (was …) when …` with past-tense inner verbs.
+- Multiple changelog bullets only when (a) the PR has two logically distinct changes, (b) types differ — then use `[repo type]` override on the divergent bullets, or (c) the change must land in multiple repos/packages, in which case each extra bullet is prefixed with `[<repo-or-package>]`.
+- Title under ~70 characters; Conventional Commits prefix where natural.
+- Release-branch PRs (`release/*`): unreleased-bug fixes use `changelog: non-user-facing` and `Fixes an unreleased bug where …`.
+
+### Tests and coverage
+
+- New or changed PHP classes/methods should ship unit tests under `tests/Unit/…` mirroring the source path. One test method per tested method; shared setup via abstract base classes or traits.
+- Coverage should not decrease. If it does, the PR's *Relevant technical choices* section must explain why tests weren't feasible.
+- Flag PRs touching WP-integration code that have no integration coverage and no mention of `composer test-wp-env`.
+
+### Code style and structure
+
+- PHP must pass **Yoast Coding Standards** (`yoast/yoastcs`, a WPCS superset) — flag violations `composer check-branch-cs` would catch. Classes use snake_case with underscores (e.g. `Introductions_Collector`); namespaces under `Yoast\WP\SEO\…`.
+- New self-contained features go under `src/<feature>/{domain,application,infrastructure,user-interface}/`. Dependencies point inward only — domain must not reference WP functions or infrastructure.
+- Concept-based folders (`src/integrations/`, `src/generators/`, `src/presenters/`, …) are still valid when extending existing features.
+- `admin/` and `inc/` are **maintenance-only** — flag new features placed there.
+- New classes or changed constructors require `composer compile-di` and a committed `src/generated/container.php`.
+
+### Safety
+
+- Never hand-edited: `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/`.
+- Flag any committed secrets, credentials, or API keys.
+- Flag disabled CS checks, skipped tests, or bypassed CI gates without explanation.
+- Breaking changes to public extension points (filters, actions, surfaces, REST routes) must be called out in the PR body.
+
+### Security
+
+- Watch for SQL injection, XSS, CSRF, unescaped output, missing nonces on state-changing requests, and capability checks that are missing or wrong.
+- Sanitise at input boundary (`sanitize_text_field`, `absint`, …) and escape on output (`esc_html`, `esc_attr`, `esc_url`).
+
+## What NOT to flag
+
+- Pre-existing issues in unchanged lines — focus on the diff.
+- Thresholded phpcs warnings in legacy code; only flag *new* errors/warnings attributable to this PR.
+- Style variants that match the surrounding file.
+- Minor changelog wording variations that still follow the PR-template grammar rules.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,6 @@
 # GitHub Copilot review instructions
 
-Copilot is used in this repository primarily for **pull request reviews**.
-
-The authoritative guidance lives in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md), and [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md). If anything below contradicts those, prefer them.
+Copilot is used here primarily for **pull request reviews**. Authoritative rules live in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md), and [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md); if anything below contradicts them, prefer those.
 
 ## Review priorities
 
@@ -15,6 +13,7 @@ The authoritative guidance lives in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.
 - Multiple changelog bullets only when (a) the PR has two logically distinct changes, (b) types differ — then use `[repo type]` override on the divergent bullets, or (c) the change must land in multiple repos/packages, in which case each extra bullet is prefixed with `[<repo-or-package>]`.
 - Title under ~70 characters; Conventional Commits prefix where natural.
 - Prefer atomic commits: if the PR mixes unrelated changes in a single commit (e.g. bugfix + refactor + tooling), suggest splitting into separate commits (or separate PRs) when practical.
+- Flag padded PR descriptions. *Context* and *Relevant technical choices* should be one or two sentences; *Test instructions* should be concrete steps, not prose. Replace restatements of linked issues/epics with the link itself.
 - Release-branch PRs (`release/*`): unreleased-bug fixes use `changelog: non-user-facing` and `Fixes an unreleased bug where …`.
 
 ### Tests and coverage

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # GitHub Copilot review instructions
 
-Copilot is used here primarily for **pull request reviews**. Authoritative rules live in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md), and [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md); if anything below contradicts them, prefer those.
+Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./CONTRIBUTING.md) and [`PULL_REQUEST_TEMPLATE.md`](./PULL_REQUEST_TEMPLATE.md). [`AGENTS.md`](../AGENTS.md) adds agent-behaviour guidance. If anything below contradicts these, prefer them.
 
 ## Review priorities
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,10 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 - Flag disabled CS checks, skipped tests, or bypassed CI gates without explanation.
 - Breaking changes to public extension points (filters, actions, surfaces, REST routes) must be called out in the PR body.
 
+### Assets
+
+- If the diff adds or edits image files (`.png`, `.jpg`, `.gif`, `.svg` — primarily under `images/` or `svn-assets/`), the author must run `grunt build:images` (or plain `grunt build`) and commit the resulting optimised files. The *Quality assurance* checkbox "I have run `grunt build:images` and committed the results…" in the PR template is the canonical signal — if image files are in the diff and that checkbox is unticked, flag it. The release pipeline fails on images that haven't been pre-optimised.
+
 ### Security
 
 - Watch for SQL injection, XSS, CSRF, unescaped output, missing nonces on state-changing requests, and capability checks that are missing or wrong.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ The authoritative guidance lives in [`AGENTS.md`](../AGENTS.md), [`CONTRIBUTING.
 - Bugfix entries follow `Fixes a bug where … (was …) when …` with past-tense inner verbs.
 - Multiple changelog bullets only when (a) the PR has two logically distinct changes, (b) types differ — then use `[repo type]` override on the divergent bullets, or (c) the change must land in multiple repos/packages, in which case each extra bullet is prefixed with `[<repo-or-package>]`.
 - Title under ~70 characters; Conventional Commits prefix where natural.
+- Prefer atomic commits: if the PR mixes unrelated changes in a single commit (e.g. bugfix + refactor + tooling), suggest splitting into separate commits (or separate PRs) when practical.
 - Release-branch PRs (`release/*`): unreleased-bug fixes use `changelog: non-user-facing` and `Fixes an unreleased bug where …`.
 
 ### Tests and coverage

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,7 +13,8 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 - Multiple changelog bullets only when (a) the PR has two logically distinct changes, (b) types differ — then use `[repo type]` override on the divergent bullets, or (c) the change must land in multiple repos/packages, in which case each extra bullet is prefixed with `[<repo-or-package>]`.
 - Title under ~70 characters; Conventional Commits prefix where natural.
 - Prefer atomic commits: if the PR mixes unrelated changes in a single commit (e.g. bugfix + refactor + tooling), suggest splitting into separate commits (or separate PRs) when practical.
-- Flag padded PR descriptions. *Context* and *Relevant technical choices* should be one or two sentences; *Test instructions* should be concrete steps, not prose. Replace restatements of linked issues/epics with the link itself.
+- Flag *Test instructions* written as prose rather than concrete steps, and restatements of linked issues/epics that should be links instead.
+- Flag changelog bullets that run more than one sentence, or stack multiple independent clauses with commas, colons, or semicolons. Long-form explanation belongs in *Context* / *Relevant technical choices*.
 - Release-branch PRs (`release/*`): unreleased-bug fixes use `changelog: non-user-facing` and `Fixes an unreleased bug where …`.
 
 ### Tests and coverage
@@ -50,4 +51,4 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 - Pre-existing issues in unchanged lines — focus on the diff.
 - Thresholded phpcs warnings in legacy code; only flag *new* errors/warnings attributable to this PR.
 - Style variants that match the surrounding file.
-- Minor changelog wording variations that still follow the PR-template grammar rules.
+- Cosmetic wording choices in changelog bullets that still respect the conciseness and grammar rules.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,11 +28,10 @@ Used here for **pull request reviews**. Canonical rules: [`CONTRIBUTING.md`](./C
 - New self-contained features go under `src/<feature>/{domain,application,infrastructure,user-interface}/`. Dependencies point inward only — domain must not reference WP functions or infrastructure.
 - Concept-based folders (`src/integrations/`, `src/generators/`, `src/presenters/`, …) are still valid when extending existing features.
 - `admin/` and `inc/` are **maintenance-only** — flag new features placed there.
-- New classes or changed constructors require `composer compile-di` and a committed `src/generated/container.php`.
 
 ### Safety
 
-- Never hand-edited: `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/`.
+- Flag any file under `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, or `node_modules/` appearing in the diff — these paths are generated or vendored and gitignored; they must not be committed.
 - Flag any committed secrets, credentials, or API keys.
 - Flag disabled CS checks, skipped tests, or bypassed CI gates without explanation.
 - Breaking changes to public extension points (filters, actions, surfaces, REST routes) must be called out in the PR body.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,148 +1,27 @@
-# AGENTS.md — Yoast SEO
+# AGENTS.md — Yoast SEO agent delta
 
-This file is the shared context for coding agents and human contributors working on the Yoast SEO plugin. It follows the [AGENTS.md](https://agents.md/) convention, which is recognised by most major AI coding tools (OpenAI Codex, Cursor, Aider, Zed, Copilot, Gemini CLI, Windsurf, JetBrains Junie, and others). Claude Code reads it via a thin `CLAUDE.md` pointer.
+This file follows the [AGENTS.md](https://agents.md/) convention (supported natively by OpenAI Codex, Cursor, Aider, Zed, Copilot, Gemini CLI, Windsurf, JetBrains Junie, and others; Claude Code reads it via a thin `CLAUDE.md` pointer).
 
-Use it to orient yourself to the conventions, tooling, and architectural direction of the repository. External contributors are encouraged to read it before opening a PR.
+**Read [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md) first.** It is the canonical source of truth for everything in this repository: architecture, repository layout, code placement, dependency injection, build and test commands, coding standards, commits, branches, the PR opening procedure, changelog rules, license, and security. This file does not repeat any of that — it only lists the behaviours specific to working in this repo as an **AI coding agent**.
 
-If something here contradicts `.github/CONTRIBUTING.md`, prefer the latter. If you find a genuinely stale or incorrect instruction, please update it in the same PR.
+If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md), prefer those. Edit the source, not this delta.
 
-## Project at a glance
+## Behaviour rules for agents
 
-- **What it is:** the Yoast SEO WordPress plugin, distributed on wordpress.org and extended by a family of premium add-ons.
-- **Default branch:** `trunk` (active development). All PRs should target `trunk` unless a reviewer asks otherwise. A separate `main` branch also exists and tracks the latest released version — it is **not** the development branch; do not open PRs against it.
-- **Supported runtime versions:** PHP 7.4 (also supports PHP 8.x). WordPress: the latest two major versions are officially supported.
-- **Packaging model:** single PHP plugin, plus a Yarn workspaces / Lerna monorepo of JS packages under `packages/*`.
+- **Delegate long-running commands.** Do not run `composer`, `yarn`, or `grunt` in the main session — the output clutters context. If a build-runner-style agent is available, delegate to it and have it return PASS/FAIL plus failing-case details only. When no such agent is available, summarise the output rather than inlining it.
 
-## Repository layout
+- **Verify before you recommend.** Before citing a file path, function name, class, flag, or any other code identifier from memory, confirm it still exists — `ls`, `grep`, or a file read. Memory is a snapshot; the tree may have moved.
 
-Top-level folders you will touch (or explicitly avoid):
+- **Ask, don't guess.**
+  - If a change might affect Premium, Shopify, the Google Docs extension, another JS package, or any other repo but the diff does not prove it, ask before adding a cross-repo changelog entry or label.
+  - If the licensing status of a piece of reused or AI-generated code is unclear, ask before including it. See [CONTRIBUTING.md → "License and copyright"](./.github/CONTRIBUTING.md#license-and-copyright).
 
-| Path | Purpose | Editable? |
-| --- | --- | --- |
-| `src/` | Namespaced PHP. All new backend work lives here. | Yes |
-| `packages/js/` | The primary JS bundle shipped with the plugin. | Yes |
-| `packages/*` | Shared JS/TS libraries (UI library, analysis engine, etc.). | Yes |
-| `tests/` | PHPUnit tests (unit + WP integration). | Yes |
-| `config/` | Grunt, webpack, php-scoper, wp-env, composer actions, build scripts. | Yes, with care |
-| `docs/` | Repo-local developer notes. | Yes |
-| `admin/`, `inc/` | Legacy non-namespaced PHP. | **Maintenance only** — see below |
-| `lib/` | Low-level utilities (ORM, migrations). Touch only when needed. | Maintenance |
-| `src/generated/` | Compiled Symfony DI container. | **Never hand-edit** — regenerate via `composer compile-di` |
-| `vendor/`, `vendor_prefixed/` | Composer dependencies (prefixed copies are scoped with `YoastSEO_Vendor`). | Never hand-edit |
-| `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
-| `wp-seo.php`, `wp-seo-main.php`, `index.php` | Plugin bootstrap. Change only when the bootstrap itself needs to change. | With care |
+- **Prefer editing over creating.** Before adding a new file, a new abstraction, or a new directory, search for where similar functionality already lives and extend that instead. New files are the last resort.
 
-## Where to put new code
+- **Don't paper over failures.** If a pre-push check, test, or coding-standard rule fails, fix it or flag it. Do not skip tests, lower CS thresholds, add ignore pragmas, bypass CI gates, or untick quality-assurance boxes on the PR template without explicit permission.
 
-Two organisational patterns coexist inside `src/`:
+- **Respect the creator / merger split on PRs.** When opening a PR, never set the milestone and never add the `community-patch` label. Both are the merger's or automation's job. The full procedure lives in [`docs/workflows/create-pr.md`](./docs/workflows/create-pr.md) — follow it instead of reinventing the steps.
 
-1. **Concept-based (older, still valid for extensions of existing features).** Code is grouped by its role in the plugin: `src/integrations/`, `src/conditionals/`, `src/generators/`, `src/actions/`, `src/presenters/`, `src/surfaces/`, `src/helpers/`, etc. When you are expanding a feature that already follows this layout — for example adding a new Schema piece, a new admin integration, or a new REST action — keep it in the matching folder and follow the surrounding patterns. See `src/README.md` for a description of each concept folder.
+- **Don't hand-edit generated or vendored files.** `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` — regenerate via the appropriate tooling. The full list and the tool for each is in [CONTRIBUTING.md → "Repository layout"](./.github/CONTRIBUTING.md#repository-layout).
 
-2. **Feature-folder with onion layers (preferred for new self-contained features).** A new feature gets its own directory under `src/` with four subfolders:
-
-   ```
-   src/<feature>/
-   ├── domain/          Pure business logic — no WordPress, no I/O.
-   ├── application/     Use cases, orchestration, DTOs, interfaces.
-   ├── infrastructure/  WordPress/DB/HTTP adapters; repository implementations.
-   └── user-interface/  Integrations, REST routes, WP-CLI, presenters.
-   ```
-
-   Live examples in the repo: `src/dashboard/`, `src/introductions/`, `src/llms-txt/`, `src/schema-aggregator/`, `src/ai-*/`.
-
-### Onion dependency rules
-
-- Domain depends on **nothing** outside itself (no WP functions, no framework, no infrastructure).
-- Application depends on Domain only, and defines interfaces for anything it needs from Infrastructure.
-- Infrastructure and User-Interface depend on Application and Domain — never the other way round.
-- Cross-layer wiring happens through constructor injection via the Symfony DI container.
-
-### Legacy folders (`admin/`, `inc/`)
-
-These contain pre-namespace, pre-onion code. Treat them as **maintenance-only**: fix bugs, keep them compatible, but do not add new features there. When a legacy class needs significant changes, consider whether the work justifies moving (or extracting a new service for) the affected responsibility into `src/`.
-
-## Dependency injection
-
-The plugin uses a compiled Symfony DI container. Services are auto-wired from `src/` based on their type hints.
-
-- **Run `composer compile-di` whenever a change would affect the container.** In practice this means:
-  - You added a new class under `src/`.
-  - You changed a constructor signature of an existing class.
-  - You added/removed a service definition or tag in `config/dependency-injection/` (if applicable).
-- Commit the regenerated `src/generated/container.php` and `src/generated/container.php.meta`. The `post-autoload-dump` hook also runs this, so it usually happens automatically on `composer install` / `composer update`.
-- If CI complains about the container being out of sync, re-run `composer compile-di` and commit the result.
-
-## PHP workflow
-
-All commands are run from the repo root.
-
-| Command | What it does |
-| --- | --- |
-| `composer install` | Install PHP dependencies (also compiles DI and prefixes vendor packages). |
-| `composer lint` | PHP parse-error check across the repo. |
-| `composer lint-branch` | Same, but only for files changed on the current branch. |
-| `composer check-cs` | Run phpcs with the Yoast ruleset (errors only). |
-| `composer check-branch-cs` | Run phpcs against the files changed on the current branch. |
-| `composer fix-cs` | Auto-fix fixable phpcs violations. |
-| `composer test` | Run PHPUnit unit tests (no WP, no coverage). |
-| `composer test-wp-env` | Run WP integration tests inside the `wp-env` Docker environment (preferred way to run integration tests locally). |
-| `composer coverage` / `coverage-wp-env` | Same, with coverage. |
-| `composer compile-di` | Rebuild the DI container. |
-| `composer generate-migration` | Scaffold a new DB migration under `src/config/migrations/`. |
-| `composer generate-unit-test` | Scaffold a unit-test file for a fully-qualified class name. |
-
-Coding standards are enforced by the Yoast Coding Standard (`yoast/yoastcs`) — a superset of WordPress Coding Standards — plus parallel-lint for syntax. Run `composer check-branch-cs` before opening a PR.
-
-## JavaScript workflow
-
-| Command | What it does |
-| --- | --- |
-| `yarn install` | Install JS dependencies for the whole workspace. |
-| `yarn start` | Webpack dev build with watch for the main JS bundle. |
-| `yarn build` | Run the `build` script of every workspace package. |
-| `yarn lint` | Lint every workspace package plus the repo-level tooling. |
-| `yarn test` | Run every workspace's `test` script (Jest). |
-| `grunt build` / `grunt build:dev` | Full plugin build (assets + images + i18n) via Grunt. |
-
-Each package under `packages/*` has its own `package.json` with local scripts; prefer running those directly when iterating on a single package.
-
-## Testing policy
-
-- **Every PR that changes PHP behaviour should ship unit tests.** Place them under `tests/Unit/...` mirroring the path of the class under test.
-- **Integration tests** (those that boot WordPress) live under `tests/WP/...` and run via `composer test-wp-env`, which starts an isolated WP in Docker through `@wordpress/env`.
-- Test one method per test class where practical; share setup via abstract base classes or traits (examples already exist under `tests/Unit`).
-- JS tests use Jest and live inside the relevant `packages/*/tests/` folder.
-- If you cannot run the integration tests in your environment, say so explicitly in the PR description rather than skipping them silently.
-
-## Code style
-
-- Follow the existing code. When two styles look plausible, match the file you are editing.
-- PHP: Yoast CS (`yoast/yoastcs`). Class files use **snake_case with underscores** (e.g. `Introductions_Collector`) — this is Yoast's convention even though it differs from PSR. Namespaces live under `Yoast\WP\SEO\...`.
-- JavaScript/TypeScript: the shared `@yoast/eslint-config`, plus per-package overrides where they exist.
-- Comments: document **why**, not **what**. End every inline comment with a full stop.
-- Don't add features, scaffolding, or abstractions the task doesn't need.
-
-## Commits, branches, and pull requests
-
-- **Conventional Commits** (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`, `style:`). Include a scope when useful: `feat(dashboard): ...`.
-- **Prefer atomic commits whenever practical.** Each commit should represent a single logical change that compiles, passes tests on its own, and can be reviewed (or reverted) in isolation. If a PR mixes unrelated changes — e.g. a bug fix plus a refactor plus a tooling tweak — split them into separate commits (or, ideally, separate PRs). It's fine to combine closely coupled changes into one commit when splitting would be artificial.
-- Branch names: `<issue-number>-<short-description>` when the work tracks a GitHub issue (e.g. `2056-paid-upgrades`).
-- Target `trunk`. Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` — every section is there for a reason; fill it in even for small changes.
-- **Keep PR and issue descriptions focused.** Fill each template section with what's actually needed — one or two clear sentences in *Context* / *Relevant technical choices* is usually enough. Don't pad or restate the linked issue/epic. Reviewers read every line, and padding hides the substance.
-- Apply a changelog label: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, or `changelog: non-user-facing`.
-- External contributors do **not** need to apply any special label — the `community-patch` label is applied automatically on GitHub.
-- Never commit generated artifacts by hand; let the tooling regenerate them (DI container, i18n files, built JS/CSS, prefixed vendors).
-
-## License and copyright
-
-Yoast SEO is licensed under [GPL-2.0-or-later](./license.txt). By contributing, you agree that your code is offered under the same license. Do not include code copied from incompatible sources (proprietary, GPL-3.0-only, CC restrictions) or code whose licensing status is unclear — including AI-generated code whose terms you have not verified. See [`.github/CONTRIBUTING.md` → "License and copyright"](./.github/CONTRIBUTING.md) for the full guidance.
-
-## Security
-
-Do **not** file security issues in public GitHub. Email `security@yoast.com` — see `.github/CONTRIBUTING.md` for details. Never commit credentials, API keys, or test fixtures that contain sensitive data.
-
-## Further reading
-
-- [Yoast developer portal](https://developer.yoast.com/) — user-facing extension and integration documentation (schema, indexables, surfaces, filters).
-- `src/README.md` — overview of the concept-based folders inside `src/`.
-- [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).
+- **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md`, the PR template, or `src/README.md`. Read those before making assumptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ Each package under `packages/*` has its own `package.json` with local scripts; p
 - **Prefer atomic commits whenever practical.** Each commit should represent a single logical change that compiles, passes tests on its own, and can be reviewed (or reverted) in isolation. If a PR mixes unrelated changes — e.g. a bug fix plus a refactor plus a tooling tweak — split them into separate commits (or, ideally, separate PRs). It's fine to combine closely coupled changes into one commit when splitting would be artificial.
 - Branch names: `<issue-number>-<short-description>` when the work tracks a GitHub issue (e.g. `2056-paid-upgrades`).
 - Target `trunk`. Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` — every section is there for a reason; fill it in even for small changes.
+- **Keep PR and issue descriptions focused.** Fill each template section with what's actually needed — one or two clear sentences in *Context* / *Relevant technical choices* is usually enough. Don't pad or restate the linked issue/epic. Reviewers read every line, and padding hides the substance.
 - Apply a changelog label: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, or `changelog: non-user-facing`.
 - External contributors do **not** need to apply any special label — the `community-patch` label is applied automatically on GitHub.
 - Never commit generated artifacts by hand; let the tooling regenerate them (DI container, i18n files, built JS/CSS, prefixed vendors).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Each package under `packages/*` has its own `package.json` with local scripts; p
 ## Commits, branches, and pull requests
 
 - **Conventional Commits** (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`, `style:`). Include a scope when useful: `feat(dashboard): ...`.
-- Small, atomic commits are preferred over a single squash commit that mixes concerns.
+- **Prefer atomic commits whenever practical.** Each commit should represent a single logical change that compiles, passes tests on its own, and can be reviewed (or reverted) in isolation. If a PR mixes unrelated changes — e.g. a bug fix plus a refactor plus a tooling tweak — split them into separate commits (or, ideally, separate PRs). It's fine to combine closely coupled changes into one commit when splitting would be artificial.
 - Branch names: `<issue-number>-<short-description>` when the work tracks a GitHub issue (e.g. `2056-paid-upgrades`).
 - Target `trunk`. Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` — every section is there for a reason; fill it in even for small changes.
 - Apply a changelog label: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, or `changelog: non-user-facing`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,143 @@
+# AGENTS.md — Yoast SEO
+
+This file is the shared context for coding agents and human contributors working on the Yoast SEO plugin. It follows the [AGENTS.md](https://agents.md/) convention, which is recognised by most major AI coding tools (OpenAI Codex, Cursor, Aider, Zed, Copilot, Gemini CLI, Windsurf, JetBrains Junie, and others). Claude Code reads it via a thin `CLAUDE.md` pointer.
+
+Use it to orient yourself to the conventions, tooling, and architectural direction of the repository. External contributors are encouraged to read it before opening a PR.
+
+If something here contradicts `.github/CONTRIBUTING.md`, prefer the latter. If you find a genuinely stale or incorrect instruction, please update it in the same PR.
+
+## Project at a glance
+
+- **What it is:** the Yoast SEO WordPress plugin, distributed on wordpress.org and extended by a family of premium add-ons.
+- **Default branch:** `trunk` (active development). All PRs should target `trunk` unless a reviewer asks otherwise. A separate `main` branch also exists and tracks the latest released version — it is **not** the development branch; do not open PRs against it.
+- **Supported runtime versions:** PHP 7.4 (also supports PHP 8.x). WordPress: the latest two major versions are officially supported.
+- **Packaging model:** single PHP plugin, plus a Yarn workspaces / Lerna monorepo of JS packages under `packages/*`.
+
+## Repository layout
+
+Top-level folders you will touch (or explicitly avoid):
+
+| Path | Purpose | Editable? |
+| --- | --- | --- |
+| `src/` | Namespaced PHP. All new backend work lives here. | Yes |
+| `packages/js/` | The primary JS bundle shipped with the plugin. | Yes |
+| `packages/*` | Shared JS/TS libraries (UI library, analysis engine, etc.). | Yes |
+| `tests/` | PHPUnit tests (unit + WP integration). | Yes |
+| `config/` | Grunt, webpack, php-scoper, wp-env, composer actions, build scripts. | Yes, with care |
+| `docs/` | Repo-local developer notes. | Yes |
+| `admin/`, `inc/` | Legacy non-namespaced PHP. | **Maintenance only** — see below |
+| `lib/` | Low-level utilities (ORM, migrations). Touch only when needed. | Maintenance |
+| `src/generated/` | Compiled Symfony DI container. | **Never hand-edit** — regenerate via `composer compile-di` |
+| `vendor/`, `vendor_prefixed/` | Composer dependencies (prefixed copies are scoped with `YoastSEO_Vendor`). | Never hand-edit |
+| `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` | Generated or distribution artifacts. | Never hand-edit |
+| `wp-seo.php`, `wp-seo-main.php`, `index.php` | Plugin bootstrap. Change only when the bootstrap itself needs to change. | With care |
+
+## Where to put new code
+
+Two organisational patterns coexist inside `src/`:
+
+1. **Concept-based (older, still valid for extensions of existing features).** Code is grouped by its role in the plugin: `src/integrations/`, `src/conditionals/`, `src/generators/`, `src/actions/`, `src/presenters/`, `src/surfaces/`, `src/helpers/`, etc. When you are expanding a feature that already follows this layout — for example adding a new Schema piece, a new admin integration, or a new REST action — keep it in the matching folder and follow the surrounding patterns. See `src/README.md` for a description of each concept folder.
+
+2. **Feature-folder with onion layers (preferred for new self-contained features).** A new feature gets its own directory under `src/` with four subfolders:
+
+   ```
+   src/<feature>/
+   ├── domain/          Pure business logic — no WordPress, no I/O.
+   ├── application/     Use cases, orchestration, DTOs, interfaces.
+   ├── infrastructure/  WordPress/DB/HTTP adapters; repository implementations.
+   └── user-interface/  Integrations, REST routes, WP-CLI, presenters.
+   ```
+
+   Live examples in the repo: `src/dashboard/`, `src/introductions/`, `src/llms-txt/`, `src/schema-aggregator/`, `src/ai-*/`.
+
+### Onion dependency rules
+
+- Domain depends on **nothing** outside itself (no WP functions, no framework, no infrastructure).
+- Application depends on Domain only, and defines interfaces for anything it needs from Infrastructure.
+- Infrastructure and User-Interface depend on Application and Domain — never the other way round.
+- Cross-layer wiring happens through constructor injection via the Symfony DI container.
+
+### Legacy folders (`admin/`, `inc/`)
+
+These contain pre-namespace, pre-onion code. Treat them as **maintenance-only**: fix bugs, keep them compatible, but do not add new features there. When a legacy class needs significant changes, consider whether the work justifies moving (or extracting a new service for) the affected responsibility into `src/`.
+
+## Dependency injection
+
+The plugin uses a compiled Symfony DI container. Services are auto-wired from `src/` based on their type hints.
+
+- **Run `composer compile-di` whenever a change would affect the container.** In practice this means:
+  - You added a new class under `src/`.
+  - You changed a constructor signature of an existing class.
+  - You added/removed a service definition or tag in `config/dependency-injection/` (if applicable).
+- Commit the regenerated `src/generated/container.php` and `src/generated/container.php.meta`. The `post-autoload-dump` hook also runs this, so it usually happens automatically on `composer install` / `composer update`.
+- If CI complains about the container being out of sync, re-run `composer compile-di` and commit the result.
+
+## PHP workflow
+
+All commands are run from the repo root.
+
+| Command | What it does |
+| --- | --- |
+| `composer install` | Install PHP dependencies (also compiles DI and prefixes vendor packages). |
+| `composer lint` | PHP parse-error check across the repo. |
+| `composer lint-branch` | Same, but only for files changed on the current branch. |
+| `composer check-cs` | Run phpcs with the Yoast ruleset (errors only). |
+| `composer check-branch-cs` | Run phpcs against the files changed on the current branch. |
+| `composer fix-cs` | Auto-fix fixable phpcs violations. |
+| `composer test` | Run PHPUnit unit tests (no WP, no coverage). |
+| `composer test-wp-env` | Run WP integration tests inside the `wp-env` Docker environment (preferred way to run integration tests locally). |
+| `composer coverage` / `coverage-wp-env` | Same, with coverage. |
+| `composer compile-di` | Rebuild the DI container. |
+| `composer generate-migration` | Scaffold a new DB migration under `src/config/migrations/`. |
+| `composer generate-unit-test` | Scaffold a unit-test file for a fully-qualified class name. |
+
+Coding standards are enforced by the Yoast Coding Standard (`yoast/yoastcs`) — a superset of WordPress Coding Standards — plus parallel-lint for syntax. Run `composer check-branch-cs` before opening a PR.
+
+## JavaScript workflow
+
+| Command | What it does |
+| --- | --- |
+| `yarn install` | Install JS dependencies for the whole workspace. |
+| `yarn start` | Webpack dev build with watch for the main JS bundle. |
+| `yarn build` | Run the `build` script of every workspace package. |
+| `yarn lint` | Lint every workspace package plus the repo-level tooling. |
+| `yarn test` | Run every workspace's `test` script (Jest). |
+| `grunt build` / `grunt build:dev` | Full plugin build (assets + images + i18n) via Grunt. |
+
+Each package under `packages/*` has its own `package.json` with local scripts; prefer running those directly when iterating on a single package.
+
+## Testing policy
+
+- **Every PR that changes PHP behaviour should ship unit tests.** Place them under `tests/Unit/...` mirroring the path of the class under test.
+- **Integration tests** (those that boot WordPress) live under `tests/WP/...` and run via `composer test-wp-env`, which starts an isolated WP in Docker through `@wordpress/env`.
+- Test one method per test class where practical; share setup via abstract base classes or traits (examples already exist under `tests/Unit`).
+- JS tests use Jest and live inside the relevant `packages/*/tests/` folder.
+- If you cannot run the integration tests in your environment, say so explicitly in the PR description rather than skipping them silently.
+
+## Code style
+
+- Follow the existing code. When two styles look plausible, match the file you are editing.
+- PHP: Yoast CS (`yoast/yoastcs`). Class files use **snake_case with underscores** (e.g. `Introductions_Collector`) — this is Yoast's convention even though it differs from PSR. Namespaces live under `Yoast\WP\SEO\...`.
+- JavaScript/TypeScript: the shared `@yoast/eslint-config`, plus per-package overrides where they exist.
+- Comments: document **why**, not **what**. End every inline comment with a full stop.
+- Don't add features, scaffolding, or abstractions the task doesn't need.
+
+## Commits, branches, and pull requests
+
+- **Conventional Commits** (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`, `style:`). Include a scope when useful: `feat(dashboard): ...`.
+- Small, atomic commits are preferred over a single squash commit that mixes concerns.
+- Branch names: `<issue-number>-<short-description>` when the work tracks a GitHub issue (e.g. `2056-paid-upgrades`).
+- Target `trunk`. Use the PR template at `.github/PULL_REQUEST_TEMPLATE.md` — every section is there for a reason; fill it in even for small changes.
+- Apply a changelog label: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, or `changelog: non-user-facing`.
+- External contributors do **not** need to apply any special label — the `community-patch` label is applied automatically on GitHub.
+- Never commit generated artifacts by hand; let the tooling regenerate them (DI container, i18n files, built JS/CSS, prefixed vendors).
+
+## Security
+
+Do **not** file security issues in public GitHub. Email `security@yoast.com` — see `.github/CONTRIBUTING.md` for details. Never commit credentials, API keys, or test fixtures that contain sensitive data.
+
+## Further reading
+
+- [Yoast developer portal](https://developer.yoast.com/) — user-facing extension and integration documentation (schema, indexables, surfaces, filters).
+- `src/README.md` — overview of the concept-based folders inside `src/`.
+- [WordPress Coding Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [PHP inline-documentation standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,6 @@ If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.gith
 
 - **Respect the creator / merger split on PRs.** When opening a PR, never set the milestone and never add the `community-patch` label. Both are the merger's or automation's job. The full procedure lives in [`docs/workflows/create-pr.md`](./docs/workflows/create-pr.md) — follow it instead of reinventing the steps.
 
-- **Don't hand-edit generated or vendored files.** `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `svn-assets/`, `languages/`, `node_modules/` — regenerate via the appropriate tooling. The full list and the tool for each is in [CONTRIBUTING.md → "Repository layout"](./.github/CONTRIBUTING.md#repository-layout).
+- **Don't hand-edit generated or vendored files.** `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `languages/`, `node_modules/` — regenerate via the appropriate tooling. The full list and the tool for each is in [CONTRIBUTING.md → "Repository layout"](./.github/CONTRIBUTING.md#repository-layout).
 
 - **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md`, the PR template, or `src/README.md`. Read those before making assumptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,6 @@ If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.gith
 
 - **Run `grunt build:images` when you touch images.** Adding or editing any `.png`, `.jpg`, `.gif`, or `.svg` file — primarily under `images/` or `svn-assets/` — requires running `grunt build:images` (or plain `grunt build`, which includes it) and committing the optimised output before the PR is opened or updated. The release pipeline re-runs `imagemin` and fails if the committed images aren't already optimised. Full detail in [CONTRIBUTING.md → "Before you push or open/update a PR"](./.github/CONTRIBUTING.md#before-you-push-or-openupdate-a-pr).
 
+- **Keep changelog bullets to one short sentence.** Extra context goes in *Context* or *Relevant technical choices*, not in the bullet. See [CONTRIBUTING.md → "Changelog entry and label"](./.github/CONTRIBUTING.md#changelog-entry-and-label).
+
 - **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md`, the PR template, or `src/README.md`. Read those before making assumptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,6 @@ If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.gith
 
 - **Don't hand-edit generated or vendored files.** `src/generated/`, `vendor/`, `vendor_prefixed/`, `build/`, `js/dist/`, `css/dist/`, `artifact/`, `languages/`, `node_modules/` — regenerate via the appropriate tooling. The full list and the tool for each is in [CONTRIBUTING.md → "Repository layout"](./.github/CONTRIBUTING.md#repository-layout).
 
+- **Run `grunt build:images` when you touch images.** Adding or editing any `.png`, `.jpg`, `.gif`, or `.svg` file — primarily under `images/` or `svn-assets/` — requires running `grunt build:images` (or plain `grunt build`, which includes it) and committing the optimised output before the PR is opened or updated. The release pipeline re-runs `imagemin` and fails if the committed images aren't already optimised. Full detail in [CONTRIBUTING.md → "Before you push or open/update a PR"](./.github/CONTRIBUTING.md#before-you-push-or-openupdate-a-pr).
+
 - **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md`, the PR template, or `src/README.md`. Read those before making assumptions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,10 @@ Each package under `packages/*` has its own `package.json` with local scripts; p
 - External contributors do **not** need to apply any special label — the `community-patch` label is applied automatically on GitHub.
 - Never commit generated artifacts by hand; let the tooling regenerate them (DI container, i18n files, built JS/CSS, prefixed vendors).
 
+## License and copyright
+
+Yoast SEO is licensed under [GPL-2.0-or-later](./license.txt). By contributing, you agree that your code is offered under the same license. Do not include code copied from incompatible sources (proprietary, GPL-3.0-only, CC restrictions) or code whose licensing status is unclear — including AI-generated code whose terms you have not verified. See [`.github/CONTRIBUTING.md` → "License and copyright"](./.github/CONTRIBUTING.md) for the full guidance.
+
 ## Security
 
 Do **not** file security issues in public GitHub. Email `security@yoast.com` — see `.github/CONTRIBUTING.md` for details. Never commit credentials, API keys, or test fixtures that contain sensitive data.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
-This project uses [`AGENTS.md`](./AGENTS.md) as the single source of truth for coding-agent and contributor instructions. The content below is pulled in automatically by Claude Code so the guidance matches what every other tool sees.
+The canonical contributor guide for this repository is [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md) — it covers architecture, tooling, workflows, testing, code style, commits, and PR conventions. [`AGENTS.md`](./AGENTS.md) layers a short set of behaviours specific to AI coding agents on top. Both are pulled into context below so Claude Code sees them on every session.
+
+@.github/CONTRIBUTING.md
 
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This project uses [`AGENTS.md`](./AGENTS.md) as the single source of truth for coding-agent and contributor instructions. The content below is pulled in automatically by Claude Code so the guidance matches what every other tool sees.
+
+@AGENTS.md

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -1,0 +1,92 @@
+# Creating a pull request
+
+This is the canonical workflow for opening a pull request on this repository. It is written to be followed by both humans and AI coding agents. Tool-specific entry points — the Claude Code skill, the Cursor rule, any future Copilot chat mode — should be thin pointers to this file so every tool follows the same procedure.
+
+Rules and templates live elsewhere — this file is the **procedure**:
+
+- **Changelog grammar, label rules, bracket-prefix rules, release-branch rules** → [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+- **Pre-push checks, coverage policy, Yoast CS ruleset, test commands** → [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md)
+- **Branching model, commit style, architecture, placement rules** → [`AGENTS.md`](../../AGENTS.md)
+
+If anything here contradicts those files, prefer them. Edits to rules belong there, not in this file.
+
+## 0. Creator vs. merger responsibilities
+
+Every merged PR needs a milestone, a changelog entry, and a changelog label. Split:
+
+- **Creator provides:** a changelog entry (in the PR body) and a changelog label on the PR.
+- **Creator MUST NOT set:** the milestone. That is the merger's job. Do not add a milestone via `gh pr edit --milestone`.
+
+## 1. Gather context
+
+Run in parallel:
+
+- `git status`
+- `git diff`
+- `git log <base>..HEAD` and `git diff <base>...HEAD` — inspect **every** commit since the branch diverged, not just the tip
+- Check whether the branch has an upstream and is up to date
+
+Identify the base branch: usually `trunk`. PRs targeting `release/*` follow stricter label rules — see the PR template.
+
+Read [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) so the PR body matches it section-for-section.
+
+## 2. Verify checks
+
+Follow the pre-push checklist in [`.github/CONTRIBUTING.md` — "Before you push or open/update a PR"](../../.github/CONTRIBUTING.md). All required checks must pass **before** calling `gh pr create`. Do not silently skip a check; if something cannot be run locally (e.g. `composer test-wp-env` without Docker), disclose it in the PR body's *Test instructions* section.
+
+Do not paper over failures by excluding tests, lowering CS thresholds, or adding ignore pragmas without explicit permission.
+
+If a `build-runner`-style agent is available in your tool, delegate the actual command execution there so the main session stays focused on the workflow.
+
+## 3. Decide how many changelog bullets the PR needs
+
+Default is **one bullet**, describing one logical change. Write more than one bullet only in these cases:
+
+- **Case A — multiple distinct changes in the same repo and same label.** One bullet per change; no brackets.
+- **Case B — bullets with different changelog types.** Add a `[repo type]` override only on the bullets whose type *differs* from the PR label; bullets that match the PR label stay unprefixed.
+- **Case C — impact on multiple repos or packages.** One bullet per affected changelog, each prefixed with `[<repo-or-package>]`. Routing prefix is mandatory for non-Free targets.
+
+Grammar, bracket syntax, semver hints, bugfix template, and the release-branch label rules all live in the PR template — follow the template, do not restate the rules here or in the PR body.
+
+If you are not certain a change affects another repo (Premium, Shopify, etc.), ask the user rather than guessing.
+
+## 4. Fill every PR-template section
+
+Cover every section of `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- **Context** — *why* the change is being made.
+- **Summary** — the bullet(s) from step 3.
+- **Relevant technical choices** — non-obvious decisions, trade-offs, architectural notes. **If coverage decreased, explain here why tests weren't feasible.**
+- **Test instructions (acceptance)** — step-by-step, aimed at non-technical users.
+- **Relevant test scenarios** — tick the boxes that apply and explain why for each ticked box.
+- **QA instructions** — tick the "same steps as above" box if applicable, otherwise write separate steps (or link to the epic).
+- **Impact check** — parts of the plugin that may need regression testing.
+- **Other environments** — tick Shopify / Google Docs boxes only when the corresponding entry is present in step 3.
+- **Documentation / Quality assurance / Innovation** checkboxes — tick only those that are actually true.
+- **Fixes #** — link the issue being closed, if any.
+
+Preserve the HTML comments from the template so future editors keep the same structure.
+
+## 5. Create and label the PR
+
+1. Push the branch if it has no upstream: `git push -u origin <branch>`.
+2. `gh pr create --title "<title>" --body "$(cat <<'EOF' ... EOF)"`.
+   - Title under 70 characters. Use a Conventional Commits prefix when natural (`fix: …`, `feat(dashboard): …`).
+   - The body is the completed template, verbatim-structured.
+3. Apply the changelog label immediately: `gh pr edit <number> --add-label "changelog: <type>"`. Attach Shopify / Google Docs / innovation labels in the same call only when the corresponding condition holds.
+4. **Never set the milestone.**
+5. Return the PR URL.
+
+## 6. Self-check
+
+Before reporting the PR as created, verify:
+
+- [ ] Pre-push checks (step 2) ran and passed — any skipped check is disclosed in the PR body.
+- [ ] Coverage increased or held flat — or the *Relevant technical choices* section explains why tests weren't feasible.
+- [ ] The body contains at least one changelog bullet, correctly prefixed for every affected changelog.
+- [ ] Exactly one `changelog:` label is attached; Shopify / Google Docs / innovation labels match the content.
+- [ ] Bugfix bullets follow the template's `Fixes a bug where … (was …) when …` pattern with past-tense inner verbs.
+- [ ] Every PR-template section has content — no empty bullets, no leftover placeholder text.
+- [ ] No milestone was set.
+
+If any item fails, fix it (edit the body or labels with `gh pr edit`) before returning the URL.

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -85,7 +85,7 @@ Before reporting the PR as created, verify:
 - [ ] Coverage increased or held flat — or the *Relevant technical choices* section explains why tests weren't feasible.
 - [ ] The body contains at least one changelog bullet, correctly prefixed for every affected changelog.
 - [ ] Exactly one `changelog:` label is attached; Shopify / Google Docs / innovation labels match the content.
-- [ ] Bugfix bullets follow the template's `Fixes a bug where … (was …) when …` pattern with past-tense inner verbs.
+- [ ] Bugfix bullets describe the incorrect behaviour followed by the triggering condition, in past tense, per the PR template's grammar rules.
 - [ ] Every PR-template section has content — no empty bullets, no leftover placeholder text.
 - [ ] No milestone was set.
 

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -89,5 +89,6 @@ Before reporting the PR as created, verify:
 - [ ] Every PR-template section has content — no empty bullets, no leftover placeholder text.
 - [ ] No milestone was set.
 - [ ] If the branch adds or edits any image or SVG, `grunt build:images` was run and its optimised output committed. Tick the matching *Quality assurance* checkbox in the PR body.
+- [ ] Each changelog bullet is one short sentence; extra context lives in *Context* or *Relevant technical choices*.
 
 If any item fails, fix it (edit the body or labels with `gh pr edit`) before returning the URL.

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -59,7 +59,7 @@ Cover every section of `.github/PULL_REQUEST_TEMPLATE.md`:
 - **Relevant technical choices** — non-obvious decisions, trade-offs, architectural notes. **If coverage decreased, explain here why tests weren't feasible.**
 - **Test instructions (acceptance)** — step-by-step, aimed at non-technical users.
 - **Relevant test scenarios** — tick the boxes that apply and explain why for each ticked box.
-- **QA instructions** — tick the "same steps as above" box if applicable, otherwise write separate steps (or link to the epic).
+- **QA instructions** — for non-user-facing PRs (docs, pure refactors, tooling), leave the checkbox unticked and write "Not applicable". Otherwise tick "same steps as above" when acceptance and QA match, or write separate steps (or link to the epic).
 - **Impact check** — parts of the plugin that may need regression testing.
 - **Other environments** — tick Shopify / Google Docs boxes only when the corresponding entry is present in step 3.
 - **Documentation / Quality assurance / Innovation** checkboxes — tick only those that are actually true.

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -88,5 +88,6 @@ Before reporting the PR as created, verify:
 - [ ] Bugfix bullets describe the incorrect behaviour followed by the triggering condition, in past tense, per the PR template's grammar rules.
 - [ ] Every PR-template section has content — no empty bullets, no leftover placeholder text.
 - [ ] No milestone was set.
+- [ ] If the branch adds or edits any image or SVG, `grunt build:images` was run and its optimised output committed. Tick the matching *Quality assurance* checkbox in the PR body.
 
 If any item fails, fix it (edit the body or labels with `gh pr edit`) before returning the URL.

--- a/docs/workflows/create-pr.md
+++ b/docs/workflows/create-pr.md
@@ -5,8 +5,8 @@ This is the canonical workflow for opening a pull request on this repository. It
 Rules and templates live elsewhere — this file is the **procedure**:
 
 - **Changelog grammar, label rules, bracket-prefix rules, release-branch rules** → [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
-- **Pre-push checks, coverage policy, Yoast CS ruleset, test commands** → [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md)
-- **Branching model, commit style, architecture, placement rules** → [`AGENTS.md`](../../AGENTS.md)
+- **Architecture, repository layout, placement rules, dependency injection, build/test commands, Yoast CS ruleset, testing policy, coverage policy, commit style, branching, pre-push checks** → [`.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md)
+- **Agent-specific behaviours (delegate long-running commands, verify before recommending, ask don't guess)** → [`AGENTS.md`](../../AGENTS.md)
 
 If anything here contradicts those files, prefer them. Edits to rules belong there, not in this file.
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Establishes a single canonical contributor guide for this repository that humans and AI coding tools (Claude Code, Cursor, GitHub Copilot, OpenAI Codex, and others following the AGENTS.md convention) can share, instead of each tool carrying its own duplicated and drifting copy of the rules.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces a shared contributor guide for humans and AI coding tools.

## Relevant technical choices:

* CONTRIBUTING.md is the single source of truth; `AGENTS.md`, `.cursor/rules/*.mdc`, `.github/copilot-instructions.md`, `CLAUDE.md`, and the Claude Code `create-pr` skill all reference it rather than duplicating rules. Edits to rules land in CONTRIBUTING.md (or the PR template) so every tool picks them up.
* Pre-push checks (`composer test`, `test-wp-env`, `check-branch-cs`, `lint-branch`, `yarn lint`, `yarn test`, `grunt build:images`) were not run: the diff contains only Markdown and `.mdc` files — no PHP, JS, CSS, images, or other runtime code.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Open `.github/CONTRIBUTING.md` and read through it section by section; confirm the table of contents and all intra-repo links (to `AGENTS.md`, `PULL_REQUEST_TEMPLATE.md`, `docs/workflows/create-pr.md`, `license.txt`, `src/README.md`) resolve.
* Open `AGENTS.md` and confirm it reads as a short agent-behaviour delta that points back at CONTRIBUTING.md.
* Open `docs/workflows/create-pr.md` and walk through the PR-creation procedure end to end.
* Open `.github/copilot-instructions.md` and confirm the review-priority sections are coherent as Copilot review guidance.
* Open `.cursor/rules/agents.mdc` and `.cursor/rules/create-pr.mdc` and confirm the `@../../…` include directives reference the expected files.
* Open `CLAUDE.md` at the repo root and confirm the two `@` includes point at CONTRIBUTING.md and AGENTS.md.
* Open `.github/PULL_REQUEST_TEMPLATE.md` and confirm the Quality-assurance checkbox about `grunt build:images` reads "committed" (not "commited") and covers both new and edited images.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable — this is a non-user-facing documentation change, so there is nothing for QA to verify at RC time.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No plugin runtime behaviour is affected. The impact is on the contributor / AI-tool onboarding experience for anyone editing this repository.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
