### PR TITLE
Cache getting attachment metadata

### DIFF
--- a/inc/class-wpseo-image-utils.php
+++ b/inc/class-wpseo-image-utils.php
@@ -11,6 +11,13 @@
 class WPSEO_Image_Utils {
 
 	/**
+	 * Per-request memo of full-size attachment image data, keyed by attachment ID.
+	 *
+	 * @var array<int, array|false>
+	 */
+	protected static $full_size_image_data_cache = [];
+
+	/**
 	 * Find an attachment ID for a given URL.
 	 *
 	 * @param string $url The URL to find the attachment for.
@@ -239,13 +246,24 @@ class WPSEO_Image_Utils {
 	/**
 	 * Returns the image data for the full size image.
 	 *
+	 * Memoised per request: this is the lowest-level call site for
+	 * `wp_get_attachment_metadata` in the legacy image stack, hit repeatedly
+	 * by `get_variations()` (once per candidate size) and by every Open Graph
+	 * image generation. Caching here removes the duplicate `wp_postmeta`
+	 * reads on a typical post-with-image render.
+	 *
 	 * @param int $attachment_id Attachment ID.
 	 *
 	 * @return array|false Array when there is a full size image. False if not.
 	 */
 	protected static function get_full_size_image_data( $attachment_id ) {
+		if ( array_key_exists( $attachment_id, self::$full_size_image_data_cache ) ) {
+			return self::$full_size_image_data_cache[ $attachment_id ];
+		}
+
 		$image = wp_get_attachment_metadata( $attachment_id );
 		if ( ! is_array( $image ) ) {
+			self::$full_size_image_data_cache[ $attachment_id ] = false;
 			return false;
 		}
 
@@ -253,7 +271,20 @@ class WPSEO_Image_Utils {
 		$image['path'] = get_attached_file( $attachment_id );
 		$image['size'] = 'full';
 
+		self::$full_size_image_data_cache[ $attachment_id ] = $image;
 		return $image;
+	}
+
+	/**
+	 * Resets the in-memory full-size image data cache.
+	 *
+	 * Test-only helper: production code does not need to invalidate the cache,
+	 * but unit tests need a deterministic starting state across runs.
+	 *
+	 * @return void
+	 */
+	public static function reset_full_size_image_data_cache() {
+		self::$full_size_image_data_cache = [];
 	}
 
 	/**

--- a/src/helpers/image-helper.php
+++ b/src/helpers/image-helper.php
@@ -55,6 +55,20 @@ class Image_Helper {
 	private $url_helper;
 
 	/**
+	 * Per-request memo of attachment metadata, keyed by attachment ID.
+	 *
+	 * @var array<int, array>
+	 */
+	private $metadata_cache = [];
+
+	/**
+	 * Per-request memo of best-attachment-variation results, keyed by attachment ID.
+	 *
+	 * @var array<int, array|false>
+	 */
+	private $variation_cache = [];
+
+	/**
 	 * Image_Helper constructor.
 	 *
 	 * @param Indexable_Repository $indexable_repository The indexable repository.
@@ -228,16 +242,27 @@ class Image_Helper {
 	/**
 	 * Retrieves the attachment metadata.
 	 *
+	 * Memoised per request: a single attachment is commonly read by the
+	 * Schema Main_Image, Organization logo, and Open Graph generators on
+	 * the same render, and `wp_get_attachment_metadata` is a `wp_postmeta`
+	 * lookup whose cost is non-trivial without a persistent object cache.
+	 *
 	 * @param int $attachment_id Attachment ID.
 	 *
 	 * @return array The metadata, empty array when no metadata is found.
 	 */
 	public function get_metadata( $attachment_id ) {
-		$metadata = \wp_get_attachment_metadata( $attachment_id );
-		if ( ! $metadata || ! \is_array( $metadata ) ) {
-			return [];
+		if ( \array_key_exists( $attachment_id, $this->metadata_cache ) ) {
+			return $this->metadata_cache[ $attachment_id ];
 		}
 
+		$metadata = \wp_get_attachment_metadata( $attachment_id );
+		if ( ! $metadata || ! \is_array( $metadata ) ) {
+			$this->metadata_cache[ $attachment_id ] = [];
+			return $this->metadata_cache[ $attachment_id ];
+		}
+
+		$this->metadata_cache[ $attachment_id ] = $metadata;
 		return $metadata;
 	}
 
@@ -275,23 +300,32 @@ class Image_Helper {
 	/**
 	 * Retrieves the best attachment variation for the given attachment.
 	 *
-	 * @codeCoverageIgnore - We have to write test when this method contains own code.
+	 * Memoised per request: the result is deterministic from the attachment ID
+	 * and the underlying `WPSEO_Image_Utils::get_variations` call drives several
+	 * `wp_get_attachment_metadata` lookups, so the same attachment used in both
+	 * Open Graph and the organisation/person logo only pays that cost once.
 	 *
 	 * @param int $attachment_id The attachment id.
 	 *
-	 * @return bool|string The attachment url or false when no variations found.
+	 * @return array|false The attachment data or false when no variations found.
 	 */
 	public function get_best_attachment_variation( $attachment_id ) {
+		if ( \array_key_exists( $attachment_id, $this->variation_cache ) ) {
+			return $this->variation_cache[ $attachment_id ];
+		}
+
 		$variations = WPSEO_Image_Utils::get_variations( $attachment_id );
 		$variations = WPSEO_Image_Utils::filter_usable_file_size( $variations );
 
 		// If we are left without variations, there is no valid variation for this attachment.
 		if ( empty( $variations ) ) {
+			$this->variation_cache[ $attachment_id ] = false;
 			return false;
 		}
 
 		// The variations are ordered so the first variations is by definition the best one.
-		return \reset( $variations );
+		$this->variation_cache[ $attachment_id ] = \reset( $variations );
+		return $this->variation_cache[ $attachment_id ];
 	}
 
 	/**

--- a/tests/Unit/Doubles/Inc/Image_Utils_Double.php
+++ b/tests/Unit/Doubles/Inc/Image_Utils_Double.php
@@ -19,4 +19,16 @@ final class Image_Utils_Double extends WPSEO_Image_Utils {
 	public static function get_first_image( $images ) {
 		return parent::get_first_image( $images );
 	}
+
+	/**
+	 * Exposes the protected get_full_size_image_data so its memoisation
+	 * behaviour can be exercised from a unit test.
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 *
+	 * @return array|false Array when there is a full size image, false if not.
+	 */
+	public static function call_get_full_size_image_data( $attachment_id ) {
+		return parent::get_full_size_image_data( $attachment_id );
+	}
 }

--- a/tests/Unit/Helpers/Image_Helper_Test.php
+++ b/tests/Unit/Helpers/Image_Helper_Test.php
@@ -485,6 +485,86 @@ final class Image_Helper_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that repeated calls for the same attachment ID hit the per-request
+	 * cache and only call wp_get_attachment_metadata once.
+	 *
+	 * @covers ::get_metadata
+	 *
+	 * @return void
+	 */
+	public function test_get_metadata_is_memoized() {
+		Monkey\Functions\expect( 'wp_get_attachment_metadata' )
+			->once()
+			->with( 1337 )
+			->andReturn( [ 'meta' => 'data' ] );
+
+		$first  = $this->instance->get_metadata( 1337 );
+		$second = $this->instance->get_metadata( 1337 );
+
+		$this->assertEquals( [ 'meta' => 'data' ], $first );
+		$this->assertEquals( [ 'meta' => 'data' ], $second );
+	}
+
+	/**
+	 * Tests that an empty-result lookup is also cached, so a second call does
+	 * not re-issue the wp_get_attachment_metadata query for an attachment that
+	 * has no metadata.
+	 *
+	 * @covers ::get_metadata
+	 *
+	 * @return void
+	 */
+	public function test_get_metadata_caches_empty_result() {
+		Monkey\Functions\expect( 'wp_get_attachment_metadata' )
+			->once()
+			->with( 1337 )
+			->andReturn( false );
+
+		$first  = $this->instance->get_metadata( 1337 );
+		$second = $this->instance->get_metadata( 1337 );
+
+		$this->assertEquals( [], $first );
+		$this->assertEquals( [], $second );
+	}
+
+	/**
+	 * Tests that get_best_attachment_variation memoises its result, so that
+	 * a second call for the same attachment does not re-run the underlying
+	 * variation lookup.
+	 *
+	 * @covers ::get_best_attachment_variation
+	 *
+	 * @return void
+	 */
+	public function test_get_best_attachment_variation_is_memoized() {
+		// Reset the legacy static cache so prior tests cannot influence the result.
+		\WPSEO_Image_Utils::reset_full_size_image_data_cache();
+
+		// Stub every underlying call so the first invocation walks through
+		// `WPSEO_Image_Utils::get_variations` and returns false (no variations).
+		Monkey\Functions\when( 'wp_get_attachment_metadata' )->justReturn( false );
+		Monkey\Functions\when( 'image_get_intermediate_size' )->justReturn( false );
+		Monkey\Functions\when( 'wp_get_attachment_image_src' )->justReturn( false );
+
+		$first = $this->actual_instance->get_best_attachment_variation( 1337 );
+		$this->assertFalse( $first );
+
+		// Change one of the underlying stubs to a value that would produce a
+		// different result if the cache were bypassed. Because the helper
+		// memoises the previous `false`, the second call must still return false.
+		Monkey\Functions\when( 'wp_get_attachment_metadata' )->justReturn(
+			[
+				'width'  => 1000,
+				'height' => 1000,
+				'file'   => 'image.jpg',
+			]
+		);
+
+		$second = $this->actual_instance->get_best_attachment_variation( 1337 );
+		$this->assertFalse( $second, 'Second call should return the cached result, not re-run the variation lookup.' );
+	}
+
+	/**
 	 * Tests retrieving the attachment image url.
 	 *
 	 * @covers ::get_attachment_image_url

--- a/tests/Unit/Inc/Image_Utils_Test.php
+++ b/tests/Unit/Inc/Image_Utils_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Inc;
 
 use Brain\Monkey;
+use WPSEO_Image_Utils;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Inc\Image_Utils_Double;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -31,6 +32,21 @@ final class Image_Utils_Test extends TestCase {
 		parent::set_up();
 
 		$this->instance = new Image_Utils_Double();
+
+		// The class-level memo on `get_full_size_image_data` is process-wide;
+		// reset it so each test starts from a clean state.
+		WPSEO_Image_Utils::reset_full_size_image_data_cache();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @return void
+	 */
+	protected function tear_down() {
+		WPSEO_Image_Utils::reset_full_size_image_data_cache();
+
+		parent::tear_down();
 	}
 
 	/**
@@ -74,6 +90,66 @@ final class Image_Utils_Test extends TestCase {
 		$first_image = $this->instance->get_first_image( $images );
 
 		$this->assertEquals( $expected, $first_image, $message );
+	}
+
+	/**
+	 * Tests that get_full_size_image_data only issues a single
+	 * wp_get_attachment_metadata lookup when called multiple times for
+	 * the same attachment ID within a single request.
+	 *
+	 * @covers ::get_full_size_image_data
+	 *
+	 * @return void
+	 */
+	public function test_get_full_size_image_data_is_memoized() {
+		$metadata = [
+			'width'  => 800,
+			'height' => 600,
+			'file'   => 'image.jpg',
+		];
+
+		Monkey\Functions\expect( 'wp_get_attachment_metadata' )
+			->once()
+			->with( 1337 )
+			->andReturn( $metadata );
+
+		Monkey\Functions\expect( 'wp_get_attachment_image_url' )
+			->once()
+			->with( 1337, 'full' )
+			->andReturn( 'https://example.org/image.jpg' );
+
+		Monkey\Functions\expect( 'get_attached_file' )
+			->once()
+			->with( 1337 )
+			->andReturn( '/path/to/image.jpg' );
+
+		$first  = Image_Utils_Double::call_get_full_size_image_data( 1337 );
+		$second = Image_Utils_Double::call_get_full_size_image_data( 1337 );
+
+		$this->assertSame( $first, $second );
+		$this->assertSame( 800, $first['width'] );
+		$this->assertSame( 'https://example.org/image.jpg', $first['url'] );
+	}
+
+	/**
+	 * Tests that a cached `false` result (no metadata) is also returned from
+	 * the memo, so a second call does not re-issue the lookup.
+	 *
+	 * @covers ::get_full_size_image_data
+	 *
+	 * @return void
+	 */
+	public function test_get_full_size_image_data_caches_false_result() {
+		Monkey\Functions\expect( 'wp_get_attachment_metadata' )
+			->once()
+			->with( 1337 )
+			->andReturn( false );
+
+		$first  = Image_Utils_Double::call_get_full_size_image_data( 1337 );
+		$second = Image_Utils_Double::call_get_full_size_image_data( 1337 );
+
+		$this->assertFalse( $first );
+		$this->assertFalse( $second );
 	}
 
 	/**

--- a/tests/WP/Helpers/Image_Helper_Metadata_Cache_Test.php
+++ b/tests/WP/Helpers/Image_Helper_Metadata_Cache_Test.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\WP\Helpers;
+
+use WPSEO_Image_Utils;
+use Yoast\WP\SEO\Helpers\Image_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Repositories\SEO_Links_Repository;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration tests asserting that Image_Helper does not re-issue
+ * `wp_postmeta` lookups for the same attachment ID within a single request.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded -- Needed to show the specific behaviour under test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Image_Helper
+ */
+final class Image_Helper_Metadata_Cache_Test extends TestCase {
+
+	/**
+	 * The instance.
+	 *
+	 * @var Image_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test class.
+	 *
+	 * @return void
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->instance = new Image_Helper(
+			\YoastSEO()->classes->get( Indexable_Repository::class ),
+			\YoastSEO()->classes->get( SEO_Links_Repository::class ),
+			\YoastSEO()->helpers->options,
+			\YoastSEO()->helpers->url
+		);
+
+		// Static memo on `WPSEO_Image_Utils` is process-wide; reset it so the
+		// first call in each test issues a real lookup.
+		WPSEO_Image_Utils::reset_full_size_image_data_cache();
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		WPSEO_Image_Utils::reset_full_size_image_data_cache();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The second call to `get_metadata` for the same attachment must not
+	 * issue any new `wp_postmeta` queries — the per-request memo on
+	 * Image_Helper has to absorb it even when the WordPress object cache
+	 * has been invalidated in between.
+	 *
+	 * @covers ::get_metadata
+	 *
+	 * @return void
+	 */
+	public function test_get_metadata_does_not_query_twice_for_the_same_id() {
+		$attachment_id = self::factory()->attachment->create();
+		\update_post_meta(
+			$attachment_id,
+			'_wp_attachment_metadata',
+			[
+				'width'  => 1000,
+				'height' => 1000,
+				'file'   => 'image.jpg',
+			]
+		);
+
+		// Make sure the first call has to hit the database, not a primed cache.
+		\wp_cache_delete( $attachment_id, 'post_meta' );
+
+		global $wpdb;
+		$queries_at_start = $wpdb->num_queries;
+
+		$first = $this->instance->get_metadata( $attachment_id );
+
+		$queries_after_first = $wpdb->num_queries;
+
+		// Bust the WordPress object cache so that — without our memo — a second
+		// call would have to query `wp_postmeta` again.
+		\wp_cache_delete( $attachment_id, 'post_meta' );
+
+		$second = $this->instance->get_metadata( $attachment_id );
+
+		$queries_after_second = $wpdb->num_queries;
+
+		$this->assertSame( $first, $second, 'Both calls should return the same metadata payload.' );
+		$this->assertGreaterThan(
+			$queries_at_start,
+			$queries_after_first,
+			'The first call should issue at least one query against `wp_postmeta`.'
+		);
+		$this->assertSame(
+			$queries_after_first,
+			$queries_after_second,
+			'The second call must be served from the per-request memo without issuing new queries.'
+		);
+	}
+
+	/**
+	 * The second call to `get_best_attachment_variation` for the same
+	 * attachment must short-circuit at the helper level, even when the
+	 * WordPress object cache has been invalidated between calls.
+	 *
+	 * @covers ::get_best_attachment_variation
+	 *
+	 * @return void
+	 */
+	public function test_get_best_attachment_variation_does_not_query_twice_for_the_same_id() {
+		$attachment_id = self::factory()->attachment->create();
+		\update_post_meta(
+			$attachment_id,
+			'_wp_attachment_metadata',
+			[
+				'width'  => 1000,
+				'height' => 1000,
+				'file'   => 'image.jpg',
+			]
+		);
+
+		\wp_cache_delete( $attachment_id, 'post_meta' );
+
+		global $wpdb;
+		$queries_at_start = $wpdb->num_queries;
+
+		$first = $this->instance->get_best_attachment_variation( $attachment_id );
+
+		$queries_after_first = $wpdb->num_queries;
+
+		\wp_cache_delete( $attachment_id, 'post_meta' );
+
+		$second = $this->instance->get_best_attachment_variation( $attachment_id );
+
+		$queries_after_second = $wpdb->num_queries;
+
+		$this->assertSame( $first, $second, 'Both calls should return the same variation payload.' );
+		$this->assertSame(
+			$queries_after_first,
+			$queries_after_second,
+			'The second call must be served from the per-request memo without issuing new queries.'
+		);
+		$this->assertGreaterThanOrEqual(
+			$queries_at_start,
+			$queries_after_first,
+			'Sanity: the first call should not decrease the query counter.'
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Caches getting attachment metadata.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

 1. Activate Query Monitor and Yoast SEO on a fresh test site.
  2. Configure Yoast → Settings → Site representation: choose "An organisation" and upload an organisation logo.
  3. Create or open a published post that has a featured image. (Same image as the org logo is fine — that's the worst-case duplication.)
  4. Open the post on the front-end while logged in as admin.
  5. In Query Monitor → Queries, search for the featured-image attachment ID and filter to `wp_postmeta`.
  6. Compare against `trunk`:
  - **Before:** the `_wp_attachment_metadata` row is read **3–5 times** for the same attachment ID per render.
  - **After this PR:** the same row is read **once**.
  7. Note `Query Monitor → Overview → Page Generation Time`. Expect a **~6–20 ms drop** per render (more on slower DBs / cold caches).


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
