### PR TITLE
Show Subscription required error in Content Planner without licence

### DIFF
--- a/packages/js/src/ai-content-planner/components/content-planner-error.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-error.js
@@ -1,4 +1,5 @@
 /* eslint-disable complexity */
+import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { Button, useModalContext } from "@yoast/ui-library";
 import { noop } from "lodash";
@@ -7,6 +8,7 @@ import {
 	BadWPRequestAlert,
 	GenericAlert,
 	RateLimitAlert,
+	SubscriptionError,
 	TimeoutAlert,
 } from "../../ai-generator/components/errors";
 import { SiteUnreachableAlert } from "../../ai-generator/components/errors/site-unreachable-alert";
@@ -15,6 +17,7 @@ import { SiteUnreachableAlert } from "../../ai-generator/components/errors/site-
  * @param {number} errorCode The error code.
  * @param {string} [errorIdentifier=""] The error identifier.
  * @param {string} [errorMessage=""] The error message.
+ * @param {string[]} [missingLicenses=[]] Products with an invalid subscription.
  * @param {function} [onRetry=noop] Called to retry.
  * @returns {JSX.Element} The element.
  */
@@ -22,9 +25,17 @@ export const ContentPlannerError = ( {
 	errorCode,
 	errorIdentifier = "",
 	errorMessage = "",
+	missingLicenses = [],
 	onRetry = noop,
 } ) => {
 	const { onClose } = useModalContext();
+	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
+
+	// Premium installed but licence missing/expired: surface the renew/activate flow.
+	// Free-only sites are handled earlier by the Approve modal upsell, so they fall through to the generic alert here.
+	if ( errorCode === 402 && isPremium ) {
+		return <SubscriptionError invalidSubscriptions={ missingLicenses } />;
+	}
 
 	let alert;
 	switch ( errorCode ) {
@@ -69,5 +80,6 @@ ContentPlannerError.propTypes = {
 	errorCode: PropTypes.number.isRequired,
 	errorIdentifier: PropTypes.string,
 	errorMessage: PropTypes.string,
+	missingLicenses: PropTypes.arrayOf( PropTypes.string ),
 	onRetry: PropTypes.func,
 };

--- a/packages/js/src/ai-content-planner/components/content-planner-error.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-error.js
@@ -32,8 +32,15 @@ export const ContentPlannerError = ( {
 	const isPremium = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsPremium(), [] );
 
 	// Premium installed but licence missing/expired: surface the renew/activate flow.
-	// Free-only sites are handled earlier by the Approve modal upsell, so they fall through to the generic alert here.
-	if ( errorCode === 402 && isPremium ) {
+	// The backend returns 402 when the licence is invalid, and 429 with USAGE_LIMIT_REACHED
+	// once a no-licence Premium user exhausts the free sparks (Too_Many_Requests_Exception
+	// extends Payment_Required_Exception in the PHP layer).
+	// Free-only sites are handled earlier by the Approve modal upsell, so they fall through here.
+	const isSubscriptionRequired = isPremium && (
+		errorCode === 402 ||
+		( errorCode === 429 && errorIdentifier === "USAGE_LIMIT_REACHED" )
+	);
+	if ( isSubscriptionRequired ) {
 		return <SubscriptionError invalidSubscriptions={ missingLicenses } />;
 	}
 

--- a/packages/js/src/ai-content-planner/components/content-planner-error.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-error.js
@@ -41,7 +41,10 @@ export const ContentPlannerError = ( {
 		( errorCode === 429 && errorIdentifier === "USAGE_LIMIT_REACHED" )
 	);
 	if ( isSubscriptionRequired ) {
-		return <SubscriptionError invalidSubscriptions={ missingLicenses } />;
+		// If the backend response has no `missingLicenses` we fall back to "Yoast SEO Premium" so the alert
+		// always renders with a product name, instead of "active undefined subscription".
+		const invalidSubscriptions = missingLicenses.length > 0 ? missingLicenses : [ "Yoast SEO Premium" ];
+		return <SubscriptionError invalidSubscriptions={ invalidSubscriptions } />;
 	}
 
 	let alert;

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -183,6 +183,7 @@ export const OutlineModalContent = ( {
 					errorCode={ error.errorCode }
 					errorIdentifier={ error.errorIdentifier }
 					errorMessage={ error.errorMessage }
+					missingLicenses={ error.missingLicenses }
 					onRetry={ handleRetry }
 				/>
 			</Modal.Container.Content>

--- a/packages/js/src/ai-content-planner/components/suggestions-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/suggestions-modal-content.js
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import { Modal, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
@@ -134,10 +133,10 @@ export const SuggestionsModalContent = ( {
 					<SuggestionsList suggestions={ suggestions } onSuggestionClick={ onSuggestionClick } />
 				</Transition>
 				{ status === ASYNC_ACTION_STATUS.error && <ContentPlannerError
-					errorCode={ error?.errorCode }
-					errorIdentifier={ error?.errorIdentifier }
-					errorMessage={ error?.errorMessage }
-					missingLicenses={ error?.missingLicenses }
+					errorCode={ error.errorCode }
+					errorIdentifier={ error.errorIdentifier }
+					errorMessage={ error.errorMessage }
+					missingLicenses={ error.missingLicenses }
 					onRetry={ fetchContentSuggestions }
 				/> }
 			</div>

--- a/packages/js/src/ai-content-planner/components/suggestions-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/suggestions-modal-content.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Modal, useSvgAria } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as Yoast } from "../../../images/yoast.svg";
@@ -136,6 +137,7 @@ export const SuggestionsModalContent = ( {
 					errorCode={ error?.errorCode }
 					errorIdentifier={ error?.errorIdentifier }
 					errorMessage={ error?.errorMessage }
+					missingLicenses={ error?.missingLicenses }
 					onRetry={ fetchContentSuggestions }
 				/> }
 			</div>

--- a/packages/js/src/ai-content-planner/constants.js
+++ b/packages/js/src/ai-content-planner/constants.js
@@ -21,6 +21,7 @@ export const ERROR_DEFAULT = {
 	errorCode: null,
 	errorIdentifier: null,
 	errorMessage: null,
+	missingLicenses: [],
 };
 
 /**

--- a/packages/js/src/ai-content-planner/containers/approve-modal.js
+++ b/packages/js/src/ai-content-planner/containers/approve-modal.js
@@ -20,9 +20,9 @@ export default compose( [
 			isPremium,
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
 			learnMoreLink: selectLink( "https://yoa.st/content-planner-learn-more" ),
-			// Premium-installed users with an invalid licence should fall through to the
-			// API call so the 402 response surfaces a "Subscription required" error, rather
-			// than the "Unlock with Premium" upsell intended for free-only users.
+			// Premium-installed users with an invalid licence should continue through the
+			// suggestions flow so the "Subscription required" syntethetic 402 UI error is shown,
+			// rather than the "Unlock with Premium" upsell intended for free-only users.
 			isUpsell: isUsageCountLimitReached() && ! hasValidPremiumSubscription && ! isPremium,
 		};
 	} ),

--- a/packages/js/src/ai-content-planner/containers/approve-modal.js
+++ b/packages/js/src/ai-content-planner/containers/approve-modal.js
@@ -13,13 +13,17 @@ export default compose( [
 
 		const { isUsageCountLimitReached, selectPremiumSubscription } = select( STORE_NAME_AI );
 		const hasValidPremiumSubscription = selectPremiumSubscription();
+		const isPremium = getIsPremium();
 		return {
 			isEmptyPost: count( content, "words", {} ) === 0,
 			isOpen: selectFeatureModalStatus() === FEATURE_MODAL_STATUS.idle,
-			isPremium: getIsPremium(),
+			isPremium,
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
 			learnMoreLink: selectLink( "https://yoa.st/content-planner-learn-more" ),
-			isUpsell: isUsageCountLimitReached() && ! hasValidPremiumSubscription,
+			// Premium-installed users with an invalid licence should fall through to the
+			// API call so the 402 response surfaces a "Subscription required" error, rather
+			// than the "Unlock with Premium" upsell intended for free-only users.
+			isUpsell: isUsageCountLimitReached() && ! hasValidPremiumSubscription && ! isPremium,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {

--- a/packages/js/src/ai-content-planner/containers/approve-modal.js
+++ b/packages/js/src/ai-content-planner/containers/approve-modal.js
@@ -21,7 +21,7 @@ export default compose( [
 			upsellLink: selectLink( "https://yoa.st/content-planner-approve-modal" ),
 			learnMoreLink: selectLink( "https://yoa.st/content-planner-learn-more" ),
 			// Premium-installed users with an invalid licence should continue through the
-			// suggestions flow so the "Subscription required" syntethetic 402 UI error is shown,
+			// suggestions flow so the "Subscription required" synthetic 402 UI error is shown,
 			// rather than the "Unlock with Premium" upsell intended for free-only users.
 			isUpsell: isUsageCountLimitReached() && ! hasValidPremiumSubscription && ! isPremium,
 		};

--- a/packages/js/src/ai-content-planner/helpers/fetch.js
+++ b/packages/js/src/ai-content-planner/helpers/fetch.js
@@ -51,6 +51,7 @@ async function buildHttpError( error ) {
 		errorCode: error.status || 502,
 		errorIdentifier: body.errorIdentifier || body.code || "",
 		errorMessage: body.message || "",
+		missingLicenses: body.missingLicenses || [],
 	};
 }
 

--- a/packages/js/src/ai-content-planner/helpers/normalize-error.js
+++ b/packages/js/src/ai-content-planner/helpers/normalize-error.js
@@ -3,8 +3,9 @@
  * Handles plain `Error` instances, raw strings, and partial error objects by filling in defaults.
  *
  * @param {*} payload The raw error payload from the fetch generator.
- * @returns {{ errorCode: number, errorIdentifier: string, errorMessage: string }} The structured error.
+ * @returns {{ errorCode: number, errorIdentifier: string, errorMessage: string, missingLicenses: string[] }} The structured error.
  */
+// eslint-disable-next-line complexity
 export const normalizeError = ( payload ) => {
 	const source = payload || {};
 	// Bad gateway error will not have a payload, so we set a default error.
@@ -12,5 +13,6 @@ export const normalizeError = ( payload ) => {
 		errorCode: source.errorCode || 502,
 		errorIdentifier: source.errorIdentifier || "",
 		errorMessage: source.errorMessage || source.message || "",
+		missingLicenses: source.missingLicenses || [],
 	};
 };

--- a/packages/js/src/ai-content-planner/helpers/normalize-error.js
+++ b/packages/js/src/ai-content-planner/helpers/normalize-error.js
@@ -1,3 +1,5 @@
+import { mapValues } from "lodash";
+
 /**
  * Normalizes an error payload to the structured shape expected by `ContentPlannerError`.
  * Handles plain `Error` instances, raw strings, and partial error objects by filling in defaults.
@@ -5,14 +7,17 @@
  * @param {*} payload The raw error payload from the fetch generator.
  * @returns {{ errorCode: number, errorIdentifier: string, errorMessage: string, missingLicenses: string[] }} The structured error.
  */
-// eslint-disable-next-line complexity
 export const normalizeError = ( payload ) => {
-	const source = payload || {};
-	// Bad gateway error will not have a payload, so we set a default error.
-	return {
-		errorCode: source.errorCode || 502,
-		errorIdentifier: source.errorIdentifier || "",
-		errorMessage: source.errorMessage || source.message || "",
-		missingLicenses: source.missingLicenses || [],
+	const defaultError = {
+		errorCode: 502,
+		errorIdentifier: "",
+		errorMessage: "",
+		missingLicenses: [],
 	};
+
+	// Bad gateway error will not have a payload, so we set a default error.
+	// Normalize errorMessage to also accept the plain Error `message` property.
+	const source = { ...( payload || {} ), errorMessage: payload?.errorMessage || payload?.message };
+
+	return mapValues( defaultError, ( defaultVal, key ) => source[ key ] || defaultVal );
 };

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -16,7 +16,7 @@ import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
  */
 export const useFetchContentSuggestions = () => {
 	const { endpoint, postType, contentLocale, editorApiValue, isUsageCountLimitReached,
-		usageCountEndpoint, hasValidPremiumSubscription } = useSelect( ( select ) => {
+		usageCountEndpoint, hasValidPremiumSubscription, isPremium } = useSelect( ( select ) => {
 		return {
 			endpoint: select( CONTENT_PLANNER_STORE ).selectContentSuggestionsEndpoint(),
 			postType: select( "yoast-seo/editor" ).getPostType(),
@@ -25,15 +25,32 @@ export const useFetchContentSuggestions = () => {
 			usageCountEndpoint: select( STORE_NAME_AI ).selectUsageCountEndpoint(),
 			isUsageCountLimitReached: select( STORE_NAME_AI ).isUsageCountLimitReached(),
 			hasValidPremiumSubscription: select( STORE_NAME_AI ).selectPremiumSubscription(),
+			isPremium: select( "yoast-seo/editor" ).getIsPremium(),
 		};
 	}, [] );
 
-	const { fetchContentPlannerSuggestions, setFeatureModalStatus, setContentSuggestionsStatus } = useDispatch( CONTENT_PLANNER_STORE );
+	const {
+		fetchContentPlannerSuggestions,
+		setFeatureModalStatus,
+		setContentSuggestionsStatus,
+		setSuggestionsError,
+	} = useDispatch( CONTENT_PLANNER_STORE );
 	const { fetchUsageCount, addUsageCount } = useDispatch( STORE_NAME_AI );
 
 	// eslint-disable-next-line complexity
 	return useCallback( async() => {
-		// Before fetching usage count, check if it's already known that the limit has been reached to avoid unnecessary API calls.
+		// Premium-installed users without a valid subscription get the "Subscription required"
+		// error directly — no API call, no ~2s site-analysis loading state. Free users still
+		// short-circuit to idle (the Approve modal upsell handled them earlier).
+		if ( isPremium && ! hasValidPremiumSubscription ) {
+			setFeatureModalStatus( FEATURE_MODAL_STATUS.contentSuggestions );
+			setSuggestionsError( {
+				errorCode: 402,
+				errorIdentifier: "PAYMENT_REQUIRED",
+				missingLicenses: [ "Yoast SEO Premium" ],
+			} );
+			return;
+		}
 		if ( isUsageCountLimitReached && ! hasValidPremiumSubscription ) {
 			setFeatureModalStatus( FEATURE_MODAL_STATUS.idle );
 			return;
@@ -58,6 +75,7 @@ export const useFetchContentSuggestions = () => {
 		editorApiValue,
 		isUsageCountLimitReached,
 		hasValidPremiumSubscription,
+		isPremium,
 		usageCountEndpoint,
 		fetchContentPlannerSuggestions,
 		addUsageCount,

--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-suggestions.js
@@ -80,5 +80,7 @@ export const useFetchContentSuggestions = () => {
 		fetchContentPlannerSuggestions,
 		addUsageCount,
 		fetchUsageCount,
-		setFeatureModalStatus ] );
+		setFeatureModalStatus,
+		setContentSuggestionsStatus,
+		setSuggestionsError ] );
 };

--- a/packages/js/src/ai-content-planner/store/content-suggestions.js
+++ b/packages/js/src/ai-content-planner/store/content-suggestions.js
@@ -32,6 +32,12 @@ const slice = createSlice( {
 			}
 			state.suggestions[ index ] = payload;
 		},
+		// Surface a synthetic error (e.g. known-invalid Premium subscription) without making an API call.
+		setSuggestionsError: ( state, { payload } ) => {
+			state.status = ASYNC_ACTION_STATUS.error;
+			state.suggestions = [];
+			state.error = normalizeError( payload );
+		},
 	},
 	extraReducers: ( builder ) => {
 		builder.addCase( `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {

--- a/packages/js/tests/ai-content-planner/components/content-planner-error.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-planner-error.test.js
@@ -116,6 +116,15 @@ describe( "ContentPlannerError", () => {
 			expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
 		} );
 
+		it( "falls back to Yoast SEO Premium when Premium is installed and the 402 response has no missingLicenses", () => {
+			mockIsPremium( true );
+			// Default missingLicenses=[] via prop default.
+			renderError( { errorCode: 402 } );
+			const alert = screen.getByTestId( "subscription-error" );
+			expect( alert ).toBeInTheDocument();
+			expect( alert ).toHaveTextContent( "Yoast SEO Premium" );
+		} );
+
 		it( "renders the GenericAlert for 402 when Premium is not installed", () => {
 			mockIsPremium( false );
 			renderError( { errorCode: 402, missingLicenses: [] } );

--- a/packages/js/tests/ai-content-planner/components/content-planner-error.test.js
+++ b/packages/js/tests/ai-content-planner/components/content-planner-error.test.js
@@ -6,12 +6,27 @@ jest.mock( "../../../src/ai-generator/components/errors", () => ( {
 	BadWPRequestAlert: ( { errorMessage } ) => <div data-testid="bad-wp-request-alert">{ errorMessage }</div>,
 	GenericAlert: () => <div data-testid="generic-alert" />,
 	RateLimitAlert: () => <div data-testid="rate-limit-alert" />,
+	SubscriptionError: ( { invalidSubscriptions } ) => (
+		<div data-testid="subscription-error">{ invalidSubscriptions.join( "," ) }</div>
+	),
 	TimeoutAlert: () => <div data-testid="timeout-alert" />,
 } ) );
 
 jest.mock( "../../../src/ai-generator/components/errors/site-unreachable-alert", () => ( {
 	SiteUnreachableAlert: () => <div data-testid="site-unreachable-alert" />,
 } ) );
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+import { useSelect } from "@wordpress/data";
+
+const mockIsPremium = ( isPremium ) => {
+	useSelect.mockImplementation( ( mapSelect ) => mapSelect( () => ( {
+		getIsPremium: () => isPremium,
+	} ) ) );
+};
 
 const renderError = ( props = {} ) => render(
 	<Modal isOpen={ true } onClose={ jest.fn() }>
@@ -22,6 +37,10 @@ const renderError = ( props = {} ) => render(
 );
 
 describe( "ContentPlannerError", () => {
+	beforeEach( () => {
+		mockIsPremium( false );
+	} );
+
 	describe( "alert selection", () => {
 		it( "renders the SiteUnreachableAlert for 400 + SITE_UNREACHABLE", () => {
 			renderError( { errorCode: 400, errorIdentifier: "SITE_UNREACHABLE" } );
@@ -49,14 +68,60 @@ describe( "ContentPlannerError", () => {
 			expect( screen.getByTestId( "timeout-alert" ) ).toBeInTheDocument();
 		} );
 
-		it( "renders the RateLimitAlert for 429", () => {
+		it( "renders the RateLimitAlert for 429 without a USAGE_LIMIT_REACHED identifier", () => {
 			renderError( { errorCode: 429 } );
 			expect( screen.getByTestId( "rate-limit-alert" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the RateLimitAlert for 429 + USAGE_LIMIT_REACHED when Premium is not installed", () => {
+			mockIsPremium( false );
+			renderError( { errorCode: 429, errorIdentifier: "USAGE_LIMIT_REACHED" } );
+			expect( screen.getByTestId( "rate-limit-alert" ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( "subscription-error" ) ).not.toBeInTheDocument();
+		} );
+
+		it( "renders the SubscriptionError for 429 + USAGE_LIMIT_REACHED when Premium is installed", () => {
+			mockIsPremium( true );
+			renderError( {
+				errorCode: 429,
+				errorIdentifier: "USAGE_LIMIT_REACHED",
+				missingLicenses: [ "Yoast SEO Premium" ],
+			} );
+			const alert = screen.getByTestId( "subscription-error" );
+			expect( alert ).toBeInTheDocument();
+			expect( alert ).toHaveTextContent( "Yoast SEO Premium" );
+			expect( screen.queryByTestId( "rate-limit-alert" ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
+		} );
+
+		it( "renders the RateLimitAlert for 429 + non-USAGE_LIMIT_REACHED identifier when Premium is installed", () => {
+			mockIsPremium( true );
+			renderError( { errorCode: 429, errorIdentifier: "REQUEST_RATE_LIMITED" } );
+			expect( screen.getByTestId( "rate-limit-alert" ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( "subscription-error" ) ).not.toBeInTheDocument();
 		} );
 
 		it( "renders the GenericAlert for unmapped error codes", () => {
 			renderError( { errorCode: 500 } );
 			expect( screen.getByTestId( "generic-alert" ) ).toBeInTheDocument();
+		} );
+
+		it( "renders the SubscriptionError for 402 when Premium is installed", () => {
+			mockIsPremium( true );
+			renderError( { errorCode: 402, missingLicenses: [ "Yoast SEO Premium" ] } );
+			const alert = screen.getByTestId( "subscription-error" );
+			expect( alert ).toBeInTheDocument();
+			expect( alert ).toHaveTextContent( "Yoast SEO Premium" );
+			// SubscriptionError renders its own actions, so the wrapping Close / Try again footer must not appear.
+			expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
+		} );
+
+		it( "renders the GenericAlert for 402 when Premium is not installed", () => {
+			mockIsPremium( false );
+			renderError( { errorCode: 402, missingLicenses: [] } );
+			expect( screen.getByTestId( "generic-alert" ) ).toBeInTheDocument();
+			expect( screen.queryByTestId( "subscription-error" ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( "button", { name: "Try again" } ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -14,6 +14,7 @@ const ERROR_DEFAULT = {
 	errorCode: null,
 	errorIdentifier: null,
 	errorMessage: null,
+	missingLicenses: [],
 };
 
 /* eslint-disable camelcase -- API field names use snake_case. */
@@ -134,6 +135,7 @@ describe( "suggestions store", () => {
 					errorCode: 403,
 					errorIdentifier: "forbidden",
 					errorMessage: "Access denied.",
+					missingLicenses: [],
 				},
 			} );
 		} );
@@ -148,6 +150,36 @@ describe( "suggestions store", () => {
 			);
 
 			expect( result.error.errorCode ).toBe( 502 );
+		} );
+
+		it( "setSuggestionsError sets the error state without an API call, clearing any prior suggestions", () => {
+			const previousState = {
+				endpoint: "",
+				status: ASYNC_ACTION_STATUS.success,
+				suggestions: transformedSuggestions,
+				error: ERROR_DEFAULT,
+			};
+
+			const result = contentSuggestionsReducer( previousState, {
+				type: `${ CONTENT_SUGGESTIONS_NAME }/setSuggestionsError`,
+				payload: {
+					errorCode: 402,
+					errorIdentifier: "PAYMENT_REQUIRED",
+					missingLicenses: [ "Yoast SEO Premium" ],
+				},
+			} );
+
+			expect( result ).toEqual( {
+				endpoint: "",
+				status: ASYNC_ACTION_STATUS.error,
+				suggestions: [],
+				error: {
+					errorCode: 402,
+					errorIdentifier: "PAYMENT_REQUIRED",
+					errorMessage: "",
+					missingLicenses: [ "Yoast SEO Premium" ],
+				},
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## Context

The Yoast Content Planner did not surface the **Subscription required** error when a user had Yoast SEO Premium installed but no active licence. Instead the user saw either the *You're out of free sparks* upsell (intended for Free users) or the generic *Yoast AI rate limit* modal— both of which give the wrong call-to-action (buy Premium) for someone who already has the Premium plugin and just needs to renew or activate their subscription.

This PR plumbs the backend's `missingLicenses` payload through to the React error UI and adds the right gating, mirroring how Yoast AI Generator already handles the same situation. It also short-circuits the request when the frontend already knows the licence is invalid, so the right modal appears instantly rather than after the fetch call showing the Suggestions modal loading. 


## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the *Subscription required* error was missing in the Content Planner when Yoast SEO Premium was installed without an active licence.

## Relevant technical choices:

* Reuses the existing `SubscriptionError` component from `ai-generator/components/errors` rather than duplicating it — same copy, same Activate-in-MyYoast / Get-new-subscription / Refresh-page actions across both AI flows.
* Handles both `402` and `429 + USAGE_LIMIT_REACHED` as "subscription required" for Premium-installed users, because the PHP `Too_Many_Requests_Exception extends Payment_Required_Exception`. A no-licence Premium user with sparks still available gets `402`; once sparks are exhausted, the same user gets `429 + USAGE_LIMIT_REACHED`. Both should resolve to the same UX.
* **Shows the Subscription required modal *before* the API fetch.** When the frontend already knows `isPremium && !hasValidPremiumSubscription`, the hook dispatches a synthetic 402 error directly into the store and skips the request entirely. 
* Adds a `setSuggestionsError` reducer action so the hook can surface the synthetic error without tunnelling a fake response through the existing fetch generator.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps.

**Scenario A — Premium installed, NO active licence (the bug):**

1. Install and activate Yoast SEO Free 27.6+ and Yoast SEO Premium 27.6+.
2. Open **Yoast SEO → Plans** and confirm **no** Premium licence is active.
3. Have at least 5 published posts.
4. Open any post in the Block (Gutenberg) editor.
5. In the **Yoast SEO Premium** meta box (right-hand side), click **Get content suggestions**.
6. In the small Approve modal that opens, click **Get content suggestions** again.

**Expected**: the Content suggestions modal opens **immediately** (no spinner / no "Composing your content suggestions…") and shows:
   * Heading: **Subscription required**
   * Body text with two links — *activate your subscription in MyYoast* and *get a new Yoast SEO Premium subscription*
   * Action buttons: **Close** and **Refresh page**

7. Click both links and confirm they each open MyYoast in a new tab.
8. Click **Refresh page** and confirm the editor reloads.

**Scenario B — Premium installed, VALID licence (regression check):**

1. Activate the Premium licence in **Yoast SEO → Plans**.
2. Open any post in the editor.
3. In the Yoast SEO Premium meta box, click **Get content suggestions** → **Get content suggestions**.

**Expected**: the modal opens, shows the loading text, and after a few seconds populates 5 content suggestions. Clicking a suggestion opens the Outline modal as usual.

**Scenario C — Free-only (no Premium plugin) (regression check):**

1. Deactivate Yoast SEO Premium. Keep at least 5 published posts.
2. Open any post in the editor and click **Get content suggestions**.

**Expected (sparks remaining)**: the Approve modal shows the **Get content suggestions** button — clicking it generates real suggestions and consumes one spark.
**Expected (sparks exhausted)**: the Approve modal shows **You're out of free sparks** with the **Unlock with Yoast SEO Premium** button — same as before, no regression.

#### Relevant test scenarios

* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Why these are checked: the Redux store gained a new action (`setSuggestionsError`), so a quick browser-console glance for warnings is worth it. Content Planner runs on every post type that has the Yoast meta box, and across the Block, Classic, and Elementor editors — please verify the Subscription required modal appears in each.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* **Yoast SEO Premium meta box → Get content suggestions** flow (Content Planner Approve modal + Suggestions modal + Outline modal error handling).
* **Approve modal upsell gating** — `isUpsell` now also excludes Premium-installed users; please verify the upsell still appears for Free-only users with exhausted sparks.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run \`grunt build:images\` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the \`innovation\` label.
* [x] I have added my hours to the WBSO document.

Fixes [#2976](https://github.com/Yoast/plugins-automated-testing/issues/2976)