### PR TITLE
fix(content-planner): guard content-suggestion block registration against duplicate bundles

### DIFF
--- a/packages/js/src/ai-content-planner/blocks/content-suggestion-block.js
+++ b/packages/js/src/ai-content-planner/blocks/content-suggestion-block.js
@@ -1,57 +1,62 @@
-import { createBlock, registerBlockType } from "@wordpress/blocks";
+import { createBlock, registerBlockType, getBlockType } from "@wordpress/blocks";
 import { useBlockProps } from "@wordpress/block-editor";
 import { useEffect, useRef } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { ContentSuggestionBlock } from "../components/content-suggestion-block";
 
-registerBlockType( "yoast-seo/content-suggestion", {
-	apiVersion: 3,
-	title: __( "Content Suggestion", "wordpress-seo" ),
-	category: "text",
-	supports: { inserter: false },
-	transforms: {
-		to: [
-			{
-				type: "block",
-				blocks: [ "core/list" ],
-				transform: ( { suggestions } ) =>
-					createBlock(
-						"core/list",
-						{},
-						suggestions.map( ( suggestion ) => createBlock( "core/list-item", { content: suggestion } ) )
-					),
-			},
-		],
-	},
-	attributes: {
-		title: { type: "string", "default": "" },
-		suggestions: { type: "array", items: { type: "string" }, "default": [] },
-	},
-	edit: ( { attributes } ) => {
-		const ref = useRef( null );
-		const blockProps = useBlockProps( { ref } );
+// Both the `ai-content-planner` and `block-editor` webpack bundles load this
+// module independently (each has its own module registry), so the call below
+// can execute twice on the same page. Guard against the duplicate warning.
+if ( ! getBlockType( "yoast-seo/content-suggestion" ) ) {
+	registerBlockType( "yoast-seo/content-suggestion", {
+		apiVersion: 3,
+		title: __( "Content Suggestion", "wordpress-seo" ),
+		category: "text",
+		supports: { inserter: false },
+		transforms: {
+			to: [
+				{
+					type: "block",
+					blocks: [ "core/list" ],
+					transform: ( { suggestions } ) =>
+						createBlock(
+							"core/list",
+							{},
+							suggestions.map( ( suggestion ) => createBlock( "core/list-item", { content: suggestion } ) )
+						),
+				},
+			],
+		},
+		attributes: {
+			title: { type: "string", "default": "" },
+			suggestions: { type: "array", items: { type: "string" }, "default": [] },
+		},
+		edit: ( { attributes } ) => {
+			const ref = useRef( null );
+			const blockProps = useBlockProps( { ref } );
 
-		useEffect( () => {
-			const ownerDoc = ref.current?.ownerDocument ?? document;
-			if ( ownerDoc === window.document || ownerDoc.getElementById( "yoast-seo-tailwind-css" ) ) {
-				return;
-			}
-			const mainLink = window.document.getElementById( "yoast-seo-tailwind-css" );
-			if ( ! mainLink ) {
-				return;
-			}
-			const link = ownerDoc.createElement( "link" );
-			link.id = "yoast-seo-tailwind-css";
-			link.rel = "stylesheet";
-			link.href = mainLink.href;
-			ownerDoc.head.appendChild( link );
-		}, [] );
+			useEffect( () => {
+				const ownerDoc = ref.current?.ownerDocument ?? document;
+				if ( ownerDoc === window.document || ownerDoc.getElementById( "yoast-seo-tailwind-css" ) ) {
+					return;
+				}
+				const mainLink = window.document.getElementById( "yoast-seo-tailwind-css" );
+				if ( ! mainLink ) {
+					return;
+				}
+				const link = ownerDoc.createElement( "link" );
+				link.id = "yoast-seo-tailwind-css";
+				link.rel = "stylesheet";
+				link.href = mainLink.href;
+				ownerDoc.head.appendChild( link );
+			}, [] );
 
-		return (
-			<div { ...blockProps }>
-				<ContentSuggestionBlock contentNotes={ attributes.suggestions } />
-			</div>
-		);
-	},
-	save: () => null,
-} );
+			return (
+				<div { ...blockProps }>
+					<ContentSuggestionBlock contentNotes={ attributes.suggestions } />
+				</div>
+			);
+		},
+		save: () => null,
+	} );
+}

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -26,6 +26,7 @@ jest.mock( "@wordpress/data", () => ( {
 jest.mock( "@wordpress/blocks", () => ( {
 	createBlock: jest.fn( ( name, attributes, innerBlocks ) => ( { name, attributes, innerBlocks } ) ),
 	registerBlockType: jest.fn(),
+	getBlockType: jest.fn( () => null ),
 } ) );
 
 jest.mock( "@wordpress/block-editor", () => ( {
@@ -112,5 +113,20 @@ describe( "content-suggestion block transform", () => {
 
 		expect( result.name ).toBe( "core/list" );
 		expect( result.innerBlocks ).toHaveLength( 0 );
+	} );
+} );
+
+describe( "content-suggestion block registration guard", () => {
+	test( "skips registerBlockType when the block is already registered", () => {
+		const { registerBlockType: mockRegisterBlockType, getBlockType: mockGetBlockType } = require( "@wordpress/blocks" );
+
+		mockGetBlockType.mockReturnValueOnce( { name: "yoast-seo/content-suggestion" } );
+		mockRegisterBlockType.mockClear();
+
+		jest.isolateModules( () => {
+			require( "../../src/ai-content-planner/blocks/content-suggestion-block" );
+		} );
+
+		expect( mockRegisterBlockType ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `ai-content-planner` and `block-editor` webpack entry points each have
  their own module registry, so `registerBlockType` was called once per bundle
  when both scripts were enqueued on the post-edit page, producing the
  "Block already registered" console warning. Wrap the call in a
  `getBlockType` guard so only the first bundle to execute registers the block.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a warning was triggered in the console when editing a post with the Content Planner feature enabled.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In `wp-config.php` file add the following:
```php
define( ‘SCRIPT_DEBUG’, true );
```
* Edit a post with Yoast AI feature enabled.
* Open the dev tool console and check you don't get a warning `Block "yoast-seo/content-suggestion" is already registered`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [Fix console warning for content suggestions block registration](https://github.com/Yoast/reserved-tasks/issues/1210)
