### PR TITLE
Refactor upsell logic to include premium subscription validation

### DIFF
--- a/packages/js/src/ai-content-planner/containers/approve-modal.js
+++ b/packages/js/src/ai-content-planner/containers/approve-modal.js
@@ -11,14 +11,14 @@ export default compose( [
 		const content = select( "core/editor" ).getEditedPostContent();
 		const { getIsPremium, selectLink } = select( "yoast-seo/editor" );
 
-		const { isUsageCountLimitReached } = select( STORE_NAME_AI );
-
+		const { isUsageCountLimitReached, selectPremiumSubscription } = select( STORE_NAME_AI );
+		const hasValidPremiumSubscription = selectPremiumSubscription();
 		return {
 			isEmptyPost: count( content, "words", {} ) === 0,
 			isOpen: selectFeatureModalStatus() === FEATURE_MODAL_STATUS.idle,
 			isPremium: getIsPremium(),
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
-			isUpsell: isUsageCountLimitReached(),
+			isUpsell: isUsageCountLimitReached() && ! hasValidPremiumSubscription,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -15,7 +15,8 @@ import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
  * @returns {Function} Callback to trigger the content suggestions fetch.
  */
 export const useFetchContentSuggestions = () => {
-	const { endpoint, postType, contentLocale, editorApiValue, isUsageCountLimitReached, usageCountEndpoint } = useSelect( ( select ) => {
+	const { endpoint, postType, contentLocale, editorApiValue, isUsageCountLimitReached,
+		usageCountEndpoint, hasValidPremiumSubscription } = useSelect( ( select ) => {
 		return {
 			endpoint: select( CONTENT_PLANNER_STORE ).selectContentSuggestionsEndpoint(),
 			postType: select( "yoast-seo/editor" ).getPostType(),
@@ -23,6 +24,7 @@ export const useFetchContentSuggestions = () => {
 			editorApiValue: select( "yoast-seo/editor" ).getEditorTypeApiValue(),
 			usageCountEndpoint: select( STORE_NAME_AI ).selectUsageCountEndpoint(),
 			isUsageCountLimitReached: select( STORE_NAME_AI ).isUsageCountLimitReached(),
+			hasValidPremiumSubscription: select( STORE_NAME_AI ).selectPremiumSubscription(),
 		};
 	}, [] );
 
@@ -32,7 +34,7 @@ export const useFetchContentSuggestions = () => {
 	// eslint-disable-next-line complexity
 	return useCallback( async() => {
 		// Before fetching usage count, check if it's already known that the limit has been reached to avoid unnecessary API calls.
-		if ( isUsageCountLimitReached ) {
+		if ( isUsageCountLimitReached && ! hasValidPremiumSubscription ) {
 			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
 			return;
 		}
@@ -42,7 +44,7 @@ export const useFetchContentSuggestions = () => {
 		const { payload } = await fetchUsageCount( { endpoint: usageCountEndpoint, isWooProductEntity: false } );
 		const sparksLimitReached = ( payload?.errorCode === 429 && payload?.errorIdentifier === "USAGE_LIMIT_REACHED" ) || payload.count >= payload.limit;
 
-		if ( sparksLimitReached ) {
+		if ( sparksLimitReached && ! hasValidPremiumSubscription ) {
 			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
 			setContentSuggestionsStatus( ASYNC_ACTION_STATUS.idle );
 			return;
@@ -55,6 +57,7 @@ export const useFetchContentSuggestions = () => {
 		contentLocale,
 		editorApiValue,
 		isUsageCountLimitReached,
+		hasValidPremiumSubscription,
 		usageCountEndpoint,
 		fetchContentPlannerSuggestions,
 		addUsageCount,

--- a/packages/js/tests/ai-content-planner/components/approve-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/approve-modal.test.js
@@ -89,4 +89,17 @@ describe( "ApproveModal", () => {
 			expect( onClick ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
+	describe( "premium subscription with usage limit reached", () => {
+		it( "shows 'Get content suggestions' button (not upsell) when isUpsell is false even with premium", () => {
+			renderApproveModal( { isPremium: true, isUpsell: false } );
+			expect( screen.getByRole( "button", { name: "Get content suggestions" } ) ).toBeInTheDocument();
+			expect( screen.queryByText( "Unlock with Yoast SEO Premium" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "shows upsell when isUpsell is true and user is not premium", () => {
+			renderApproveModal( { isPremium: false, isUpsell: true } );
+			expect( screen.getByText( "Unlock with Yoast SEO Premium" ) ).toBeInTheDocument();
+			expect( screen.queryByRole( "button", { name: "Get content suggestions" } ) ).not.toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/approve-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/approve-modal.test.js
@@ -89,17 +89,4 @@ describe( "ApproveModal", () => {
 			expect( onClick ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
-	describe( "premium subscription with usage limit reached", () => {
-		it( "shows 'Get content suggestions' button (not upsell) when isUpsell is false even with premium", () => {
-			renderApproveModal( { isPremium: true, isUpsell: false } );
-			expect( screen.getByRole( "button", { name: "Get content suggestions" } ) ).toBeInTheDocument();
-			expect( screen.queryByText( "Unlock with Yoast SEO Premium" ) ).not.toBeInTheDocument();
-		} );
-
-		it( "shows upsell when isUpsell is true and user is not premium", () => {
-			renderApproveModal( { isPremium: false, isUpsell: true } );
-			expect( screen.getByText( "Unlock with Yoast SEO Premium" ) ).toBeInTheDocument();
-			expect( screen.queryByRole( "button", { name: "Get content suggestions" } ) ).not.toBeInTheDocument();
-		} );
-	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the upsell modal was shown unexpectedly on the Content Planner for Premium users when the monthly spark limit (100) had been previously reached.

## Relevant technical choices:

* The isUsageCountLimitReached selector only checks whether `count >= limit` without considering whether the user holds a valid Premium subscription. The AI Generator (`ai-generator/components/app.js`) already handles this correctly via `checkSubscriptions()`. This fix applies the same pattern to the Content Planner by adding a `selectPremiumSubscription()` check alongside `isUsageCountLimitReached` in both the approve modal container and the `useFetchContentSuggestions` hook.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

- Install and activate Yoast SEO (without Premium enabled).
- Create or edit a post and use AI features (AI Generator or Content Planner) until you exhaust all 10 free sparks.
- Verify the upsell modal is shown (expected for free users).
- Enable Premium (activate a valid Premium subscription).
- Go to the post again and open the Content Planner feature.
- Run `wp.data.dispatch( "yoast-seo/ai-generator").setUsageCount(100)` in the browser console to simulate a high usage count
- Use the AI Generator 👉🏽 verify it works without showing an upsell modal.
- Use the Content Planner by clicking on "Get content suggestions" button, verify that:
   - you don't see the upsell modal anymore
   - the suggestions are generated successfully
   - You see "You've used 100 sparks this month." notification

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
