### PR TITLE
Make content planner inline banner permanently dismissible

### DIFF
--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -46,7 +46,7 @@ export const InlineBanner = ( { isPremium, onDismiss, onDismissPermanently, onCl
 			<p className="yst-grow yst-text-slate-800 yst-font-medium"> { __( "Stuck on what to write next?", "wordpress-seo" ) }</p>
 		</div>
 		<p className="yst-text-sm yst-text-slate-600 yst-mb-1 yst-max-w-xl">
-			{ __( "Let Yoast analyze your content and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
+			{ __( "Let Yoast AI Content Planner analyze your content and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
 		</p>
 		<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-font-medium yst-no-underline">
 			{ __( "Learn more", "wordpress-seo" ) }

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -46,7 +46,7 @@ export const InlineBanner = ( { isPremium, onDismiss, onDismissPermanently, onCl
 			<p className="yst-grow yst-text-slate-800 yst-font-medium"> { __( "Stuck on what to write next?", "wordpress-seo" ) }</p>
 		</div>
 		<p className="yst-text-sm yst-text-slate-600 yst-mb-1 yst-max-w-xl">
-			{ __( "Let Yoast analyze your site and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
+			{ __( "Let Yoast analyze your content and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
 		</p>
 		<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-font-medium yst-no-underline">
 			{ __( "Learn more", "wordpress-seo" ) }

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -1,6 +1,6 @@
 import { __ } from "@wordpress/i18n";
-import { Button, GradientSparklesIcon, Link, Root, useSvgAria } from "@yoast/ui-library";
-import { ArrowNarrowRightIcon, XIcon } from "@heroicons/react/solid";
+import { Button, DropdownMenu, GradientSparklesIcon, Link, Root, useSvgAria } from "@yoast/ui-library";
+import { ArrowNarrowRightIcon, TrashIcon, XIcon } from "@heroicons/react/solid";
 import { OneSparkNote } from "./one-spark-note";
 import { OutboundLink } from "../../shared-admin/components";
 
@@ -10,23 +10,42 @@ import { OutboundLink } from "../../shared-admin/components";
  *
  * @param {object}    props     The block props passed by Gutenberg.
  * @param {boolean}  props.isPremium Whether the user has a premium add-on activated.
- * @param {Function} props.onDismiss The function to call when the banner is dismissed.
+ * @param {Function} props.onDismiss The function to call when the banner is dismissed for the current post.
+ * @param {Function} props.onDismissPermanently The function to call when the banner is permanently dismissed for the current user.
  * @param {Function} props.onClick   The function to call when the "Get content suggestions" button is clicked.
  * @param {string}  props.learnMoreLink The link to the learn more page about the AI Content Planner.
  * @returns {JSX.Element} The inline banner with the button.
  */
-export const InlineBanner = ( { isPremium, onDismiss, onClick, learnMoreLink } ) => {
+export const InlineBanner = ( { isPremium, onDismiss, onDismissPermanently, onClick, learnMoreLink } ) => {
 	const ariaProps = useSvgAria();
 	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg">
-		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1">
+		<DropdownMenu as="span" className="yst-absolute yst-top-4 yst-end-4">
+			<DropdownMenu.IconTrigger
+				screenReaderTriggerLabel={ __( "Open banner options", "wordpress-seo" ) }
+				className="yst-float-end"
+			/>
+			<DropdownMenu.List className="yst-mt-8 yst-w-56">
+				<DropdownMenu.ButtonItem
+					className="yst-text-slate-600 yst-border-b yst-border-slate-200 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4 yst-font-normal"
+					onClick={ onDismiss }
+				>
+					<XIcon className="yst-w-4 yst-text-slate-400 yst-shrink-0" { ...ariaProps } />
+					{ __( "Remove for this post", "wordpress-seo" ) }
+				</DropdownMenu.ButtonItem>
+				<DropdownMenu.ButtonItem
+					className="yst-text-red-500 yst-flex yst-py-2 yst-justify-start yst-gap-2 yst-px-4 yst-font-normal"
+					onClick={ onDismissPermanently }
+				>
+					<TrashIcon className="yst-w-4 yst-shrink-0" { ...ariaProps } />
+					{ __( "Remove for all posts", "wordpress-seo" ) }
+				</DropdownMenu.ButtonItem>
+			</DropdownMenu.List>
+		</DropdownMenu>
+		<div className="yst-flex yst-items-center yst-gap-2 yst-mb-1 yst-pe-8">
 			<GradientSparklesIcon className="yst-h-4 yst-w-4" { ...ariaProps } />
 			<p className="yst-grow yst-text-slate-800 yst-font-medium"> { __( "Stuck on what to write next?", "wordpress-seo" ) }</p>
-			<button type="button" onClick={ onDismiss } className="yst-modal__close-button">
-				<XIcon className="yst-h-6 yst-w-6 yst-text-slate-400" { ...ariaProps } />
-				<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
-			</button>
 		</div>
-		<p className="yst-text-sm yst-text-slate-600 yst-mb-1">
+		<p className="yst-text-sm yst-text-slate-600 yst-mb-1 yst-max-w-xl">
 			{ __( "Let Yoast analyze your site and suggest high-impact topics that fill content gaps and strengthen your SEO strategy.", "wordpress-seo" ) }
 		</p>
 		<Link as={ OutboundLink } href={ learnMoreLink } variant="primary" className="yst-font-medium yst-no-underline">

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -2,12 +2,12 @@ import apiFetch from "@wordpress/api-fetch";
 import { createHigherOrderComponent } from "@wordpress/compose";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
-import { get, noop } from "lodash";
+import { noop } from "lodash";
 import { InlineBanner } from "./inline-banner";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS, INJECTED_STYLE_ID } from "../constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../ai-generator/constants";
 import { useFetchContentSuggestions } from "../hooks/use-fetch-content-suggestions";
-import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigation";
+import { handleBannerTabNavigation, preventArrowNavInMenu } from "../helpers/handle-banner-tab-navigation";
 
 /**
  * Returns true when the mousedown target is outside the dropdown.
@@ -25,25 +25,6 @@ function isClickOutsideDropdown( bannerEl, event ) {
 }
 
 /**
- * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
- * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
- * set, so calling preventDefault() here lets HeadlessUI still process the key.
- *
- * @param {HTMLElement}  bannerEl The banner wrapper element.
- * @param {KeyboardEvent} event   The keydown event.
- * @returns {void}
- */
-function preventArrowNavInMenu( bannerEl, event ) {
-	if ( ! [ "ArrowDown", "ArrowUp" ].includes( event.key ) ) {
-		return;
-	}
-	const menuEl = bannerEl?.querySelector( "[role='menu']" );
-	if ( menuEl && ( menuEl === event.target || menuEl.contains( event.target ) ) ) {
-		event.preventDefault();
-	}
-}
-
-/**
  * The component that conditionally renders the Content Planner inline banner and injects the Tailwind stylesheet into the editor iframe.
  * @param {Function}   BlockListBlock The Gutenberg block component to wrap.
  * @param {Object}   props The block props passed by Gutenberg.
@@ -52,7 +33,7 @@ function preventArrowNavInMenu( bannerEl, event ) {
 const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 	const {
 		isNewPost, isBannerDismissed, isBannerRendered, isBannerPermanentlyDismissed,
-		hasConsent, isPremium, minPostsMet, learnMoreLink,
+		bannerPermanentDismissalEndpoint, hasConsent, isPremium, minPostsMet, learnMoreLink,
 	} = useSelect( ( select ) => {
 		const planner = select( CONTENT_PLANNER_STORE );
 		return {
@@ -60,6 +41,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 			isBannerDismissed: planner.selectIsBannerDismissed(),
 			isBannerRendered: planner.selectIsBannerRendered(),
 			isBannerPermanentlyDismissed: planner.selectIsBannerPermanentlyDismissed(),
+			bannerPermanentDismissalEndpoint: planner.selectBannerPermanentDismissalEndpoint(),
 			isPremium: select( STORE_NAME_EDITOR ).getIsPremium(),
 			hasConsent: select( STORE_NAME_AI ).selectHasAiGeneratorConsent(),
 			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
@@ -78,18 +60,17 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 	}, [ setBannerDismissed ] );
 
 	const handleDismissPermanently = useCallback( () => {
-		const path = get( window, "wpseoContentPlanner.endpoints.bannerPermanentDismissal", "" );
-		if ( ! path ) {
+		if ( ! bannerPermanentDismissalEndpoint ) {
 			return;
 		}
 		setBannerPermanentlyDismissed();
 		apiFetch( {
-			path,
+			path: bannerPermanentDismissalEndpoint,
 			method: "POST",
 			// eslint-disable-next-line camelcase
 			data: { is_dismissed: true },
 		} ).catch( noop );
-	}, [ setBannerPermanentlyDismissed ] );
+	}, [ setBannerPermanentlyDismissed, bannerPermanentDismissalEndpoint ] );
 
 	const handleClick = useCallback( () => {
 		if ( hasConsent ) {

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -1,11 +1,32 @@
+import apiFetch from "@wordpress/api-fetch";
 import { createHigherOrderComponent } from "@wordpress/compose";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
+import { get, noop } from "lodash";
 import { InlineBanner } from "./inline-banner";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS, INJECTED_STYLE_ID } from "../constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../ai-generator/constants";
 import { useFetchContentSuggestions } from "../hooks/use-fetch-content-suggestions";
 import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigation";
+
+/**
+ * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
+ * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
+ * set, so calling preventDefault() here lets HeadlessUI still process the key.
+ *
+ * @param {HTMLElement}  bannerEl The banner wrapper element.
+ * @param {KeyboardEvent} event   The keydown event.
+ * @returns {void}
+ */
+function preventArrowNavInMenu( bannerEl, event ) {
+	if ( ! [ "ArrowDown", "ArrowUp" ].includes( event.key ) ) {
+		return;
+	}
+	const menuEl = bannerEl?.querySelector( "[role='menu']" );
+	if ( menuEl && ( menuEl === event.target || menuEl.contains( event.target ) ) ) {
+		event.preventDefault();
+	}
+}
 
 /**
  * The component that conditionally renders the Content Planner inline banner and injects the Tailwind stylesheet into the editor iframe.
@@ -14,12 +35,16 @@ import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigati
  * @returns {JSX.Element} The wrapped block component with the inline banner conditionally rendered before it.
  */
 const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
-	const { isNewPost, isBannerDismissed, isBannerRendered, hasConsent, isPremium, minPostsMet, learnMoreLink } = useSelect( ( select ) => {
+	const {
+		isNewPost, isBannerDismissed, isBannerRendered, isBannerPermanentlyDismissed,
+		hasConsent, isPremium, minPostsMet, learnMoreLink,
+	} = useSelect( ( select ) => {
 		const planner = select( CONTENT_PLANNER_STORE );
 		return {
 			isNewPost: select( "core/editor" ).isEditedPostNew(),
 			isBannerDismissed: planner.selectIsBannerDismissed(),
 			isBannerRendered: planner.selectIsBannerRendered(),
+			isBannerPermanentlyDismissed: planner.selectIsBannerPermanentlyDismissed(),
 			isPremium: select( STORE_NAME_EDITOR ).getIsPremium(),
 			hasConsent: select( STORE_NAME_AI ).selectHasAiGeneratorConsent(),
 			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
@@ -27,15 +52,25 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 		};
 	}, [] );
 
-	const { setFeatureModalStatus, setBannerDismissed, setBannerRendered } = useDispatch( CONTENT_PLANNER_STORE );
+	const { setFeatureModalStatus, setBannerDismissed, setBannerRendered, setBannerPermanentlyDismissed } = useDispatch( CONTENT_PLANNER_STORE );
 	const fetchContentSuggestions = useFetchContentSuggestions();
 	const ref = useRef( null );
 
-	const shouldShow = ! isBannerDismissed && ( isNewPost || isBannerRendered ) && minPostsMet;
+	const shouldShow = ! isBannerPermanentlyDismissed && ! isBannerDismissed && ( isNewPost || isBannerRendered ) && minPostsMet;
 
 	const handleDismiss = useCallback( () => {
 		setBannerDismissed();
 	}, [ setBannerDismissed ] );
+
+	const handleDismissPermanently = useCallback( () => {
+		setBannerPermanentlyDismissed();
+		apiFetch( {
+			path: get( window, "wpseoContentPlanner.endpoints.bannerPermanentDismissal", "" ),
+			method: "POST",
+			// eslint-disable-next-line camelcase
+			data: { is_dismissed: true },
+		} ).catch( noop );
+	}, [ setBannerPermanentlyDismissed ] );
 
 	const handleClick = useCallback( () => {
 		if ( hasConsent ) {
@@ -80,22 +115,27 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 		// skipped. Attaching a capture-phase listener lets us act before Gutenberg does;
 		// once we call preventDefault(), Gutenberg's early-return guard fires and leaves
 		// focus alone.
+		//
+		// The same guard applies to ArrowUp/ArrowDown: Gutenberg's use-arrow-nav
+		// handler bails early when defaultPrevented is set, so calling preventDefault()
+		// here lets HeadlessUI still process the key while Gutenberg stays out of the way.
 		const ownerDoc = ref.current?.ownerDocument;
 		if ( ! ownerDoc ) {
 			return;
 		}
 
 		/**
-		 * Forwards keydown events to the banner Tab navigation helper.
+		 * Handles keydown events for banner Tab and dropdown arrow-key navigation.
 		 * @param {KeyboardEvent} event The keydown event.
 		 * @returns {void}
 		 */
-		function handleTabNavigation( event ) {
+		function handleKeydownEvents( event ) {
 			handleBannerTabNavigation( ref.current, event );
+			preventArrowNavInMenu( ref.current, event );
 		}
 
-		ownerDoc.addEventListener( "keydown", handleTabNavigation, { capture: true } );
-		return () => ownerDoc.removeEventListener( "keydown", handleTabNavigation, { capture: true } );
+		ownerDoc.addEventListener( "keydown", handleKeydownEvents, { capture: true } );
+		return () => ownerDoc.removeEventListener( "keydown", handleKeydownEvents, { capture: true } );
 	}, [ shouldShow ] );
 
 	return (
@@ -105,6 +145,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 					<InlineBanner
 						isPremium={ isPremium }
 						onDismiss={ handleDismiss }
+						onDismissPermanently={ handleDismissPermanently }
 						onClick={ handleClick }
 						learnMoreLink={ learnMoreLink }
 					/>

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -1,8 +1,6 @@
-import apiFetch from "@wordpress/api-fetch";
 import { createHigherOrderComponent } from "@wordpress/compose";
 import { useSelect, useDispatch } from "@wordpress/data";
 import { useCallback, useEffect, useRef } from "@wordpress/element";
-import { noop } from "lodash";
 import { InlineBanner } from "./inline-banner";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS, INJECTED_STYLE_ID } from "../constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../ai-generator/constants";
@@ -49,7 +47,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 		};
 	}, [] );
 
-	const { setFeatureModalStatus, setBannerDismissed, setBannerRendered, setBannerPermanentlyDismissed } = useDispatch( CONTENT_PLANNER_STORE );
+	const { setFeatureModalStatus, setBannerDismissed, setBannerRendered, dismissBannerPermanently } = useDispatch( CONTENT_PLANNER_STORE );
 	const fetchContentSuggestions = useFetchContentSuggestions();
 	const ref = useRef( null );
 
@@ -60,17 +58,8 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 	}, [ setBannerDismissed ] );
 
 	const handleDismissPermanently = useCallback( () => {
-		if ( ! bannerPermanentDismissalEndpoint ) {
-			return;
-		}
-		setBannerPermanentlyDismissed();
-		apiFetch( {
-			path: bannerPermanentDismissalEndpoint,
-			method: "POST",
-			// eslint-disable-next-line camelcase
-			data: { is_dismissed: true },
-		} ).catch( noop );
-	}, [ setBannerPermanentlyDismissed, bannerPermanentDismissalEndpoint ] );
+		dismissBannerPermanently( bannerPermanentDismissalEndpoint );
+	}, [ dismissBannerPermanently, bannerPermanentDismissalEndpoint ] );
 
 	const handleClick = useCallback( () => {
 		if ( hasConsent ) {

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -19,7 +19,7 @@ import { handleBannerTabNavigation, preventArrowNavInMenu } from "../helpers/han
 function isClickOutsideDropdown( bannerEl, event ) {
 	const trigger = bannerEl?.querySelector( ".yst-dropdown-menu__icon-trigger[aria-expanded='true']" );
 	const menu = trigger && bannerEl.querySelector( "[role='menu']" );
-	return menu && ! trigger.contains( event.target ) && ! menu.contains( event.target );
+	return Boolean( menu ) && ! trigger.contains( event.target ) && ! menu.contains( event.target );
 }
 
 /**

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -5,7 +5,7 @@ import { InlineBanner } from "./inline-banner";
 import { CONTENT_PLANNER_STORE, FEATURE_MODAL_STATUS, INJECTED_STYLE_ID } from "../constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../ai-generator/constants";
 import { useFetchContentSuggestions } from "../hooks/use-fetch-content-suggestions";
-import { handleBannerTabNavigation, preventArrowNavInMenu } from "../helpers/handle-banner-tab-navigation";
+import { handleBannerKeyNavigation } from "../helpers/handle-banner-tab-navigation";
 
 /**
  * Returns true when the mousedown target is outside the dropdown.
@@ -119,8 +119,7 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 		 * @returns {void}
 		 */
 		function handleKeydownEvents( event ) {
-			handleBannerTabNavigation( ref.current, event );
-			preventArrowNavInMenu( ref.current, event );
+			handleBannerKeyNavigation( ref.current, event );
 		}
 
 		const onMousedown = ( event ) => {

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -63,9 +63,13 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 	}, [ setBannerDismissed ] );
 
 	const handleDismissPermanently = useCallback( () => {
+		const path = get( window, "wpseoContentPlanner.endpoints.bannerPermanentDismissal", "" );
+		if ( ! path ) {
+			return;
+		}
 		setBannerPermanentlyDismissed();
 		apiFetch( {
-			path: get( window, "wpseoContentPlanner.endpoints.bannerPermanentDismissal", "" ),
+			path,
 			method: "POST",
 			// eslint-disable-next-line camelcase
 			data: { is_dismissed: true },

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -10,6 +10,21 @@ import { useFetchContentSuggestions } from "../hooks/use-fetch-content-suggestio
 import { handleBannerTabNavigation } from "../helpers/handle-banner-tab-navigation";
 
 /**
+ * Returns true when the mousedown target is outside the dropdown.
+ * HeadlessUI's built-in outside-click detection uses the top-level window and
+ * misses iframe clicks — replicated here via a capture-phase mousedown listener.
+ *
+ * @param {HTMLElement} bannerEl The banner wrapper element.
+ * @param {MouseEvent}  event    The mousedown event.
+ * @returns {boolean}
+ */
+function isClickOutsideDropdown( bannerEl, event ) {
+	const trigger = bannerEl?.querySelector( ".yst-dropdown-menu__icon-trigger[aria-expanded='true']" );
+	const menu = trigger && bannerEl.querySelector( "[role='menu']" );
+	return menu && ! trigger.contains( event.target ) && ! menu.contains( event.target );
+}
+
+/**
  * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
  * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
  * set, so calling preventDefault() here lets HeadlessUI still process the key.
@@ -138,8 +153,18 @@ const FirstBlockWithBanner = ( { BlockListBlock, props } ) => {
 			preventArrowNavInMenu( ref.current, event );
 		}
 
+		const onMousedown = ( event ) => {
+			if ( isClickOutsideDropdown( ref.current, event ) ) {
+				ref.current.querySelector( ".yst-dropdown-menu__icon-trigger" ).click();
+			}
+		};
+
 		ownerDoc.addEventListener( "keydown", handleKeydownEvents, { capture: true } );
-		return () => ownerDoc.removeEventListener( "keydown", handleKeydownEvents, { capture: true } );
+		ownerDoc.addEventListener( "mousedown", onMousedown, { capture: true } );
+		return () => {
+			ownerDoc.removeEventListener( "keydown", handleKeydownEvents, { capture: true } );
+			ownerDoc.removeEventListener( "mousedown", onMousedown, { capture: true } );
+		};
 	}, [ shouldShow ] );
 
 	return (

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -1,25 +1,6 @@
 import { focus } from "@wordpress/dom";
 
 /**
- * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
- * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
- * set, so calling preventDefault() here lets HeadlessUI still process the key.
- *
- * @param {HTMLElement}  bannerEl The banner wrapper element.
- * @param {KeyboardEvent} event   The keydown event.
- * @returns {void}
- */
-export function preventArrowNavInMenu( bannerEl, event ) {
-	if ( ! [ "ArrowDown", "ArrowUp" ].includes( event.key ) ) {
-		return;
-	}
-	const menuEl = bannerEl?.querySelector( "[role='menu']" );
-	if ( menuEl && ( menuEl === event.target || menuEl.contains( event.target ) ) ) {
-		event.preventDefault();
-	}
-}
-
-/**
  * Get sibling function.
  *
  * @param {KeyboardEvent} event The keydown event.
@@ -41,23 +22,32 @@ const getFindSibling = ( event ) => {
 const involvesBanner = ( bannerEl, target, next ) => bannerEl.contains( target ) || bannerEl.contains( next );
 
 /**
- * Keydown handler that keeps the inline banner reachable via Tab inside the Gutenberg
- * writing flow. Gutenberg's useTabNav hook intercepts Tab in the bubble phase and
- * redirects focus to sentinel divs when the next tabbable element is not inside the
- * same [data-block] wrapper. Because the banner sits outside any real block, it is
- * normally skipped. This handler is meant to be attached in the capture phase so it
- * runs before Gutenberg; once it calls preventDefault(), Gutenberg's early-return guard
- * fires and leaves focus alone.
+ * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
+ * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
+ * set, so calling preventDefault() here lets HeadlessUI still process the key.
  *
  * @param {HTMLElement}  bannerEl The banner wrapper element.
  * @param {KeyboardEvent} event   The keydown event.
  * @returns {void}
  */
-export function handleBannerTabNavigation( bannerEl, event ) {
-	if ( event.defaultPrevented || event.key !== "Tab" || ! bannerEl ) {
-		return;
+function handleArrowNavInMenu( bannerEl, event ) {
+	const menuEl = bannerEl.querySelector( "[role='menu']" );
+	if ( menuEl && ( menuEl === event.target || menuEl.contains( event.target ) ) ) {
+		event.preventDefault();
 	}
+}
 
+/**
+ * Handles Tab / Shift+Tab to keep the banner reachable inside Gutenberg's writing flow.
+ * Because the banner sits outside any real block, it is normally skipped. This handler is
+ * attached in the capture phase so it runs first; once it calls preventDefault(),
+ * Gutenberg's early-return guard fires and leaves focus alone.
+ *
+ * @param {HTMLElement}  bannerEl The banner wrapper element.
+ * @param {KeyboardEvent} event   The keydown event.
+ * @returns {void}
+ */
+function handleTabNavigation( bannerEl, event ) {
 	const findSibling = getFindSibling( event );
 	const next = findSibling( event.target );
 
@@ -66,5 +56,29 @@ export function handleBannerTabNavigation( bannerEl, event ) {
 	if ( next && involvesBanner( bannerEl, event.target, next ) ) {
 		event.preventDefault();
 		next.focus();
+	}
+}
+
+/**
+ * Keydown handler for the inline banner. Covers two cases:
+ *
+ * 1. Tab / Shift+Tab — keeps the banner reachable inside Gutenberg's writing flow.
+ * 2. ArrowUp / ArrowDown — prevents Gutenberg's use-arrow-nav handler from stealing
+ *    focus when the HeadlessUI dropdown menu is open.
+ *
+ * @param {HTMLElement}  bannerEl The banner wrapper element.
+ * @param {KeyboardEvent} event   The keydown event.
+ * @returns {void}
+ */
+export function handleBannerKeyNavigation( bannerEl, event ) {
+	if ( event.defaultPrevented || ! bannerEl ) {
+		return;
+	}
+	if ( [ "ArrowDown", "ArrowUp" ].includes( event.key ) ) {
+		handleArrowNavInMenu( bannerEl, event );
+		return;
+	}
+	if ( event.key === "Tab" ) {
+		handleTabNavigation( bannerEl, event );
 	}
 }

--- a/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
+++ b/packages/js/src/ai-content-planner/helpers/handle-banner-tab-navigation.js
@@ -1,6 +1,25 @@
 import { focus } from "@wordpress/dom";
 
 /**
+ * Prevents Gutenberg's arrow-nav handler from stealing focus when the dropdown
+ * menu is open. Gutenberg's use-arrow-nav exits early when defaultPrevented is
+ * set, so calling preventDefault() here lets HeadlessUI still process the key.
+ *
+ * @param {HTMLElement}  bannerEl The banner wrapper element.
+ * @param {KeyboardEvent} event   The keydown event.
+ * @returns {void}
+ */
+export function preventArrowNavInMenu( bannerEl, event ) {
+	if ( ! [ "ArrowDown", "ArrowUp" ].includes( event.key ) ) {
+		return;
+	}
+	const menuEl = bannerEl?.querySelector( "[role='menu']" );
+	if ( menuEl && ( menuEl === event.target || menuEl.contains( event.target ) ) ) {
+		event.preventDefault();
+	}
+}
+
+/**
  * Get sibling function.
  *
  * @param {KeyboardEvent} event The keydown event.

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -121,6 +121,7 @@ export default function initContentPlanner() {
 				isBannerDismissed: getIsBannerDismissedFromInput(),
 				isBannerRendered: getIsBannerRenderedFromInput(),
 				isBannerPermanentlyDismissed: get( window, "wpseoContentPlanner.isBannerPermanentlyDismissed", false ),
+				bannerPermanentDismissalEndpoint: get( window, "wpseoContentPlanner.endpoints.bannerPermanentDismissal", "" ),
 			},
 		} );
 		// Register the inline banner filter after the store is registered,

--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -120,6 +120,7 @@ export default function initContentPlanner() {
 			[ BANNER_NAME ]: {
 				isBannerDismissed: getIsBannerDismissedFromInput(),
 				isBannerRendered: getIsBannerRenderedFromInput(),
+				isBannerPermanentlyDismissed: get( window, "wpseoContentPlanner.isBannerPermanentlyDismissed", false ),
 			},
 		} );
 		// Register the inline banner filter after the store is registered,

--- a/packages/js/src/ai-content-planner/store/banner.js
+++ b/packages/js/src/ai-content-planner/store/banner.js
@@ -1,8 +1,10 @@
+import apiFetch from "@wordpress/api-fetch";
 import { createSlice } from "@reduxjs/toolkit";
-import { get } from "lodash";
+import { get, noop } from "lodash";
 import { setBannerDismissedInput, setBannerRenderedInput } from "../helpers/fields";
 
 export const BANNER_NAME = "banner";
+const DISMISS_BANNER_PERMANENTLY = "dismissBannerPermanently";
 
 const slice = createSlice( {
 	name: BANNER_NAME,
@@ -30,6 +32,30 @@ export const getInitialBannerState = slice.getInitialState;
 export const bannerReducer = slice.reducer;
 
 /**
+ * Marks the banner as permanently dismissed and fires a fire-and-forget
+ * REST POST to persist the dismissal in user meta.
+ *
+ * @param {string} endpoint The REST endpoint path.
+ * @returns {Generator}
+ */
+export function* dismissBannerPermanently( endpoint ) {
+	if ( ! endpoint ) {
+		return;
+	}
+	yield slice.actions.setBannerPermanentlyDismissed();
+	yield{ type: DISMISS_BANNER_PERMANENTLY, endpoint };
+}
+
+export const bannerControls = {
+	[ DISMISS_BANNER_PERMANENTLY ]: ( { endpoint } ) => apiFetch( {
+		path: endpoint,
+		method: "POST",
+		// eslint-disable-next-line camelcase
+		data: { is_dismissed: true },
+	} ).catch( noop ),
+};
+
+/**
  * Public banner actions wrap the slice actions so that dispatching them
  * also writes the matching value to the hidden meta input. The metabox
  * save pipeline then persists "1" to post meta on the next save.
@@ -44,6 +70,7 @@ export const bannerActions = {
 		return slice.actions.setBannerDismissed();
 	},
 	setBannerPermanentlyDismissed: () => slice.actions.setBannerPermanentlyDismissed(),
+	dismissBannerPermanently,
 };
 
 export const bannerSelectors = {

--- a/packages/js/src/ai-content-planner/store/banner.js
+++ b/packages/js/src/ai-content-planner/store/banner.js
@@ -10,6 +10,7 @@ const slice = createSlice( {
 		isBannerDismissed: false,
 		isBannerRendered: false,
 		isBannerPermanentlyDismissed: false,
+		bannerPermanentDismissalEndpoint: "",
 	},
 	reducers: {
 		setBannerRendered: ( state ) => {
@@ -49,4 +50,5 @@ export const bannerSelectors = {
 	selectIsBannerDismissed: ( state ) => get( state, [ BANNER_NAME, "isBannerDismissed" ], slice.getInitialState().isBannerDismissed ),
 	selectIsBannerRendered: ( state ) => get( state, [ BANNER_NAME, "isBannerRendered" ], slice.getInitialState().isBannerRendered ),
 	selectIsBannerPermanentlyDismissed: ( state ) => get( state, [ BANNER_NAME, "isBannerPermanentlyDismissed" ], slice.getInitialState().isBannerPermanentlyDismissed ),
+	selectBannerPermanentDismissalEndpoint: ( state ) => get( state, [ BANNER_NAME, "bannerPermanentDismissalEndpoint" ], slice.getInitialState().bannerPermanentDismissalEndpoint ),
 };

--- a/packages/js/src/ai-content-planner/store/banner.js
+++ b/packages/js/src/ai-content-planner/store/banner.js
@@ -9,6 +9,7 @@ const slice = createSlice( {
 	initialState: {
 		isBannerDismissed: false,
 		isBannerRendered: false,
+		isBannerPermanentlyDismissed: false,
 	},
 	reducers: {
 		setBannerRendered: ( state ) => {
@@ -16,6 +17,9 @@ const slice = createSlice( {
 		},
 		setBannerDismissed: ( state ) => {
 			state.isBannerDismissed = true;
+		},
+		setBannerPermanentlyDismissed: ( state ) => {
+			state.isBannerPermanentlyDismissed = true;
 		},
 	},
 } );
@@ -38,9 +42,11 @@ export const bannerActions = {
 		setBannerDismissedInput();
 		return slice.actions.setBannerDismissed();
 	},
+	setBannerPermanentlyDismissed: () => slice.actions.setBannerPermanentlyDismissed(),
 };
 
 export const bannerSelectors = {
 	selectIsBannerDismissed: ( state ) => get( state, [ BANNER_NAME, "isBannerDismissed" ], slice.getInitialState().isBannerDismissed ),
 	selectIsBannerRendered: ( state ) => get( state, [ BANNER_NAME, "isBannerRendered" ], slice.getInitialState().isBannerRendered ),
+	selectIsBannerPermanentlyDismissed: ( state ) => get( state, [ BANNER_NAME, "isBannerPermanentlyDismissed" ], slice.getInitialState().isBannerPermanentlyDismissed ),
 };

--- a/packages/js/src/ai-content-planner/store/index.js
+++ b/packages/js/src/ai-content-planner/store/index.js
@@ -34,6 +34,7 @@ import {
 import {
 	BANNER_NAME,
 	bannerActions,
+	bannerControls,
 	bannerReducer,
 	bannerSelectors,
 	getInitialBannerState,
@@ -64,6 +65,7 @@ export const createStore = ( initialState ) => {
 		controls: {
 			...contentSuggestionsControls,
 			...contentOutlineControls,
+			...bannerControls,
 		},
 		initialState: merge(
 			{},

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -12,9 +12,10 @@ jest.mock( "@wordpress/compose", () => ( {
 } ) );
 
 jest.mock( "../../../src/ai-content-planner/components/inline-banner", () => ( {
-	InlineBanner: ( { onDismiss, onClick, isPremium } ) => (
+	InlineBanner: ( { onDismiss, onDismissPermanently, onClick, isPremium } ) => (
 		<div data-testid="inline-banner" data-is-premium={ isPremium }>
 			<button data-testid="dismiss-btn" onClick={ onDismiss } />
+			<button data-testid="dismiss-permanently-btn" onClick={ onDismissPermanently } />
 			<button data-testid="click-btn" onClick={ onClick } />
 		</div>
 	),
@@ -40,12 +41,14 @@ const MockBlockListBlock = ( props ) => <div data-testid="block-list-block" { ..
 const mockSetFeatureModalStatus = jest.fn();
 const mockSetBannerDismissed = jest.fn();
 const mockSetBannerRendered = jest.fn();
+const mockSetBannerPermanentlyDismissed = jest.fn();
 
 const setupMocks = ( overrides = {} ) => {
 	const defaults = {
 		isFirstBlock: true,
 		isNewPost: true,
 		isBannerDismissed: false,
+		isBannerPermanentlyDismissed: false,
 		isBannerRendered: false,
 		hasConsent: false,
 		isPremium: false,
@@ -65,6 +68,7 @@ const setupMocks = ( overrides = {} ) => {
 			return {
 				selectIsBannerDismissed: () => values.isBannerDismissed,
 				selectIsBannerRendered: () => values.isBannerRendered,
+				selectIsBannerPermanentlyDismissed: () => values.isBannerPermanentlyDismissed,
 				selectIsMinPostsMet: () => values.minPostsMet,
 			};
 		}
@@ -81,6 +85,7 @@ const setupMocks = ( overrides = {} ) => {
 		setFeatureModalStatus: mockSetFeatureModalStatus,
 		setBannerDismissed: mockSetBannerDismissed,
 		setBannerRendered: mockSetBannerRendered,
+		setBannerPermanentlyDismissed: mockSetBannerPermanentlyDismissed,
 	} );
 };
 
@@ -102,6 +107,14 @@ describe( "withInlineBanner", () => {
 
 	test( "does not render the banner when it is dismissed", () => {
 		setupMocks( { isBannerDismissed: true } );
+		const { queryByTestId, getByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
+		expect( getByTestId( "block-list-block" ) ).toBeInTheDocument();
+	} );
+
+	test( "does not render the banner when it is permanently dismissed", () => {
+		setupMocks( { isBannerPermanentlyDismissed: true } );
 		const { queryByTestId, getByTestId } = render( <WithInlineBanner clientId="client-1" /> );
 
 		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -50,6 +50,7 @@ const setupMocks = ( overrides = {} ) => {
 		isBannerDismissed: false,
 		isBannerPermanentlyDismissed: false,
 		isBannerRendered: false,
+		bannerPermanentDismissalEndpoint: "/wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal",
 		hasConsent: false,
 		isPremium: false,
 		minPostsMet: true,
@@ -69,6 +70,7 @@ const setupMocks = ( overrides = {} ) => {
 				selectIsBannerDismissed: () => values.isBannerDismissed,
 				selectIsBannerRendered: () => values.isBannerRendered,
 				selectIsBannerPermanentlyDismissed: () => values.isBannerPermanentlyDismissed,
+				selectBannerPermanentDismissalEndpoint: () => values.bannerPermanentDismissalEndpoint,
 				selectIsMinPostsMet: () => values.minPostsMet,
 			};
 		}

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -50,7 +50,7 @@ const setupMocks = ( overrides = {} ) => {
 		isBannerDismissed: false,
 		isBannerPermanentlyDismissed: false,
 		isBannerRendered: false,
-		bannerPermanentDismissalEndpoint: "/wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal",
+		bannerPermanentDismissalEndpoint: "yoast/v1/ai_content_planner/banner_permanent_dismissal",
 		hasConsent: false,
 		isPremium: false,
 		minPostsMet: true,
@@ -164,7 +164,7 @@ describe( "withInlineBanner", () => {
 		const { getByTestId } = render( <WithInlineBanner clientId="client-1" /> );
 
 		getByTestId( "dismiss-permanently-btn" ).click();
-		expect( mockDismissBannerPermanently ).toHaveBeenCalledWith( "/wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal" );
+		expect( mockDismissBannerPermanently ).toHaveBeenCalledWith( "yoast/v1/ai_content_planner/banner_permanent_dismissal" );
 	} );
 
 	test( "calls fetchContentSuggestions when click button is clicked and has consent", () => {

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -41,7 +41,7 @@ const MockBlockListBlock = ( props ) => <div data-testid="block-list-block" { ..
 const mockSetFeatureModalStatus = jest.fn();
 const mockSetBannerDismissed = jest.fn();
 const mockSetBannerRendered = jest.fn();
-const mockSetBannerPermanentlyDismissed = jest.fn();
+const mockDismissBannerPermanently = jest.fn();
 
 const setupMocks = ( overrides = {} ) => {
 	const defaults = {
@@ -87,7 +87,7 @@ const setupMocks = ( overrides = {} ) => {
 		setFeatureModalStatus: mockSetFeatureModalStatus,
 		setBannerDismissed: mockSetBannerDismissed,
 		setBannerRendered: mockSetBannerRendered,
-		setBannerPermanentlyDismissed: mockSetBannerPermanentlyDismissed,
+		dismissBannerPermanently: mockDismissBannerPermanently,
 	} );
 };
 
@@ -157,6 +157,14 @@ describe( "withInlineBanner", () => {
 
 		getByTestId( "dismiss-btn" ).click();
 		expect( mockSetBannerDismissed ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( "calls dismissBannerPermanently with the endpoint when the permanently-dismiss button is clicked", () => {
+		setupMocks();
+		const { getByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		getByTestId( "dismiss-permanently-btn" ).click();
+		expect( mockDismissBannerPermanently ).toHaveBeenCalledWith( "/wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal" );
 	} );
 
 	test( "calls fetchContentSuggestions when click button is clicked and has consent", () => {

--- a/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
+++ b/packages/js/tests/ai-content-planner/helpers/handle-banner-tab-navigation.test.js
@@ -1,4 +1,4 @@
-import { handleBannerTabNavigation } from "../../../src/ai-content-planner/helpers/handle-banner-tab-navigation";
+import { handleBannerKeyNavigation } from "../../../src/ai-content-planner/helpers/handle-banner-tab-navigation";
 
 const mockFindNext = jest.fn();
 const mockFindPrevious = jest.fn();
@@ -26,7 +26,7 @@ const makeEvent = ( overrides = {} ) => ( {
 	...overrides,
 } );
 
-describe( "handleBannerTabNavigation", () => {
+describe( "handleBannerKeyNavigation", () => {
 	let bannerEl;
 	let insideButton;
 	let outsideButton;
@@ -51,21 +51,21 @@ describe( "handleBannerTabNavigation", () => {
 	describe( "early returns", () => {
 		it( "does nothing when event.defaultPrevented is true", () => {
 			const event = makeEvent( { defaultPrevented: true } );
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 			expect( mockFindNext ).not.toHaveBeenCalled();
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 
-		it( "does nothing for non-Tab keys", () => {
+		it( "does nothing for non-Tab, non-Arrow keys", () => {
 			const event = makeEvent( { key: "Enter" } );
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 			expect( mockFindNext ).not.toHaveBeenCalled();
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 
 		it( "does nothing when bannerEl is null", () => {
 			const event = makeEvent();
-			handleBannerTabNavigation( null, event );
+			handleBannerKeyNavigation( null, event );
 			expect( mockFindNext ).not.toHaveBeenCalled();
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
@@ -73,14 +73,14 @@ describe( "handleBannerTabNavigation", () => {
 		it( "does nothing when there is no next tabbable element", () => {
 			mockFindNext.mockReturnValue( null );
 			const event = makeEvent( { target: outsideButton } );
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 
 		it( "does nothing when there is no previous tabbable element (Shift+Tab)", () => {
 			mockFindPrevious.mockReturnValue( null );
 			const event = makeEvent( { shiftKey: true, target: outsideButton } );
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 	} );
@@ -91,7 +91,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( insideButton, "focus" );
 			const event = makeEvent( { target: outsideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -102,7 +102,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( insideButton, "focus" );
 			const event = makeEvent( { shiftKey: true, target: outsideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -115,7 +115,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( outsideButton, "focus" );
 			const event = makeEvent( { target: insideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -126,7 +126,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( outsideButton, "focus" );
 			const event = makeEvent( { shiftKey: true, target: insideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -141,7 +141,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( secondInsideButton, "focus" );
 			const event = makeEvent( { target: insideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -154,7 +154,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( insideButton, "focus" );
 			const event = makeEvent( { shiftKey: true, target: secondInsideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
 			expect( focusSpy ).toHaveBeenCalledTimes( 1 );
@@ -169,7 +169,7 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( anotherOutsideButton, "focus" );
 			const event = makeEvent( { target: outsideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 			expect( focusSpy ).not.toHaveBeenCalled();
@@ -182,10 +182,55 @@ describe( "handleBannerTabNavigation", () => {
 			const focusSpy = jest.spyOn( anotherOutsideButton, "focus" );
 			const event = makeEvent( { shiftKey: true, target: outsideButton } );
 
-			handleBannerTabNavigation( bannerEl, event );
+			handleBannerKeyNavigation( bannerEl, event );
 
 			expect( event.preventDefault ).not.toHaveBeenCalled();
 			expect( focusSpy ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( "ArrowDown / ArrowUp in dropdown menu", () => {
+		let menuEl;
+
+		beforeEach( () => {
+			menuEl = document.createElement( "ul" );
+			menuEl.setAttribute( "role", "menu" );
+			bannerEl.appendChild( menuEl );
+		} );
+
+		it( "prevents default on ArrowDown when focus is on the menu element itself", () => {
+			const event = makeEvent( { key: "ArrowDown", target: menuEl } );
+			handleBannerKeyNavigation( bannerEl, event );
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "prevents default on ArrowDown when focus is inside the menu", () => {
+			const menuItem = document.createElement( "li" );
+			menuEl.appendChild( menuItem );
+			const event = makeEvent( { key: "ArrowDown", target: menuItem } );
+			handleBannerKeyNavigation( bannerEl, event );
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "prevents default on ArrowUp when focus is inside the menu", () => {
+			const menuItem = document.createElement( "li" );
+			menuEl.appendChild( menuItem );
+			const event = makeEvent( { key: "ArrowUp", target: menuItem } );
+			handleBannerKeyNavigation( bannerEl, event );
+			expect( event.preventDefault ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( "does not prevent default on ArrowDown when focus is outside the menu", () => {
+			const event = makeEvent( { key: "ArrowDown", target: outsideButton } );
+			handleBannerKeyNavigation( bannerEl, event );
+			expect( event.preventDefault ).not.toHaveBeenCalled();
+		} );
+
+		it( "does not prevent default on ArrowDown when the banner has no menu", () => {
+			bannerEl.removeChild( menuEl );
+			const event = makeEvent( { key: "ArrowDown", target: insideButton } );
+			handleBannerKeyNavigation( bannerEl, event );
+			expect( event.preventDefault ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/src/ai/content-planner/infrastructure/endpoints/banner-permanent-dismissal-endpoint.php
+++ b/src/ai/content-planner/infrastructure/endpoints/banner-permanent-dismissal-endpoint.php
@@ -1,0 +1,50 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Endpoints;
+
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+/**
+ * Represents the content planner endpoint to permanently dismiss the inline banner.
+ */
+class Banner_Permanent_Dismissal_Endpoint implements Content_Planner_Endpoint_Interface {
+
+	/**
+	 * Gets the name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'bannerPermanentDismissal';
+	}
+
+	/**
+	 * Gets the namespace.
+	 *
+	 * @return string
+	 */
+	public function get_namespace(): string {
+		return Banner_Permanent_Dismissal_Route::ROUTE_NAMESPACE;
+	}
+
+	/**
+	 * Gets the route.
+	 *
+	 * @return string
+	 */
+	public function get_route(): string {
+		return Banner_Permanent_Dismissal_Route::ROUTE_PREFIX;
+	}
+
+	/**
+	 * Gets the URL.
+	 *
+	 * @return string
+	 */
+	public function get_url(): string {
+		return \rest_url( $this->get_namespace() . $this->get_route() );
+	}
+}

--- a/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
+++ b/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
@@ -1,0 +1,113 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\AI\Content_Planner\User_Interface;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Main;
+use Yoast\WP\SEO\Routes\Route_Interface;
+
+/**
+ * Registers a route to permanently dismiss the AI Content Planner inline banner for the current user.
+ */
+class Banner_Permanent_Dismissal_Route implements Route_Interface {
+
+	use No_Conditionals;
+
+	/**
+	 * The user meta key used to store the permanent dismissal state.
+	 *
+	 * @var string
+	 */
+	public const USER_META_KEY = '_yoast_wpseo_ai_content_planner_banner_permanently_dismissed';
+
+	/**
+	 * The namespace for this route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_NAMESPACE = Main::API_V1_NAMESPACE;
+
+	/**
+	 * The prefix for this route.
+	 *
+	 * @var string
+	 */
+	public const ROUTE_PREFIX = '/ai_content_planner/banner_permanent_dismissal';
+
+	/**
+	 * Holds the user helper instance.
+	 *
+	 * @var User_Helper
+	 */
+	private $user_helper;
+
+	/**
+	 * Constructs the class.
+	 *
+	 * @param User_Helper $user_helper The user helper.
+	 */
+	public function __construct( User_Helper $user_helper ) {
+		$this->user_helper = $user_helper;
+	}
+
+	/**
+	 * Registers routes with WordPress.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		\register_rest_route(
+			self::ROUTE_NAMESPACE,
+			self::ROUTE_PREFIX,
+			[
+				[
+					'methods'             => 'POST',
+					'callback'            => [ $this, 'set_banner_permanent_dismissal' ],
+					'permission_callback' => [ $this, 'check_capabilities' ],
+					'args'                => [
+						'is_dismissed' => [
+							'required'          => true,
+							'type'              => 'bool',
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permanently dismisses the AI Content Planner banner for the current user.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response The success or failure response.
+	 */
+	public function set_banner_permanent_dismissal( WP_REST_Request $request ) {
+		$is_dismissed = $request->get_param( 'is_dismissed' );
+		$user_id      = $this->user_helper->get_current_user_id();
+		$result       = $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $is_dismissed );
+
+		return new WP_REST_Response(
+			[
+				'success' => (bool) $result,
+			],
+			( $result !== false ) ? 200 : 400
+		);
+	}
+
+	/**
+	 * Checks if the current user has the required capabilities.
+	 *
+	 * @return bool
+	 */
+	public function check_capabilities() {
+		return \current_user_can( 'edit_posts' );
+	}
+}

--- a/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
+++ b/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
@@ -78,7 +78,7 @@ class Banner_Permanent_Dismissal_Route implements Route_Interface {
 						],
 					],
 				],
-			]
+			],
 		);
 	}
 
@@ -94,11 +94,18 @@ class Banner_Permanent_Dismissal_Route implements Route_Interface {
 		$user_id      = $this->user_helper->get_current_user_id();
 		$result       = $this->user_helper->update_meta( $user_id, self::USER_META_KEY, $is_dismissed );
 
+		// update_meta returns false both on failure and when the stored value is already identical.
+		// Check the existing value to distinguish the two cases and keep the endpoint idempotent.
+		if ( $result === false ) {
+			$existing = $this->user_helper->get_meta( $user_id, self::USER_META_KEY, true );
+			$result   = ( (bool) $existing === (bool) $is_dismissed );
+		}
+
 		return new WP_REST_Response(
 			[
 				'success' => (bool) $result,
 			],
-			( $result !== false ) ? 200 : 400
+			( $result !== false ) ? 200 : 400,
 		);
 	}
 

--- a/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
+++ b/src/ai/content-planner/user-interface/banner-permanent-dismissal-route.php
@@ -7,7 +7,7 @@ namespace Yoast\WP\SEO\AI\Content_Planner\User_Interface;
 
 use WP_REST_Request;
 use WP_REST_Response;
-use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Conditionals\AI_Conditional;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
@@ -16,8 +16,6 @@ use Yoast\WP\SEO\Routes\Route_Interface;
  * Registers a route to permanently dismiss the AI Content Planner inline banner for the current user.
  */
 class Banner_Permanent_Dismissal_Route implements Route_Interface {
-
-	use No_Conditionals;
 
 	/**
 	 * The user meta key used to store the permanent dismissal state.
@@ -48,9 +46,20 @@ class Banner_Permanent_Dismissal_Route implements Route_Interface {
 	private $user_helper;
 
 	/**
+	 * Gets the conditionals required to load this class.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		return [ AI_Conditional::class ];
+	}
+
+	/**
 	 * Constructs the class.
 	 *
 	 * @param User_Helper $user_helper The user helper.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public function __construct( User_Helper $user_helper ) {
 		$this->user_helper = $user_helper;

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -95,7 +95,7 @@ class Content_Planner_Integration implements Integration_Interface {
 	/**
 	 * Returns the script data for the content planner.
 	 *
-	 * @return array{endpoints: array<string, string>, minPostsMet: bool}
+	 * @return array{endpoints: array<string, string>, minPostsMet: bool, isBannerPermanentlyDismissed: bool}
 	 */
 	public function get_script_data(): array {
 		return [

--- a/src/ai/content-planner/user-interface/content-planner-integration.php
+++ b/src/ai/content-planner/user-interface/content-planner-integration.php
@@ -8,6 +8,7 @@ use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Planner_Endpoints_Repository;
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
 use Yoast\WP\SEO\Conditionals\AI_Editor_Conditional;
+use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 
@@ -43,6 +44,13 @@ class Content_Planner_Integration implements Integration_Interface {
 	private $indexable_repository;
 
 	/**
+	 * The user helper.
+	 *
+	 * @var User_Helper
+	 */
+	private $user_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -57,15 +65,18 @@ class Content_Planner_Integration implements Integration_Interface {
 	 * @param WPSEO_Admin_Asset_Manager            $asset_manager        The admin asset manager.
 	 * @param Content_Planner_Endpoints_Repository $endpoints_repository The endpoints repository.
 	 * @param Indexable_Repository                 $indexable_repository The indexable repository.
+	 * @param User_Helper                          $user_helper          The user helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Content_Planner_Endpoints_Repository $endpoints_repository,
-		Indexable_Repository $indexable_repository
+		Indexable_Repository $indexable_repository,
+		User_Helper $user_helper
 	) {
 		$this->asset_manager        = $asset_manager;
 		$this->endpoints_repository = $endpoints_repository;
 		$this->indexable_repository = $indexable_repository;
+		$this->user_helper          = $user_helper;
 	}
 
 	/**
@@ -88,8 +99,9 @@ class Content_Planner_Integration implements Integration_Interface {
 	 */
 	public function get_script_data(): array {
 		return [
-			'endpoints'   => $this->endpoints_repository->get_all_endpoints()->to_paths_array(),
-			'minPostsMet' => $this->is_minimum_posts_met(),
+			'endpoints'                    => $this->endpoints_repository->get_all_endpoints()->to_paths_array(),
+			'minPostsMet'                  => $this->is_minimum_posts_met(),
+			'isBannerPermanentlyDismissed' => $this->is_banner_permanently_dismissed(),
 		];
 	}
 
@@ -115,5 +127,16 @@ class Content_Planner_Integration implements Integration_Interface {
 		$posts = $this->indexable_repository->get_recently_modified_posts( 'post', self::MIN_PUBLISHED_POSTS, false );
 
 		return \count( $posts ) >= self::MIN_PUBLISHED_POSTS;
+	}
+
+	/**
+	 * Determines whether the current user has permanently dismissed the inline banner.
+	 *
+	 * @return bool Whether the banner is permanently dismissed for this user.
+	 */
+	private function is_banner_permanently_dismissed(): bool {
+		$user_id = $this->user_helper->get_current_user_id();
+
+		return (bool) $this->user_helper->get_meta( $user_id, Banner_Permanent_Dismissal_Route::USER_META_KEY, true );
 	}
 }

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Abstract_Banner_Permanent_Dismissal_Endpoint_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Abstract_Banner_Permanent_Dismissal_Endpoint_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint;
+
+use Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Banner_Permanent_Dismissal_Endpoint tests.
+ *
+ * @group ai-content-planner
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Banner_Permanent_Dismissal_Endpoint_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Banner_Permanent_Dismissal_Endpoint
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->instance = new Banner_Permanent_Dismissal_Endpoint();
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Name_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Name_Test.php
@@ -1,0 +1,27 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Endpoint get_name method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint::get_name
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Name_Test extends Abstract_Banner_Permanent_Dismissal_Endpoint_Test {
+
+	/**
+	 * Tests the get_name method.
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'bannerPermanentDismissal', $this->instance->get_name() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Route_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Route_Test.php
@@ -1,0 +1,27 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Endpoint get_route method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint::get_route
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Route_Test extends Abstract_Banner_Permanent_Dismissal_Endpoint_Test {
+
+	/**
+	 * Tests the get_route method.
+	 *
+	 * @return void
+	 */
+	public function test_get_route() {
+		$this->assertSame( '/ai_content_planner/banner_permanent_dismissal', $this->instance->get_route() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Url_Test.php
+++ b/tests/Unit/AI/Content_Planner/Infrastructure/Endpoints/Banner_Permanent_Dismissal_Endpoint/Get_Url_Test.php
@@ -1,0 +1,36 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Endpoint get_url method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Endpoints\Banner_Permanent_Dismissal_Endpoint::get_url
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Url_Test extends Abstract_Banner_Permanent_Dismissal_Endpoint_Test {
+
+	/**
+	 * Tests the get_url method.
+	 *
+	 * @return void
+	 */
+	public function test_get_url() {
+		$url = 'yoast/v1/ai_content_planner/banner_permanent_dismissal';
+
+		Functions\expect( 'rest_url' )
+			->once()
+			->with( $url )
+			->andReturn( $url );
+
+		$this->assertSame( $url, $this->instance->get_url() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Abstract_Banner_Permanent_Dismissal_Route_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Abstract_Banner_Permanent_Dismissal_Route_Test.php
@@ -1,0 +1,48 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+use Mockery;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Base class for the Banner_Permanent_Dismissal_Route tests.
+ *
+ * @group ai-content-planner
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Banner_Permanent_Dismissal_Route_Test extends TestCase {
+
+	/**
+	 * Holds the user helper mock.
+	 *
+	 * @var Mockery\MockInterface|User_Helper
+	 */
+	protected $user_helper;
+
+	/**
+	 * Holds the instance under test.
+	 *
+	 * @var Banner_Permanent_Dismissal_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->user_helper = Mockery::mock( User_Helper::class );
+
+		$this->instance = new Banner_Permanent_Dismissal_Route( $this->user_helper );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Check_Capabilities_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Check_Capabilities_Test.php
@@ -1,0 +1,42 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Route check_capabilities method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route::check_capabilities
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Check_Capabilities_Test extends Abstract_Banner_Permanent_Dismissal_Route_Test {
+
+	/**
+	 * Tests that check_capabilities returns true when the user has the edit_posts capability.
+	 *
+	 * @return void
+	 */
+	public function test_check_capabilities_returns_true_when_user_can_edit_posts() {
+		Functions\when( 'current_user_can' )->justReturn( true );
+
+		$this->assertTrue( $this->instance->check_capabilities() );
+	}
+
+	/**
+	 * Tests that check_capabilities returns false when the user lacks the edit_posts capability.
+	 *
+	 * @return void
+	 */
+	public function test_check_capabilities_returns_false_when_user_cannot_edit_posts() {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$this->assertFalse( $this->instance->check_capabilities() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Register_Routes_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Register_Routes_Test.php
@@ -1,0 +1,56 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+use Brain\Monkey\Functions;
+use Mockery;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Route register_routes method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route::register_routes
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Register_Routes_Test extends Abstract_Banner_Permanent_Dismissal_Route_Test {
+
+	/**
+	 * Tests that register_routes registers the expected route configuration.
+	 *
+	 * @return void
+	 */
+	public function test_register_routes() {
+		$captured_config = null;
+
+		Functions\expect( 'register_rest_route' )
+			->once()
+			->with(
+				'yoast/v1',
+				'/ai_content_planner/banner_permanent_dismissal',
+				Mockery::on(
+					static function ( $config ) use ( &$captured_config ) {
+						$captured_config = $config;
+						return true;
+					},
+				),
+			);
+
+		$this->instance->register_routes();
+
+		$route = $captured_config[0];
+
+		$this->assertSame( 'POST', $route['methods'] );
+		$this->assertSame( [ $this->instance, 'set_banner_permanent_dismissal' ], $route['callback'] );
+		$this->assertSame( [ $this->instance, 'check_capabilities' ], $route['permission_callback'] );
+
+		$this->assertArrayHasKey( 'is_dismissed', $route['args'] );
+		$this->assertTrue( $route['args']['is_dismissed']['required'] );
+		$this->assertSame( 'bool', $route['args']['is_dismissed']['type'] );
+		$this->assertSame( 'rest_sanitize_boolean', $route['args']['is_dismissed']['sanitize_callback'] );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Set_Banner_Permanent_Dismissal_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Banner_Permanent_Dismissal_Route/Set_Banner_Permanent_Dismissal_Test.php
@@ -1,0 +1,100 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+use Mockery;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+
+/**
+ * Tests the Banner_Permanent_Dismissal_Route set_banner_permanent_dismissal method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route::set_banner_permanent_dismissal
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Set_Banner_Permanent_Dismissal_Test extends Abstract_Banner_Permanent_Dismissal_Route_Test {
+
+	/**
+	 * Tests that set_banner_permanent_dismissal returns a 200 success response when the meta is updated.
+	 *
+	 * @return void
+	 */
+	public function test_returns_200_when_meta_is_updated() {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'is_dismissed' )->andReturn( true );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper->expects( 'update_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( 42 );
+
+		$wp_rest_response = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response->expects( '__construct' )->once()->with( [ 'success' => true ], 200 );
+
+		$result = $this->instance->set_banner_permanent_dismissal( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+	}
+
+	/**
+	 * Tests that set_banner_permanent_dismissal returns 200 when the value is already set (idempotent).
+	 *
+	 * @return void
+	 */
+	public function test_returns_200_when_value_already_set() {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'is_dismissed' )->andReturn( true );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper->expects( 'update_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( false );
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '1' );
+
+		$wp_rest_response = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response->expects( '__construct' )->once()->with( [ 'success' => true ], 200 );
+
+		$result = $this->instance->set_banner_permanent_dismissal( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+	}
+
+	/**
+	 * Tests that set_banner_permanent_dismissal returns 400 when the update fails.
+	 *
+	 * @return void
+	 */
+	public function test_returns_400_when_update_fails() {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'is_dismissed' )->andReturn( true );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper->expects( 'update_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( false );
+		$this->user_helper->expects( 'get_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '' );
+
+		$wp_rest_response = Mockery::mock( 'overload:' . WP_REST_Response::class );
+		$wp_rest_response->expects( '__construct' )->once()->with( [ 'success' => false ], 400 );
+
+		$result = $this->instance->set_banner_permanent_dismissal( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+	}
+}


### PR DESCRIPTION
## Context

The AI Content Planner inline banner in the Gutenberg editor had a single close button that dismissed it for the current post only. Users had no way to permanently stop seeing the banner without dismissing it on every new post.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a dropdown menu to the AI Content Planner inline banner with options to dismiss it for the current post or remove it permanently across all posts for the current user.

## Relevant technical choices:

* The dropdown replaces the plain X button, matching the existing pattern used on the Site Kit setup widget in the Yoast Dashboard (`DropdownMenu` from `@yoast/ui-library`).
* Permanent dismissal is stored in user meta (`_yoast_wpseo_ai_content_planner_banner_permanently_dismissed`) rather than site options, so each user controls their own preference independently.
* A new REST endpoint (`POST /wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal`) handles the user meta write, wired via the existing `Content_Planner_Endpoint_Interface` variadic injection pattern so it appears automatically in the `wpseoContentPlanner.endpoints` JS object.
* The PHP integration reads the user meta at page load and passes `isBannerPermanentlyDismissed` in the localized script data, seeding the Redux store so the banner is hidden immediately on load without a round-trip.
* A capture-phase `keydown` listener prevents Gutenberg's `use-arrow-nav` handler from stealing focus while the dropdown menu is open (Gutenberg bails early when `defaultPrevented` is set; HeadlessUI still processes the arrow key via its own handler).
* A capture-phase `mousedown` listener on the editor iframe's document closes the dropdown when clicking outside it. HeadlessUI's built-in outside-click detection listens on the top-level window, which doesn't receive events from inside the Gutenberg iframe.
* The `dismissBannerPermanently` store action (generator + control) owns the API call, following the existing controls pattern used by `fetchContentPlannerSuggestions`. The banner endpoint URL is seeded into the Redux store at boot so the component passes it through without reading from `window` directly.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

1. Ensure you have at least 5 published posts (the `minPostsMet` threshold).
2. Open a new post in Gutenberg, the AI Content Planner banner should appear below the title block.
3. Confirm the copy of the inline-banner says _Let Yoast AI Content Planner analyze your content and suggest high-impact topics that fill content gaps and strengthen your SEO strategy._ as per this 🧵 [thread](https://yoast.slack.com/archives/C0A99L6MSTB/p1778155895977989?thread_ts=1778154467.454069&cid=C0A99L6MSTB)
4. Click the three-dots icon (top-right of the banner) — a dropdown with two options should appear without shifting any banner content.
5. Use ArrowDown/ArrowUp keys — focus should move between the two dropdown items.
6. Click somewhere outside the dropdown (e.g. the post title or editor canvas) — the dropdown should close.
7. Open the dropdown again and press **Esc** — the dropdown should close.

8. Click **"Remove for this post"** — banner hides. Open another new post — banner reappears.
9. Open a new post again, click the three-dots, then click **"Remove for all posts"** — banner hides. Reload the page and open additional new posts — banner no longer appears for this user.
10. Log in as a different user — banner should still appear for them.
11. Verify the REST endpoint is called: check the Network tab for a `POST` to `/wp-json/yoast/v1/ai_content_planner/banner_permanent_dismissal`.

> **To reset the permanent dismissal and re-test step 7**, delete the meta_key from the user_meta in the database:
> ```
> _yoast_wpseo_ai_content_planner_banner_permanently_dismissed
> ```
> Or via WP-CLI: `wp user meta delete <user_id> _yoast_wpseo_ai_content_planner_banner_permanently_dismissed`

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* AI Content Planner inline banner (Gutenberg block editor)
* New REST API endpoint for user meta

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to the WBSO document.

Fixes [#1205](https://github.com/Yoast/reserved-tasks/issues/1205)