### PR TITLE
perf: lazy-load AI Content Planner from the block editor

### DIFF
--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -53,7 +53,6 @@ const getEntries = ( sourceDirectory = "./packages/js/src" ) => ( {
 	workouts: `${ sourceDirectory }/workouts.js`,
 	"frontend-inspector-resources": `${ sourceDirectory }/frontend-inspector-resources.js`,
 	"ai-generator": `${ sourceDirectory }/ai-generator/initialize.js`,
-	"ai-content-planner": `${ sourceDirectory }/ai-content-planner/initialize.js`,
 	"ai-consent": `${ sourceDirectory }/ai-consent/initialize.js`,
 	plans: `${ sourceDirectory }/plans/initialize.js`,
 } );

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -1,6 +1,6 @@
 /* External dependencies */
 import { useSelect } from "@wordpress/data";
-import { Fragment } from "@wordpress/element";
+import { Fragment, lazy, Suspense } from "@wordpress/element";
 import { Fill } from "@wordpress/components";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
@@ -24,8 +24,13 @@ import { BlackFridayPromotion } from "../BlackFridayPromotion";
 import { withMetaboxWarningsCheck } from "../higherorder/withMetaboxWarningsCheck";
 import isBlockEditor from "../../helpers/isBlockEditor";
 import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
-import ContentPlannerEditorItem from "../../ai-content-planner/containers/content-planner-editor-item";
 import { EditorIntro } from "../EditorIntro";
+
+// Lazy-loaded so the planner module is not bundled into block-editor.js.
+const ContentPlannerEditorItem = lazy( () => import(
+	/* webpackChunkName: "ai-content-planner-editor" */
+	"../../ai-content-planner/containers/content-planner-editor-item"
+) );
 
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
 
@@ -77,7 +82,9 @@ export default function MetaboxFill( { settings } ) {
 					</SidebarItem>
 				) }
 				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>
-					<ContentPlannerEditorItem location="metabox" />
+					<Suspense fallback={ null }>
+						<ContentPlannerEditorItem location="metabox" />
+					</Suspense>
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -1,6 +1,6 @@
 /* External dependencies */
 import { Fill } from "@wordpress/components";
-import { Fragment } from "@wordpress/element";
+import { Fragment, lazy, Suspense } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
@@ -23,8 +23,13 @@ import WincherSEOPerformanceModal from "../../containers/WincherSEOPerformanceMo
 import KeywordUpsell from "../modals/KeywordUpsell";
 import isBlockEditor from "../../helpers/isBlockEditor";
 import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
-import ContentPlannerEditorItem from "../../ai-content-planner/containers/content-planner-editor-item";
 import { EditorIntro } from "../EditorIntro";
