### PR TITLE
Add loading skeleton rows to Outline modal structure section

### DIFF
--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -8,12 +8,12 @@ import { ContentPlannerError } from "./content-planner-error";
 import classNames from "classnames";
 import { IntentCallout } from "./intent-callout";
 import { StructureRow, StructureRowSkeleton } from "./structure-row";
-
-const SKELETON_ROW_COUNT = 4;
 import { CategorySection } from "./category-section";
 import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { useDraggableStructure, useFetchContentOutline } from "../hooks";
 import { Transition } from "@headlessui/react";
+
+const SKELETON_ROW_COUNT = 4;
 
 /**
  * @typedef {import( "../constants" ).Suggestion} Suggestion

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -16,6 +16,22 @@ import { Transition } from "@headlessui/react";
 const SKELETON_ROW_COUNT = 4;
 
 /**
+ * Section header for the Blog post structure list, shared by the loading and loaded states.
+ *
+ * @returns {JSX.Element} The StructureSectionHeader component.
+ */
+const StructureSectionHeader = () => (
+	<div className="yst-flex yst-items-end yst-justify-between" style={ { marginBottom: "-16px" } }>
+		<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+			{ __( "Blog post structure", "wordpress-seo" ) }
+		</span>
+		<span className="yst-text-xs yst-text-slate-500">
+			{ __( "Drag to reorder", "wordpress-seo" ) }
+		</span>
+	</div>
+);
+
+/**
  * @typedef {import( "../constants" ).Suggestion} Suggestion
  */
 
