### PR TITLE
Mark wpseo_content_planner_min_posts filter as @internal

### DIFF
--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -113,6 +113,8 @@ class Content_Planner_Integration implements Integration_Interface {
 		 * Filter: 'wpseo_content_planner_min_posts' - Allows overriding the minimum number of published posts
 		 * required for the Content Planner feature to be available.
 		 *
+		 * @internal Used internally by the Yoast SEO Content Planner UI to gate availability; not part of the plugin's public filter surface.
+		 *
 		 * @param int $min_posts The default minimum number of published posts.
 		 */
 		return (int) \apply_filters( 'wpseo_content_planner_min_posts', self::MIN_PUBLISHED_POSTS );


### PR DESCRIPTION
## Context

Sibling change to [#23208](https://github.com/Yoast/wordpress-seo/pull/23208) (which marked the Content Planner REST routes `@internal`). This PR does the same for the one filter the feature exposes — `wpseo_content_planner_min_posts` in `src/ai/content-planner/user-interface/content-planner-integration.php`.

The filter gates UI availability based on how many published posts a site has. Like the rest of the Content Planner feature's server-side surface, it is admin-UI plumbing rather than a public extension point we intend to support for third parties.

The trigger for this PR was a developer-portal docs-sync agent run on 27.6-RC2 ([Yoast/developer run #25102184836](https://github.com/Yoast/developer/actions/runs/25102184836)) which flagged the filter as a borderline case (mixed signals — the docblock looks developer-facing but the registering method is `private` and lives under `user-interface/`). The agent skipped it under the "when in doubt, do not document" rule and asked a maintainer to confirm. Confirming here by making the intent explicit in code.

## Summary

This PR can be summarized in the following changelog entry:

* Marks the `wpseo_content_planner_min_posts` filter as `@internal` to signal that it is not part of the plugin's public filter surface.

(`changelog: non-user-facing` label.)

## Relevant technical choices:

* Used a per-call `@internal` PHPDoc tag on the filter's docblock rather than annotating the registering method or class. This keeps the marker close to the `apply_filters()` call so any future reader (or filter-scanner) sees it directly.
* Phrasing mirrors the description used on the Content Planner route classes in #23208 ("not part of the plugin's public … surface") for consistency.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

Not applicable — this PR only adds a PHPDoc annotation; runtime behaviour is identical.

* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — non-user-facing PHPDoc change.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* None. PHPDoc tags are not evaluated at runtime; the filter, its default value, and consumers' ability to override it are unchanged.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. The `@internal` annotation itself is the documentation: it tells future readers and external tooling that this filter is not part of the plugin's public extension-point surface.
