### PR TITLE
Add filter to hide AI Content Planner inline banner

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -361,8 +361,17 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$screen          = WP_Screen::get();
 		$is_block_editor = $screen && $screen->is_block_editor();
 		if ( $is_block_editor && $this->get_metabox_post()->post_type === 'post' ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in class.
-			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'content_planner' );
+			/**
+			 * Filter: 'wpseo_enable_ai_content_planner_inline_banner' - Allows hiding the AI Content Planner inline banner site-wide.
+			 *
+			 * Returning false stops the hidden meta inputs from being rendered, which the editor JS treats as "banner disabled".
+			 *
+			 * @param bool $enabled Whether the inline banner should be available in the editor. Default true.
+			 */
+			if ( apply_filters( 'wpseo_enable_ai_content_planner_inline_banner', true ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in class.
+				echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'content_planner' );
+			}
 		}
 
 		/**

--- a/packages/js/src/ai-content-planner/helpers/fields.js
+++ b/packages/js/src/ai-content-planner/helpers/fields.js
@@ -22,10 +22,16 @@ const getInputValue = ( id ) => {
 };
 
 /**
- * Helper functions to get the value of whether the banner is dismissed or rendered.
- * @returns {boolean} True if the banner is dismissed or rendered, false otherwise.
+ * Helper function to get the dismissed state of the inline banner from the post meta.
+ *
+ * Returns true when the hidden input is missing, so a server-side filter that stops the input from rendering keeps the banner hidden site-wide.
+ *
+ * @returns {boolean} True if the banner is dismissed or its hidden input is absent, false otherwise.
  */
-export const getIsBannerDismissedFromInput = () => getInputValue( "yoast_wpseo_is_content_planner_banner_dismissed" ) === "1";
+export const getIsBannerDismissedFromInput = () => {
+	const input = document.getElementById( "yoast_wpseo_is_content_planner_banner_dismissed" );
+	return input === null || input.value === "1";
+};
 
 /**
  * Helper function to get the value of whether the banner is rendered.

--- a/packages/js/tests/ai-content-planner/helpers/fields.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/fields.test.js
@@ -1,0 +1,31 @@
+import { getIsBannerDismissedFromInput } from "../../../src/ai-content-planner/helpers/fields";
+
+const INPUT_ID = "yoast_wpseo_is_content_planner_banner_dismissed";
+
+const renderInput = ( value ) => {
+	const input = document.createElement( "input" );
+	input.id = INPUT_ID;
+	input.type = "hidden";
+	input.value = value;
+	document.body.appendChild( input );
+};
+
+describe( "getIsBannerDismissedFromInput", () => {
+	afterEach( () => {
+		document.body.innerHTML = "";
+	} );
+
+	it( "returns true when the hidden input is absent so a server-side filter can hide the banner", () => {
+		expect( getIsBannerDismissedFromInput() ).toBe( true );
+	} );
+
+	it( "returns true when the hidden input value is \"1\"", () => {
+		renderInput( "1" );
+		expect( getIsBannerDismissedFromInput() ).toBe( true );
+	} );
+
+	it( "returns false when the hidden input value is \"0\"", () => {
+		renderInput( "0" );
+		expect( getIsBannerDismissedFromInput() ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Context

Site owners might want a way to hide the AI Content Planner inline banner from the post editor without per-post dismissal.

## Summary

This PR can be summarized in the following changelog entry:

* Adds the `wpseo_enable_ai_content_planner_inline_banner` filter to hide the AI Content Planner inline banner from the post editor.

## Relevant technical choices:

* The filter gates the `Meta_Fields_Presenter('content_planner')` call in the metabox: returning `false` stops the hidden post-meta inputs from rendering at all.
* The editor JS now treats an absent `yoast_wpseo_is_content_planner_banner_dismissed` input as "banner disabled" by checking the input element's existence instead of comparing its value to `"1"`.
* The "Get content suggestions" sidebar/metabox button is unaffected — only the inline banner is hidden.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. On a clean install with the AI Content Planner feature available, edit a new post in the block editor. The "AI Content Planner" inline banner appears above the first block (requires at least 5 published posts).
2. Add the following snippet to a mu-plugin or your theme's `functions.php`:
   ```php
   add_filter( 'wpseo_enable_ai_content_planner_inline_banner', '__return_false' );
   ```
3. Reload the post editor. The inline banner is no longer rendered, and the hidden input `yoast_wpseo_is_content_planner_banner_dismissed` is absent from the page source.
4. Open the Yoast sidebar / metabox. The "Get content suggestions" button is still present and functional.
5. Remove the filter. Reload the editor. The banner is back on new posts.
6. Verify dismissed posts: dismiss the banner on a post (with the filter removed), reload — the banner stays hidden for that post. Add the filter, reload — still hidden. Remove the filter, reload — still hidden (per-post dismissal preserved).

#### Relevant test scenarios
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The AI Content Planner inline banner JS bootstrap (`packages/js/src/ai-content-planner/helpers/fields.js`) — the dismissal-state seed now reads the input element directly. Per-post dismiss/re-render flows are unchanged.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1196