### PR TITLE
Add class to inline banner div for styling consistency

### DIFF
--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -70,7 +70,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 	return (
 		<>
 			{ shouldShow && (
-				<div ref={ ref }>
+				<div ref={ ref } className="wp-block">
 					<InlineBanner
 						isPremium={ isPremium }
 						onDismiss={ handleDismiss }

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -179,5 +179,15 @@ describe( "withInlineBanner", () => {
 
 		expect( getByTestId( "block-list-block" ) ).toBeInTheDocument();
 	} );
+
+	test( "wraps the banner in a div with the wp-block class so it inherits Gutenberg's per-block content-width rule", () => {
+		// Regression guard: without this class, themes that constrain block width via the `.wp-block` selector
+		// (rather than via direct children of `.is-layout-constrained`) render the banner full-canvas-width instead of matching adjacent blocks.
+		setupMocks();
+		const { getByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		const wrapper = getByTestId( "inline-banner" ).parentElement;
+		expect( wrapper ).toHaveClass( "wp-block" );
+	} );
 } );
 


### PR DESCRIPTION
## Context

*

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the Content Planner inline banner was wider than adjacent blocks in Twenty Twenty-One theme.

## Relevant technical choices:

* Adding `className="wp-block"` to the banner wrapper makes it pick up the same width rule Gutenberg applies to real blocks. The rule resolves correctly across `is-layout-flow` and `is-layout-constrained` layouts, and degrades to the parent's width in classic themes that don't define `--wp--style--global--content-size` — i.e., it matches whatever a sibling paragraph block does.
* Confirmed against the actual DOM in the broken theme (Twenty Twenty-One): the banner sat alongside `<p class="… wp-block …">` inside `.block-editor-block-list__layout.is-layout-flow`. Adding `wp-block` to the wrapper aligns the two on the same CSS rule path.
* Not changing the filter architecture or porting the banner out of `editor.BlockListBlock`: that would be a larger refactor, and 27.6 is already in RC. The minimal class addition is scoped to the visible bug.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install and activate Yoast SEO
2. Enable AI Feature and give consent
3. Make sure you have at least 5 published posts so the Content Planner banner is eligible to render
4. **Modern block theme path** (regression check — should look unchanged):
   1. Activate **Twenty Twenty-Five**.
   2. Open *Posts → Add New*.
   3. Confirm the inline banner appears between the title and the first paragraph placeholder.
   4. Confirm the banner's left/right edges line up with the title and the paragraph placeholder
   
<img width="1632" height="389" alt="Screenshot 2026-05-04 at 13 51 04" src="https://github.com/user-attachments/assets/fc0a2c14-03c2-4062-91f3-9e351eade10a" />

5. **Twenty Twenty-One**:
   1. Activate Twenty Twenty-One.
   2. Open *Posts → Add New*.
   3. Confirm the banner now matches the width of the title and the paragraph block underneath it. **Before this fix it spanned the full canvas width; after this fix it should not.**
<img width="1658" height="503" alt="Screenshot 2026-05-04 at 14 55 53" src="https://github.com/user-attachments/assets/6db4b5f9-3277-481a-bbab-41491fc412ec" />


6. **Sanity checks (any theme):**
   - Banner still dismisses via the X and stays dismissed across reloads.
   - "Get content suggestions" button still opens the modal flow as before.
   - No new console errors or warnings.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies — banner only renders on the post-type configured for Content Planner ("post"), but verify other post types are unaffected.
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other) — the banner only applies to the block editor; classic editor should be unaffected.
* [x] Changes should be tested on different browsers — Chrome, Firefox, Safari (different CSS engines render `var(--wp--style--global--content-size)` consistently, but worth a glance).
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Content Planner inline banner that renders on new posts in the block editor (introduced earlier in 27.6). No other surface is touched — change is scoped to a single className on the banner wrapper.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. The reasoning is captured in *Relevant technical choices* above and is preserved by the existing block comment on `withInlineBanner` in `packages/js/src/ai-content-planner/components/with-inline-banner.js`.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended. Not applicable: the change is a single className, and existing snapshot/rendering tests assert behavior; visual width is a CSS-driven outcome that is not meaningfully covered by unit tests.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs. Not applicable — no image changes.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [reserved-tasks#1194](https://github.com/Yoast/reserved-tasks/issues/1194)