### PR TITLE
Content planner: Adjust header padding in content planner modal for improved spacing

### DIFF
--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -99,7 +99,7 @@ export const FeatureModal = ( {
 						? __( "Close content suggestions modal", "wordpress-seo" ) : __( "Close content outline modal", "wordpress-seo" ) }
 				/>
 				<Modal.Container>
-					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-12 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
+					<Modal.Container.Header className="yst-flex yst-items-center yst-gap-2 yst-pe-14 yst-py-6 yst-ps-6 yst-border-b yst-border-slate-200">
 						<YoastIcon className="yst-fill-primary-500 yst-w-4 yst-mb-[1px]" { ...svgAriaProps } />
 						<Modal.Title size="2">{ isSuggestions ? __( "Content suggestions", "wordpress-seo" ) : __( "Content outline", "wordpress-seo" ) }</Modal.Title>
 						<Link


### PR DESCRIPTION
## Context

Polish fix for the Content Planner *Content suggestions* and *Content outline* modal headers: the rightmost header element (the `Beta` badge or the `UsageCounter` "x / 10" sparks counter) sat flush against the close (X) button, missing the 8px design-system gap.

## Summary

This PR can be summarized in the following changelog entry:

* Adds 8px of horizontal spacing between the rightmost header element and the close button in the Content Planner *Content suggestions* and *Content outline* modals.

## Relevant technical choices

* Changed the header right padding from `yst-pe-12` (48px) to `yst-pe-14` (56px) in `packages/js/src/ai-content-planner/components/feature-modal.js`. The close button is absolutely positioned, so the header already reserves space via padding rather than via margin on the rightmost child — bumping the padding adds the 8px gap regardless of which child is rightmost (`Badge` in the error path, `UsageCounter` otherwise), and avoids touching two elements.
* RTL-safe: the header uses `padding-inline-end` (`yst-pe-*`) and the close button is positioned with `inset-inline-end` (`yst-end-4` in the Modal CSS), so both flip together when the site direction is RTL.
* No unit test added. The change is a single Tailwind utility swap with no behavioral surface to assert on; the existing tests in `feature-modal.test.js` cover behavior (render paths, callbacks). The actual 8px gap is a CSS layout result that jsdom does not compute, so a `toHaveClass("yst-pe-14")` assertion would only re-state the source. Coverage is unchanged.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:
Prerequisties:
- Have at least 5 published posts
- Enable AI features and give your consent

1. Create a new post
2. Open the **Yoast SEO** meta box/sidebar → **Get content suggestions** → **Get content suggestions**. OR click on the **Get content suggestions** button inside the Inline banner in the editor
3. In the *Content suggestions* modal, look at the top-right of the header. The `x / 10` sparks counter (or, if it errored, the `Beta` badge) should have a visible gap to the X close button — no longer flush against it.
4. Click any suggestion to open the *Content outline* modal. The same gap should be visible in its header.
5. To verify the exact gap is at least 8px, with the modal still open paste this into the browser console:
   ```js
   const dialog = document.querySelector('[role="dialog"]');
   const closeBtn = dialog.querySelector('button[aria-label*="Close"]');
   const header = dialog.querySelector('.yst-modal__container-header');
   const lastChild = header.children[header.children.length - 1];
   const closeRect = closeBtn.getBoundingClientRect();
   const childRect = lastChild.getBoundingClientRect();
   const isRTL = getComputedStyle(dialog).direction === 'rtl';
   console.log(isRTL ? childRect.left - closeRect.right : closeRect.left - childRect.right);
   ```
   The logged number should be `>= 8`.
6. Alternatively,  you can also inspect the header element → Computed tab → filter for padding. You should see:         
   
  - **Before** fix: padding-inline-end: 48px                                                  
  - **After** fix: padding-inline-end: 56px
                                                                                          
  👉🏽 That difference (8px) is the gap that was added.   

 7. Switch the WordPress site language to an RTL language (e.g. Arabic, Hebrew), reload the editor, and repeat steps 2–5. The X close button is now on the left side of the header, but the gap should still be present and the console snippet should still log `>= 8`.

#### Relevant test scenarios

* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

This is a CSS-only polish to a modal that only renders inside the block editor when a Premium user invokes the Content Planner feature. The only meaningful axis is cross-browser rendering of `padding-inline-end` — please verify in Chrome, Firefox, and Safari. RTL is covered explicitly in the steps above. Post type, editor type, and multisite do not change the rendering of this modal header, so they are not separately required.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following the acceptance test steps above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* `FeatureModal` header in `packages/js/src/ai-content-planner/components/feature-modal.js`. No other modals or components are touched — only the spacing in the Content Planner *Content suggestions* and *Content outline* modal headers changes.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. (N/A — pure UI polish, no API or behavior change.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended. (See *Relevant technical choices* — no behavioral surface to assert on; coverage is unchanged.)
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off. (N/A — no feature flag.)
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs. (N/A — no images touched.)

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1191