### PR TITLE
Disable feature when less 5 published posts

### DIFF
--- a/packages/js/src/ai-content-planner/blocks/banner-block.js
+++ b/packages/js/src/ai-content-planner/blocks/banner-block.js
@@ -23,10 +23,11 @@ const INJECTED_STYLE_ID = "yoast-seo-tailwind-css";
 const Edit = ( { clientId } ) => {
 	const blockProps = useBlockProps();
 	const ref = useRef( null );
-	const { isPremium, hasConsent } = useSelect( select => {
+	const { isPremium, hasConsent, minPostsMet } = useSelect( select => {
 		return {
 			isPremium: select( STORE_NAME_EDITOR ).getIsPremium(),
 			hasConsent: select( STORE_NAME_AI ).selectHasAiGeneratorConsent(),
+			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
 		};
 	}, [] );
 	const { removeBlock } = useDispatch( "core/block-editor" );
@@ -61,6 +62,10 @@ const Edit = ( { clientId } ) => {
 		link.href = mainLink.href;
 		ownerDoc.head.appendChild( link );
 	}, [] );
+
+	if ( ! minPostsMet ) {
+		return null;
+	}
 
 	return (
 		<div { ...blockProps } ref={ ref }>

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -1,7 +1,9 @@
 import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
+import { useSelect } from "@wordpress/data";
 import { Button, Root } from "@yoast/ui-library";
-import { FEATURE_MODAL_STATUS } from "../constants";
+import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS } from "../constants";
+import classNames from "classnames";
 
 /**
  * The section for the content planner feature in the Yoast sidebar.
@@ -16,10 +18,27 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 		setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
 	}, [ setFeatureModalStatus ] );
 
+	const minPostsMet = useSelect( select => select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(), [] );
+
 	return <Root><div className="yst-p-4">
-		<Button variant="ai-secondary" onClick={ handleClick } className={ location === "sidebar" ? "yst-w-full" : "" }>
+		<Button
+			variant="ai-secondary"
+			onClick={ handleClick }
+			disabled={ ! minPostsMet }
+			className={ location === "sidebar" ? "yst-w-full" : "" }
+		>
 			{ __( "Get content suggestions", "wordpress-seo" ) }
 		</Button>
+		{ ! minPostsMet && (
+			<span
+				className={ classNames(
+					"yst-text-sm yst-flex yst-mt-1 yst-text-slate-500 yst-italic",
+					location === "sidebar" ? "yst-justify-center" : "yst-justify-start"
+				) }
+			>
+				{ __( "Available after 5 published posts", "wordpress-seo" ) }
+			</span>
+		) }
 	</div>
 	</Root>;
 };

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -31,7 +31,6 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 			variant="ai-secondary"
 			onClick={ handleClick }
 			disabled={ ! minPostsMet }
-			aria-disabled={ ! minPostsMet }
 			aria-describedby={ minPostsMet ? null : helperTextId }
 			className={ location === "sidebar" ? "yst-w-full" : "" }
 		>

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -19,6 +19,7 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 	}, [ setFeatureModalStatus ] );
 
 	const minPostsMet = useSelect( select => select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(), [] );
+	const helperTextId = "yoast-content-planner-min-posts-notice-" + location;
 
 	return <Root><div
 		className={ classNames(
@@ -30,12 +31,15 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 			variant="ai-secondary"
 			onClick={ handleClick }
 			disabled={ ! minPostsMet }
+			aria-disabled={ ! minPostsMet }
+			aria-describedby={ minPostsMet ? null : helperTextId }
 			className={ location === "sidebar" ? "yst-w-full" : "" }
 		>
 			{ __( "Get content suggestions", "wordpress-seo" ) }
 		</Button>
 		{ ! minPostsMet && (
 			<span
+				id={ helperTextId }
 				className={ classNames(
 					"yst-text-sm yst-text-slate-500 yst-italic",
 					location === "sidebar" && "yst-flex yst-mt-1 yst-justify-center"

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -20,7 +20,12 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 
 	const minPostsMet = useSelect( select => select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(), [] );
 
-	return <Root><div className="yst-p-4">
+	return <Root><div
+		className={ classNames(
+			"yst-p-4",
+			location === "metabox" && "yst-flex yst-items-center yst-gap-3"
+		) }
+	>
 		<Button
 			variant="ai-secondary"
 			onClick={ handleClick }
@@ -32,8 +37,8 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 		{ ! minPostsMet && (
 			<span
 				className={ classNames(
-					"yst-text-sm yst-flex yst-mt-1 yst-text-slate-500 yst-italic",
-					location === "sidebar" ? "yst-justify-center" : "yst-justify-start"
+					"yst-text-sm yst-text-slate-500 yst-italic",
+					location === "sidebar" && "yst-flex yst-mt-1 yst-justify-center"
 				) }
 			>
 				{ __( "Available after 5 published posts", "wordpress-seo" ) }

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -6,9 +6,11 @@ import { get } from "lodash";
 import { App } from "./components/app";
 import { registerBannerBlock } from "./blocks/banner-block";
 import "./blocks/content-suggestion-block";
+import { CONTENT_PLANNER_STORE } from "./constants";
 import { registerStore } from "./store";
 import { CONTENT_SUGGESTIONS_NAME } from "./store/content-suggestions";
 import { CONTENT_OUTLINE_NAME } from "./store/content-outline";
+import { AVAILABILITY_NAME } from "./store/availability";
 
 /**
  * Inserts a Content Planner Banner block after the first paragraph in the editor.
@@ -54,23 +56,24 @@ export function insertBannerAfterFirstParagraph( blocks, insertBlock ) {
 export const ContentPlannerEditorPlugin = () => {
 	const hasInserted = useRef( false );
 
-	const { isNewPost, postType, blocks } = useSelect( select => {
+	const { isNewPost, postType, blocks, minPostsMet } = useSelect( select => {
 		return {
 			isNewPost: select( "core/editor" ).isEditedPostNew(),
 			postType: select( "core/editor" ).getCurrentPostType(),
 			blocks: select( "core/block-editor" ).getBlocks(),
+			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
 		};
 	}, [] );
 
 	const { insertBlock } = useDispatch( "core/block-editor" );
 
 	useEffect( () => {
-		if ( hasInserted.current || ! isNewPost || postType !== "post" ) {
+		if ( hasInserted.current || ! isNewPost || postType !== "post" || ! minPostsMet ) {
 			return;
 		}
 
 		hasInserted.current = insertBannerAfterFirstParagraph( blocks, insertBlock );
-	}, [ blocks, isNewPost, postType, insertBlock ] );
+	}, [ blocks, isNewPost, postType, insertBlock, minPostsMet ] );
 
 	return (
 		<App />
@@ -94,6 +97,9 @@ export default function initContentPlanner() {
 		},
 		[ CONTENT_OUTLINE_NAME ]: {
 			endpoint: get( window, "wpseoContentPlanner.endpoints.getOutline", "" ),
+		},
+		[ AVAILABILITY_NAME ]: {
+			minPostsMet: get( window, "wpseoContentPlanner.minPostsMet", false ),
 		},
 	} );
 	registerPlugin( "yoast-content-planner", { render: ContentPlannerEditorPlugin } );

--- a/packages/js/src/ai-content-planner/store/availability.js
+++ b/packages/js/src/ai-content-planner/store/availability.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+export const AVAILABILITY_NAME = "availability";
+
+const slice = createSlice( {
+	name: AVAILABILITY_NAME,
+	initialState: {
+		minPostsMet: false,
+	},
+	reducers: {},
+} );
+
+export const getInitialAvailabilityState = slice.getInitialState;
+
+export const availabilityReducer = slice.reducer;
+
+export const availabilityActions = {
+	...slice.actions,
+};
+
+export const availabilitySelectors = {
+	selectIsMinPostsMet: ( state ) => get( state, [ AVAILABILITY_NAME, "minPostsMet" ], slice.getInitialState().minPostsMet ),
+};

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -24,6 +24,13 @@ import {
 	modalSelectors,
 	getInitialModalState,
 } from "./modal";
+import {
+	AVAILABILITY_NAME,
+	availabilityActions,
+	availabilityReducer,
+	availabilitySelectors,
+	getInitialAvailabilityState,
+} from "./availability";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -37,11 +44,13 @@ export const createStore = ( initialState ) => {
 			...contentSuggestionsActions,
 			...contentOutlineActions,
 			...modalActions,
+			...availabilityActions,
 		},
 		selectors: {
 			...contentSuggestionsSelectors,
 			...contentOutlineSelectors,
 			...modalSelectors,
+			...availabilitySelectors,
 		},
 		controls: {
 			...contentSuggestionsControls,
@@ -53,6 +62,7 @@ export const createStore = ( initialState ) => {
 				[ CONTENT_SUGGESTIONS_NAME ]: getInitialContentSuggestionsState(),
 				[ CONTENT_OUTLINE_NAME ]: getInitialContentOutlineState(),
 				[ MODAL_NAME ]: getInitialModalState(),
+				[ AVAILABILITY_NAME ]: getInitialAvailabilityState(),
 			},
 			initialState
 		),
@@ -60,6 +70,7 @@ export const createStore = ( initialState ) => {
 			[ CONTENT_SUGGESTIONS_NAME ]: contentSuggestionsReducer,
 			[ CONTENT_OUTLINE_NAME ]: contentOutlineReducer,
 			[ MODAL_NAME ]: modalReducer,
+			[ AVAILABILITY_NAME ]: availabilityReducer,
 		} ),
 	} );
 };

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -102,6 +102,7 @@ describe( "ContentPlannerEditorPlugin", () => {
 		isNewPost: true,
 		postType: "post",
 		blocks: [],
+		minPostsMet: true,
 	};
 
 	/**
@@ -119,6 +120,9 @@ describe( "ContentPlannerEditorPlugin", () => {
 			},
 			"core/block-editor": {
 				getBlocks: () => opts.blocks,
+			},
+			"yoast-seo/content-planner": {
+				selectIsMinPostsMet: () => opts.minPostsMet,
 			},
 		};
 		useSelect.mockImplementation( ( selector ) => selector( ( storeName ) => stores[ storeName ] ) );
@@ -167,6 +171,12 @@ describe( "ContentPlannerEditorPlugin", () => {
 
 	test( "should not insert a block when the post type is not 'post'", () => {
 		mockSelect( { isNewPost: true, postType: "page", blocks: [] } );
+		render( <ContentPlannerEditorPlugin /> );
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+	} );
+
+	test( "should not insert a block when the minimum-posts threshold is not met", () => {
+		mockSelect( { isNewPost: true, postType: "post", blocks: [ { name: "core/paragraph" } ], minPostsMet: false } );
 		render( <ContentPlannerEditorPlugin /> );
 		expect( mockInsertBlock ).not.toHaveBeenCalled();
 	} );

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -84,7 +84,7 @@ class Content_Planner_Integration implements Integration_Interface {
 	/**
 	 * Returns the script data for the content planner.
 	 *
-	 * @return array{endpoints: array<string>, minPostsMet: bool}
+	 * @return array{endpoints: array<string, string>, minPostsMet: bool}
 	 */
 	public function get_script_data(): array {
 		return [

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -89,7 +89,7 @@ class Content_Planner_Integration implements Integration_Interface {
 	public function get_script_data(): array {
 		return [
 			'endpoints'   => $this->endpoints_repository->get_all_endpoints()->to_paths_array(),
-			'minPostsMet' => $this->is_minimum_published_posts_met(),
+			'minPostsMet' => $this->is_minimum_posts_met(),
 		];
 	}
 
@@ -126,7 +126,7 @@ class Content_Planner_Integration implements Integration_Interface {
 	 *
 	 * @return bool Whether the site has met the minimum-posts threshold.
 	 */
-	private function is_minimum_published_posts_met(): bool {
+	private function is_minimum_posts_met(): bool {
 		$threshold = $this->get_min_posts_threshold();
 		$posts     = $this->indexable_repository->get_recently_modified_posts( 'post', $threshold, false );
 

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -9,11 +9,17 @@ use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Planner_Endpoints_Reposi
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
 use Yoast\WP\SEO\Conditionals\AI_Editor_Conditional;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
 /**
  * Content_Planner_Integration class.
  */
 class Content_Planner_Integration implements Integration_Interface {
+
+	/**
+	 * The minimum number of published posts required for the feature to be available.
+	 */
+	public const MIN_PUBLISHED_POSTS = 5;
 
 	/**
 	 * Represents the admin asset manager.
@@ -30,6 +36,13 @@ class Content_Planner_Integration implements Integration_Interface {
 	private $endpoints_repository;
 
 	/**
+	 * The indexable repository.
+	 *
+	 * @var Indexable_Repository
+	 */
+	private $indexable_repository;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -43,13 +56,16 @@ class Content_Planner_Integration implements Integration_Interface {
 	 *
 	 * @param WPSEO_Admin_Asset_Manager            $asset_manager        The admin asset manager.
 	 * @param Content_Planner_Endpoints_Repository $endpoints_repository The endpoints repository.
+	 * @param Indexable_Repository                 $indexable_repository The indexable repository.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
-		Content_Planner_Endpoints_Repository $endpoints_repository
+		Content_Planner_Endpoints_Repository $endpoints_repository,
+		Indexable_Repository $indexable_repository
 	) {
 		$this->asset_manager        = $asset_manager;
 		$this->endpoints_repository = $endpoints_repository;
+		$this->indexable_repository = $indexable_repository;
 	}
 
 	/**
@@ -68,11 +84,12 @@ class Content_Planner_Integration implements Integration_Interface {
 	/**
 	 * Returns the script data for the content planner.
 	 *
-	 * @return array<string, array<string>>
+	 * @return array{endpoints: array<string>, minPostsMet: bool}
 	 */
 	public function get_script_data(): array {
 		return [
-			'endpoints' => $this->endpoints_repository->get_all_endpoints()->to_paths_array(),
+			'endpoints'   => $this->endpoints_repository->get_all_endpoints()->to_paths_array(),
+			'minPostsMet' => $this->is_minimum_published_posts_met(),
 		];
 	}
 
@@ -84,5 +101,35 @@ class Content_Planner_Integration implements Integration_Interface {
 	public function enqueue_assets() {
 		$this->asset_manager->enqueue_script( 'ai-content-planner' );
 		$this->asset_manager->localize_script( 'ai-content-planner', 'wpseoContentPlanner', $this->get_script_data() );
+	}
+
+	/**
+	 * Returns the minimum-posts threshold, allowing override via filter.
+	 *
+	 * @return int The minimum number of published posts required.
+	 */
+	private function get_min_posts_threshold(): int {
+		/**
+		 * Filter: 'wpseo_content_planner_min_posts' - Allows overriding the minimum number of published posts
+		 * required for the Content Planner feature to be available.
+		 *
+		 * @param int $min_posts The default minimum number of published posts.
+		 */
+		return (int) \apply_filters( 'wpseo_content_planner_min_posts', self::MIN_PUBLISHED_POSTS );
+	}
+
+	/**
+	 * Determines whether the site has at least the minimum number of published posts.
+	 *
+	 * Reuses Indexable_Repository::get_recently_modified_posts() with a limit equal to the threshold,
+	 * so we never load more rows than necessary just to answer a "≥ N" question.
+	 *
+	 * @return bool Whether the site has met the minimum-posts threshold.
+	 */
+	private function is_minimum_published_posts_met(): bool {
+		$threshold = $this->get_min_posts_threshold();
+		$posts     = $this->indexable_repository->get_recently_modified_posts( 'post', $threshold, false );
+
+		return \count( $posts ) >= $threshold;
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Disables content planner when there's not enough posts already published.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have a site with less than 5 published posts
* Go to create a new post and confirm that you **don't** see the inline banner:
<img width="773" height="185" alt="image" src="https://github.com/user-attachments/assets/8d43a703-c01d-42f8-8857-bcb116ec95b3" />

* In the yoast sidebar/metabox, you see the `Get content suggestions` button but disabled, with a `Available after 5 published posts` message below, like [the designs](https://www.figma.com/proto/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?node-id=0-1&p=f&viewport=1232%2C-541%2C0.15&t=joO77UdkquKDvJdF-0&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=1464%3A4242&show-proto-sidebar=1).
  * The same is true for existing posts too.
* Publish 5 or more posts
* Go to create a new post and confirm that you see the inline banner properly as well as the `Get content suggestions` button in the sidebar/metabox enabled
  * The sidebar/metabox button is enabled in existing posts too
* Save the post with the inline banner there
* Delete all posts except the one with the inline banner saved in its content
* Go to the post with the inline banner saved in its content and confirm that you dont see it anymore
  * Go to the post's frontend and confirm no errors.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
