### PR TITLE
1195 content planner improve inline banner accessibility

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -21,6 +21,7 @@
     "@wordpress/components": "^28.8.12",
     "@wordpress/compose": "^7.8.4",
     "@wordpress/data": "^10.8.4",
+    "@wordpress/dom": "^4.27.0",
     "@wordpress/dom-ready": "^4.8.1",
     "@wordpress/editor": "^14.33.10",
     "@wordpress/element": "^6.8.1",

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -1,4 +1,4 @@
-import { Button, Modal, GradientSparklesIcon, useSvgAria } from "@yoast/ui-library";
+import { Button, Modal, GradientSparklesIcon, Link, useSvgAria } from "@yoast/ui-library";
 import { ArrowNarrowRightIcon } from "@heroicons/react/solid";
 import { LockOpenIcon } from "@heroicons/react/outline";
 
@@ -66,15 +66,6 @@ export const ApproveModal = ( { isEmptyPost, isPremium, isUpsell, onClick, upsel
 	const { title, description } = getModalContent( isEmptyPost, isUpsell );
 	const svgAriaProps = useSvgAria();
 
-	const learnMoreLinkStructure = {
-		a: <OutboundLink
-			href={ learnMoreLink }
-			className="yst-inline-flex yst-items-center yst-gap-1 yst-no-underline yst-font-medium"
-			variant="primary"
-		/>,
-		ArrowNarrowRightIcon: <ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180" />,
-	};
-
 	return (
 		<Modal isOpen={ isOpen } onClose={ onClose }>
 			<Modal.Panel className="yst-text-center yst-w-96" closeButtonScreenReaderText={ __( "Close modal", "wordpress-seo" ) }>
@@ -100,19 +91,10 @@ export const ApproveModal = ( { isEmptyPost, isPremium, isUpsell, onClick, upsel
 				</Button>
 					: <Button onClick={ onClick } variant="ai-primary" className="yst-w-full"> { __( "Get content suggestions", "wordpress-seo" ) } </Button> }
 				<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
-					{ safeCreateInterpolateElement(
-						sprintf(
-							/* translators: %1$s and %3$s are anchor tags; %2$s is the arrow icon. */
-							__(
-								"%1$sLearn more%2$s%3$s",
-								"wordpress-seo"
-							),
-							"<a>",
-							"<ArrowNarrowRightIcon />",
-							"</a>"
-						),
-						learnMoreLinkStructure
-					) }
+					<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-inline yst-no-underline yst-font-medium">
+						{ __( "Learn more", "wordpress-seo" ) }
+						<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180 yst-inline yst-ms-1.5" />
+					</Link>
 				</div>
 			</Modal.Panel>
 		</Modal>

--- a/packages/js/src/ai-content-planner/components/approve-modal.js
+++ b/packages/js/src/ai-content-planner/components/approve-modal.js
@@ -90,7 +90,7 @@ export const ApproveModal = ( { isEmptyPost, isPremium, isUpsell, onClick, upsel
 					</span>
 				</Button>
 					: <Button onClick={ onClick } variant="ai-primary" className="yst-w-full"> { __( "Get content suggestions", "wordpress-seo" ) } </Button> }
-				<div className="yst-mt-2 yst-text-slate-600 yst-text-sm">
+				<div className="yst-mt-2 yst-text-sm">
 					<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-inline yst-no-underline yst-font-medium">
 						{ __( "Learn more", "wordpress-seo" ) }
 						<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180 yst-inline yst-ms-1.5" />

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -15,7 +15,7 @@ import { OneSparkNote } from "./one-spark-note";
  */
 export const InlineBanner = ( { isPremium, onDismiss, onClick } ) => {
 	const ariaProps = useSvgAria();
-	return <Root><div className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg yst-max-w">
+	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg yst-max-w-xl">
 		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1">
 			<GradientSparklesIcon className="yst-h-4 yst-w-4" { ...ariaProps } />
 			<p className="yst-grow yst-text-slate-800 yst-font-medium"> { __( "Stuck on what to write next?", "wordpress-seo" ) }</p>

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -15,7 +15,7 @@ import { OneSparkNote } from "./one-spark-note";
  */
 export const InlineBanner = ( { isPremium, onDismiss, onClick } ) => {
 	const ariaProps = useSvgAria();
-	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg yst-max-w-xl">
+	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg">
 		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1">
 			<GradientSparklesIcon className="yst-h-4 yst-w-4" { ...ariaProps } />
 			<p className="yst-grow yst-text-slate-800 yst-font-medium"> { __( "Stuck on what to write next?", "wordpress-seo" ) }</p>

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -31,7 +31,7 @@ export const InlineBanner = ( { isPremium, onDismiss, onClick, learnMoreLink } )
 		</p>
 		<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-font-medium yst-no-underline">
 			{ __( "Learn more", "wordpress-seo" ) }
-			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180 yst-inline yst-ms-1" />
+			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180 yst-inline yst-ms-1.5" />
 		</Link>
 		<div className="yst-mt-1 yst-flex yst-justify-end yst-gap-2 yst-items-center">
 			{ ! isPremium && <>

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -1,7 +1,8 @@
 import { __ } from "@wordpress/i18n";
-import { Button, GradientSparklesIcon, Root, useSvgAria } from "@yoast/ui-library";
-import { XIcon } from "@heroicons/react/solid";
+import { Button, GradientSparklesIcon, Link, Root, useSvgAria } from "@yoast/ui-library";
+import { ArrowNarrowRightIcon, XIcon } from "@heroicons/react/solid";
 import { OneSparkNote } from "./one-spark-note";
+import { OutboundLink } from "../../shared-admin/components";
 
 /**
  * The inline banner that is shown when the user has no content in a new post using the block editor.
@@ -11,9 +12,10 @@ import { OneSparkNote } from "./one-spark-note";
  * @param {boolean}  props.isPremium Whether the user has a premium add-on activated.
  * @param {Function} props.onDismiss The function to call when the banner is dismissed.
  * @param {Function} props.onClick   The function to call when the "Get content suggestions" button is clicked.
+ * @param {string}  props.learnMoreLink The link to the learn more page about the AI Content Planner.
  * @returns {JSX.Element} The inline banner with the button.
  */
-export const InlineBanner = ( { isPremium, onDismiss, onClick } ) => {
+export const InlineBanner = ( { isPremium, onDismiss, onClick, learnMoreLink } ) => {
 	const ariaProps = useSvgAria();
 	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg">
 		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1">
@@ -24,9 +26,13 @@ export const InlineBanner = ( { isPremium, onDismiss, onClick } ) => {
 				<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
 			</button>
 		</div>
-		<p className="yst-text-sm yst-text-slate-600">
+		<p className="yst-text-sm yst-text-slate-600 yst-mb-1">
 			{ __( "Let Yoast analyze your site and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
 		</p>
+		<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-font-medium yst-no-underline">
+			{ __( "Learn more", "wordpress-seo" ) }
+			<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 rtl:yst-rotate-180 yst-inline yst-ms-1" />
+		</Link>
 		<div className="yst-mt-1 yst-flex yst-justify-end yst-gap-2 yst-items-center">
 			{ ! isPremium && <>
 				<OneSparkNote />

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 import { createHigherOrderComponent } from "@wordpress/compose";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
@@ -85,6 +84,11 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 			return;
 		}
 
+		/**
+		 * Forwards keydown events to the banner Tab navigation helper.
+		 * @param {KeyboardEvent} event The keydown event.
+		 * @returns {void}
+		 */
 		function handleTabNavigation( event ) {
 			handleBannerTabNavigation( ref.current, event );
 		}

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -14,7 +14,7 @@ import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigati
  * @returns {JSX.Element} The wrapped block component with the inline banner conditionally rendered before it.
  */
 const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
-	const { isNewPost, isBannerDismissed, isBannerRendered, hasConsent, isPremium, minPostsMet } = useSelect( ( select ) => {
+	const { isNewPost, isBannerDismissed, isBannerRendered, hasConsent, isPremium, minPostsMet, learnMoreLink } = useSelect( ( select ) => {
 		const planner = select( CONTENT_PLANNER_STORE );
 		return {
 			isNewPost: select( "core/editor" ).isEditedPostNew(),
@@ -23,6 +23,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 			isPremium: select( STORE_NAME_EDITOR ).getIsPremium(),
 			hasConsent: select( STORE_NAME_AI ).selectHasAiGeneratorConsent(),
 			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
+			learnMoreLink: select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/content-planner-learn-more" ),
 		};
 	}, [] );
 
@@ -105,6 +106,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 						isPremium={ isPremium }
 						onDismiss={ handleDismiss }
 						onClick={ handleClick }
+						learnMoreLink={ learnMoreLink }
 					/>
 				</div>
 			) }

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import { createHigherOrderComponent } from "@wordpress/compose";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
@@ -5,6 +6,7 @@ import { InlineBanner } from "./inline-banner";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS, INJECTED_STYLE_ID } from "../constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../ai-generator/constants";
 import { useFetchContentSuggestions } from "../hooks/use-fetch-content-suggestions";
+import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigation";
 
 /**
  * The component that conditionally renders the Content Planner inline banner and injects the Tailwind stylesheet into the editor iframe.
@@ -67,10 +69,34 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 		ownerDoc.head.appendChild( link );
 	}, [ shouldShow ] );
 
+	useEffect( () => {
+		if ( ! shouldShow ) {
+			return;
+		}
+
+		// Gutenberg's writing-flow Tab handler runs in the bubble phase and redirects
+		// focus to sentinel divs when the next tabbable is not inside the same block.
+		// The banner sits outside any [data-block] block wrapper, so it is always
+		// skipped. Attaching a capture-phase listener lets us act before Gutenberg does;
+		// once we call preventDefault(), Gutenberg's early-return guard fires and leaves
+		// focus alone.
+		const ownerDoc = ref.current?.ownerDocument;
+		if ( ! ownerDoc ) {
+			return;
+		}
+
+		function handleTabNavigation( event ) {
+			handleBannerTabNavigation( ref.current, event );
+		}
+
+		ownerDoc.addEventListener( "keydown", handleTabNavigation, { capture: true } );
+		return () => ownerDoc.removeEventListener( "keydown", handleTabNavigation, { capture: true } );
+	}, [ shouldShow ] );
+
 	return (
 		<>
 			{ shouldShow && (
-				<div ref={ ref } className="wp-block">
+				<div ref={ ref } className="wp-block" data-block="yoast-content-planner-banner">
 					<InlineBanner
 						isPremium={ isPremium }
 						onDismiss={ handleDismiss }

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -13,7 +13,6 @@ import { focus } from "@wordpress/dom";
  * @param {KeyboardEvent} event   The keydown event.
  * @returns {void}
  */
-// eslint-disable-next-line complexity
 export function handleBannerTabNavigation( bannerEl, event ) {
 	if ( event.defaultPrevented || event.keyCode !== 9 || ! bannerEl ) {
 		return;
@@ -21,13 +20,10 @@ export function handleBannerTabNavigation( bannerEl, event ) {
 
 	const findSibling = event.shiftKey ? focus.tabbable.findPrevious : focus.tabbable.findNext;
 	const next = findSibling( event.target );
-	if ( ! next ) {
-		return;
-	}
 
 	// Intercept only when Tab or Shift+Tab crosses the banner boundary (entering or leaving).
 	// Intra-banner navigation is already handled by Gutenberg via the data-block attribute.
-	if ( bannerEl.contains( event.target ) !== bannerEl.contains( next ) ) {
+	if ( next && bannerEl.contains( event.target ) !== bannerEl.contains( next ) ) {
 		event.preventDefault();
 		next.focus();
 	}

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -1,6 +1,5 @@
 import { focus } from "@wordpress/dom";
 
-
 /**
  * Get sibling function.
  *
@@ -21,6 +20,7 @@ const getFindSibling = ( event ) => {
  * @returns {boolean} Whether the banner is involved in the navigation.
  */
 const involvesBanner = ( bannerEl, target, next ) => bannerEl.contains( target ) || bannerEl.contains( next );
+
 /**
  * Keydown handler that keeps the inline banner reachable via Tab inside the Gutenberg
  * writing flow. Gutenberg's useTabNav hook intercepts Tab in the bubble phase and

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -1,5 +1,16 @@
 import { focus } from "@wordpress/dom";
 
+
+/**
+ * Get sibling function.
+ *
+ * @param {KeyboardEvent} event The keydown event.
+ * @returns {Function} The function to find the next or previous tabbable element.
+ */
+const getFindSibling = ( event ) => {
+	return event.shiftKey ? focus.tabbable.findPrevious : focus.tabbable.findNext;
+};
+
 /**
  * Keydown handler that keeps the inline banner reachable via Tab inside the Gutenberg
  * writing flow. Gutenberg's useTabNav hook intercepts Tab in the bubble phase and
@@ -18,7 +29,7 @@ export function handleBannerTabNavigation( bannerEl, event ) {
 		return;
 	}
 
-	const findSibling = event.shiftKey ? focus.tabbable.findPrevious : focus.tabbable.findNext;
+	const findSibling = getFindSibling( event );
 	const next = findSibling( event.target );
 
 	// Intercept only when Tab or Shift+Tab crosses the banner boundary (entering or leaving).

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -32,9 +32,11 @@ export function handleBannerTabNavigation( bannerEl, event ) {
 	const findSibling = getFindSibling( event );
 	const next = findSibling( event.target );
 
-	// Intercept only when Tab or Shift+Tab crosses the banner boundary (entering or leaving).
-	// Intra-banner navigation is already handled by Gutenberg via the data-block attribute.
-	if ( next && bannerEl.contains( event.target ) !== bannerEl.contains( next ) ) {
+	// Intercept whenever focus is inside the banner or entering it.
+	// Gutenberg's WritingFlow Tab handler redirects focus to the next block rather than
+	// moving between tabbable elements inside the banner wrapper, so we must handle all
+	// banner-related Tab navigation ourselves — both intra-banner and boundary-crossing.
+	if ( next && ( bannerEl.contains( event.target ) || bannerEl.contains( next ) ) ) {
 		event.preventDefault();
 		next.focus();
 	}

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -13,6 +13,7 @@ import { focus } from "@wordpress/dom";
  * @param {KeyboardEvent} event   The keydown event.
  * @returns {void}
  */
+// eslint-disable-next-line complexity
 export function handleBannerTabNavigation( bannerEl, event ) {
 	if ( event.defaultPrevented || event.keyCode !== 9 || event.shiftKey || ! bannerEl ) {
 		return;

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -1,0 +1,32 @@
+import { focus } from "@wordpress/dom";
+
+/**
+ * Keydown handler that keeps the inline banner reachable via Tab inside the Gutenberg
+ * writing flow. Gutenberg's useTabNav hook intercepts Tab in the bubble phase and
+ * redirects focus to sentinel divs when the next tabbable element is not inside the
+ * same [data-block] wrapper. Because the banner sits outside any real block, it is
+ * normally skipped. This handler is meant to be attached in the capture phase so it
+ * runs before Gutenberg; once it calls preventDefault(), Gutenberg's early-return guard
+ * fires and leaves focus alone.
+ *
+ * @param {HTMLElement}  bannerEl The banner wrapper element.
+ * @param {KeyboardEvent} event   The keydown event.
+ * @returns {void}
+ */
+export function handleBannerTabNavigation( bannerEl, event ) {
+	if ( event.defaultPrevented || event.keyCode !== 9 || event.shiftKey || ! bannerEl ) {
+		return;
+	}
+
+	const next = focus.tabbable.findNext( event.target );
+	if ( ! next ) {
+		return;
+	}
+
+	// Intercept only when Tab crosses the banner boundary (entering or leaving).
+	// Intra-banner Tab is already handled by Gutenberg via the data-block attribute.
+	if ( bannerEl.contains( event.target ) !== bannerEl.contains( next ) ) {
+		event.preventDefault();
+		next.focus();
+	}
+}

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -14,7 +14,7 @@ import { focus } from "@wordpress/dom";
  * @returns {void}
  */
 export function handleBannerTabNavigation( bannerEl, event ) {
-	if ( event.defaultPrevented || event.keyCode !== 9 || ! bannerEl ) {
+	if ( event.defaultPrevented || event.key !== "Tab" || ! bannerEl ) {
 		return;
 	}
 

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -15,17 +15,18 @@ import { focus } from "@wordpress/dom";
  */
 // eslint-disable-next-line complexity
 export function handleBannerTabNavigation( bannerEl, event ) {
-	if ( event.defaultPrevented || event.keyCode !== 9 || event.shiftKey || ! bannerEl ) {
+	if ( event.defaultPrevented || event.keyCode !== 9 || ! bannerEl ) {
 		return;
 	}
 
-	const next = focus.tabbable.findNext( event.target );
+	const findSibling = event.shiftKey ? focus.tabbable.findPrevious : focus.tabbable.findNext;
+	const next = findSibling( event.target );
 	if ( ! next ) {
 		return;
 	}
 
-	// Intercept only when Tab crosses the banner boundary (entering or leaving).
-	// Intra-banner Tab is already handled by Gutenberg via the data-block attribute.
+	// Intercept only when Tab or Shift+Tab crosses the banner boundary (entering or leaving).
+	// Intra-banner navigation is already handled by Gutenberg via the data-block attribute.
 	if ( bannerEl.contains( event.target ) !== bannerEl.contains( next ) ) {
 		event.preventDefault();
 		next.focus();

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -12,6 +12,16 @@ const getFindSibling = ( event ) => {
 };
 
 /**
+ * Returns whether a Tab navigation involves the banner — i.e. focus is currently inside
+ * the banner or is about to enter it.
+ *
+ * @param {HTMLElement} bannerEl The banner wrapper element.
+ * @param {HTMLElement} target   The currently focused element.
+ * @param {HTMLElement} next     The next tabbable element.
+ * @returns {boolean} Whether the banner is involved in the navigation.
+ */
+const involvesBanner = ( bannerEl, target, next ) => bannerEl.contains( target ) || bannerEl.contains( next );
+/**
  * Keydown handler that keeps the inline banner reachable via Tab inside the Gutenberg
  * writing flow. Gutenberg's useTabNav hook intercepts Tab in the bubble phase and
  * redirects focus to sentinel divs when the next tabbable element is not inside the
@@ -32,11 +42,9 @@ export function handleBannerTabNavigation( bannerEl, event ) {
 	const findSibling = getFindSibling( event );
 	const next = findSibling( event.target );
 
-	// Intercept whenever focus is inside the banner or entering it.
-	// Gutenberg's WritingFlow Tab handler redirects focus to the next block rather than
-	// moving between tabbable elements inside the banner wrapper, so we must handle all
-	// banner-related Tab navigation ourselves — both intra-banner and boundary-crossing.
-	if ( next && ( bannerEl.contains( event.target ) || bannerEl.contains( next ) ) ) {
+	// Intercept only when Tab or Shift+Tab crosses the banner boundary (entering or leaving).
+	// Intra-banner navigation is already handled by Gutenberg via the data-block attribute.
+	if ( next && involvesBanner( bannerEl, event.target, next ) ) {
 		event.preventDefault();
 		next.focus();
 	}

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -50,6 +50,7 @@ const setupMocks = ( overrides = {} ) => {
 		hasConsent: false,
 		isPremium: false,
 		minPostsMet: true,
+		learnMoreLink: "https://yoa.st/content-planner-learn-more",
 	};
 	const values = { ...defaults, ...overrides };
 
@@ -68,7 +69,7 @@ const setupMocks = ( overrides = {} ) => {
 			};
 		}
 		if ( storeName === "yoast-seo/editor" ) {
-			return { getIsPremium: () => values.isPremium };
+			return { getIsPremium: () => values.isPremium, selectLink: () => values.learnMoreLink };
 		}
 		if ( storeName === "yoast-seo/ai-generator" ) {
 			return { selectHasAiGeneratorConsent: () => values.hasConsent };

--- a/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
@@ -1,11 +1,13 @@
 import { handleBannerTabNavigation } from "../../../src/ai-content-planner/helpers/handle-banner-tab-navigation";
 
 const mockFindNext = jest.fn();
+const mockFindPrevious = jest.fn();
 
 jest.mock( "@wordpress/dom", () => ( {
 	focus: {
 		tabbable: {
 			findNext: ( ...args ) => mockFindNext( ...args ),
+			findPrevious: ( ...args ) => mockFindPrevious( ...args ),
 		},
 	},
 } ) );
@@ -39,6 +41,7 @@ describe( "handleBannerTabNavigation", () => {
 		document.body.appendChild( outsideButton );
 
 		mockFindNext.mockReset();
+		mockFindPrevious.mockReset();
 	} );
 
 	afterEach( () => {
@@ -60,13 +63,6 @@ describe( "handleBannerTabNavigation", () => {
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 
-		it( "does nothing for Shift+Tab", () => {
-			const event = makeEvent( { shiftKey: true } );
-			handleBannerTabNavigation( bannerEl, event );
-			expect( mockFindNext ).not.toHaveBeenCalled();
-			expect( event.preventDefault ).not.toHaveBeenCalled();
-		} );
-
 		it( "does nothing when bannerEl is null", () => {
 			const event = makeEvent();
 			handleBannerTabNavigation( null, event );
@@ -80,10 +76,17 @@ describe( "handleBannerTabNavigation", () => {
 			handleBannerTabNavigation( bannerEl, event );
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
+
+		it( "does nothing when there is no previous tabbable element (Shift+Tab)", () => {
+			mockFindPrevious.mockReturnValue( null );
+			const event = makeEvent( { shiftKey: true, target: outsideButton } );
+			handleBannerTabNavigation( bannerEl, event );
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( "Tab into banner", () => {
-		it( "focuses the first banner button and prevents default when tabbing from outside", () => {
+		it( "focuses the first banner button and prevents default when tabbing forward from outside", () => {
 			mockFindNext.mockReturnValue( insideButton );
 			const focusSpy = jest.spyOn( insideButton, "focus" );
 			const event = makeEvent( { target: outsideButton } );
@@ -93,13 +96,35 @@ describe( "handleBannerTabNavigation", () => {
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( "focuses the last banner button and prevents default when shift-tabbing backward from outside", () => {
+			mockFindPrevious.mockReturnValue( insideButton );
+			const focusSpy = jest.spyOn( insideButton, "focus" );
+			const event = makeEvent( { shiftKey: true, target: outsideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( "Tab out of banner", () => {
-		it( "focuses the next element outside the banner and prevents default when tabbing from the last button", () => {
+		it( "focuses the next element outside and prevents default when tabbing forward from the last button", () => {
 			mockFindNext.mockReturnValue( outsideButton );
 			const focusSpy = jest.spyOn( outsideButton, "focus" );
 			const event = makeEvent( { target: insideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "focuses the previous element outside and prevents default when shift-tabbing from the first button", () => {
+			mockFindPrevious.mockReturnValue( outsideButton );
+			const focusSpy = jest.spyOn( outsideButton, "focus" );
+			const event = makeEvent( { shiftKey: true, target: insideButton } );
 
 			handleBannerTabNavigation( bannerEl, event );
 
@@ -121,6 +146,19 @@ describe( "handleBannerTabNavigation", () => {
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 			expect( focusSpy ).not.toHaveBeenCalled();
 		} );
+
+		it( "does not intercept when both current and previous tabbable are inside the banner (Shift+Tab)", () => {
+			const secondInsideButton = document.createElement( "button" );
+			bannerEl.appendChild( secondInsideButton );
+			mockFindPrevious.mockReturnValue( insideButton );
+			const focusSpy = jest.spyOn( insideButton, "focus" );
+			const event = makeEvent( { shiftKey: true, target: secondInsideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( focusSpy ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( "Tab outside banner entirely", () => {
@@ -130,6 +168,19 @@ describe( "handleBannerTabNavigation", () => {
 			mockFindNext.mockReturnValue( anotherOutsideButton );
 			const focusSpy = jest.spyOn( anotherOutsideButton, "focus" );
 			const event = makeEvent( { target: outsideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( focusSpy ).not.toHaveBeenCalled();
+		} );
+
+		it( "does not intercept when both current and previous tabbable are outside the banner (Shift+Tab)", () => {
+			const anotherOutsideButton = document.createElement( "button" );
+			document.body.appendChild( anotherOutsideButton );
+			mockFindPrevious.mockReturnValue( anotherOutsideButton );
+			const focusSpy = jest.spyOn( anotherOutsideButton, "focus" );
+			const event = makeEvent( { shiftKey: true, target: outsideButton } );
 
 			handleBannerTabNavigation( bannerEl, event );
 

--- a/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
@@ -1,0 +1,140 @@
+import { handleBannerTabNavigation } from "../../../src/ai-content-planner/helpers/handle-banner-tab-navigation";
+
+const mockFindNext = jest.fn();
+
+jest.mock( "@wordpress/dom", () => ( {
+	focus: {
+		tabbable: {
+			findNext: ( ...args ) => mockFindNext( ...args ),
+		},
+	},
+} ) );
+
+/**
+ * Creates a minimal keydown event mock.
+ * @param {object} overrides Properties to override on the default Tab event.
+ * @returns {object} The event mock.
+ */
+const makeEvent = ( overrides = {} ) => ( {
+	defaultPrevented: false,
+	keyCode: 9,
+	shiftKey: false,
+	target: document.createElement( "button" ),
+	preventDefault: jest.fn(),
+	...overrides,
+} );
+
+describe( "handleBannerTabNavigation", () => {
+	let bannerEl;
+	let insideButton;
+	let outsideButton;
+
+	beforeEach( () => {
+		bannerEl = document.createElement( "div" );
+		insideButton = document.createElement( "button" );
+		outsideButton = document.createElement( "button" );
+
+		bannerEl.appendChild( insideButton );
+		document.body.appendChild( bannerEl );
+		document.body.appendChild( outsideButton );
+
+		mockFindNext.mockReset();
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = "";
+	} );
+
+	describe( "early returns", () => {
+		it( "does nothing when event.defaultPrevented is true", () => {
+			const event = makeEvent( { defaultPrevented: true } );
+			handleBannerTabNavigation( bannerEl, event );
+			expect( mockFindNext ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( "does nothing for non-Tab keys", () => {
+			const event = makeEvent( { keyCode: 13 } );
+			handleBannerTabNavigation( bannerEl, event );
+			expect( mockFindNext ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( "does nothing for Shift+Tab", () => {
+			const event = makeEvent( { shiftKey: true } );
+			handleBannerTabNavigation( bannerEl, event );
+			expect( mockFindNext ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( "does nothing when bannerEl is null", () => {
+			const event = makeEvent();
+			handleBannerTabNavigation( null, event );
+			expect( mockFindNext ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( "does nothing when there is no next tabbable element", () => {
+			mockFindNext.mockReturnValue( null );
+			const event = makeEvent( { target: outsideButton } );
+			handleBannerTabNavigation( bannerEl, event );
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( "Tab into banner", () => {
+		it( "focuses the first banner button and prevents default when tabbing from outside", () => {
+			mockFindNext.mockReturnValue( insideButton );
+			const focusSpy = jest.spyOn( insideButton, "focus" );
+			const event = makeEvent( { target: outsideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( "Tab out of banner", () => {
+		it( "focuses the next element outside the banner and prevents default when tabbing from the last button", () => {
+			mockFindNext.mockReturnValue( outsideButton );
+			const focusSpy = jest.spyOn( outsideButton, "focus" );
+			const event = makeEvent( { target: insideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( "Tab within banner", () => {
+		it( "does not intercept when both current and next tabbable are inside the banner", () => {
+			const secondInsideButton = document.createElement( "button" );
+			bannerEl.appendChild( secondInsideButton );
+			mockFindNext.mockReturnValue( secondInsideButton );
+			const focusSpy = jest.spyOn( secondInsideButton, "focus" );
+			const event = makeEvent( { target: insideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( focusSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( "Tab outside banner entirely", () => {
+		it( "does not intercept when both current and next tabbable are outside the banner", () => {
+			const anotherOutsideButton = document.createElement( "button" );
+			document.body.appendChild( anotherOutsideButton );
+			mockFindNext.mockReturnValue( anotherOutsideButton );
+			const focusSpy = jest.spyOn( anotherOutsideButton, "focus" );
+			const event = makeEvent( { target: outsideButton } );
+
+			handleBannerTabNavigation( bannerEl, event );
+
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+			expect( focusSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
@@ -134,7 +134,7 @@ describe( "handleBannerTabNavigation", () => {
 	} );
 
 	describe( "Tab within banner", () => {
-		it( "does not intercept when both current and next tabbable are inside the banner", () => {
+		it( "intercepts and moves focus when both current and next tabbable are inside the banner", () => {
 			const secondInsideButton = document.createElement( "button" );
 			bannerEl.appendChild( secondInsideButton );
 			mockFindNext.mockReturnValue( secondInsideButton );
@@ -143,11 +143,11 @@ describe( "handleBannerTabNavigation", () => {
 
 			handleBannerTabNavigation( bannerEl, event );
 
-			expect( event.preventDefault ).not.toHaveBeenCalled();
-			expect( focusSpy ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( "does not intercept when both current and previous tabbable are inside the banner (Shift+Tab)", () => {
+		it( "intercepts and moves focus when both current and previous tabbable are inside the banner (Shift+Tab)", () => {
 			const secondInsideButton = document.createElement( "button" );
 			bannerEl.appendChild( secondInsideButton );
 			mockFindPrevious.mockReturnValue( insideButton );
@@ -156,8 +156,8 @@ describe( "handleBannerTabNavigation", () => {
 
 			handleBannerTabNavigation( bannerEl, event );
 
-			expect( event.preventDefault ).not.toHaveBeenCalled();
-			expect( focusSpy ).not.toHaveBeenCalled();
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
@@ -19,7 +19,7 @@ jest.mock( "@wordpress/dom", () => ( {
  */
 const makeEvent = ( overrides = {} ) => ( {
 	defaultPrevented: false,
-	keyCode: 9,
+	key: "Tab",
 	shiftKey: false,
 	target: document.createElement( "button" ),
 	preventDefault: jest.fn(),
@@ -57,7 +57,7 @@ describe( "handleBannerTabNavigation", () => {
 		} );
 
 		it( "does nothing for non-Tab keys", () => {
-			const event = makeEvent( { keyCode: 13 } );
+			const event = makeEvent( { key: "Enter" } );
 			handleBannerTabNavigation( bannerEl, event );
 			expect( mockFindNext ).not.toHaveBeenCalled();
 			expect( event.preventDefault ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Context

The inline content planner banner was made non-block in PR #23221 (it no longer lives in Gutenberg's block data model). As a side-effect, its buttons became unreachable via keyboard Tab and Shift+Tab navigation and invisible to screen readers.

The root cause is Gutenberg's `useTabNav` hook, which intercepts all Tab events inside the writing flow in the bubble phase. It only allows natural tabbing when the next tabbable element is inside the same `[data-block]` wrapper as the current focus. Because the banner sits outside any real block, Tab was always redirected to the sentinel divs — skipping the banner entirely.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the content planner inline banner's buttons could not be reached via keyboard Tab and Shift+Tab navigation and were not announced by screen readers, which was caused by the banner sitting outside Gutenberg's block wrappers.
* Adds learn more link to the conten planner inline banner and refactor the learn more link in the content planner approve modal.

## Relevant technical choices:

* Added `data-block="yoast-content-planner-banner"` to the banner wrapper div. This satisfies Gutenberg's `target.closest('[data-block]')` check for intra-banner Tab: `isInSameBlock` compares `.block-editor-block-list__block` ancestors, both of which are `null` for elements inside the banner (since it is not inside a real block) — `null === null` evaluates to `true`, so Gutenberg allows Tab between the banner's own buttons without intervention.
* Added a capture-phase `keydown` listener on the editor's `ownerDocument` to handle Tab and Shift+Tab crossing the banner boundary (entering from a preceding block, leaving from the last button, entering from a following block via Shift+Tab, or leaving from the first button via Shift+Tab). Capture fires before Gutenberg's bubble-phase handler; calling `preventDefault()` there triggers Gutenberg's early-return guard (`if (event.defaultPrevented) return`) and leaves focus management to our handler. Intra-banner navigation is intentionally not intercepted — it is already handled correctly by Gutenberg via the `data-block` attribute above.
* Navigation logic extracted to `handle-banner-tab-navigation.js` so it can be unit-tested independently of the component. The helper picks `findPrevious` or `findNext` based on `shiftKey` and applies the same boundary-crossing XOR check for both directions.
* Added `role="group"` and `aria-label` to the `InlineBanner` container so screen readers announce the banner as a distinct region when navigating with the virtual cursor.
* Added `@wordpress/dom` as an explicit direct dependency in `packages/js/package.json` (previously only available transitively via `@wordpress/block-editor`).
* While adding the learn more link I refactor the learn more link in the approve modal to support styling consistency with Link component from ui library and avoiding the placeholder in translation, and by that we use out already translated string.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Open a new post in the Gutenberg block editor with the content planner banner visible (new post, minimum posts threshold met, banner not dismissed).
2. Tab into the editor from the toolbar above and verify focus reaches the "×" (dismiss) button on the banner.
3.  Press Tab again — verify focus moves to the "learn more link" button.
4. Press Tab again — verify focus moves to the "Get content suggestions" button.
5. Press Tab again — verify focus moves to the first content block, not back to the toolbar.
6. From the first content block, press Shift+Tab — verify focus moves back to the "Get content suggestions" button.
7. Press Shift+Tab again — verify focus moves to the "×" button.
8. Press Shift+Tab again — verify focus leaves the banner upward (toward the title or toolbar).
9. Activate the dismiss button via Enter — verify the banner is dismissed.
10. Reload and repeat with a screen reader (e.g. VoiceOver or NVDA) — verify the banner is announced as "Content suggestions banner, group" when the virtual cursor enters it.
11. Click on the yoast sidebar and click on the "Get content suggestion" button, check the modal has the learn more link centered at the bottom of the modal with the same link.

RTL:
1. Switch to RTL language.
2. Crete a new post, check the arrow in the learn more link is directed to the left.
3. Repeat the test for the learn more link in the approve modal by clicking on the get content suggestions button in the editor or yoast sidebar.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

1. Open a new post in the Gutenberg block editor (banner must be visible).
4. Tab into the editor and verify the banner buttons ("×" and "Get content suggestions") are reachable via Tab in order.
5. Verify Tab from the last banner button moves focus into the first content block.
6. From the first content block, Shift+Tab back through the banner buttons and verify focus leaves the banner upward.
7. Optionally verify with a screen reader that the banner is announced as a group with its label.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Content planner inline banner (keyboard navigation and screen reader accessibility).
* No changes to block data model, store, or persistence logic.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1195