+
+// Lazy-loaded so the planner module is not bundled into block-editor.js.
+const ContentPlannerEditorItem = lazy( () => import(
+	/* webpackChunkName: "ai-content-planner-editor" */
+	"../../ai-content-planner/containers/content-planner-editor-item"
+) );
 
 /* eslint-disable complexity */
 /**
@@ -66,7 +71,9 @@ export default function SidebarFill( { settings } ) {
 					</EditorIntro>
 				</SidebarItem>
 				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>
-					<ContentPlannerEditorItem location="sidebar" />
+					<Suspense fallback={ null }>
+						<ContentPlannerEditorItem location="sidebar" />
+					</Suspense>
 				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -27,7 +27,6 @@ import SidebarFill from "../containers/SidebarFill";
 import WincherPostPublish from "../containers/WincherPostPublish";
 import { isAnnotationAvailable } from "../decorator/gutenberg";
 import { link } from "../inline-links/edit-link";
-import initContentPlanner from "../ai-content-planner/initialize";
 import { getIsAiFeatureEnabled } from "../redux/selectors/preferences";
 
 /**
@@ -211,7 +210,11 @@ export default function initBlockEditorIntegration( store ) {
 	registerFormats();
 	initializeAnnotations( store );
 	if ( getIsAiFeatureEnabled() ) {
-		initContentPlanner();
+		// Lazy-loaded so the planner module is not bundled into block-editor.js.
+		import(
+			/* webpackChunkName: "ai-content-planner-editor" */
+			"../ai-content-planner/initialize"
+		).then( ( { "default": initContentPlanner } ) => initContentPlanner() );
 	}
 
 	const yoastTab = getQueryArg( window.location.href, "yoast-tab" );

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -61,8 +61,6 @@ class Content_Planner_Integration implements Integration_Interface {
 	 */
 	public function register_hooks() {
 		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
-		// Enqueue after Elementor_Premium integration, which re-registers the assets.
-		\add_action( 'elementor/editor/before_enqueue_scripts', [ $this, 'enqueue_assets' ], 11 );
 	}
 
 	/**
@@ -77,12 +75,12 @@ class Content_Planner_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Localizes the content planner script data.
+	 * Localizes the content planner script data onto the block-editor bundle,
+	 * which lazy-loads the planner module on demand.
 	 *
 	 * @return void
 	 */
 	public function enqueue_assets() {
-		$this->asset_manager->enqueue_script( 'ai-content-planner' );
-		$this->asset_manager->localize_script( 'ai-content-planner', 'wpseoContentPlanner', $this->get_script_data() );
+		$this->asset_manager->localize_script( 'block-editor', 'wpseoContentPlanner', $this->get_script_data() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The 27.6 release zip crossed the 5 MB mark (5,235,914 → 5,370,411 bytes vs 27.5). Investigation traced ~95 KB compressed of that growth to the AI Content Planner module being bundled twice: statically imported into `block-editor.js` (+161 KB raw / +28 KB gzipped) **and** shipped as a separate standalone `ai-content-planner.js` entry (~177 KB raw / 54 KB gzipped).
* The standalone bundle's `initialize.js` only exports `initContentPlanner()` and never invokes it — so on Elementor and classic-editor pages, where the standalone bundle was the only enqueue path, the planner UI never actually mounted. The bundle was effectively dead weight. The Block Editor flow worked because `block-editor-integration.js` separately calls `initContentPlanner()`.
* This PR splits the planner into a lazy-loaded chunk under a single `webpackChunkName`, removes the redundant standalone entry, and rewires the PHP integration to localize `wpseoContentPlanner` onto the block-editor handle.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
-->
This PR can be summarized in the following changelog entry:

* Improves block editor load time by lazy-loading the AI Content Planner module on demand.

## Relevant technical choices:

* `block-editor-integration.js` now uses dynamic `import()` to load `ai-content-planner/initialize` only when `getIsAiFeatureEnabled()` is true; both fills (`SidebarFill.js`, `MetaboxFill.js`) use `React.lazy` + `Suspense` for `ContentPlannerEditorItem`. All three call sites share the same `webpackChunkName: "ai-content-planner-editor"` so webpack emits a single async chunk.
* Dynamic `import()`, `React.lazy` and `Suspense` are first-uses in this codebase. Webpack 5's `output.publicPath: "auto"` resolves the chunk URL from `document.currentScript.src` at runtime, which matches our `/wp-content/plugins/wordpress-seo/js/dist/` layout.
* The standalone `ai-content-planner` webpack entry is dropped from `config/webpack/paths.js`. The script handle disappears from the regenerated `src/generated/assets/plugin.php` automatically (the asset manager auto-registers from that manifest).
* `Content_Planner_Integration::enqueue_assets` now localizes `wpseoContentPlanner` onto the `block-editor` handle (which lazy-loads the planner). The `elementor/editor/before_enqueue_scripts` hook is removed: it was only enqueuing the dead-weight bundle. If/when the planner is wanted in Elementor, the right pattern is the AI generator one — a `domReady(() => init…())` self-bootstrap inside `initialize.js` plus an Elementor mount path inside the React tree.
* Net `js/dist/` size delta vs 27.6 (gzip-9, summed across all files): **-25.8 KiB**. `block-editor.js` raw: 368 KB → 264 KB (-104 KB raw / -28 KB gzipped). The new async chunk is ~91 KB raw / 23 KB gzipped, plus a small ~6 KB shared helper.
* No new unit tests added: the PHP change is a 3-line refactor with no new logic, and the JS changes are pure wiring (replacing static imports with dynamic equivalents, no new branches to cover). All 4973 PHPUnit tests and 1380 Jest tests pass locally.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Check out this branch and run a production build (`yarn build` or `grunt build`).
2. Verify `js/dist/ai-content-planner.js` no longer exists, but `js/dist/ai-content-planner-editor.js` does (along with a small numbered chunk like `833.js`).
3. In a WordPress install with Yoast SEO active **and the AI features enabled**, open a Post in the Block Editor.
4. Open the browser DevTools Network tab and reload. Confirm `block-editor.js` loads, then `ai-content-planner-editor.js` is fetched on demand shortly after (deferred chunk).
5. Open the Yoast sidebar — the Content Planner item should appear and behave exactly as on 27.6: open the modal, generate suggestions, generate an outline, and verify the Content Planner Banner block is auto-inserted on a new post.
6. Disable the AI feature (Yoast → Settings) and reload a post. Confirm `block-editor.js` loads but `ai-content-planner-editor.js` is **not** fetched.
7. Open the same post in Elementor. Confirm the planner UI is absent (same as on 27.6) and that no `ai-content-planner*.js` file is requested.
8. Open the same post in the Classic Editor. Same expectation as Elementor.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
* Console: watch for chunk-loading errors (`ChunkLoadError`, 404 on `ai-content-planner-editor.js`, etc.) — this is the first use of webpack code-splitting in the plugin.
* Editors: the most important coverage is the Block Editor (planner runs there). Elementor and Classic editor are covered to confirm the previously-shipped-but-non-functional bundle is no longer loaded — a regression here would be the planner UI failing to appear in Block Editor, or appearing where it didn't before.
* Browsers: dynamic `import()` is supported across all browsers we already target, but a quick sanity check on Chrome / Firefox / Safari is worthwhile because this is a new pattern in our build.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Block Editor integration (`packages/js/src/initializers/block-editor-integration.js` and its sidebar/metabox fills) — the AI Content Planner UI is now loaded asynchronously instead of synchronously.
* `WPSEO_Admin_Asset_Manager`'s registered script handles — the `ai-content-planner` handle is removed (auto, via the regenerated `src/generated/assets/plugin.php` manifest).
* `Content_Planner_Integration::enqueue_assets` — now localizes onto `block-editor` instead of `ai-content-planner`. Behaviour in the Block Editor is unchanged; behaviour in Elementor / classic-editor changes from "ship 177 KB of dead-weight JS" to "ship nothing", which is what was already happening at the user-experience level (no UI ever mounted there).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #

---

**Local checks status (run before opening this PR):**

* `composer check-branch-cs` ✅ (1 file checked, no errors)
* `composer lint-branch` ✅ (1 file checked, no syntax errors)
* `composer test` ✅ (4973 tests, 26234 assertions, all pass)
* `yarn lint` ✅ in `packages/js` (3 errors / 43 warnings — same as trunk baseline; **no new errors or warnings introduced**)
* `yarn test` ✅ in `packages/js` (1380 tests across 155 suites, all pass)
* `composer test-wp-env` ⚠️ **not run** (requires Docker `wp-env`, not available in this environment) — disclosed for QA awareness
* Manual smoke test in a real WordPress install ⚠️ **not run** — the lazy-load path uses `import()` / `React.lazy` for the first time in this codebase. CI plus QA acceptance testing should validate chunk-loading in Block Editor / Elementor / Classic editor before merge.