@@ -91,18 +107,11 @@ const LoadingOutlineModalContent = () => {
 				<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
 			</div>
 			<hr className="yst-border-slate-200" />
-			<div className="yst-flex yst-items-end yst-justify-between" style={ { marginBottom: "-16px" } }>
-				<span className="yst-font-medium yst-text-sm yst-text-slate-800">
-					{ __( "Blog post structure", "wordpress-seo" ) }
-				</span>
-				<span className="yst-text-xs yst-text-slate-500">
-					{ __( "Drag to reorder", "wordpress-seo" ) }
-				</span>
-			</div>
+			<StructureSectionHeader />
 			<div
 				role="listbox"
 				aria-label={ __( "Blog post structure", "wordpress-seo" ) }
-				aria-busy="true"
+				aria-busy={ true }
 				className="yst-flex yst-flex-col yst-gap-2"
 			>
 				{ Array.from( { length: SKELETON_ROW_COUNT } ).map( ( _, index ) => (
@@ -286,14 +295,7 @@ export const OutlineModalContent = ( {
 								</div>
 							</div>
 							<hr className="yst-border-slate-200" />
-							<div className="yst-flex yst-items-end yst-justify-between" style={ { marginBottom: "-16px" } }>
-								<span className="yst-font-medium yst-text-sm yst-text-slate-800">
-									{ __( "Blog post structure", "wordpress-seo" ) }
-								</span>
-								<span className="yst-text-xs yst-text-slate-500">
-									{ __( "Drag to reorder", "wordpress-seo" ) }
-								</span>
-							</div>
+							<StructureSectionHeader />
 							<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) } className="yst-flex yst-flex-col yst-gap-2">
 								{ structure.map( ( item, index ) => (
 									<StructureRow

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -12,8 +12,7 @@ import { CategorySection } from "./category-section";
 import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { useDraggableStructure, useFetchContentOutline } from "../hooks";
 import { Transition } from "@headlessui/react";
-
-const SKELETON_ROW_COUNT = 4;
+import { SKELETON_ROW_COUNT } from "../constants";
 
 /**
  * Section header for the Blog post structure list, shared by the loading and loaded states.
@@ -21,7 +20,7 @@ const SKELETON_ROW_COUNT = 4;
  * @returns {JSX.Element} The StructureSectionHeader component.
  */
 const StructureSectionHeader = () => (
-	<div className="yst-flex yst-items-end yst-justify-between" style={ { marginBottom: "-16px" } }>
+	<div className="yst-flex yst-items-end yst-justify-between yst-mb-2">
 		<span className="yst-font-medium yst-text-sm yst-text-slate-800">
 			{ __( "Blog post structure", "wordpress-seo" ) }
 		</span>
@@ -100,13 +99,13 @@ const LoadingOutlineModalContent = () => {
 		<CategorySection
 			isLoading={ true }
 		/>
-		<div className="yst-flex yst-flex-col yst-gap-6">
+		<div className="yst-flex yst-flex-col">
 			<div className="yst-flex yst-flex-col yst-gap-4">
 				<SkeletonFormField label={ __( "Focus Keyphrase", "wordpress-seo" ) } />
 				<SkeletonFormField label={ __( "Title", "wordpress-seo" ) } />
 				<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
 			</div>
-			<hr className="yst-border-slate-200" />
+			<hr className="yst-border-slate-200 yst-my-6" />
 			<StructureSectionHeader />
 			<div
 				role="listbox"
@@ -263,7 +262,7 @@ export const OutlineModalContent = ( {
 								onToggle={ handleCategoryToggle }
 							/>
 						) }
-						<div className="yst-flex yst-flex-col yst-gap-6">
+						<div className="yst-flex yst-flex-col">
 							<div className="yst-flex yst-flex-col yst-gap-4">
 								<TextField
 									id="content-outline-focus-keyphrase"
@@ -294,7 +293,7 @@ export const OutlineModalContent = ( {
 
 								</div>
 							</div>
-							<hr className="yst-border-slate-200" />
+							<hr className="yst-border-slate-200 yst-my-6" />
 							<StructureSectionHeader />
 							<div role="listbox" aria-label={ __( "Blog post structure", "wordpress-seo" ) } className="yst-flex yst-flex-col yst-gap-2">
 								{ structure.map( ( item, index ) => (

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -7,7 +7,9 @@ import { getDescriptionProgress, getProgressColor } from "@yoast/search-metadata
 import { ContentPlannerError } from "./content-planner-error";
 import classNames from "classnames";
 import { IntentCallout } from "./intent-callout";
-import { StructureRow } from "./structure-row";
+import { StructureRow, StructureRowSkeleton } from "./structure-row";
+
+const SKELETON_ROW_COUNT = 4;
 import { CategorySection } from "./category-section";
 import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { useDraggableStructure, useFetchContentOutline } from "../hooks";
@@ -82,10 +84,31 @@ const LoadingOutlineModalContent = () => {
 		<CategorySection
 			isLoading={ true }
 		/>
-		<div className="yst-flex yst-flex-col yst-gap-4">
-			<SkeletonFormField label={ __( "Focus Keyphrase", "wordpress-seo" ) } />
-			<SkeletonFormField label={ __( "Title", "wordpress-seo" ) } />
-			<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
+		<div className="yst-flex yst-flex-col yst-gap-6">
+			<div className="yst-flex yst-flex-col yst-gap-4">
+				<SkeletonFormField label={ __( "Focus Keyphrase", "wordpress-seo" ) } />
+				<SkeletonFormField label={ __( "Title", "wordpress-seo" ) } />
+				<SkeletonFormField label={ __( "Meta description", "wordpress-seo" ) } multiline={ true } />
+			</div>
+			<hr className="yst-border-slate-200" />
+			<div className="yst-flex yst-items-end yst-justify-between" style={ { marginBottom: "-16px" } }>
+				<span className="yst-font-medium yst-text-sm yst-text-slate-800">
+					{ __( "Blog post structure", "wordpress-seo" ) }
+				</span>
+				<span className="yst-text-xs yst-text-slate-500">
+					{ __( "Drag to reorder", "wordpress-seo" ) }
+				</span>
+			</div>
+			<div
+				role="listbox"
+				aria-label={ __( "Blog post structure", "wordpress-seo" ) }
+				aria-busy="true"
+				className="yst-flex yst-flex-col yst-gap-2"
+			>
+				{ Array.from( { length: SKELETON_ROW_COUNT } ).map( ( _, index ) => (
+					<StructureRowSkeleton key={ `structure-row-skeleton-${ index }` } />
+				) ) }
+			</div>
 		</div>
 	</>;
 };

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -316,7 +316,7 @@ export const OutlineModalContent = ( {
 									className={ classNames(
 										"yst-rounded-md yst-transition-all yst-border-2",
 										dragOverIndex === structure.length
-											? "yst-border-primary-500 yst-h-8"
+											? "yst-border-primary-500 yst-h-10"
 											: "yst-border-transparent yst-h-2"
 									) }
 									onDragOver={ handleSentinelDragOver }

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -1,7 +1,20 @@
-import { useSvgAria } from "@yoast/ui-library";
+import { SkeletonLoader, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
 import classNames from "classnames";
+
+const ROW_CONTAINER_CLASSES = "yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-select-none";
+
+const GripIcon = ( { svgAriaProps } ) => (
+	<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" { ...svgAriaProps }>
+		<circle cx="2" cy="2" r="1.5" />
+		<circle cx="8" cy="2" r="1.5" />
+		<circle cx="2" cy="8" r="1.5" />
+		<circle cx="8" cy="8" r="1.5" />
+		<circle cx="2" cy="14" r="1.5" />
+		<circle cx="8" cy="14" r="1.5" />
+	</svg>
+);
 
 /**
  * A single draggable row in the blog post structure list.
@@ -45,7 +58,8 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		aria-roledescription={ __( "Draggable section", "wordpress-seo" ) }
 		tabIndex="0"
 		className={ classNames(
-			"yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-cursor-grab yst-select-none yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
+			ROW_CONTAINER_CLASSES,
+			"yst-cursor-grab yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
 			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
 		) }
 		draggable="true"
@@ -55,18 +69,28 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		onDragEnd={ onDragEnd }
 		onKeyDown={ handleKeyDown }
 	>
-		{ /* Drag handle icon (6-dot grip) */ }
-		<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" { ...svgAriaProps }>
-			<circle cx="2" cy="2" r="1.5" />
-			<circle cx="8" cy="2" r="1.5" />
-			<circle cx="2" cy="8" r="1.5" />
-			<circle cx="8" cy="8" r="1.5" />
-			<circle cx="2" cy="14" r="1.5" />
-			<circle cx="8" cy="14" r="1.5" />
-		</svg>
+		{ /* Drag handle icon (6-dot grip). */ }
+		<GripIcon svgAriaProps={ svgAriaProps } />
 		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0 yst-text-sm">
 			<span className="yst-font-medium yst-text-slate-500 yst-shrink-0">H2</span>
 			<span className="yst-text-slate-600">{ heading }</span>
+		</div>
+	</div> );
+};
+
+/**
+ * Loading placeholder mirroring the StructureRow layout.
+ *
+ * @returns {JSX.Element} The StructureRowSkeleton component.
+ */
+export const StructureRowSkeleton = () => {
+	const svgAriaProps = useSvgAria();
+
+	return ( <div className={ ROW_CONTAINER_CLASSES } aria-hidden="true">
+		<GripIcon svgAriaProps={ svgAriaProps } />
+		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0 yst-text-sm">
+			<SkeletonLoader className="yst-h-4 yst-w-5 yst-rounded yst-shrink-0" />
+			<SkeletonLoader className="yst-h-4 yst-w-32 yst-rounded" />
 		</div>
 	</div> );
 };

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -17,7 +17,7 @@ export const Row = ( { children, className, ...props } ) => {
 
 	return ( <div
 		className={ classNames(
-			"yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-select-none",
+			"yst-h-10 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-select-none",
 			className
 		) }
 		{ ...props }

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -3,18 +3,44 @@ import { __ } from "@wordpress/i18n";
 import { useCallback } from "@wordpress/element";
 import classNames from "classnames";
 
-const ROW_CONTAINER_CLASSES = "yst-bg-slate-50 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-select-none";
+/**
+ * Base row layout shared by StructureRow and StructureRowSkeleton.
+ *
+ * @param {Object}    props           The component props.
+ * @param {ReactNode} props.children  The content to display inside the row.
+ * @param {string}    props.className Additional class names for styling.
+ *
+ * @returns {JSX.Element} The Row component.
+ */
+export const Row = ( { children, className, ...props } ) => {
+	const svgAriaProps = useSvgAria();
 
-const GripIcon = ( { svgAriaProps } ) => (
-	<svg className="yst-w-2.5 yst-h-4 yst-text-slate-400 yst-shrink-0" viewBox="0 0 10 16" fill="currentColor" { ...svgAriaProps }>
-		<circle cx="2" cy="2" r="1.5" />
-		<circle cx="8" cy="2" r="1.5" />
-		<circle cx="2" cy="8" r="1.5" />
-		<circle cx="8" cy="8" r="1.5" />
-		<circle cx="2" cy="14" r="1.5" />
-		<circle cx="8" cy="14" r="1.5" />
-	</svg>
-);
+	return ( <div
+		className={ classNames(
+			"yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-py-2 yst-select-none",
+			className
+		) }
+		{ ...props }
+	>
+		{ /* Drag handle icon (6-dot grip). */ }
+		<svg
+			className="yst-w-2.5 yst-h-4 yst-shrink-0"
+			viewBox="0 0 10 16"
+			fill="currentColor"
+			{ ...svgAriaProps }
+		>
+			<circle cx="2" cy="2" r="1.5" />
+			<circle cx="8" cy="2" r="1.5" />
+			<circle cx="2" cy="8" r="1.5" />
+			<circle cx="8" cy="8" r="1.5" />
+			<circle cx="2" cy="14" r="1.5" />
+			<circle cx="8" cy="14" r="1.5" />
+		</svg>
+		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0">
+			{ children }
+		</div>
+	</div> );
+};
 
 /**
  * A single draggable row in the blog post structure list.
@@ -33,7 +59,6 @@ const GripIcon = ( { svgAriaProps } ) => (
  * @returns {JSX.Element} The StructureRow component.
  */
 export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDragOver, onDrop, onDragEnd, onMoveUp, onMoveDown, totalItems } ) => {
-	const svgAriaProps = useSvgAria();
 	const handleDragStart = useCallback( ( e ) => onDragStart( e, index ), [ onDragStart, index ] );
 	const handleDragOver = useCallback( ( e ) => onDragOver( e, index ), [ onDragOver, index ] );
 	const handleDrop = useCallback( ( e ) => onDrop( e, index ), [ onDrop, index ] );
@@ -51,15 +76,14 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		}
 	}, [ index, totalItems, onMoveUp, onMoveDown ] );
 
-	return ( <div
+	return ( <Row
 		role="option"
 		aria-selected="false"
 		aria-label={ `H2 ${ heading }` }
 		aria-roledescription={ __( "Draggable section", "wordpress-seo" ) }
 		tabIndex="0"
 		className={ classNames(
-			ROW_CONTAINER_CLASSES,
-			"yst-cursor-grab yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
+			"yst-bg-slate-50 yst-text-slate-400 yst-text-sm yst-cursor-grab yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
 			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
 		) }
 		draggable="true"
@@ -69,13 +93,9 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		onDragEnd={ onDragEnd }
 		onKeyDown={ handleKeyDown }
 	>
-		{ /* Drag handle icon (6-dot grip). */ }
-		<GripIcon svgAriaProps={ svgAriaProps } />
-		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0 yst-text-sm">
-			<span className="yst-font-medium yst-text-slate-500 yst-shrink-0">H2</span>
-			<span className="yst-text-slate-600">{ heading }</span>
-		</div>
-	</div> );
+		<span className="yst-font-medium yst-text-slate-500">H2</span>
+		<span className="yst-text-slate-600">{ heading }</span>
+	</Row> );
 };
 
 /**
@@ -84,13 +104,11 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
  * @returns {JSX.Element} The StructureRowSkeleton component.
  */
 export const StructureRowSkeleton = () => {
-	const svgAriaProps = useSvgAria();
-
-	return ( <div className={ ROW_CONTAINER_CLASSES } aria-hidden="true">
-		<GripIcon svgAriaProps={ svgAriaProps } />
-		<div className="yst-flex yst-items-center yst-gap-3 yst-flex-1 yst-min-w-0 yst-text-sm">
-			<SkeletonLoader className="yst-h-4 yst-w-5 yst-rounded yst-shrink-0" />
-			<SkeletonLoader className="yst-h-4 yst-w-32 yst-rounded" />
-		</div>
-	</div> );
+	return ( <Row
+		aria-hidden="true"
+		className="yst-bg-white yst-text-slate-300"
+	>
+		<SkeletonLoader className="yst-h-3.5 yst-w-5 yst-rounded yst-shrink-0" />
+		<SkeletonLoader className="yst-h-3.5 yst-w-32 yst-rounded" />
+	</Row> );
 };

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -17,7 +17,7 @@ export const Row = ( { children, className, ...props } ) => {
 
 	return ( <div
 		className={ classNames(
-			"yst-h-10 yst-border yst-border-slate-300 yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-select-none",
+			"yst-h-10 yst-border yst-rounded-md yst-shadow yst-flex yst-items-center yst-gap-3 yst-px-3 yst-select-none",
 			className
 		) }
 		{ ...props }
@@ -83,7 +83,7 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 		aria-roledescription={ __( "Draggable section", "wordpress-seo" ) }
 		tabIndex="0"
 		className={ classNames(
-			"yst-bg-slate-50 yst-text-slate-400 yst-text-sm yst-cursor-grab yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
+			"yst-bg-slate-50 yst-text-slate-400 yst-border-slate-300 yst-text-sm yst-cursor-grab yst-transition-all focus:yst-outline focus:yst-outline-2 focus:yst-outline-offset-2 focus:yst-outline-primary-500",
 			dragOverIndex === index && "yst-border-primary-500 yst-border-2"
 		) }
 		draggable="true"
@@ -106,7 +106,7 @@ export const StructureRow = ( { heading, index, dragOverIndex, onDragStart, onDr
 export const StructureRowSkeleton = () => {
 	return ( <Row
 		aria-hidden="true"
-		className="yst-bg-white yst-text-slate-300"
+		className="yst-bg-white yst-text-slate-300 yst-border-slate-200"
 	>
 		<SkeletonLoader className="yst-h-3.5 yst-w-5 yst-rounded yst-shrink-0" />
 		<SkeletonLoader className="yst-h-3.5 yst-w-32 yst-rounded" />

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -23,6 +23,8 @@ export const ERROR_DEFAULT = {
 	errorMessage: null,
 };
 
+export const SKELETON_ROW_COUNT = 4;
+
 /**
  * The category type for a content suggestion.
  * @typedef {Object} Category

--- a/packages/js/tests/ai-content-planner/components/outline-modal-content.test.js
+++ b/packages/js/tests/ai-content-planner/components/outline-modal-content.test.js
@@ -4,6 +4,7 @@ import { OutlineModalContent } from "../../../src/ai-content-planner/components/
 import { ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
 import { getDescriptionProgress, getProgressColor } from "@yoast/search-metadata-previews";
 import { useFetchContentOutline } from "../../../src/ai-content-planner/hooks";
+import { SKELETON_ROW_COUNT } from "../../../src/ai-content-planner/constants";
 
 jest.mock( "@wordpress/data", () => ( {
 	useSelect: jest.fn( () => false ),
@@ -234,7 +235,7 @@ describe( "ContentOutlineModal", () => {
 			expect( listbox ).toHaveAttribute( "aria-busy", "true" );
 			// Skeleton rows are aria-hidden placeholders, so they are not exposed as options.
 			expect( screen.queryAllByRole( "option" ) ).toHaveLength( 0 );
-			expect( listbox.children ).toHaveLength( 4 );
+			expect( listbox.children ).toHaveLength( SKELETON_ROW_COUNT );
 		} );
 
 		it( "still shows the intent callout when loading", () => {

--- a/packages/js/tests/ai-content-planner/components/outline-modal-content.test.js
+++ b/packages/js/tests/ai-content-planner/components/outline-modal-content.test.js
@@ -102,12 +102,14 @@ describe( "ContentOutlineModal", () => {
 	} );
 
 	describe( "accessibility", () => {
-		it( "does not show the structure section when loading", () => {
+		it( "exposes the structure listbox as busy while loading", () => {
 			renderModal();
 			act( () => {
 				jest.advanceTimersByTime( 100 );
 			} );
-			expect( screen.queryByRole( "listbox" ) ).not.toBeInTheDocument();
+			const listbox = screen.getByRole( "listbox", { name: "Blog post structure" } );
+			expect( listbox ).toHaveAttribute( "aria-busy", "true" );
+			expect( screen.queryAllByRole( "option" ) ).toHaveLength( 0 );
 		} );
 
 		it( "renders the intent callout with role='note'", () => {
@@ -214,13 +216,25 @@ describe( "ContentOutlineModal", () => {
 			expect( screen.queryByDisplayValue( defaultSuggestion.meta_description ) ).not.toBeInTheDocument();
 		} );
 
-		it( "does not show the blog post structure section when loading", () => {
+		it( "shows the blog post structure section header when loading", () => {
 			renderModal();
 			act( () => {
 				jest.advanceTimersByTime( 100 );
 			} );
-			expect( screen.queryByText( "Blog post structure" ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( "Drag to reorder" ) ).not.toBeInTheDocument();
+			expect( screen.getByText( "Blog post structure" ) ).toBeInTheDocument();
+			expect( screen.getByText( "Drag to reorder" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders four skeleton structure rows when loading", () => {
+			renderModal();
+			act( () => {
+				jest.advanceTimersByTime( 100 );
+			} );
+			const listbox = screen.getByRole( "listbox", { name: "Blog post structure" } );
+			expect( listbox ).toHaveAttribute( "aria-busy", "true" );
+			// Skeleton rows are aria-hidden placeholders, so they are not exposed as options.
+			expect( screen.queryAllByRole( "option" ) ).toHaveLength( 0 );
+			expect( listbox.children ).toHaveLength( 4 );
 		} );
 
 		it( "still shows the intent callout when loading", () => {


### PR DESCRIPTION
## Context

While the Content Planner outline modal is fetching its content outline from the API, the **Blog post structure** section was hidden entirely until the response arrived. This PR adds a loading skeleton placeholder for the heading rows so the section is visible from the start of the request, matching the [design](https://www.figma.com/design/LiVR1UxC5qd06GSdm7zTrW/Content-suggestions?node-id=1394-4126&t=woUJLRADF5FbubeC-4). There are two small differences with the design (see this 🧵 [thread](https://yoast.slack.com/archives/C03KU0EHCNQ/p1777461622564069)): 
* The with of the text skeleton per row is 128px (not 120px)
* The skeletons has 4 rows (instead of 7) 


## Summary

- Adds a loading skeleton for the blog post structure rows in the Content Planner outline modal.

## Relevant technical choices

- A new `StructureRowSkeleton` component is co-located with `StructureRow` so the two stay visually in sync; both share an extracted `ROW_CONTAINER_CLASSES` constant and a `GripIcon` helper.
- The skeleton row uses two `SkeletonLoader` blocks (one for the H2 badge, one for the heading text) inside the same row container, with the wrapper marked `aria-hidden="true"`.
- The list container in the loading state is rendered as `role="listbox"` with `aria-busy="true"`, exposing the loading state to assistive tech without producing per-row option announcements.
- Existing accessibility tests that asserted the structure section was absent during loading were flipped; new tests cover the busy listbox, the absence of real `option` rows, and the four skeleton children.

## Test instructions for the acceptance test before the PR gets merged

1. Open a post or add a new on in the Block editor.
2. Open the Yoast SEO Content Planner.
3. Pick a content suggestion and open the Outline modal.
4. While the request is being made, verify the **Blog post structure** section is visible with four loading skeleton rows underneath the form-field skeletons.
5. Once the response loads, the skeleton rows are replaced by real H2 rows without a layout jump.
6. To hold the loading state for a longer visual check: open DevTools → Network → block the outline request URL (right-click the request → "Block request URL"), then reopen the modal.

## Relevant test scenarios

- [x] Changes should be tested with the browser console open
- [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
- [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
- [x] Changes should be tested on different browsers
- [ ] Changes should be tested on multisite

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- AI Content Planner — Outline modal loading state.

## Other environments

- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [x] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation

- [ ] No innovation project is applicable for this PR.
- [x] This PR falls under an innovation project. I have attached the innovation label.
- [x] I have added my hours to the WBSO document.

Fixes[ #1189](https://github.com/Yoast/reserved-tasks/issues/1189)