### PR TITLE
Mark AI Content Planner REST routes as @internal

### DIFF
--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -18,6 +18,8 @@ use Yoast\WP\SEO\Routes\Route_Interface;
 /**
  * Registers a route to get a content outline from the AI API.
  *
+ * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the `edit_posts` capability (see {@see self::check_permissions()}), and may change at any time without notice.
+ *
  * @makePublic
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded

--- a/src/ai/content-planner/user-interface/get-suggestions-route.php
+++ b/src/ai/content-planner/user-interface/get-suggestions-route.php
@@ -18,6 +18,8 @@ use Yoast\WP\SEO\Routes\Route_Interface;
 /**
  * Registers a route to get content suggestions from the AI API.
  *
+ * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the `edit_posts` capability (see {@see self::check_permissions()}), and may change at any time without notice.
+ *
  * @makePublic
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded


### PR DESCRIPTION
## Context

The two REST route classes registering `GET yoast/v1/ai_content_planner/get_suggestions` and `POST yoast/v1/ai_content_planner/get_outline` exist solely to back the Content Planner UI inside the Yoast SEO admin. Their authentication (logged-in user with `edit_posts`), request/response shape, and lifetime are coupled to the admin-UI's needs, and we don't intend to support them as third-party-consumable public APIs.

This came up via an experimental developer-portal docs-sync workflow ([Yoast/developer#393](https://github.com/Yoast/developer/pull/393)) that triaged the 27.6-RC1 diff and proposed publishing both routes in the Yoast developer portal as if they were public APIs. There is currently no in-code signal that says *"don't treat this as public surface"*, which is the gap this PR closes.

## Summary

This PR can be summarized in the following changelog entry:

* Marks the AI Content Planner REST route classes as `@internal` to signal that they are not part of the plugin's public REST API surface.

## Relevant technical choices:

* Used a class-level `@internal` PHPDoc tag rather than moving the routes to a non-`yoast/v1/...` namespace or renaming files. PHPDoc is the cheapest way to record intent without changing URLs that the admin UI already calls.
* Kept the existing `@makePublic` tag — that one is a Yoast scoper-tool annotation telling the build to keep the class symbol reachable, which is unrelated to whether the API surface is public.
* Description in the `@internal` tag also points at the `check_permissions()` method as the auth gate, so future readers see the full picture without reading both files.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

Not applicable — this PR only adds a PHPDoc annotation; runtime behaviour is identical.

* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — non-user-facing PHPDoc change.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* None. PHPDoc tags are not evaluated at runtime; the autoloader, route registration, and request/response handling are unchanged.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. The `@internal` annotation itself is the documentation: it tells future readers and external tooling that these routes are not part of the plugin's public REST API surface.
