### PR TITLE
Fix the last and first items drag and drop for the outline of the content planner.

### DIFF
--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -136,6 +136,9 @@ export const OutlineModalContent = ( {
 		handleMoveDown,
 	} = useDraggableStructure();
 
+	const handleSentinelDragOver = useCallback( ( e ) => handleDragOver( e, structure.length ), [ handleDragOver, structure.length ] );
+	const handleSentinelDrop = useCallback( ( e ) => handleDrop( e, structure.length ), [ handleDrop, structure.length ] );
+
 	useEffect( () => {
 		setFocusKeyphrase( suggestion.keyphrase );
 		setTitle( suggestion.title );
@@ -284,6 +287,17 @@ export const OutlineModalContent = ( {
 										totalItems={ structure.length }
 									/>
 								) ) }
+								{ /* Sentinel drop zone: allows dropping an item into the last position. */ }
+								<div
+									className={ classNames(
+										"yst-rounded-md yst-transition-all yst-border-2",
+										dragOverIndex === structure.length
+											? "yst-border-primary-500 yst-h-8"
+											: "yst-border-transparent yst-h-2"
+									) }
+									onDragOver={ handleSentinelDragOver }
+									onDrop={ handleSentinelDrop }
+								/>
 							</div>
 						</div>
 					</Transition>

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -45,7 +45,7 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		aria-roledescription={ __( "Draggable section", "wordpress-seo" ) }
 		tabIndex="0"
 		className={ classNames(
-			"yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-cursor-grab yst-select-none yst-transition-all",
+			"yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-cursor-grab yst-select-none yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
 			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
 		) }
 		draggable="true"

--- a/packages/js/src/ai-content-planner/hooks/use-draggable-structure.js
+++ b/packages/js/src/ai-content-planner/hooks/use-draggable-structure.js
@@ -54,9 +54,6 @@ export const useDraggableStructure = () => {
 	}, [] );
 
 	const handleMoveUp = useCallback( ( index ) => {
-		if ( index <= 0 ) {
-			return;
-		}
 		setStructure( ( prev ) => {
 			const updated = [ ...prev ];
 			const [ moved ] = updated.splice( index, 1 );
@@ -67,9 +64,6 @@ export const useDraggableStructure = () => {
 
 	const handleMoveDown = useCallback( ( index ) => {
 		setStructure( ( prev ) => {
-			if ( index >= prev.length - 1 ) {
-				return prev;
-			}
 			const updated = [ ...prev ];
 			const [ moved ] = updated.splice( index, 1 );
 			updated.splice( index + 1, 0, moved );

--- a/packages/js/src/ai-content-planner/hooks/use-draggable-structure.js
+++ b/packages/js/src/ai-content-planner/hooks/use-draggable-structure.js
@@ -54,6 +54,9 @@ export const useDraggableStructure = () => {
 	}, [] );
 
 	const handleMoveUp = useCallback( ( index ) => {
+		if ( index <= 0 ) {
+			return;
+		}
 		setStructure( ( prev ) => {
 			const updated = [ ...prev ];
 			const [ moved ] = updated.splice( index, 1 );
@@ -64,6 +67,9 @@ export const useDraggableStructure = () => {
 
 	const handleMoveDown = useCallback( ( index ) => {
 		setStructure( ( prev ) => {
+			if ( index >= prev.length - 1 ) {
+				return prev;
+			}
 			const updated = [ ...prev ];
 			const [ moved ] = updated.splice( index, 1 );
 			updated.splice( index + 1, 0, moved );

--- a/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
@@ -214,6 +214,25 @@ describe( "useDraggableStructure", () => {
 			expect( e.preventDefault ).toHaveBeenCalledTimes( 1 );
 		} );
 
+		it( "places an item at the last position when dropped onto the sentinel (dropIndex equals length)", () => {
+			const { result } = renderHook( () => useDraggableStructure() );
+
+			act( () => {
+				result.current.handleDragStart( mockEvent(), 0 );
+			} );
+			act( () => {
+				result.current.handleDrop( mockEvent(), 3 );
+			} );
+
+			// Dragging index 0 to sentinel (length=3): dest = 3-1 = 2
+			// [Introduction, Body, Conclusion] → [Body, Conclusion, Introduction]
+			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( [
+				"Body",
+				"Conclusion",
+				"Introduction",
+			] );
+		} );
+
 		it( "resets dragOverIndex to null and does not reorder when no drag was started", () => {
 			const { result } = renderHook( () => useDraggableStructure() );
 			const originalHeadings = result.current.structure.map( ( i ) => i.heading );

--- a/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
@@ -294,20 +294,6 @@ describe( "useDraggableStructure", () => {
 				"Body",
 			] );
 		} );
-
-		it( "does nothing when called on the first item", () => {
-			const { result } = renderHook( () => useDraggableStructure() );
-
-			act( () => {
-				result.current.handleMoveUp( 0 );
-			} );
-
-			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( [
-				"Introduction",
-				"Body",
-				"Conclusion",
-			] );
-		} );
 	} );
 
 	describe( "handleMoveDown", () => {
@@ -336,20 +322,6 @@ describe( "useDraggableStructure", () => {
 				"Introduction",
 				"Conclusion",
 				"Body",
-			] );
-		} );
-
-		it( "does nothing when called on the last item", () => {
-			const { result } = renderHook( () => useDraggableStructure() );
-
-			act( () => {
-				result.current.handleMoveDown( 2 );
-			} );
-
-			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( [
-				"Introduction",
-				"Body",
-				"Conclusion",
 			] );
 		} );
 	} );

--- a/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-draggable-structure.test.js
@@ -43,6 +43,11 @@ describe( "useDraggableStructure", () => {
 	} );
 
 	describe( "initial state", () => {
+		it( "initialises structure from the outline", () => {
+			const { result } = renderHook( () => useDraggableStructure() );
+			expect( result.current.structure ).toEqual( mockOutline );
+		} );
+
 		it( "initialises dragOverIndex to null", () => {
 			const { result } = renderHook( () => useDraggableStructure() );
 			expect( result.current.dragOverIndex ).toBeNull();
@@ -208,6 +213,22 @@ describe( "useDraggableStructure", () => {
 			} );
 			expect( e.preventDefault ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( "resets dragOverIndex to null and does not reorder when no drag was started", () => {
+			const { result } = renderHook( () => useDraggableStructure() );
+			const originalHeadings = result.current.structure.map( ( i ) => i.heading );
+
+			act( () => {
+				result.current.handleDragOver( mockEvent(), 1 );
+			} );
+			act( () => {
+				// Drop without a prior handleDragStart — dragIndex is null.
+				result.current.handleDrop( mockEvent(), 1 );
+			} );
+
+			expect( result.current.dragOverIndex ).toBeNull();
+			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( originalHeadings );
+		} );
 	} );
 
 	describe( "handleDragEnd", () => {
@@ -254,6 +275,20 @@ describe( "useDraggableStructure", () => {
 				"Body",
 			] );
 		} );
+
+		it( "does nothing when called on the first item", () => {
+			const { result } = renderHook( () => useDraggableStructure() );
+
+			act( () => {
+				result.current.handleMoveUp( 0 );
+			} );
+
+			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( [
+				"Introduction",
+				"Body",
+				"Conclusion",
+			] );
+		} );
 	} );
 
 	describe( "handleMoveDown", () => {
@@ -282,6 +317,20 @@ describe( "useDraggableStructure", () => {
 				"Introduction",
 				"Conclusion",
 				"Body",
+			] );
+		} );
+
+		it( "does nothing when called on the last item", () => {
+			const { result } = renderHook( () => useDraggableStructure() );
+
+			act( () => {
+				result.current.handleMoveDown( 2 );
+			} );
+
+			expect( result.current.structure.map( ( i ) => i.heading ) ).toEqual( [
+				"Introduction",
+				"Body",
+				"Conclusion",
 			] );
 		} );
 	} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

- We want to fix a bug when dragging a row to the end of the list.
- We want to add focus styling for keyboard reordering.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where reordering sections in the content planner outline via drag-and-drop did not work correctly for the last item and adds focus styling.

## Relevant technical choices:
* A sentinel drop zone is added below the last row so drag-and-drop can place an item at the last position. Previously the `dropIndex - 1` adjustment in `handleDrop` made the last slot unreachable.
* Focus styling (`focus:yst-outline`) added to structure rows so keyboard users can see which row is active when reordering with Alt+Arrow.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Open a post or page in the WordPress editor with the Yoast SEO plugin active.
2. Open the AI content planner and generate content suggestions.
3. Select a suggestion and proceed to the outline step so the list of sections is visible.

**Keyboard reordering (Alt+Arrow keys):**

4. Click a section row to focus it — it should show a visible primary color outline.
5. With the **first section** focused, press **Alt+ArrowUp**.
   - Expected: nothing happens (it is already first).
   - this is a regression test, it was working properly before too
6. With the **first section** focused, press **Alt+ArrowDown**.
   - Expected: the section moves to the second position.
   - this is a regression test, it was working properly before too
7. Click the **last section** to focus it, then press **Alt+ArrowDown**.
   - Expected: nothing happens (it is already last).
   - this is a regression test, it was working properly before too
8. With the **last section** focused, press **Alt+ArrowUp**.
   - Expected: the section moves to the second-to-last position.
   - this is a regression test, it was working properly before too

**Drag-and-drop reordering:**

9. Drag any section and drop it onto a section in the middle of the list.
   - Expected: the section moves to the correct dropped position.
   - this is a regression test, it was working properly before too
10. Drag any section and drop it **below the last row** onto the drop zone at the bottom of the list.
    - Expected: the section moves to the last position.
11. Drag any section and drop it onto the **first row**.
    - Expected: the section moves to the first position.
   - this is a regression test, it was working properly before too
12. Verify the outline content looks correct after each reorder before applying it.
   - this is a regression test, it was working properly before too

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Content planner: fix drag and drop of first and last items in outline.](https://github.com/Yoast/reserved-tasks/issues/1185)