### PR TITLE
Add unit tests for AI content planner store slices

### DIFF
--- a/packages/js/tests/ai-content-planner/store/availability.test.js
+++ b/packages/js/tests/ai-content-planner/store/availability.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	AVAILABILITY_NAME,
+	availabilityReducer,
+	availabilitySelectors,
+	getInitialAvailabilityState,
+} from "../../../src/ai-content-planner/store/availability";
+
+describe( "availability store", () => {
+	describe( "getInitialAvailabilityState", () => {
+		it( "should return the initial state", () => {
+			expect( getInitialAvailabilityState() ).toEqual( {
+				minPostsMet: false,
+			} );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		it( "should return the initial state for an unknown action", () => {
+			expect( availabilityReducer( undefined, { type: "@@INIT" } ) ).toEqual( {
+				minPostsMet: false,
+			} );
+		} );
+
+		it( "should not change state for an unknown action", () => {
+			const state = { minPostsMet: true };
+			expect( availabilityReducer( state, { type: "UNKNOWN" } ) ).toEqual( state );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		it( "should return minPostsMet from state", () => {
+			const state = { [ AVAILABILITY_NAME ]: { minPostsMet: true } };
+			expect( availabilitySelectors.selectIsMinPostsMet( state ) ).toBe( true );
+		} );
+
+		it( "should return the default minPostsMet when state is missing", () => {
+			expect( availabilitySelectors.selectIsMinPostsMet( {} ) ).toBe( false );
+		} );
+
+		it( "should return the current minPostsMet value when it is false", () => {
+			const state = { [ AVAILABILITY_NAME ]: { minPostsMet: false } };
+			expect( availabilitySelectors.selectIsMinPostsMet( state ) ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/store/availability.test.js
+++ b/packages/js/tests/ai-content-planner/store/availability.test.js
@@ -37,10 +37,5 @@ describe( "availability store", () => {
 		it( "should return the default minPostsMet when state is missing", () => {
 			expect( availabilitySelectors.selectIsMinPostsMet( {} ) ).toBe( false );
 		} );
-
-		it( "should return the current minPostsMet value when it is false", () => {
-			const state = { [ AVAILABILITY_NAME ]: { minPostsMet: false } };
-			expect( availabilitySelectors.selectIsMinPostsMet( state ) ).toBe( false );
-		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/store/banner.test.js
+++ b/packages/js/tests/ai-content-planner/store/banner.test.js
@@ -78,18 +78,6 @@ describe( "banner store", () => {
 			expect( action.type ).toBe( `${ BANNER_NAME }/setBannerDismissed` );
 		} );
 
-		it( "setBannerRendered action can be applied to the reducer", () => {
-			const action = bannerActions.setBannerRendered();
-			const state = bannerReducer( getInitialBannerState(), action );
-			expect( state.isBannerRendered ).toBe( true );
-		} );
-
-		it( "setBannerDismissed action can be applied to the reducer", () => {
-			const action = bannerActions.setBannerDismissed();
-			const state = bannerReducer( getInitialBannerState(), action );
-			expect( state.isBannerDismissed ).toBe( true );
-		} );
-
 		it( "setBannerPermanentlyDismissed returns the slice action without calling DOM helpers", () => {
 			const action = bannerActions.setBannerPermanentlyDismissed();
 			expect( action.type ).toBe( `${ BANNER_NAME }/setBannerPermanentlyDismissed` );

--- a/packages/js/tests/ai-content-planner/store/banner.test.js
+++ b/packages/js/tests/ai-content-planner/store/banner.test.js
@@ -17,7 +17,7 @@ jest.mock( "../../../src/ai-content-planner/helpers/fields", () => ( {
 
 jest.mock( "@wordpress/api-fetch", () => jest.fn() );
 
-const apiFetch = require( "@wordpress/api-fetch" );
+import apiFetch from "@wordpress/api-fetch";
 
 describe( "banner store", () => {
 	beforeEach( () => {

--- a/packages/js/tests/ai-content-planner/store/banner.test.js
+++ b/packages/js/tests/ai-content-planner/store/banner.test.js
@@ -1,10 +1,12 @@
-import { describe, expect, it, beforeEach } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import { setBannerRenderedInput, setBannerDismissedInput } from "../../../src/ai-content-planner/helpers/fields";
 import {
 	BANNER_NAME,
 	bannerActions,
+	bannerControls,
 	bannerReducer,
 	bannerSelectors,
+	dismissBannerPermanently,
 	getInitialBannerState,
 } from "../../../src/ai-content-planner/store/banner";
 
@@ -13,10 +15,15 @@ jest.mock( "../../../src/ai-content-planner/helpers/fields", () => ( {
 	setBannerDismissedInput: jest.fn(),
 } ) );
 
+jest.mock( "@wordpress/api-fetch", () => jest.fn() );
+
+const apiFetch = require( "@wordpress/api-fetch" );
+
 describe( "banner store", () => {
 	beforeEach( () => {
 		setBannerRenderedInput.mockClear();
 		setBannerDismissedInput.mockClear();
+		apiFetch.mockClear();
 	} );
 
 	describe( "getInitialBannerState", () => {
@@ -24,6 +31,8 @@ describe( "banner store", () => {
 			expect( getInitialBannerState() ).toEqual( {
 				isBannerDismissed: false,
 				isBannerRendered: false,
+				isBannerPermanentlyDismissed: false,
+				bannerPermanentDismissalEndpoint: "",
 			} );
 		} );
 	} );
@@ -33,6 +42,8 @@ describe( "banner store", () => {
 			expect( bannerReducer( undefined, { type: "@@INIT" } ) ).toEqual( {
 				isBannerDismissed: false,
 				isBannerRendered: false,
+				isBannerPermanentlyDismissed: false,
+				bannerPermanentDismissalEndpoint: "",
 			} );
 		} );
 
@@ -46,6 +57,11 @@ describe( "banner store", () => {
 			const result = bannerReducer( getInitialBannerState(), { type: `${ BANNER_NAME }/setBannerDismissed` } );
 			expect( result.isBannerDismissed ).toBe( true );
 			expect( result.isBannerRendered ).toBe( false );
+		} );
+
+		it( "should set isBannerPermanentlyDismissed to true on setBannerPermanentlyDismissed", () => {
+			const result = bannerReducer( getInitialBannerState(), { type: `${ BANNER_NAME }/setBannerPermanentlyDismissed` } );
+			expect( result.isBannerPermanentlyDismissed ).toBe( true );
 		} );
 	} );
 
@@ -73,12 +89,78 @@ describe( "banner store", () => {
 			const state = bannerReducer( getInitialBannerState(), action );
 			expect( state.isBannerDismissed ).toBe( true );
 		} );
+
+		it( "setBannerPermanentlyDismissed returns the slice action without calling DOM helpers", () => {
+			const action = bannerActions.setBannerPermanentlyDismissed();
+			expect( action.type ).toBe( `${ BANNER_NAME }/setBannerPermanentlyDismissed` );
+			expect( setBannerRenderedInput ).not.toHaveBeenCalled();
+			expect( setBannerDismissedInput ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( "dismissBannerPermanently generator", () => {
+		it( "should return early without yielding when endpoint is falsy", () => {
+			const generator = dismissBannerPermanently( "" );
+			const result = generator.next();
+			expect( result.done ).toBe( true );
+			expect( result.value ).toBeUndefined();
+		} );
+
+		it( "should yield the setBannerPermanentlyDismissed action then the control action when endpoint is provided", () => {
+			const endpoint = "yoast/v1/ai_content_planner/dismiss_banner";
+			const generator = dismissBannerPermanently( endpoint );
+
+			// First yield: slice action to update state.
+			const firstResult = generator.next();
+			expect( firstResult.value.type ).toBe( `${ BANNER_NAME }/setBannerPermanentlyDismissed` );
+			expect( firstResult.done ).toBe( false );
+
+			// Second yield: control action to fire the REST call.
+			const secondResult = generator.next();
+			expect( secondResult.value ).toEqual( { type: "dismissBannerPermanently", endpoint } );
+			expect( secondResult.done ).toBe( false );
+
+			// Generator completes.
+			expect( generator.next().done ).toBe( true );
+		} );
+	} );
+
+	describe( "controls", () => {
+		it( "should call apiFetch with POST method and is_dismissed: true", async() => {
+			apiFetch.mockResolvedValue( undefined );
+			const endpoint = "yoast/v1/ai_content_planner/dismiss_banner";
+
+			await bannerControls.dismissBannerPermanently( { endpoint } );
+
+			expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( {
+				path: endpoint,
+				method: "POST",
+				// eslint-disable-next-line camelcase
+				data: { is_dismissed: true },
+			} ) );
+		} );
+
+		it( "should swallow apiFetch errors silently", async() => {
+			apiFetch.mockRejectedValue( new Error( "Network error" ) );
+
+			await expect(
+				bannerControls.dismissBannerPermanently( { endpoint: "yoast/v1/test" } )
+			).resolves.toBeUndefined();
+		} );
 	} );
 
 	describe( "selectors", () => {
+		const fullState = {
+			[ BANNER_NAME ]: {
+				isBannerDismissed: true,
+				isBannerRendered: true,
+				isBannerPermanentlyDismissed: true,
+				bannerPermanentDismissalEndpoint: "yoast/v1/ai_content_planner/dismiss_banner",
+			},
+		};
+
 		it( "should return isBannerDismissed from state", () => {
-			const state = { [ BANNER_NAME ]: { isBannerDismissed: true, isBannerRendered: false } };
-			expect( bannerSelectors.selectIsBannerDismissed( state ) ).toBe( true );
+			expect( bannerSelectors.selectIsBannerDismissed( fullState ) ).toBe( true );
 		} );
 
 		it( "should return the default isBannerDismissed when state is missing", () => {
@@ -86,12 +168,28 @@ describe( "banner store", () => {
 		} );
 
 		it( "should return isBannerRendered from state", () => {
-			const state = { [ BANNER_NAME ]: { isBannerDismissed: false, isBannerRendered: true } };
-			expect( bannerSelectors.selectIsBannerRendered( state ) ).toBe( true );
+			expect( bannerSelectors.selectIsBannerRendered( fullState ) ).toBe( true );
 		} );
 
 		it( "should return the default isBannerRendered when state is missing", () => {
 			expect( bannerSelectors.selectIsBannerRendered( {} ) ).toBe( false );
+		} );
+
+		it( "should return isBannerPermanentlyDismissed from state", () => {
+			expect( bannerSelectors.selectIsBannerPermanentlyDismissed( fullState ) ).toBe( true );
+		} );
+
+		it( "should return the default isBannerPermanentlyDismissed when state is missing", () => {
+			expect( bannerSelectors.selectIsBannerPermanentlyDismissed( {} ) ).toBe( false );
+		} );
+
+		it( "should return bannerPermanentDismissalEndpoint from state", () => {
+			expect( bannerSelectors.selectBannerPermanentDismissalEndpoint( fullState ) )
+				.toBe( "yoast/v1/ai_content_planner/dismiss_banner" );
+		} );
+
+		it( "should return the default bannerPermanentDismissalEndpoint when state is missing", () => {
+			expect( bannerSelectors.selectBannerPermanentDismissalEndpoint( {} ) ).toBe( "" );
 		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/store/banner.test.js
+++ b/packages/js/tests/ai-content-planner/store/banner.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach } from "@jest/globals";
+import { setBannerRenderedInput, setBannerDismissedInput } from "../../../src/ai-content-planner/helpers/fields";
+import {
+	BANNER_NAME,
+	bannerActions,
+	bannerReducer,
+	bannerSelectors,
+	getInitialBannerState,
+} from "../../../src/ai-content-planner/store/banner";
+
+jest.mock( "../../../src/ai-content-planner/helpers/fields", () => ( {
+	setBannerRenderedInput: jest.fn(),
+	setBannerDismissedInput: jest.fn(),
+} ) );
+
+describe( "banner store", () => {
+	beforeEach( () => {
+		setBannerRenderedInput.mockClear();
+		setBannerDismissedInput.mockClear();
+	} );
+
+	describe( "getInitialBannerState", () => {
+		it( "should return the initial state", () => {
+			expect( getInitialBannerState() ).toEqual( {
+				isBannerDismissed: false,
+				isBannerRendered: false,
+			} );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		it( "should return the initial state for an unknown action", () => {
+			expect( bannerReducer( undefined, { type: "@@INIT" } ) ).toEqual( {
+				isBannerDismissed: false,
+				isBannerRendered: false,
+			} );
+		} );
+
+		it( "should set isBannerRendered to true on setBannerRendered", () => {
+			const result = bannerReducer( getInitialBannerState(), { type: `${ BANNER_NAME }/setBannerRendered` } );
+			expect( result.isBannerRendered ).toBe( true );
+			expect( result.isBannerDismissed ).toBe( false );
+		} );
+
+		it( "should set isBannerDismissed to true on setBannerDismissed", () => {
+			const result = bannerReducer( getInitialBannerState(), { type: `${ BANNER_NAME }/setBannerDismissed` } );
+			expect( result.isBannerDismissed ).toBe( true );
+			expect( result.isBannerRendered ).toBe( false );
+		} );
+	} );
+
+	describe( "actions", () => {
+		it( "setBannerRendered calls setBannerRenderedInput and returns the slice action", () => {
+			const action = bannerActions.setBannerRendered();
+			expect( setBannerRenderedInput ).toHaveBeenCalledTimes( 1 );
+			expect( action.type ).toBe( `${ BANNER_NAME }/setBannerRendered` );
+		} );
+
+		it( "setBannerDismissed calls setBannerDismissedInput and returns the slice action", () => {
+			const action = bannerActions.setBannerDismissed();
+			expect( setBannerDismissedInput ).toHaveBeenCalledTimes( 1 );
+			expect( action.type ).toBe( `${ BANNER_NAME }/setBannerDismissed` );
+		} );
+
+		it( "setBannerRendered action can be applied to the reducer", () => {
+			const action = bannerActions.setBannerRendered();
+			const state = bannerReducer( getInitialBannerState(), action );
+			expect( state.isBannerRendered ).toBe( true );
+		} );
+
+		it( "setBannerDismissed action can be applied to the reducer", () => {
+			const action = bannerActions.setBannerDismissed();
+			const state = bannerReducer( getInitialBannerState(), action );
+			expect( state.isBannerDismissed ).toBe( true );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		it( "should return isBannerDismissed from state", () => {
+			const state = { [ BANNER_NAME ]: { isBannerDismissed: true, isBannerRendered: false } };
+			expect( bannerSelectors.selectIsBannerDismissed( state ) ).toBe( true );
+		} );
+
+		it( "should return the default isBannerDismissed when state is missing", () => {
+			expect( bannerSelectors.selectIsBannerDismissed( {} ) ).toBe( false );
+		} );
+
+		it( "should return isBannerRendered from state", () => {
+			const state = { [ BANNER_NAME ]: { isBannerDismissed: false, isBannerRendered: true } };
+			expect( bannerSelectors.selectIsBannerRendered( state ) ).toBe( true );
+		} );
+
+		it( "should return the default isBannerRendered when state is missing", () => {
+			expect( bannerSelectors.selectIsBannerRendered( {} ) ).toBe( false );
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/store/index.test.js
+++ b/packages/js/tests/ai-content-planner/store/index.test.js
@@ -1,5 +1,5 @@
 import { createRegistry } from "@wordpress/data";
-import { createStore } from "../../../src/ai-content-planner/store";
+import { createStore, registerStore } from "../../../src/ai-content-planner/store";
 import { CONTENT_PLANNER_STORE } from "../../../src/ai-content-planner/constants";
 
 describe( "content planner store", () => {
@@ -23,5 +23,19 @@ describe( "content planner store", () => {
 		registry.dispatch( CONTENT_PLANNER_STORE ).setFeatureModalStatus( "content-outline" );
 		registry.dispatch( CONTENT_PLANNER_STORE ).closeModal();
 		expect( registry.select( CONTENT_PLANNER_STORE ).selectFeatureModalStatus() ).toBeNull();
+	} );
+
+	it( "applies initialState when provided to createStore", () => {
+		const customRegistry = createRegistry();
+		customRegistry.register( createStore( {
+			modal: { isOpen: false, featureModalStatus: "consent" },
+		} ) );
+		expect( customRegistry.select( CONTENT_PLANNER_STORE ).selectFeatureModalStatus() ).toBe( "consent" );
+	} );
+} );
+
+describe( "registerStore", () => {
+	it( "registers the store to the default registry without throwing", () => {
+		expect( () => registerStore() ).not.toThrow();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/store/modal.test.js
+++ b/packages/js/tests/ai-content-planner/store/modal.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "@jest/globals";
+import {
+	MODAL_NAME,
+	modalActions,
+	modalReducer,
+	modalSelectors,
+	getInitialModalState,
+} from "../../../src/ai-content-planner/store/modal";
+import { FEATURE_MODAL_STATUS } from "../../../src/ai-content-planner/constants";
+import { ASYNC_ACTION_NAMES } from "../../../src/shared-admin/constants";
+import { FETCH_CONTENT_OUTLINE_ACTION_NAME } from "../../../src/ai-content-planner/store/content-outline";
+import { FETCH_CONTENT_SUGGESTIONS_ACTION_NAME } from "../../../src/ai-content-planner/store/content-suggestions";
+
+describe( "modal store", () => {
+	describe( "getInitialModalState", () => {
+		it( "should return the initial state", () => {
+			expect( getInitialModalState() ).toEqual( {
+				isOpen: false,
+				featureModalStatus: null,
+			} );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		it( "should return the initial state for an unknown action", () => {
+			expect( modalReducer( undefined, { type: "@@INIT" } ) ).toEqual( {
+				isOpen: false,
+				featureModalStatus: null,
+			} );
+		} );
+
+		it( "should reset to initial state on closeModal", () => {
+			const state = { isOpen: true, featureModalStatus: FEATURE_MODAL_STATUS.contentSuggestions };
+			expect( modalReducer( state, modalActions.closeModal() ) ).toEqual( {
+				isOpen: false,
+				featureModalStatus: null,
+			} );
+		} );
+
+		it( "should set featureModalStatus on setFeatureModalStatus", () => {
+			const result = modalReducer(
+				getInitialModalState(),
+				modalActions.setFeatureModalStatus( FEATURE_MODAL_STATUS.consent )
+			);
+			expect( result.featureModalStatus ).toBe( FEATURE_MODAL_STATUS.consent );
+		} );
+
+		it( "should set featureModalStatus to contentOutline when fetchContentOutline/request is dispatched", () => {
+			const result = modalReducer(
+				getInitialModalState(),
+				{ type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }` }
+			);
+			expect( result.featureModalStatus ).toBe( FEATURE_MODAL_STATUS.contentOutline );
+		} );
+
+		it( "should set featureModalStatus to contentSuggestions when fetchContentPlannerSuggestions/request is dispatched", () => {
+			const result = modalReducer(
+				getInitialModalState(),
+				{ type: `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }` }
+			);
+			expect( result.featureModalStatus ).toBe( FEATURE_MODAL_STATUS.contentSuggestions );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		it( "should return featureModalStatus from state", () => {
+			const state = { [ MODAL_NAME ]: { isOpen: true, featureModalStatus: FEATURE_MODAL_STATUS.contentOutline } };
+			expect( modalSelectors.selectFeatureModalStatus( state ) ).toBe( FEATURE_MODAL_STATUS.contentOutline );
+		} );
+
+		it( "should return the default featureModalStatus when state is missing", () => {
+			expect( modalSelectors.selectFeatureModalStatus( {} ) ).toBeNull();
+		} );
+
+		it( "should return null when featureModalStatus is null", () => {
+			const state = { [ MODAL_NAME ]: { isOpen: false, featureModalStatus: null } };
+			expect( modalSelectors.selectFeatureModalStatus( state ) ).toBeNull();
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -136,12 +136,14 @@ describe( "content outline store", () => {
 			} );
 
 			it( "should normalize the snake_case API response and set status to success on success", () => {
+				/* eslint-disable camelcase */
 				const apiResponse = {
 					outline: [
 						{ subheading_text: "Introduction", content_notes: [ "Write an intro" ] },
 						{ subheading_text: "Body", content_notes: [ "Add examples", "Add stats" ] },
 					],
 				};
+				/* eslint-enable camelcase */
 				const result = contentOutlineReducer(
 					getInitialContentOutlineState(),
 					{
@@ -317,6 +319,7 @@ describe( "content outline store", () => {
 			expect( controlResult.done ).toBe( false );
 
 			// Third yield: success action with the simulated API response.
+			// eslint-disable-next-line camelcase
 			const apiResponse = { outline: [ { subheading_text: "Intro", content_notes: [] } ] };
 			const successResult = generator.next( apiResponse );
 			expect( successResult.value ).toEqual( {
@@ -332,8 +335,9 @@ describe( "content outline store", () => {
 
 		it( "should yield an error action when the API call throws a non-aborted error", () => {
 			const generator = fetchContentOutline( params );
-			generator.next(); // request
-			generator.next(); // control
+			// Advance past request and control yields.
+			generator.next();
+			generator.next();
 
 			const error = new Error( "Network error" );
 			const errorResult = generator.throw( error );
@@ -350,8 +354,9 @@ describe( "content outline store", () => {
 
 		it( "should return early without yielding an error action when the error is aborted", () => {
 			const generator = fetchContentOutline( params );
-			generator.next(); // request
-			generator.next(); // control
+			// Advance past request and control yields.
+			generator.next();
+			generator.next();
 
 			const abortedError = { aborted: true };
 			const result = generator.throw( abortedError );

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -387,12 +387,25 @@ describe( "content outline store", () => {
 
 			await contentOutlineControls[ FETCH_CONTENT_OUTLINE_ACTION_NAME ]( { payload } );
 
+			/* eslint-disable camelcase */
 			expect( contentPlannerFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
 					method: "POST",
 					path: payload.endpoint,
+					data: expect.objectContaining( {
+						post_type: payload.postType,
+						language: payload.language,
+						editor: payload.editor,
+						title: payload.title,
+						intent: payload.intent,
+						explanation: payload.explanation,
+						keyphrase: payload.keyphrase,
+						meta_description: payload.meta_description,
+						category: payload.category,
+					} ),
 				} )
 			);
+			/* eslint-enable camelcase */
 		} );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "@jest/globals";
+import { contentPlannerFetch } from "../../../src/ai-content-planner/helpers/fetch";
 import {
 	CONTENT_OUTLINE_NAME,
 	FETCH_CONTENT_OUTLINE_ACTION_NAME,
@@ -8,15 +9,13 @@ import {
 	fetchContentOutline,
 	getInitialContentOutlineState,
 } from "../../../src/ai-content-planner/store/content-outline";
+import { FETCH_CONTENT_SUGGESTIONS_ACTION_NAME } from "../../../src/ai-content-planner/store/content-suggestions";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
+import { ERROR_DEFAULT } from "../../../src/ai-content-planner/constants";
 
 jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
 	contentPlannerFetch: jest.fn(),
 } ) );
-
-const { contentPlannerFetch } = require( "../../../src/ai-content-planner/helpers/fetch" );
-import { FETCH_CONTENT_SUGGESTIONS_ACTION_NAME } from "../../../src/ai-content-planner/store/content-suggestions";
-import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
-import { ERROR_DEFAULT } from "../../../src/ai-content-planner/constants";
 
 /* eslint-disable camelcase -- API field names use snake_case. */
 const mockSuggestion = {

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -1,0 +1,394 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import {
+	CONTENT_OUTLINE_NAME,
+	FETCH_CONTENT_OUTLINE_ACTION_NAME,
+	contentOutlineControls,
+	contentOutlineReducer,
+	contentOutlineSelectors,
+	fetchContentOutline,
+	getInitialContentOutlineState,
+} from "../../../src/ai-content-planner/store/content-outline";
+
+jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
+	contentPlannerFetch: jest.fn(),
+} ) );
+
+const { contentPlannerFetch } = require( "../../../src/ai-content-planner/helpers/fetch" );
+import { FETCH_CONTENT_SUGGESTIONS_ACTION_NAME } from "../../../src/ai-content-planner/store/content-suggestions";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
+import { ERROR_DEFAULT } from "../../../src/ai-content-planner/constants";
+
+/* eslint-disable camelcase -- API field names use snake_case. */
+const mockSuggestion = {
+	id: "suggestion-dog training-How to train your dog",
+	title: "How to train your dog",
+	intent: "informational",
+	keyphrase: "dog training",
+	meta_description: "Learn how to train your dog.",
+	category: "pets",
+	explanation: "A guide to dog training basics.",
+};
+/* eslint-enable camelcase */
+
+describe( "content outline store", () => {
+	describe( "getInitialContentOutlineState", () => {
+		it( "should return the initial state", () => {
+			expect( getInitialContentOutlineState() ).toEqual( {
+				suggestion: null,
+				outline: [],
+				cache: {},
+				endpoint: "",
+				status: ASYNC_ACTION_STATUS.idle,
+				error: ERROR_DEFAULT,
+			} );
+		} );
+	} );
+
+	describe( "reducer", () => {
+		describe( "setSuggestionForOutline", () => {
+			it( "should set the suggestion", () => {
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{ type: `${ CONTENT_OUTLINE_NAME }/setSuggestionForOutline`, payload: mockSuggestion }
+				);
+				expect( result.suggestion ).toEqual( mockSuggestion );
+			} );
+		} );
+
+		describe( "restoreContentOutlineFromCache", () => {
+			it( "should restore suggestion and outline, set status to success and clear error", () => {
+				const cachedOutline = [
+					{ id: "0-Introduction", heading: "Introduction", contentNotes: [ "Write an intro" ] },
+				];
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ CONTENT_OUTLINE_NAME }/restoreContentOutlineFromCache`,
+						payload: { suggestion: mockSuggestion, outline: cachedOutline },
+					}
+				);
+				expect( result.suggestion ).toEqual( mockSuggestion );
+				expect( result.outline ).toEqual( cachedOutline );
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.success );
+				expect( result.error ).toEqual( ERROR_DEFAULT );
+			} );
+		} );
+
+		describe( "saveOutlineEditsToCache", () => {
+			it( "should save structure to cache and reset state when id is provided", () => {
+				const structure = [
+					{ id: "0-Introduction", heading: "Introduction", contentNotes: [ "Intro note" ] },
+				];
+				const state = {
+					...getInitialContentOutlineState(),
+					suggestion: mockSuggestion,
+					outline: structure,
+					status: ASYNC_ACTION_STATUS.success,
+				};
+				const result = contentOutlineReducer(
+					state,
+					{
+						type: `${ CONTENT_OUTLINE_NAME }/saveOutlineEditsToCache`,
+						payload: { id: mockSuggestion.id, structure },
+					}
+				);
+				expect( result.cache[ mockSuggestion.id ] ).toEqual( structure );
+				expect( result.suggestion ).toBeNull();
+				expect( result.outline ).toEqual( [] );
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.idle );
+				expect( result.error ).toEqual( ERROR_DEFAULT );
+			} );
+
+			it( "should reset state without updating cache when id is falsy", () => {
+				const state = {
+					...getInitialContentOutlineState(),
+					suggestion: mockSuggestion,
+					outline: [ { id: "0-Intro", heading: "Intro", contentNotes: [] } ],
+					status: ASYNC_ACTION_STATUS.success,
+				};
+				const result = contentOutlineReducer(
+					state,
+					{
+						type: `${ CONTENT_OUTLINE_NAME }/saveOutlineEditsToCache`,
+						payload: { id: null, structure: [] },
+					}
+				);
+				expect( result.cache ).toEqual( {} );
+				expect( result.suggestion ).toBeNull();
+				expect( result.outline ).toEqual( [] );
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.idle );
+				expect( result.error ).toEqual( ERROR_DEFAULT );
+			} );
+		} );
+
+		describe( "fetchContentOutline extra reducers", () => {
+			it( "should set status to loading, update suggestion and clear error on request", () => {
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`,
+						payload: { suggestion: mockSuggestion },
+					}
+				);
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.loading );
+				expect( result.suggestion ).toEqual( mockSuggestion );
+				expect( result.error ).toEqual( ERROR_DEFAULT );
+			} );
+
+			it( "should normalize the snake_case API response and set status to success on success", () => {
+				const apiResponse = {
+					outline: [
+						{ subheading_text: "Introduction", content_notes: [ "Write an intro" ] },
+						{ subheading_text: "Body", content_notes: [ "Add examples", "Add stats" ] },
+					],
+				};
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
+						payload: apiResponse,
+					}
+				);
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.success );
+				expect( result.outline ).toEqual( [
+					{ id: "0-Introduction", heading: "Introduction", contentNotes: [ "Write an intro" ] },
+					{ id: "1-Body", heading: "Body", contentNotes: [ "Add examples", "Add stats" ] },
+				] );
+			} );
+
+			it( "should fall back to empty strings and arrays when API response fields are missing", () => {
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
+						payload: { outline: [ {} ] },
+					}
+				);
+				expect( result.outline[ 0 ].heading ).toBe( "" );
+				expect( result.outline[ 0 ].contentNotes ).toEqual( [] );
+				expect( result.outline[ 0 ].id ).toBe( "0-" );
+			} );
+
+			it( "should set status to error and normalize the error on error", () => {
+				const error = { errorCode: 500, errorIdentifier: "server_error", errorMessage: "Server error." };
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+						payload: error,
+					}
+				);
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.error );
+				expect( result.error.errorCode ).toBe( 500 );
+				expect( result.error.errorIdentifier ).toBe( "server_error" );
+				expect( result.error.errorMessage ).toBe( "Server error." );
+			} );
+
+			it( "should default to errorCode 502 when the error payload has no errorCode", () => {
+				const result = contentOutlineReducer(
+					getInitialContentOutlineState(),
+					{
+						type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+						payload: { errorMessage: "Bad gateway." },
+					}
+				);
+				expect( result.error.errorCode ).toBe( 502 );
+			} );
+
+			it( "should reset outline state but preserve endpoint when fetchContentPlannerSuggestions/request is dispatched", () => {
+				const state = {
+					...getInitialContentOutlineState(),
+					endpoint: "yoast/v1/ai_content_planner/get_outline",
+					suggestion: mockSuggestion,
+					outline: [ { id: "0-Intro", heading: "Intro", contentNotes: [] } ],
+					status: ASYNC_ACTION_STATUS.success,
+					cache: { [ mockSuggestion.id ]: [] },
+				};
+				const result = contentOutlineReducer(
+					state,
+					{ type: `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }` }
+				);
+				expect( result.endpoint ).toBe( "yoast/v1/ai_content_planner/get_outline" );
+				expect( result.suggestion ).toBeNull();
+				expect( result.outline ).toEqual( [] );
+				expect( result.status ).toBe( ASYNC_ACTION_STATUS.idle );
+				expect( result.error ).toEqual( ERROR_DEFAULT );
+				expect( result.cache ).toEqual( {} );
+			} );
+		} );
+	} );
+
+	describe( "selectors", () => {
+		const cachedOutline = [ { id: "0-Intro", heading: "Intro", contentNotes: [] } ];
+		const fullState = {
+			[ CONTENT_OUTLINE_NAME ]: {
+				endpoint: "yoast/v1/ai_content_planner/get_outline",
+				status: ASYNC_ACTION_STATUS.loading,
+				outline: cachedOutline,
+				error: ERROR_DEFAULT,
+				suggestion: mockSuggestion,
+				cache: { [ mockSuggestion.id ]: cachedOutline },
+			},
+		};
+
+		it( "should return the endpoint from state", () => {
+			expect( contentOutlineSelectors.selectContentOutlineEndpoint( fullState ) )
+				.toBe( "yoast/v1/ai_content_planner/get_outline" );
+		} );
+
+		it( "should return an empty string for endpoint when state is missing", () => {
+			expect( contentOutlineSelectors.selectContentOutlineEndpoint( {} ) ).toBe( "" );
+		} );
+
+		it( "should return the status from state", () => {
+			expect( contentOutlineSelectors.selectContentOutlineStatus( fullState ) ).toBe( ASYNC_ACTION_STATUS.loading );
+		} );
+
+		it( "should return the default status when state is missing", () => {
+			expect( contentOutlineSelectors.selectContentOutlineStatus( {} ) ).toBe( ASYNC_ACTION_STATUS.idle );
+		} );
+
+		it( "should return the outline from state", () => {
+			expect( contentOutlineSelectors.selectContentOutline( fullState ) ).toEqual( cachedOutline );
+		} );
+
+		it( "should return an empty array for outline when state is missing", () => {
+			expect( contentOutlineSelectors.selectContentOutline( {} ) ).toEqual( [] );
+		} );
+
+		it( "should return the error from state", () => {
+			expect( contentOutlineSelectors.selectContentOutlineError( fullState ) ).toEqual( ERROR_DEFAULT );
+		} );
+
+		it( "should return the default error when state is missing", () => {
+			expect( contentOutlineSelectors.selectContentOutlineError( {} ) ).toEqual( ERROR_DEFAULT );
+		} );
+
+		it( "should return the suggestion from state", () => {
+			expect( contentOutlineSelectors.selectSuggestion( fullState ) ).toEqual( mockSuggestion );
+		} );
+
+		it( "should return null for suggestion when state is missing", () => {
+			expect( contentOutlineSelectors.selectSuggestion( {} ) ).toBeNull();
+		} );
+
+		it( "should return the cached outline for a given id", () => {
+			expect( contentOutlineSelectors.selectContentOutlineCache( fullState, mockSuggestion.id ) )
+				.toEqual( cachedOutline );
+		} );
+
+		it( "should return null when no cache entry exists for the given id", () => {
+			expect( contentOutlineSelectors.selectContentOutlineCache( fullState, "nonexistent-id" ) ).toBeNull();
+		} );
+	} );
+
+	describe( "fetchContentOutline", () => {
+		const params = {
+			endpoint: "yoast/v1/ai_content_planner/get_outline",
+			postType: "post",
+			language: "en",
+			editor: "gutenberg",
+			suggestion: mockSuggestion,
+		};
+
+		it( "should yield a request action, a control action, a success action, then complete", () => {
+			const generator = fetchContentOutline( params );
+
+			// First yield: request action.
+			const requestResult = generator.next();
+			expect( requestResult.value ).toEqual( {
+				type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`,
+				payload: { suggestion: mockSuggestion },
+			} );
+			expect( requestResult.done ).toBe( false );
+
+			// Second yield: control action (triggers the fetch).
+			const controlResult = generator.next();
+			expect( controlResult.value ).toEqual( {
+				type: FETCH_CONTENT_OUTLINE_ACTION_NAME,
+				payload: {
+					endpoint: params.endpoint,
+					postType: params.postType,
+					language: params.language,
+					editor: params.editor,
+					...mockSuggestion,
+				},
+			} );
+			expect( controlResult.done ).toBe( false );
+
+			// Third yield: success action with the simulated API response.
+			const apiResponse = { outline: [ { subheading_text: "Intro", content_notes: [] } ] };
+			const successResult = generator.next( apiResponse );
+			expect( successResult.value ).toEqual( {
+				type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
+				payload: apiResponse,
+			} );
+			expect( successResult.done ).toBe( false );
+
+			// Generator completes after the success yield.
+			const doneResult = generator.next();
+			expect( doneResult.done ).toBe( true );
+		} );
+
+		it( "should yield an error action when the API call throws a non-aborted error", () => {
+			const generator = fetchContentOutline( params );
+			generator.next(); // request
+			generator.next(); // control
+
+			const error = new Error( "Network error" );
+			const errorResult = generator.throw( error );
+			expect( errorResult.value ).toEqual( {
+				type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`,
+				payload: error,
+			} );
+			expect( errorResult.done ).toBe( false );
+
+			// Generator completes after the error yield.
+			const doneResult = generator.next();
+			expect( doneResult.done ).toBe( true );
+		} );
+
+		it( "should return early without yielding an error action when the error is aborted", () => {
+			const generator = fetchContentOutline( params );
+			generator.next(); // request
+			generator.next(); // control
+
+			const abortedError = { aborted: true };
+			const result = generator.throw( abortedError );
+			expect( result.done ).toBe( true );
+			expect( result.value ).toBeUndefined();
+		} );
+	} );
+
+	describe( "controls", () => {
+		beforeEach( () => {
+			contentPlannerFetch.mockClear();
+		} );
+
+		it( "should call contentPlannerFetch with POST method and correct data fields", async() => {
+			const payload = {
+				endpoint: "yoast/v1/ai_content_planner/get_outline",
+				postType: "post",
+				language: "en",
+				editor: "gutenberg",
+				title: mockSuggestion.title,
+				intent: mockSuggestion.intent,
+				explanation: mockSuggestion.explanation,
+				keyphrase: mockSuggestion.keyphrase,
+				// eslint-disable-next-line camelcase
+				meta_description: mockSuggestion.meta_description,
+				category: mockSuggestion.category,
+			};
+			contentPlannerFetch.mockResolvedValue( { outline: [] } );
+
+			await contentOutlineControls[ FETCH_CONTENT_OUTLINE_ACTION_NAME ]( { payload } );
+
+			expect( contentPlannerFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					method: "POST",
+					path: payload.endpoint,
+				} )
+			);
+		} );
+	} );
+} );

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -399,7 +399,17 @@ describe( "suggestions store", () => {
 
 			expect( contentPlannerFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					path: expect.stringContaining( payload.endpoint ),
+					path: expect.stringContaining( `post_type=${ payload.postType }` ),
+				} )
+			);
+			expect( contentPlannerFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: expect.stringContaining( `language=${ payload.language }` ),
+				} )
+			);
+			expect( contentPlannerFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: expect.stringContaining( `editor=${ payload.editor }` ),
 				} )
 			);
 		} );

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "@jest/globals";
+import { contentPlannerFetch } from "../../../src/ai-content-planner/helpers/fetch";
 import {
 	CONTENT_SUGGESTIONS_NAME,
 	FETCH_CONTENT_SUGGESTIONS_ACTION_NAME,
@@ -8,6 +9,7 @@ import {
 	fetchContentPlannerSuggestions,
 	getInitialContentSuggestionsState,
 } from "../../../src/ai-content-planner/store/content-suggestions";
+import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
 
 jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
 	contentPlannerFetch: jest.fn(),
@@ -16,10 +18,6 @@ jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
 jest.mock( "@wordpress/url", () => ( {
 	addQueryArgs: jest.fn( ( path, args ) => `${ path }?${ new URLSearchParams( args ).toString() }` ),
 } ) );
-
-const { contentPlannerFetch } = require( "../../../src/ai-content-planner/helpers/fetch" );
-
-import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
 
 const ERROR_DEFAULT = {
 	errorCode: null,

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -9,6 +9,7 @@ import {
 	fetchContentPlannerSuggestions,
 	getInitialContentSuggestionsState,
 } from "../../../src/ai-content-planner/store/content-suggestions";
+import { ERROR_DEFAULT } from "../../../src/ai-content-planner/constants";
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
 
 jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
@@ -18,13 +19,6 @@ jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
 jest.mock( "@wordpress/url", () => ( {
 	addQueryArgs: jest.fn( ( path, args ) => `${ path }?${ new URLSearchParams( args ).toString() }` ),
 } ) );
-
-const ERROR_DEFAULT = {
-	errorCode: null,
-	errorIdentifier: null,
-	errorMessage: null,
-	missingLicenses: [],
-};
 
 /* eslint-disable camelcase -- API field names use snake_case. */
 const mockApiSuggestions = [

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -1,12 +1,23 @@
-import { describe, expect, it } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import {
 	CONTENT_SUGGESTIONS_NAME,
 	FETCH_CONTENT_SUGGESTIONS_ACTION_NAME,
-	getInitialContentSuggestionsState,
-	contentSuggestionsSelectors,
+	contentSuggestionsControls,
 	contentSuggestionsReducer,
+	contentSuggestionsSelectors,
 	fetchContentPlannerSuggestions,
+	getInitialContentSuggestionsState,
 } from "../../../src/ai-content-planner/store/content-suggestions";
+
+jest.mock( "../../../src/ai-content-planner/helpers/fetch", () => ( {
+	contentPlannerFetch: jest.fn(),
+} ) );
+
+jest.mock( "@wordpress/url", () => ( {
+	addQueryArgs: jest.fn( ( path, args ) => `${ path }?${ new URLSearchParams( args ).toString() }` ),
+} ) );
+
+const { contentPlannerFetch } = require( "../../../src/ai-content-planner/helpers/fetch" );
 
 import { ASYNC_ACTION_NAMES, ASYNC_ACTION_STATUS } from "../../../src/shared-admin/constants";
 
@@ -150,6 +161,42 @@ describe( "suggestions store", () => {
 			);
 
 			expect( result.error.errorCode ).toBe( 502 );
+		} );
+
+		it( "setContentSuggestionsStatus sets the status to the given value", () => {
+			const result = contentSuggestionsReducer(
+				getInitialContentSuggestionsState(),
+				{
+					type: `${ CONTENT_SUGGESTIONS_NAME }/setContentSuggestionsStatus`,
+					payload: ASYNC_ACTION_STATUS.loading,
+				}
+			);
+			expect( result.status ).toBe( ASYNC_ACTION_STATUS.loading );
+		} );
+
+		it( "setSuggestion updates an existing suggestion by id", () => {
+			const updatedSuggestion = { ...transformedSuggestions[ 0 ], title: "Updated Title" };
+			const previousState = {
+				...getInitialContentSuggestionsState(),
+				suggestions: transformedSuggestions,
+			};
+			const result = contentSuggestionsReducer( previousState, {
+				type: `${ CONTENT_SUGGESTIONS_NAME }/setSuggestion`,
+				payload: updatedSuggestion,
+			} );
+			expect( result.suggestions[ 0 ].title ).toBe( "Updated Title" );
+		} );
+
+		it( "setSuggestion does not change state when the id does not match any suggestion", () => {
+			const previousState = {
+				...getInitialContentSuggestionsState(),
+				suggestions: transformedSuggestions,
+			};
+			const result = contentSuggestionsReducer( previousState, {
+				type: `${ CONTENT_SUGGESTIONS_NAME }/setSuggestion`,
+				payload: { id: "nonexistent-id", title: "Ghost" },
+			} );
+			expect( result.suggestions ).toEqual( transformedSuggestions );
 		} );
 
 		it( "setSuggestionsError sets the error state without an API call, clearing any prior suggestions", () => {
@@ -319,6 +366,44 @@ describe( "suggestions store", () => {
 			expect( result.value.payload ).toBeInstanceOf( Error );
 			expect( result.value.payload.message ).toBe( "Invalid suggestions response: expected an array of suggestions." );
 			expect( result.done ).toBe( true );
+		} );
+
+		it( "should return early without yielding an error action when the error is aborted", () => {
+			const generator = fetchContentPlannerSuggestions( params );
+
+			// First yield: request action.
+			generator.next();
+			// Second yield: control action.
+			generator.next();
+
+			const abortedError = { aborted: true };
+			const result = generator.throw( abortedError );
+			expect( result.done ).toBe( true );
+			expect( result.value ).toBeUndefined();
+		} );
+	} );
+
+	describe( "controls", () => {
+		beforeEach( () => {
+			contentPlannerFetch.mockClear();
+		} );
+
+		it( "should call contentPlannerFetch with the correct path including query args", async() => {
+			const payload = {
+				endpoint: "yoast/v1/ai_content_planner/get_suggestions",
+				postType: "post",
+				language: "en",
+				editor: "gutenberg",
+			};
+			contentPlannerFetch.mockResolvedValue( { suggestions: [] } );
+
+			await contentSuggestionsControls[ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME ]( { payload } );
+
+			expect( contentPlannerFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: expect.stringContaining( payload.endpoint ),
+				} )
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## Context

Increases test coverage for all Redux store slices under `src/ai-content-planner/store/`. Four slices (`availability`, `banner`, `modal`, `content-outline`) had no dedicated tests at all. The existing `suggestions.test.js` also had uncovered branches (`setSuggestion`, `setContentSuggestionsStatus`, aborted error path, controls). After this PR, all six store files reach 100% statement, branch, function, and line coverage.

## Summary

This PR can be summarized in the following changelog entry:

* Adds unit tests for the AI content planner JS store slices.

## Relevant technical choices

- **`banner.test.js` — `helpers/fields` mocked, not jsdom:** `bannerActions.setBannerRendered` and `setBannerDismissed` wrap slice actions and call DOM helper functions. The test mocks those helpers so it can assert that the wrapper calls the helper exactly once and returns the correct action, without relying on a DOM element being present.
- **`outline.test.js` — generator uses `yield`, not `return`:** `fetchContentOutline` yields the success and error actions (unlike `fetchContentPlannerSuggestions`, which returns them). Tests explicitly assert `done: false` after the success/error yield and call `generator.next()` a final time to confirm the generator completes.
- **`outline.test.js` — snake_case normalization tested explicitly:** The success reducer maps `subheading_text` → `heading` and `content_notes` → `contentNotes` and synthesises `id` as `` `${i}-${heading}` ``. Tests cover both fully-populated sections and sections with missing fields, exercising the `?? ""` and `?? []` fallbacks.
- **`outline.test.js` — endpoint preserved on suggestions reset:** The `fetchContentPlannerSuggestions/request` extra reducer resets the outline slice back to `INITIAL_OUTLINE` but keeps `state.endpoint`. A dedicated test asserts this to prevent silent regressions.
- **`suggestions.test.js` — `setSuggestion` both branches covered:** The reducer no-ops when no suggestion with the given `id` exists. Both the update-found and no-op paths are now tested.
- **Controls tested via `contentPlannerFetch` mock:** Both `contentOutlineControls` and `contentSuggestionsControls` are async wrappers around `contentPlannerFetch`. Tests mock that helper and assert it is called with the expected `method`, `path`, and `data` arguments.

## Test instructions for the acceptance test before the PR gets merged

This PR only adds unit tests — no user-visible behaviour changes.

For developers:
* Run the following command and verify all store files show 100% coverage.
```
cd packages/js && yarn jest tests/ai-content-planner/store --coverage --collectCoverageFrom="src/ai-content-planner/store/**/*.js"
```

### Relevant test scenarios

* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

Not applicable — this PR only adds unit tests. There is no user-visible behaviour change.

## Impact check

This PR only affects `packages/js/tests/ai-content-planner/store/` (new and updated test files). No production source code is changed.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to the WBSO document.

Fixes https://github.com/Yoast/reserved-tasks/issues/1201