### PR TITLE
Fix FocusTrap warning and missing focus on X button in AI Content Planner replace confirmation modal

### DIFF
--- a/packages/js/src/ai-content-planner/components/app.js
+++ b/packages/js/src/ai-content-planner/components/app.js
@@ -69,6 +69,7 @@ export const App = () => {
 				handleApplyOutline={ handleApplyOutline }
 				openReplaceContentModal={ openReplaceContentModal }
 				setHasVisitedReplace={ setHasVisitedReplace }
+				isReplaceModalOpen={ replaceContentModalIsOpen && hasVisitedReplace }
 			/>
 			<ReplaceContentModal
 				onConfirm={ handleConfirmReplace }

--- a/packages/js/src/ai-content-planner/components/app.js
+++ b/packages/js/src/ai-content-planner/components/app.js
@@ -59,6 +59,8 @@ export const App = () => {
 		}
 	}, [ status ] );
 
+	const isReplaceModalOpen = replaceContentModalIsOpen && hasVisitedReplace;
+
 	return (
 		<>
 			<ApproveModal
@@ -69,11 +71,11 @@ export const App = () => {
 				handleApplyOutline={ handleApplyOutline }
 				openReplaceContentModal={ openReplaceContentModal }
 				setHasVisitedReplace={ setHasVisitedReplace }
-				isReplaceModalOpen={ replaceContentModalIsOpen && hasVisitedReplace }
+				isReplaceModalOpen={ isReplaceModalOpen }
 			/>
 			<ReplaceContentModal
 				onConfirm={ handleConfirmReplace }
-				isOpen={ replaceContentModalIsOpen && hasVisitedReplace }
+				isOpen={ isReplaceModalOpen }
 				onClose={ toggleReplaceContentModal }
 			/>
 

--- a/packages/js/src/ai-content-planner/components/app.js
+++ b/packages/js/src/ai-content-planner/components/app.js
@@ -3,7 +3,6 @@ import { useState, useEffect, useCallback, useRef } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import ApproveModal from "../containers/approve-modal";
 import { AiGrantConsent } from "../../shared-admin/components";
-import { ReplaceContentModal } from "./replace-content-modal";
 import { FEATURE_MODAL_STATUS, CONTENT_PLANNER_STORE } from "../constants";
 import { STORE_NAME_EDITOR, STORE_NAME_AI } from "../../ai-generator/constants";
 import { useFetchContentSuggestions, useApplyOutline } from "../hooks";
@@ -49,10 +48,6 @@ export const App = () => {
 		fetchContentSuggestions();
 	}, [ hasConsent, setFeatureModalStatus, fetchContentSuggestions ] );
 
-	const handleConfirmReplace = useCallback( () => {
-		handleApplyOutline();
-	}, [ handleApplyOutline ] );
-
 	useEffect( () => {
 		if ( ! status ) {
 			setHasVisitedReplace( false );
@@ -72,11 +67,7 @@ export const App = () => {
 				openReplaceContentModal={ openReplaceContentModal }
 				setHasVisitedReplace={ setHasVisitedReplace }
 				isReplaceModalOpen={ isReplaceModalOpen }
-			/>
-			<ReplaceContentModal
-				onConfirm={ handleConfirmReplace }
-				isOpen={ isReplaceModalOpen }
-				onClose={ toggleReplaceContentModal }
+				onCloseReplace={ toggleReplaceContentModal }
 			/>
 
 			<Modal isOpen={ isConsentModalOpen } onClose={ closeModal } className="yst-introduction-modal">

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -94,6 +94,7 @@ export const FeatureModal = ( {
 	}, [ isEmptyPost, handleApplyOutline, openReplaceContentModal, setHasVisitedReplace ] );
 
 	return (
+		// Close this modal when the replace confirmation is open to avoid competing FocusTrap instances.
 		<Modal isOpen={ ! isConsentModalOpen && ! isReplaceModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
 			<Modal.Panel ref={ panelRef } className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
 				<Modal.CloseButton

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -13,6 +13,7 @@ import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.sv
 import { UsageCounter } from "@yoast/ai-frontend";
 import { QuestionMarkCircleIcon } from "@heroicons/react/solid";
 import { getModalNotificationPosition } from "../../shared-admin/helpers";
+import { ReplaceContentModal } from "./replace-content-modal";
 
 /**
  * The modal that orchestrates the flow between the approve, content suggestions,
@@ -33,6 +34,7 @@ import { getModalNotificationPosition } from "../../shared-admin/helpers";
  * @param {Object}        editedOutlineRef              Ref object to store the edited content outline.
  * @param {Function}      handleApplyOutline           Function to apply the content outline to the post.
  * @param {boolean}       isReplaceModalOpen           Whether the replace content confirmation modal is open.
+ * @param {Function}      onCloseReplace               Function to close the replace content confirmation modal.
  * @returns {JSX.Element} The Content Planner Feature Modal.
  */
 export const FeatureModal = ( {
@@ -51,6 +53,7 @@ export const FeatureModal = ( {
 	editedOutlineRef,
 	handleApplyOutline,
 	isReplaceModalOpen,
+	onCloseReplace,
 } ) => {
 	const fetchContentOutline = useFetchContentOutline();
 	const isConsentModalOpen = status === FEATURE_MODAL_STATUS.consent;
@@ -94,8 +97,13 @@ export const FeatureModal = ( {
 	}, [ isEmptyPost, handleApplyOutline, openReplaceContentModal, setHasVisitedReplace ] );
 
 	return (
-		// Close this modal when the replace confirmation is open to avoid competing FocusTrap instances.
-		<Modal isOpen={ ! isConsentModalOpen && ! isReplaceModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
+		<Modal isOpen={ ! isConsentModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
+			{ /*
+			 * ReplaceContentModal is inside Modal.Panel so that:
+			 * 1. Modal receives a single element child (required by HeadlessUI Transition.Child with as=Fragment).
+			 * 2. ReplaceContentModal's Dialog is a React descendant of the outer Dialog, so HeadlessUI v1.7
+			 *    detects it as nested and manages the focus trap stack correctly (outer yields focus to inner).
+			 */ }
 			<Modal.Panel ref={ panelRef } className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
 				<Modal.CloseButton
 					ref={ closeButtonRef } screenReaderText={ isSuggestions
@@ -153,6 +161,11 @@ export const FeatureModal = ( {
 					{ contentSuggestionsStatus === ASYNC_ACTION_STATUS.success &&
 					! isOutlineError && <SparksLimitNotification /> }
 				</Notifications>
+				<ReplaceContentModal
+					isOpen={ isReplaceModalOpen }
+					onConfirm={ handleApplyOutline }
+					onClose={ onCloseReplace }
+				/>
 			</Modal.Panel>
 		</Modal>
 	);

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -52,7 +52,7 @@ export const FeatureModal = ( {
 	setHasVisitedReplace,
 	editedOutlineRef,
 	handleApplyOutline,
-	isReplaceModalOpen,
+	isReplaceModalOpen = false,
 	onCloseReplace,
 } ) => {
 	const fetchContentOutline = useFetchContentOutline();

--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -32,6 +32,7 @@ import { getModalNotificationPosition } from "../../shared-admin/helpers";
  * @param {Function}      setHasVisitedReplace          Function to set whether the user has visited the replace content confirmation modal.
  * @param {Object}        editedOutlineRef              Ref object to store the edited content outline.
  * @param {Function}      handleApplyOutline           Function to apply the content outline to the post.
+ * @param {boolean}       isReplaceModalOpen           Whether the replace content confirmation modal is open.
  * @returns {JSX.Element} The Content Planner Feature Modal.
  */
 export const FeatureModal = ( {
@@ -49,6 +50,7 @@ export const FeatureModal = ( {
 	setHasVisitedReplace,
 	editedOutlineRef,
 	handleApplyOutline,
+	isReplaceModalOpen,
 } ) => {
 	const fetchContentOutline = useFetchContentOutline();
 	const isConsentModalOpen = status === FEATURE_MODAL_STATUS.consent;
@@ -92,7 +94,7 @@ export const FeatureModal = ( {
 	}, [ isEmptyPost, handleApplyOutline, openReplaceContentModal, setHasVisitedReplace ] );
 
 	return (
-		<Modal isOpen={ ! isConsentModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
+		<Modal isOpen={ ! isConsentModalOpen && ! isReplaceModalOpen && ( isSuggestions || isOutline ) } onClose={ onClose }>
 			<Modal.Panel ref={ panelRef } className="yst-p-0 yst-max-w-2xl yst-overflow-visible" hasCloseButton={ false }>
 				<Modal.CloseButton
 					ref={ closeButtonRef } screenReaderText={ isSuggestions

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -155,7 +155,7 @@ const setupMocks = ( selectOverrides = {} ) => {
 	} ) );
 };
 
-const createModalElement = ( { status = "idle", editedOutlineRef = { current: null }, ...props } = {} ) => (
+const createModalElement = ( { status = "idle", editedOutlineRef = { current: null }, onCloseReplace = jest.fn(), ...props } = {} ) => (
 	<FeatureModal
 		onClose={ jest.fn() }
 		isEmptyPost={ true }
@@ -165,6 +165,7 @@ const createModalElement = ( { status = "idle", editedOutlineRef = { current: nu
 		openReplaceContentModal={ mockOpenReplaceContentModal }
 		setHasVisitedReplace={ mockSetHasVisitedReplace }
 		handleApplyOutline={ mockHandleApplyOutline }
+		onCloseReplace={ onCloseReplace }
 		{ ...props }
 	/>
 );
@@ -288,8 +289,10 @@ describe( "FeatureModal", () => {
 		expect( capturedCallback ).toBeDefined();
 	} );
 
-	it( "keeps the modal open when isReplaceModalOpen is true so it stays visible behind the confirmation", () => {
-		renderModal( { status: "content-suggestions", isReplaceModalOpen: true } );
-		expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
+	it( "renders both the feature modal and the replace confirmation dialog when isReplaceModalOpen is true", () => {
+		const onCloseReplace = jest.fn();
+		renderModal( { status: "content-suggestions", isReplaceModalOpen: true, onCloseReplace } );
+		expect( screen.getAllByRole( "dialog" ) ).toHaveLength( 2 );
+		expect( screen.getByText( "Replace existing content with this outline?" ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -288,13 +288,8 @@ describe( "FeatureModal", () => {
 		expect( capturedCallback ).toBeDefined();
 	} );
 
-	it( "hides the modal when status is 'content-suggestions' and isReplaceModalOpen is true", () => {
+	it( "keeps the modal open when isReplaceModalOpen is true so it stays visible behind the confirmation", () => {
 		renderModal( { status: "content-suggestions", isReplaceModalOpen: true } );
-		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
-	} );
-
-	it( "hides the modal when status is 'content-outline' and isReplaceModalOpen is true", () => {
-		renderModal( { status: "content-outline", isReplaceModalOpen: true } );
-		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( "dialog" ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/components/feature-modal.test.js
+++ b/packages/js/tests/ai-content-planner/components/feature-modal.test.js
@@ -287,4 +287,14 @@ describe( "FeatureModal", () => {
 		// If handlePanelMeasureChange runs without error, the callback was exercised.
 		expect( capturedCallback ).toBeDefined();
 	} );
+
+	it( "hides the modal when status is 'content-suggestions' and isReplaceModalOpen is true", () => {
+		renderModal( { status: "content-suggestions", isReplaceModalOpen: true } );
+		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+	} );
+
+	it( "hides the modal when status is 'content-outline' and isReplaceModalOpen is true", () => {
+		renderModal( { status: "content-outline", isReplaceModalOpen: true } );
+		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
## Context

When using the AI Content Planner on an existing post (with content), clicking `Add outline to post` in the Content Outline modal triggers a \`There are no focusable elements inside the <FocusTrap />\` console warning and the X button on the replace confirmation modal never receives focus.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a `FocusTrap` warning was thrown and the X button did not receive focus when the replace content confirmation modal from the AI Content Planner was opened. 

## Relevant technical choices:

* \`FeatureModal\` (Content Outline) and \`ReplaceContentModal\` were both rendered as sibling HeadlessUI \`Dialog\` components at the same level in \`App\`. The first dialog's \`FocusTrap\` attaches a capture-phase \`focusin\` listener on \`window\` and redirects focus back inside itself — preventing the second dialog's \`FocusTrap\` from initialising, which produced the "no focusable elements" warning and left the X button without focus.

* The fix moves \`ReplaceContentModal\` out of \`App\` and renders it **inside** \`FeatureModal\`'s \`Modal.Panel\`, making it a React descendant of the outer \`Dialog\`. 

* \`ReplaceContentModal\` is placed inside \`Modal.Panel\` (rather than as a direct sibling of \`Modal.Panel\` inside \`<Modal>\`) because \`@yoast/ui-library\`'s \`Modal\` wraps all its children in a single \`Transition.Child\` with \`as={Fragment}\`, which requires exactly one element child that can receive a forwarded \`ref\`. Passing two siblings would cause a "Passing props on Fragment" error.

* \`isReplaceModalOpen\` is defaulted to \`false\` in \`FeatureModal\`'s prop destructuring so that \`ReplaceContentModal\` always receives a proper boolean — passing \`undefined\` to HeadlessUI's \`Transition.Root show\` prop has undefined behaviour.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

1. Open a post that **already has content** in the Gutenberg editor.
2. Open the browser console.
3. In the Yoast SEO sidebar or meta box, click **Get content suggestions**.
4. In the approve modal, click **Get content suggestions** again.
5. Wait for the Content Suggestions modal to load, then click a suggestion.
6. Wait for the Content Outline modal to finish loading (the "Add outline to post" button becomes enabled).
7. Click **Add outline to post**.
8. Verify the replace content confirmation modal appears **without** a \`There are no focusable elements inside the <FocusTrap />\` console warning in the **console**.

<img width="617" height="22" alt="image" src="https://github.com/user-attachments/assets/415b01b2-7def-41e9-a24e-e8f3bf2cba38" />

9. Verify the X button (close) receives focus automatically.
10. Verify the Content Outline modal is **still visible in the background** behind the confirmation.
11. Click **Cancel** and verify focus returns to the Content Outline modal correctly.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* AI Content Planner modal flow (Content Suggestions → Content Outline → Replace confirmation) on existing posts.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with \`[shopify-seo]\`, added test instructions for Shopify and attached the \`Shopify\` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with \`[yoast-doc-extension]\`, added test instructions for Yoast SEO for Google Docs and attached the \`Google Docs Add-on\` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run \`grunt build:images\` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation
* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to the WBSO document.

Fixes https://github.com/Yoast/reserved-tasks/issues/1211