### PR TITLE
1175 fix spark notification position

### DIFF
--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -1,13 +1,14 @@
 /* eslint-disable complexity */
 import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { Badge, Modal, Notifications, useSvgAria, Link } from "@yoast/ui-library";
-import { useCallback, useRef } from "@wordpress/element";
+import { useCallback, useRef, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import SuggestionsModalContent from "../containers/suggestions-modal-content";
 import OutlineModalContent from "../containers/outline-modal-content";
 import { FEATURE_MODAL_STATUS } from "../constants";
 import { useFetchContentOutline } from "../hooks";
 import { SparksLimitNotification } from "../../ai-generator/components/sparks-limit-notification";
+import { useMeasuredRef } from "../../ai-generator/hooks";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { QuestionMarkCircleIcon } from "@heroicons/react/solid";
@@ -57,6 +58,11 @@ export const FeatureModal = ( {
 	const isOutline = status === FEATURE_MODAL_STATUS.contentOutline;
 	const isOutlineError = contentOutlineStatus === ASYNC_ACTION_STATUS.error;
 
+	const [ panelHeight, setPanelHeight ] = useState( 0 );
+	const handlePanelMeasureChange = useCallback( entry => setPanelHeight( entry.borderBoxSize[ 0 ].blockSize ), [ setPanelHeight ] );
+	const panelRef = useMeasuredRef( handlePanelMeasureChange );
+	const bottom = `calc( (${ panelHeight + 55 + "px" } - 100vh) / 2 )`;
+
 	/**
 	 * Handles the click on a content suggestion.
 	 * Sets the selected suggestion, updates the modal status to show the outline, and fetches the content outline for the selected suggestion.
@@ -86,7 +92,7 @@ export const FeatureModal = ( {
 
 	return (
 		<Modal isOpen={ ! isConsentModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
-			<Modal.Panel className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
+			<Modal.Panel ref={ panelRef } className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
 				<Modal.CloseButton
 					ref={ closeButtonRef } screenReaderText={ isSuggestions
 						? __( "Close content suggestions modal", "wordpress-seo" ) : __( "Close content outline modal", "wordpress-seo" ) }
@@ -134,11 +140,9 @@ export const FeatureModal = ( {
 					) }
 				</Modal.Container>
 				<Notifications
-					className={
-						// Margin tricks to break out of the container.
-						// Transition to prevent sudden location jumps when loading new suggestions.
-						"yst-mx-[calc(50%-50vw)] yst-transition-all"
-					}
+					// Position the notification outside the modal panel at the bottom left of the screen.
+					className="yst-mx-[calc(50%-50vw)] yst-transition-all"
+					style={ { bottom } }
 					position="bottom-left"
 				>
 					{ contentSuggestionsStatus === ASYNC_ACTION_STATUS.success &&

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -12,6 +12,7 @@ import { useMeasuredRef } from "../../ai-generator/hooks";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
 import { UsageCounter } from "@yoast/ai-frontend";
 import { QuestionMarkCircleIcon } from "@heroicons/react/solid";
+import { getModalNotificationPosition } from "../../shared-admin/helpers";
 
 /**
  * The modal that orchestrates the flow between the approve, content suggestions,
@@ -61,7 +62,7 @@ export const FeatureModal = ( {
 	const [ panelHeight, setPanelHeight ] = useState( 0 );
 	const handlePanelMeasureChange = useCallback( entry => setPanelHeight( entry.borderBoxSize[ 0 ].blockSize ), [ setPanelHeight ] );
 	const panelRef = useMeasuredRef( handlePanelMeasureChange );
-	const bottom = `calc( (${ panelHeight + 55 + "px" } - 100vh) / 2 )`;
+	const { bottom } = getModalNotificationPosition( panelHeight );
 
 	/**
 	 * Handles the click on a content suggestion.

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -135,6 +135,7 @@ export const ModalContent = ( { height } ) => {
 	const previousHeight = usePrevious( height );
 	const currentHeight = suggestions.status === ASYNC_ACTION_STATUS.success ? height : previousHeight;
 	const margin = `calc(${ currentHeight === 0 ? "50%" : currentHeight / 2 + "px" } - 40vh)`;
+	const bottom = `calc( (${ height + 55 + "px" } - 100vh) / 2 )`;
 
 	const [ contentIsScrolling, setContentIsScrolling ] = useState( false );
 	const handleContentMeasureChange = useCallback( entry => {
@@ -403,10 +404,7 @@ export const ModalContent = ( { height } ) => {
 					// Margin tricks to break out of the container. Transition to prevent sudden location jumps when loading new suggestions.
 					"yst-mx-[calc(50%-50vw)] yst-transition-all"
 				}
-				style={ {
-					// Margin tricks to break out of the container.
-					marginTop: margin,
-				} }
+				style={ { bottom, margin } }
 				position="bottom-left"
 			>
 				{ suggestions.status !== ASYNC_ACTION_STATUS.loading && (

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -404,6 +404,7 @@ export const ModalContent = ( { height } ) => {
 					// Margin tricks to break out of the container. Transition to prevent sudden location jumps when loading new suggestions.
 					"yst-mx-[calc(50%-50vw)] yst-transition-all"
 				}
+				// Margin and position tricks to break out of the container.
 				style={ { bottom, margin } }
 				position="bottom-left"
 			>

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -34,6 +34,7 @@ import {
 	useTypeContext,
 } from "../hooks";
 import { useOpenYoastSidebarWhenPublishing } from "../../hooks/use-open-yoast-sidebar-when-publishing";
+import { getModalNotificationPosition } from "../../shared-admin/helpers";
 
 /**
  * Aims to capture the text between badges.
@@ -134,8 +135,7 @@ export const ModalContent = ( { height } ) => {
 	// Used in an attempt to prevent the tip notification from moving too much when generating more suggestions.
 	const previousHeight = usePrevious( height );
 	const currentHeight = suggestions.status === ASYNC_ACTION_STATUS.success ? height : previousHeight;
-	const margin = `calc(${ currentHeight === 0 ? "50%" : currentHeight / 2 + "px" } - 40vh)`;
-	const bottom = `calc( (${ height + 55 + "px" } - 100vh) / 2 )`;
+	const { bottom } = getModalNotificationPosition( currentHeight );
 
 	const [ contentIsScrolling, setContentIsScrolling ] = useState( false );
 	const handleContentMeasureChange = useCallback( entry => {
@@ -404,8 +404,8 @@ export const ModalContent = ( { height } ) => {
 					// Margin tricks to break out of the container. Transition to prevent sudden location jumps when loading new suggestions.
 					"yst-mx-[calc(50%-50vw)] yst-transition-all"
 				}
-				// Margin and position tricks to break out of the container.
-				style={ { bottom, marginTop: margin } }
+				// Position tricks to break out of the container.
+				style={ { bottom } }
 				position="bottom-left"
 			>
 				{ suggestions.status !== ASYNC_ACTION_STATUS.loading && (

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -405,7 +405,7 @@ export const ModalContent = ( { height } ) => {
 					"yst-mx-[calc(50%-50vw)] yst-transition-all"
 				}
 				// Margin and position tricks to break out of the container.
-				style={ { bottom, margin } }
+				style={ { bottom, marginTop: margin } }
 				position="bottom-left"
 			>
 				{ suggestions.status !== ASYNC_ACTION_STATUS.loading && (

--- a/packages/js/src/shared-admin/helpers/get-modal-notification-position.js
+++ b/packages/js/src/shared-admin/helpers/get-modal-notification-position.js
@@ -6,6 +6,6 @@
  * @returns {Object} The CSS value for the bottom position of the notification.
  */
 export const getModalNotificationPosition = ( panelHeight ) => {
-	// The 32px is distance from the bottom of the screen for notifications. As done in the ui-library when the notification in not inside a modal.
+	// 32px is the distance from the bottom of the screen for notifications. As done in the ui-library when the notification in not inside a modal.
 	return { bottom: `calc( (${ panelHeight + "px" } - 100vh) / 2 + 32px )` };
 };

--- a/packages/js/src/shared-admin/helpers/get-modal-notification-position.js
+++ b/packages/js/src/shared-admin/helpers/get-modal-notification-position.js
@@ -1,0 +1,11 @@
+/**
+ * Gets the position of the notification that is triggered inside a modal. Breaks out of the modal and is positioned at the bottom left of the screen.
+ *
+ * @param {number} panelHeight The height of the modal panel.
+ *
+ * @returns {Object} The CSS value for the bottom position of the notification.
+ */
+export const getModalNotificationPosition = ( panelHeight ) => {
+	// The 32px is distance from the bottom of the screen for notifications. As done in the ui-library when the notification in not inside a modal.
+	return { bottom: `calc( (${ panelHeight + "px" } - 100vh) / 2 + 32px )` };
+};

--- a/packages/js/src/shared-admin/helpers/index.js
+++ b/packages/js/src/shared-admin/helpers/index.js
@@ -2,4 +2,5 @@ export { fixWordPressMenuScrolling } from "./fix-wordpress-menu-scrolling";
 export { updateNotificationsCount } from "./notifications-count";
 export * from "./i18n";
 export { removesLocaleVariantSuffixes } from "./locale";
+export { getModalNotificationPosition } from "./get-modal-notification-position";
 

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -60,6 +60,10 @@ jest.mock( "@wordpress/blocks", () => ( {
 	createBlock: jest.fn(),
 } ) );
 
+jest.mock( "../../../src/ai-generator/hooks", () => ( {
+	useMeasuredRef: jest.fn( () => ( { current: null } ) ),
+} ) );
+
 jest.mock( "../../../src/ai-content-planner/hooks", () => ( {
 	useFetchContentSuggestions: jest.fn(),
 	useFetchContentOutline: jest.fn(),


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes position on the spark notification when using Content planner or AI Generator.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create a new post
* Click on the "Get content suggestions" button, once suggestions are loaded increase the sparks count by executing the following command in the devtool console:
```
wp.data.dispatch( "yoast-seo/ai-generator").setUsageCount(6)
```
* Check you see the spark notification in the bottom left side of the screen.
* Add afocus keyphrase and check generate AI title or meta description. Once you get the suggestions, increase te spark cunt in the same way and check the notification is in the same bottom left position.
* Repeat the tests for mobile view and check thenotification in at the bottom of the screen.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Fix spark notification position](https://github.com/Yoast/reserved-tasks/issues/1175)
