### PR TITLE
Stabilise selector references to avoid unnecessary re-renders

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cd ../.. && wp-scripts build --config config/webpack/webpack.config.js",
     "test": "jest",
-    "lint": "eslint . --max-warnings=43"
+    "lint": "eslint . --max-warnings=42"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cd ../.. && wp-scripts build --config config/webpack/webpack.config.js",
     "test": "jest",
-    "lint": "eslint . --max-warnings=42"
+    "lint": "eslint . --max-warnings=41"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -29,7 +29,8 @@ class PrimaryTaxonomyPicker extends Component {
 
 		const { fieldId, name } = props.taxonomy;
 		this.input = document.getElementById( fieldId );
-		props.setPrimaryTaxonomyId( name, parseInt( this.input.value, 10 ) );
+		// Fallback to -1 when the field is empty (no primary term saved yet) to avoid dispatching NaN.
+		props.setPrimaryTaxonomyId( name, this.input.value ? parseInt( this.input.value, 10 ) : -1 );
 
 		this.state = {
 			selectedTerms: [],

--- a/packages/js/src/components/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/components/PrimaryTaxonomyPicker.js
@@ -29,8 +29,9 @@ class PrimaryTaxonomyPicker extends Component {
 
 		const { fieldId, name } = props.taxonomy;
 		this.input = document.getElementById( fieldId );
-		// Fallback to -1 when the field is empty (no primary term saved yet) to avoid dispatching NaN.
-		props.setPrimaryTaxonomyId( name, this.input.value ? parseInt( this.input.value, 10 ) : -1 );
+		const parsedPrimaryTaxonomyId = parseInt( this.input.value, 10 );
+		// Fallback to -1 when the field is empty or invalid to avoid dispatching NaN.
+		props.setPrimaryTaxonomyId( name, Number.isNaN( parsedPrimaryTaxonomyId ) ? -1 : parsedPrimaryTaxonomyId );
 
 		this.state = {
 			selectedTerms: [],

--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -57,7 +57,6 @@ const usePrevious = ( value ) => {
 	return ref.current;
 };
 
-
 /**
  * The WincherKeyphrasesTable component.
  *

--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -138,7 +138,7 @@ const WincherKeyphrasesTable = ( {
 					abortController.current.abort();
 				}
 				abortController.current = typeof AbortController === "undefined" ? null : new AbortController();
-				return getKeyphrases( keyphrases, startAt, permalink, abortController.current.signal );
+				return getKeyphrases( keyphrases, startAt, permalink, abortController.current?.signal );
 			},
 			( response ) => {
 				setRequestSucceeded( response );

--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -119,7 +119,7 @@ const WincherKeyphrasesTable = ( {
 	const getKeyphraseData = useCallback( ( keyphrase ) => {
 		const targetKeyphrase = keyphrase.toLowerCase();
 
-		if ( trackedKeyphrases && ! isEmpty( trackedKeyphrases ) && trackedKeyphrases.hasOwnProperty( targetKeyphrase ) ) {
+		if ( trackedKeyphrases && ! isEmpty( trackedKeyphrases ) && Object.prototype.hasOwnProperty.call( trackedKeyphrases, targetKeyphrase ) ) {
 			return trackedKeyphrases[ targetKeyphrase ];
 		}
 

--- a/packages/js/src/components/WincherKeyphrasesTable.js
+++ b/packages/js/src/components/WincherKeyphrasesTable.js
@@ -4,7 +4,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "@wo
 import { __, sprintf } from "@wordpress/i18n";
 import { Checkbox } from "@yoast/components";
 import { getDirectionalStyle, makeOutboundLink } from "@yoast/helpers";
-import { debounce, difference, filter, isEmpty, orderBy, without } from "lodash";
+import { difference, filter, isEmpty, orderBy, without } from "lodash";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import { handleAPIResponse } from "../helpers/api";
@@ -57,9 +57,6 @@ const usePrevious = ( value ) => {
 	return ref.current;
 };
 
-const debouncedGetKeyphrases = debounce( getKeyphrases, 500, {
-	leading: true,
-} );
 
 /**
  * The WincherKeyphrasesTable component.
@@ -142,7 +139,7 @@ const WincherKeyphrasesTable = ( {
 					abortController.current.abort();
 				}
 				abortController.current = typeof AbortController === "undefined" ? null : new AbortController();
-				return debouncedGetKeyphrases( keyphrases, startAt, permalink, abortController.current.signal );
+				return getKeyphrases( keyphrases, startAt, permalink, abortController.current.signal );
 			},
 			( response ) => {
 				setRequestSucceeded( response );

--- a/packages/js/src/components/contentAnalysis/KeywordInput.js
+++ b/packages/js/src/components/contentAnalysis/KeywordInput.js
@@ -61,7 +61,7 @@ class KeywordInput extends Component {
 	 *
 	 * @returns {boolean} Whether to display the message about the missing keyphrase.
 	 */
-	getMissingKeyphraseMessage( keyphrase, context ) {
+	shouldShowMissingKeyphraseMessage( keyphrase, context ) {
 		return keyphrase.trim().length === 0 && context;
 	}
 
@@ -74,11 +74,11 @@ class KeywordInput extends Component {
 		const errors = [ ...this.props.errors ];
 		const keyphrase = this.props.keyword;
 
-		if ( this.getMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphraseMessage ) ) {
+		if ( this.shouldShowMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphraseMessage ) ) {
 			errors.push( __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) );
 		}
 
-		if ( this.getMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphrasForTrackingMessage ) ) {
+		if ( this.shouldShowMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphrasForTrackingMessage ) ) {
 			errors.push( __( "Please enter a focus keyphrase first to track keyphrase performance", "wordpress-seo" ) );
 		}
 

--- a/packages/js/src/components/contentAnalysis/KeywordInput.js
+++ b/packages/js/src/components/contentAnalysis/KeywordInput.js
@@ -54,18 +54,31 @@ class KeywordInput extends Component {
 	}
 
 	/**
+	 * Determines whether to display the message about the missing keyphrase.
+	 *
+	 * @param {string} keyphrase The keyphrase to check.
+	 * @param {boolean} context Whether the message should be displayed in the current context.
+	 *
+	 * @returns {boolean} Whether to display the message about the missing keyphrase.
+	 */
+	getMissingKeyphraseMessage( keyphrase, context ) {
+		return keyphrase.trim().length === 0 && context;
+	}
+
+	/**
 	 * Validates the keyword input.
 	 *
 	 * @returns {array} The detected errors.
 	 */
 	validate() {
 		const errors = [ ...this.props.errors ];
+		const keyphrase = this.props.keyword;
 
-		if ( this.props.keyword.trim().length === 0 && this.props.displayNoKeyphraseMessage ) {
+		if ( this.getMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphraseMessage ) ) {
 			errors.push( __( "Please enter a focus keyphrase first to get related keyphrases", "wordpress-seo" ) );
 		}
 
-		if ( this.props.keyword.trim().length === 0 && this.props.displayNoKeyphrasForTrackingMessage ) {
+		if ( this.getMissingKeyphraseMessage( keyphrase, this.props.displayNoKeyphrasForTrackingMessage ) ) {
 			errors.push( __( "Please enter a focus keyphrase first to track keyphrase performance", "wordpress-seo" ) );
 		}
 

--- a/packages/js/src/containers/DocumentSidebar.js
+++ b/packages/js/src/containers/DocumentSidebar.js
@@ -31,7 +31,10 @@ const makeMapSelectToProps = () => {
 		checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
 
 		// Return the previous reference when content is identical to avoid triggering re-renders.
-		if ( JSON.stringify( checklist ) === JSON.stringify( lastChecklist ) ) {
+		if (
+			checklist.length === lastChecklist.length &&
+			checklist.every( ( item, i ) => JSON.stringify( item ) === JSON.stringify( lastChecklist[ i ] ) )
+		) {
 			return { checklist: lastChecklist };
 		}
 

--- a/packages/js/src/containers/DocumentSidebar.js
+++ b/packages/js/src/containers/DocumentSidebar.js
@@ -11,23 +11,36 @@ import {
 /**
  * Maps the select function to props for the checklist.
  *
- * @param {function} select The WordPress select function.
+ * Uses output memoization: returns the same array reference whenever the
+ * computed checklist content has not changed. This prevents `withSelect`
+ * from seeing a new reference on every render, which would cause unnecessary
+ * re-renders.
  *
- * @returns {{checklist: []}} The props for the checklist.
+ * @returns {Function} A memoized mapSelectToProps function.
  */
-export function mapSelectToProps( select ) {
-	const yoastStore = select( "yoast-seo/editor" );
+const makeMapSelectToProps = () => {
+	let lastChecklist = [];
 
-	const checklist = [];
+	return ( select ) => {
+		const yoastStore = select( "yoast-seo/editor" );
 
-	maybeAddSEOCheck( checklist, yoastStore );
-	maybeAddReadabilityCheck( checklist, yoastStore );
-	maybeAddInclusiveLanguageCheck( checklist, yoastStore );
+		const checklist = [];
+		maybeAddSEOCheck( checklist, yoastStore );
+		maybeAddReadabilityCheck( checklist, yoastStore );
+		maybeAddInclusiveLanguageCheck( checklist, yoastStore );
+		checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
 
-	checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
+		// Return the previous reference when content is identical to avoid triggering re-renders.
+		if ( JSON.stringify( checklist ) === JSON.stringify( lastChecklist ) ) {
+			return { checklist: lastChecklist };
+		}
 
-	return { checklist };
-}
+		lastChecklist = checklist;
+		return { checklist };
+	};
+};
+
+export const mapSelectToProps = makeMapSelectToProps();
 
 /**
  * Maps the dispatch function to props for the checklist.

--- a/packages/js/src/containers/DocumentSidebar.js
+++ b/packages/js/src/containers/DocumentSidebar.js
@@ -33,7 +33,11 @@ const makeMapSelectToProps = () => {
 		// Return the previous reference when content is identical to avoid triggering re-renders.
 		if (
 			checklist.length === lastChecklist.length &&
-			checklist.every( ( item, i ) => JSON.stringify( item ) === JSON.stringify( lastChecklist[ i ] ) )
+			checklist.every( ( item, i ) =>
+				item.label === lastChecklist[ i ].label &&
+			item.score === lastChecklist[ i ].score &&
+			item.scoreValue === lastChecklist[ i ].scoreValue
+			)
 		) {
 			return { checklist: lastChecklist };
 		}

--- a/packages/js/src/containers/DocumentSidebar.js
+++ b/packages/js/src/containers/DocumentSidebar.js
@@ -35,8 +35,8 @@ const makeMapSelectToProps = () => {
 			checklist.length === lastChecklist.length &&
 			checklist.every( ( item, i ) =>
 				item.label === lastChecklist[ i ].label &&
-			item.score === lastChecklist[ i ].score &&
-			item.scoreValue === lastChecklist[ i ].scoreValue
+				item.score === lastChecklist[ i ].score &&
+				item.scoreValue === lastChecklist[ i ].scoreValue
 			)
 		) {
 			return { checklist: lastChecklist };

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -13,27 +13,37 @@ import { getIsSeoDataDefault } from "../helpers/getIsSeoDataDefault";
 /**
  * Maps the select function to props for the checklist.
  *
- * @param {function} select The WordPress select function.
+ * Uses output memoization: returns the same array reference whenever the
+ * computed checklist content has not changed. This prevents `withSelect`
+ * from seeing a new reference on every render, which would cause unnecessary
+ * re-renders.
  *
- * @returns {{checklist: [], isSeoDataDefault: object}} The props for the checklist.
+ * @returns {Function} A memoized mapSelectToProps function.
  */
-export function mapSelectToProps( select ) {
-	const yoastStore = select( "yoast-seo/editor" );
+const makeMapSelectToProps = () => {
+	let lastChecklist = [];
 
-	const checklist = [];
+	return ( select ) => {
+		const yoastStore = select( "yoast-seo/editor" );
 
-	maybeAddFocusKeyphraseCheck( checklist, yoastStore );
-	maybeAddSEOCheck( checklist, yoastStore );
-	maybeAddReadabilityCheck( checklist, yoastStore );
-	maybeAddInclusiveLanguageCheck( checklist, yoastStore );
+		const checklist = [];
+		maybeAddFocusKeyphraseCheck( checklist, yoastStore );
+		maybeAddSEOCheck( checklist, yoastStore );
+		maybeAddReadabilityCheck( checklist, yoastStore );
+		maybeAddInclusiveLanguageCheck( checklist, yoastStore );
+		checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
 
-	checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
+		// Return the previous reference when content is identical to avoid triggering re-renders.
+		if ( JSON.stringify( checklist ) === JSON.stringify( lastChecklist ) ) {
+			return { checklist: lastChecklist, isSeoDataDefault: getIsSeoDataDefault( yoastStore ) };
+		}
 
-	return {
-		checklist,
-		isSeoDataDefault: getIsSeoDataDefault( yoastStore ),
+		lastChecklist = checklist;
+		return { checklist, isSeoDataDefault: getIsSeoDataDefault( yoastStore ) };
 	};
-}
+};
+
+export const mapSelectToProps = makeMapSelectToProps();
 
 /**
  * Maps the dispatch function to props for the checklist.

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -39,7 +39,11 @@ const makeMapSelectToProps = () => {
 		if (
 			lastResult !== null &&
 			checklist.length === lastResult.checklist.length &&
-			checklist.every( ( item, i ) => JSON.stringify( item ) === JSON.stringify( lastResult.checklist[ i ] ) ) &&
+			checklist.every( ( item, i ) =>
+				item.label === lastResult.checklist[ i ].label &&
+			item.score === lastResult.checklist[ i ].score &&
+			item.scoreValue === lastResult.checklist[ i ].scoreValue
+			) &&
 			isSeoDataDefault.isAllTitlesDefault === lastResult.isSeoDataDefault.isAllTitlesDefault &&
 			isSeoDataDefault.isAllDescriptionsDefault === lastResult.isSeoDataDefault.isAllDescriptionsDefault
 		) {

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -21,7 +21,7 @@ import { getIsSeoDataDefault } from "../helpers/getIsSeoDataDefault";
  * @returns {Function} A memoized mapSelectToProps function.
  */
 const makeMapSelectToProps = () => {
-	let lastChecklist = [];
+	let lastResult = null;
 
 	return ( select ) => {
 		const yoastStore = select( "yoast-seo/editor" );
@@ -33,13 +33,15 @@ const makeMapSelectToProps = () => {
 		maybeAddInclusiveLanguageCheck( checklist, yoastStore );
 		checklist.push( ...Object.values( yoastStore.getChecklistItems() ) );
 
+		const isSeoDataDefault = getIsSeoDataDefault( yoastStore );
+
 		// Return the previous reference when content is identical to avoid triggering re-renders.
-		if ( JSON.stringify( checklist ) === JSON.stringify( lastChecklist ) ) {
-			return { checklist: lastChecklist, isSeoDataDefault: getIsSeoDataDefault( yoastStore ) };
+		if ( JSON.stringify( { checklist, isSeoDataDefault } ) === JSON.stringify( lastResult ) ) {
+			return lastResult;
 		}
 
-		lastChecklist = checklist;
-		return { checklist, isSeoDataDefault: getIsSeoDataDefault( yoastStore ) };
+		lastResult = { checklist, isSeoDataDefault };
+		return lastResult;
 	};
 };
 

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -36,7 +36,13 @@ const makeMapSelectToProps = () => {
 		const isSeoDataDefault = getIsSeoDataDefault( yoastStore );
 
 		// Return the previous reference when content is identical to avoid triggering re-renders.
-		if ( JSON.stringify( { checklist, isSeoDataDefault } ) === JSON.stringify( lastResult ) ) {
+		if (
+			lastResult !== null &&
+			checklist.length === lastResult.checklist.length &&
+			checklist.every( ( item, i ) => JSON.stringify( item ) === JSON.stringify( lastResult.checklist[ i ] ) ) &&
+			isSeoDataDefault.isAllTitlesDefault === lastResult.isSeoDataDefault.isAllTitlesDefault &&
+			isSeoDataDefault.isAllDescriptionsDefault === lastResult.isSeoDataDefault.isAllDescriptionsDefault
+		) {
 			return lastResult;
 		}
 

--- a/packages/js/src/containers/PrePublish.js
+++ b/packages/js/src/containers/PrePublish.js
@@ -41,8 +41,8 @@ const makeMapSelectToProps = () => {
 			checklist.length === lastResult.checklist.length &&
 			checklist.every( ( item, i ) =>
 				item.label === lastResult.checklist[ i ].label &&
-			item.score === lastResult.checklist[ i ].score &&
-			item.scoreValue === lastResult.checklist[ i ].scoreValue
+				item.score === lastResult.checklist[ i ].score &&
+				item.scoreValue === lastResult.checklist[ i ].scoreValue
 			) &&
 			isSeoDataDefault.isAllTitlesDefault === lastResult.isSeoDataDefault.isAllTitlesDefault &&
 			isSeoDataDefault.isAllDescriptionsDefault === lastResult.isSeoDataDefault.isAllDescriptionsDefault

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -36,7 +36,8 @@ function withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId
  * @returns {Function} A memoized withSelect callback.
  */
 export const makeWithSelectProps = () => {
-	let lastResult = null;
+	// Keyed by taxonomy name so that multiple mounted instances do not share a single lastResult.
+	const lastResults = new Map();
 
 	return ( select, props ) => {
 		const { taxonomy } = props;
@@ -47,13 +48,16 @@ export const makeWithSelectProps = () => {
 		const primaryTaxonomyId = yoastData.getPrimaryTaxonomyId( taxonomy.name );
 		const learnMoreLink = yoastData.selectLink( "https://yoa.st/primary-category-more" );
 
+		const lastResult = lastResults.get( taxonomy.name ) ?? null;
+
 		// Return the previous reference when content is identical to avoid triggering re-renders.
 		if ( withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId, learnMoreLink ) ) {
 			return lastResult;
 		}
 
-		lastResult = { selectedTermIds, primaryTaxonomyId, learnMoreLink };
-		return lastResult;
+		const result = { selectedTermIds, primaryTaxonomyId, learnMoreLink };
+		lastResults.set( taxonomy.name, result );
+		return result;
 	};
 };
 

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -9,6 +9,24 @@ import PrimaryTaxonomyPicker from "../components/PrimaryTaxonomyPicker";
 const EMPTY_TERM_IDS = [];
 
 /**
+ * Checks whether the newly computed withSelect props are identical to the last memoized result.
+ *
+ * @param {Object|null} lastResult         The previously memoized result, or null on first call.
+ * @param {Array}       selectedTermIds    The newly computed selected term IDs.
+ * @param {number|null} primaryTaxonomyId  The newly computed primary taxonomy ID.
+ * @param {string}      learnMoreLink      The newly computed learn-more link.
+ *
+ * @returns {boolean} True when all props are unchanged and the cached result can be reused.
+ */
+function withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId, learnMoreLink ) {
+	return lastResult !== null &&
+		primaryTaxonomyId === lastResult.primaryTaxonomyId &&
+		learnMoreLink === lastResult.learnMoreLink &&
+		selectedTermIds.length === lastResult.selectedTermIds.length &&
+		selectedTermIds.every( ( id, i ) => id === lastResult.selectedTermIds[ i ] );
+}
+
+/**
  * Maps the select function to props.
  *
  * Uses output memoization: returns the same object reference whenever the
@@ -17,7 +35,7 @@ const EMPTY_TERM_IDS = [];
  *
  * @returns {Function} A memoized withSelect callback.
  */
-const makeWithSelectProps = () => {
+export const makeWithSelectProps = () => {
 	let lastResult = null;
 
 	return ( select, props ) => {
@@ -30,7 +48,7 @@ const makeWithSelectProps = () => {
 		const learnMoreLink = yoastData.selectLink( "https://yoa.st/primary-category-more" );
 
 		// Return the previous reference when content is identical to avoid triggering re-renders.
-		if ( JSON.stringify( { selectedTermIds, primaryTaxonomyId, learnMoreLink } ) === JSON.stringify( lastResult ) ) {
+		if ( withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId, learnMoreLink ) ) {
 			return lastResult;
 		}
 

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -5,21 +5,42 @@ import {
 import { compose } from "@wordpress/compose";
 import PrimaryTaxonomyPicker from "../components/PrimaryTaxonomyPicker";
 
-export default compose( [
-	withSelect( ( select, props ) => {
+// Stable reference for the empty-terms case, to avoid creating a new array on every render.
+const EMPTY_TERM_IDS = [];
+
+/**
+ * Maps the select function to props.
+ *
+ * Uses output memoization: returns the same object reference whenever the
+ * computed content has not changed. This prevents `withSelect` from seeing
+ * a new reference on every render, which would cause unnecessary re-renders.
+ *
+ * @returns {Function} A memoized withSelect callback.
+ */
+const makeWithSelectProps = () => {
+	let lastResult = null;
+
+	return ( select, props ) => {
+		const { taxonomy } = props;
 		const editorData = select( "core/editor" );
 		const yoastData = select( "yoast-seo/editor" );
 
-		const { taxonomy } = props;
+		const selectedTermIds = editorData.getEditedPostAttribute( taxonomy.restBase ) ?? EMPTY_TERM_IDS;
+		const primaryTaxonomyId = yoastData.getPrimaryTaxonomyId( taxonomy.name );
+		const learnMoreLink = yoastData.selectLink( "https://yoa.st/primary-category-more" );
 
-		const selectedTermIds = editorData.getEditedPostAttribute( taxonomy.restBase ) || [];
+		// Return the previous reference when content is identical to avoid triggering re-renders.
+		if ( JSON.stringify( { selectedTermIds, primaryTaxonomyId, learnMoreLink } ) === JSON.stringify( lastResult ) ) {
+			return lastResult;
+		}
 
-		return {
-			selectedTermIds,
-			primaryTaxonomyId: yoastData.getPrimaryTaxonomyId( taxonomy.name ),
-			learnMoreLink: yoastData.selectLink( "https://yoa.st/primary-category-more" ),
-		};
-	} ),
+		lastResult = { selectedTermIds, primaryTaxonomyId, learnMoreLink };
+		return lastResult;
+	};
+};
+
+export default compose( [
+	withSelect( makeWithSelectProps() ),
 	withDispatch( dispatch => {
 		const {
 			setPrimaryTaxonomyId,

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -20,7 +20,10 @@ const EMPTY_TERM_IDS = [];
  */
 function withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId, learnMoreLink ) {
 	return lastResult !== null &&
-		primaryTaxonomyId === lastResult.primaryTaxonomyId &&
+		// Object.is is used instead of === to handle NaN correctly: the component constructor
+		// dispatches setPrimaryTaxonomyId with parseInt("", 10) = NaN before the field is set,
+		// and NaN === NaN is false in JS, which would cause the memoization to miss the cache.
+		Object.is( primaryTaxonomyId, lastResult.primaryTaxonomyId ) &&
 		learnMoreLink === lastResult.learnMoreLink &&
 		selectedTermIds.length === lastResult.selectedTermIds.length &&
 		selectedTermIds.every( ( id, i ) => id === lastResult.selectedTermIds[ i ] );

--- a/packages/js/src/containers/PrimaryTaxonomyPicker.js
+++ b/packages/js/src/containers/PrimaryTaxonomyPicker.js
@@ -20,9 +20,7 @@ const EMPTY_TERM_IDS = [];
  */
 function withSelectPropsAreEqual( lastResult, selectedTermIds, primaryTaxonomyId, learnMoreLink ) {
 	return lastResult !== null &&
-		// Object.is is used instead of === to handle NaN correctly: the component constructor
-		// dispatches setPrimaryTaxonomyId with parseInt("", 10) = NaN before the field is set,
-		// and NaN === NaN is false in JS, which would cause the memoization to miss the cache.
+		// Use Object.is for an exact comparison of the memoized primary taxonomy ID.
 		Object.is( primaryTaxonomyId, lastResult.primaryTaxonomyId ) &&
 		learnMoreLink === lastResult.learnMoreLink &&
 		selectedTermIds.length === lastResult.selectedTermIds.length &&

--- a/packages/js/src/redux/selectors/WincherSEOPerformance.js
+++ b/packages/js/src/redux/selectors/WincherSEOPerformance.js
@@ -41,28 +41,54 @@ export function hasWincherTrackedKeyphrases( state ) {
 /**
  * Gets the set keyphrases.
  *
- * @param {Object} state The state.
+ * Uses output memoization: returns the same array reference whenever the
+ * computed content has not changed. This prevents `useSelect`/`withSelect`
+ * from seeing a new reference on every render, which would cause unnecessary
+ * re-renders. A simple `createSelector` approach is not sufficient here because
+ * the premium store is external and may return a new array reference on every
+ * call even when its content is unchanged.
  *
- * @returns {array} The currently set keyphrases.
+ * @returns {Function} A memoized selector that takes state and returns an array of keyphrases.
  */
-export function getWincherTrackableKeyphrases( state ) {
-	const isPremium = getL10nObject().isPremium;
-	const premiumStore = window.wp.data.select( "yoast-seo-premium/editor" );
-	const keyphrases = [ state.focusKeyword.trim() ];
-
-	if ( isPremium && premiumStore ) {
-		// eslint-disable-next-line no-undefined
-		keyphrases.push( ...premiumStore.getKeywords().filter( k => k.keyword !== undefined ).map( k => k.keyword.trim() ) );
+/**
+ * Gets keyphrases from the premium store, if the premium store is available.
+ *
+ * @returns {string[]} The premium keyphrases, or an empty array.
+ */
+function getPremiumKeyphrases() {
+	const premiumStore = window.wp?.data?.select( "yoast-seo-premium/editor" );
+	if ( ! getL10nObject().isPremium || ! premiumStore ) {
+		return [];
 	}
-
-	return uniq( keyphrases.filter( k => !! k ).map(
-		// Canonicalize the keyword the same way Wincher does
-		k => k
-			.replace( /["+:\s]+/g, " " )
-			.trim()
-			.toLocaleLowerCase()
-	) ).sort();
+	// eslint-disable-next-line no-undefined
+	return premiumStore.getKeywords().filter( k => k.keyword !== undefined ).map( k => k.keyword.trim() );
 }
+
+const makeGetWincherTrackableKeyphrases = () => {
+	let lastResult = [];
+
+	return ( state ) => {
+		const keyphrases = [ state.focusKeyword.trim(), ...getPremiumKeyphrases() ];
+
+		const result = uniq( keyphrases.filter( k => !! k ).map(
+			// Canonicalize the keyword the same way Wincher does
+			k => k
+				.replace( /["+:\s]+/g, " " )
+				.trim()
+				.toLocaleLowerCase()
+		) ).sort();
+
+		// Return the previous reference when content is identical to avoid triggering re-renders.
+		if ( result.length === lastResult.length && result.every( ( v, i ) => v === lastResult[ i ] ) ) {
+			return lastResult;
+		}
+
+		lastResult = result;
+		return result;
+	};
+};
+
+export const getWincherTrackableKeyphrases = makeGetWincherTrackableKeyphrases();
 
 /**
  * Determines whether all keyphrases being tracked are still missing ranking data.

--- a/packages/js/src/redux/selectors/WincherSEOPerformance.js
+++ b/packages/js/src/redux/selectors/WincherSEOPerformance.js
@@ -64,7 +64,7 @@ function getPremiumKeyphrases() {
  *
  * @returns {Function} A memoized selector that takes state and returns an array of keyphrases.
  */
-const makeGetWincherTrackableKeyphrases = () => {
+export const makeGetWincherTrackableKeyphrases = () => {
 	let lastResult = [];
 
 	return ( state ) => {

--- a/packages/js/src/redux/selectors/WincherSEOPerformance.js
+++ b/packages/js/src/redux/selectors/WincherSEOPerformance.js
@@ -39,18 +39,6 @@ export function hasWincherTrackedKeyphrases( state ) {
 }
 
 /**
- * Gets the set keyphrases.
- *
- * Uses output memoization: returns the same array reference whenever the
- * computed content has not changed. This prevents `useSelect`/`withSelect`
- * from seeing a new reference on every render, which would cause unnecessary
- * re-renders. A simple `createSelector` approach is not sufficient here because
- * the premium store is external and may return a new array reference on every
- * call even when its content is unchanged.
- *
- * @returns {Function} A memoized selector that takes state and returns an array of keyphrases.
- */
-/**
  * Gets keyphrases from the premium store, if the premium store is available.
  *
  * @returns {string[]} The premium keyphrases, or an empty array.
@@ -64,6 +52,18 @@ function getPremiumKeyphrases() {
 	return premiumStore.getKeywords().filter( k => k.keyword !== undefined ).map( k => k.keyword.trim() );
 }
 
+/**
+ * Creates a memoized selector for trackable keyphrases.
+ *
+ * Uses output memoization: returns the same array reference whenever the
+ * computed content has not changed. This prevents `useSelect`/`withSelect`
+ * from seeing a new reference on every render, which would cause unnecessary
+ * re-renders. A simple `createSelector` approach is not sufficient here because
+ * the premium store is external and may return a new array reference on every
+ * call even when its content is unchanged.
+ *
+ * @returns {Function} A memoized selector that takes state and returns an array of keyphrases.
+ */
 const makeGetWincherTrackableKeyphrases = () => {
 	let lastResult = [];
 
@@ -88,6 +88,13 @@ const makeGetWincherTrackableKeyphrases = () => {
 	};
 };
 
+/**
+ * Gets the set keyphrases that can be tracked by Wincher.
+ *
+ * @param {Object} state The state.
+ *
+ * @returns {string[]} The canonicalized, deduplicated, sorted list of trackable keyphrases.
+ */
 export const getWincherTrackableKeyphrases = makeGetWincherTrackableKeyphrases();
 
 /**

--- a/packages/js/src/redux/selectors/focusKeyPhrase.js
+++ b/packages/js/src/redux/selectors/focusKeyPhrase.js
@@ -1,5 +1,4 @@
 import { applyFilters } from "@wordpress/hooks";
-import { createSelector } from "@reduxjs/toolkit";
 import { get, isArray, isString } from "lodash";
 
 /**
@@ -14,14 +13,38 @@ export function getFocusKeyphrase( state ) {
 }
 
 /**
+ * Creates a memoized selector for focus keyphrase errors.
+ *
+ * Uses output memoization: always calls `applyFilters` (so filter handlers that
+ * maintain their own internal state, e.g. `hasInteractedWithFeature`, are never
+ * skipped), but returns the previous array reference when the resulting error
+ * strings are identical. This prevents `useSelect`/`withSelect` from seeing a
+ * new reference on every render when nothing has actually changed.
+ *
+ * @returns {Function} A memoized selector that takes state and returns an array of error strings.
+ */
+const makeFocusKeyphraseErrors = () => {
+	let lastResult = [];
+
+	return ( state ) => {
+		const errors = applyFilters( "yoast.focusKeyphrase.errors", [], getFocusKeyphrase( state ) );
+		const result = isArray( errors ) ? errors.filter( isString ) : [];
+
+		// Return the previous reference when content is identical to avoid triggering re-renders.
+		if ( result.length === lastResult.length && result.every( ( v, i ) => v === lastResult[ i ] ) ) {
+			return lastResult;
+		}
+
+		lastResult = result;
+		return result;
+	};
+};
+
+/**
  * Gets extra focus keyphrase errors.
+ *
  * @param {Object} state The state.
+ *
  * @returns {string[]} The errors.
  */
-export const getFocusKeyphraseErrors = createSelector(
-	getFocusKeyphrase,
-	( keyword ) => {
-		const errors = applyFilters( "yoast.focusKeyphrase.errors", [], keyword );
-		return isArray( errors ) ? errors.filter( isString ) : [];
-	}
-);
+export const getFocusKeyphraseErrors = makeFocusKeyphraseErrors();

--- a/packages/js/src/redux/selectors/focusKeyPhrase.js
+++ b/packages/js/src/redux/selectors/focusKeyPhrase.js
@@ -1,4 +1,5 @@
 import { applyFilters } from "@wordpress/hooks";
+import { createSelector } from "@reduxjs/toolkit";
 import { get, isArray, isString } from "lodash";
 
 /**
@@ -17,7 +18,10 @@ export function getFocusKeyphrase( state ) {
  * @param {Object} state The state.
  * @returns {string[]} The errors.
  */
-export const getFocusKeyphraseErrors = state => {
-	const errors = applyFilters( "yoast.focusKeyphrase.errors", [], getFocusKeyphrase( state ) );
-	return isArray( errors ) ? errors.filter( isString ) : [];
-};
+export const getFocusKeyphraseErrors = createSelector(
+	getFocusKeyphrase,
+	( keyword ) => {
+		const errors = applyFilters( "yoast.focusKeyphrase.errors", [], keyword );
+		return isArray( errors ) ? errors.filter( isString ) : [];
+	}
+);

--- a/packages/js/tests/components/PrimaryTaxonomyPicker.test.js
+++ b/packages/js/tests/components/PrimaryTaxonomyPicker.test.js
@@ -1,0 +1,47 @@
+import { render } from "../test-utils";
+import PrimaryTaxonomyPicker from "../../src/components/PrimaryTaxonomyPicker";
+
+// Return a never-settling promise so the fetchTerms .then() handler never fires
+// and no setState call escapes the act() boundary of the render.
+jest.mock( "@wordpress/api-fetch", () => jest.fn().mockReturnValue( new Promise( () => {} ) ) );
+
+const defaultProps = {
+	taxonomy: {
+		name: "category",
+		fieldId: "category-field",
+		restBase: "categories",
+		singularLabel: "Category",
+	},
+	selectedTermIds: [],
+	primaryTaxonomyId: -1,
+	learnMoreLink: "https://example.com",
+	setPrimaryTaxonomyId: jest.fn(),
+	updateReplacementVariable: jest.fn(),
+};
+
+describe( "PrimaryTaxonomyPicker constructor", () => {
+	let getElementByIdSpy;
+
+	afterEach( () => {
+		getElementByIdSpy.mockRestore();
+		jest.clearAllMocks();
+	} );
+
+	it( "dispatches -1 when the hidden input field is empty", () => {
+		getElementByIdSpy = jest.spyOn( document, "getElementById" ).mockReturnValue( { value: "" } );
+		const setPrimaryTaxonomyId = jest.fn();
+
+		render( <PrimaryTaxonomyPicker { ...defaultProps } setPrimaryTaxonomyId={ setPrimaryTaxonomyId } /> );
+
+		expect( setPrimaryTaxonomyId ).toHaveBeenCalledWith( "category", -1 );
+	} );
+
+	it( "dispatches the parsed integer when the hidden input field contains a valid id", () => {
+		getElementByIdSpy = jest.spyOn( document, "getElementById" ).mockReturnValue( { value: "42" } );
+		const setPrimaryTaxonomyId = jest.fn();
+
+		render( <PrimaryTaxonomyPicker { ...defaultProps } setPrimaryTaxonomyId={ setPrimaryTaxonomyId } /> );
+
+		expect( setPrimaryTaxonomyId ).toHaveBeenCalledWith( "category", 42 );
+	} );
+} );

--- a/packages/js/tests/components/PrimaryTaxonomyPicker.test.js
+++ b/packages/js/tests/components/PrimaryTaxonomyPicker.test.js
@@ -44,4 +44,13 @@ describe( "PrimaryTaxonomyPicker constructor", () => {
 
 		expect( setPrimaryTaxonomyId ).toHaveBeenCalledWith( "category", 42 );
 	} );
+
+	it( "dispatches -1 when the hidden input field contains a non-numeric value", () => {
+		getElementByIdSpy = jest.spyOn( document, "getElementById" ).mockReturnValue( { value: "abc" } );
+		const setPrimaryTaxonomyId = jest.fn();
+
+		render( <PrimaryTaxonomyPicker { ...defaultProps } setPrimaryTaxonomyId={ setPrimaryTaxonomyId } /> );
+
+		expect( setPrimaryTaxonomyId ).toHaveBeenCalledWith( "category", -1 );
+	} );
 } );

--- a/packages/js/tests/components/WincherKeyphrasesTable.test.js
+++ b/packages/js/tests/components/WincherKeyphrasesTable.test.js
@@ -137,6 +137,62 @@ describe( "WincherKeyphrasesTable getKeyphrases fetch", () => {
 	} );
 } );
 
+describe( "WincherKeyphrasesTable getKeyphraseData", () => {
+	const activateTrackingText = "Activate tracking to show the ranking position";
+
+	const renderWithTracked = ( keyphrases, trackedKeyphrases ) => render(
+		<WincherKeyphrasesTable
+			keyphrases={ keyphrases }
+			trackedKeyphrases={ trackedKeyphrases }
+			onAuthentication={ noop }
+			addTrackingKeyphrase={ noop }
+			newRequest={ noop }
+			setKeyphraseLimitReached={ noop }
+			setTrackedKeyphrases={ noop }
+			setRequestFailed={ noop }
+			setRequestSucceeded={ noop }
+			addTrackedKeyphrase={ noop }
+			removeTrackedKeyphrase={ noop }
+			setHasTrackedAll={ noop }
+			onSelectKeyphrases={ noop }
+			permalink=""
+			selectedKeyphrases={ [] }
+		/>
+	);
+
+	it( "shows 'Activate tracking' when trackedKeyphrases is null", () => {
+		renderWithTracked( [ "seo" ], null );
+		expect( screen.getByText( activateTrackingText ) ).toBeInTheDocument();
+	} );
+
+	it( "shows 'Activate tracking' when trackedKeyphrases is empty", () => {
+		renderWithTracked( [ "seo" ], {} );
+		expect( screen.getByText( activateTrackingText ) ).toBeInTheDocument();
+	} );
+
+	it( "shows 'Activate tracking' when the keyphrase is not in trackedKeyphrases", () => {
+		renderWithTracked( [ "seo" ], { other: { id: "1" } } );
+		expect( screen.getByText( activateTrackingText ) ).toBeInTheDocument();
+	} );
+
+	it( "does not show 'Activate tracking' when the keyphrase is an own property of trackedKeyphrases", () => {
+		renderWithTracked( [ "seo" ], { seo: { id: "1" } } );
+		expect( screen.queryByText( activateTrackingText ) ).not.toBeInTheDocument();
+	} );
+
+	it( "matches keyphrases case-insensitively against trackedKeyphrases keys", () => {
+		renderWithTracked( [ "SEO" ], { seo: { id: "1" } } );
+		expect( screen.queryByText( activateTrackingText ) ).not.toBeInTheDocument();
+	} );
+
+	it( "does not return data for inherited properties of trackedKeyphrases", () => {
+		// "constructor" exists on the Object prototype but is not an own property of a plain object.
+		// trackedKeyphrases must be non-empty so isEmpty() does not short-circuit before the hasOwnProperty check.
+		renderWithTracked( [ "constructor" ], { seo: { id: "1" } } );
+		expect( screen.getByText( activateTrackingText ) ).toBeInTheDocument();
+	} );
+} );
+
 describe( "WincherKeyphrasesTable with asterisk", () => {
 	it( "should add an asterisk after the focus keyphrase, even if the keyphrase contains capital letters", async() => {
 		renderWincherKeyphrasesTable( {

--- a/packages/js/tests/components/WincherKeyphrasesTable.test.js
+++ b/packages/js/tests/components/WincherKeyphrasesTable.test.js
@@ -6,7 +6,7 @@ global.window.wpseoAdminGlobalL10n[ "links.wincher.login" ] = "test.com";
 import WincherKeyphrasesTable
 	from "../../../js/src/components/WincherKeyphrasesTable";
 import { noop } from "lodash";
-import { trackKeyphrases } from "../../src/helpers/wincherEndpoints";
+import { getKeyphrases, trackKeyphrases } from "../../src/helpers/wincherEndpoints";
 
 jest.mock( "../../src/helpers/wincherEndpoints" );
 trackKeyphrases.mockImplementation( async fn => {
@@ -53,6 +53,87 @@ describe( "WincherKeyphrasesTable", () => {
 	it( "should have the right keyphrases present", async() => {
 		const cell = screen.getByRole( "cell", { name: "Example keyphrase" } );
 		expect( cell ).toBeInTheDocument();
+	} );
+} );
+
+describe( "WincherKeyphrasesTable getKeyphrases fetch", () => {
+	const successResponse = { status: 200, results: { seo: { keyword: "seo" } } };
+
+	const renderWithFetch = ( props = {} ) => render( <WincherKeyphrasesTable
+		keyphrases={ [ "seo" ] }
+		trackedKeyphrases={ null }
+		onAuthentication={ noop }
+		addTrackingKeyphrase={ noop }
+		newRequest={ noop }
+		setKeyphraseLimitReached={ noop }
+		setTrackedKeyphrases={ noop }
+		setRequestFailed={ noop }
+		setRequestSucceeded={ noop }
+		addTrackedKeyphrase={ noop }
+		removeTrackedKeyphrase={ noop }
+		setHasTrackedAll={ noop }
+		onSelectKeyphrases={ noop }
+		isLoggedIn={ true }
+		permalink="https://example.com"
+		startAt="2024-01-01"
+		selectedKeyphrases={ [] }
+		{ ...props }
+	/> );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		getKeyphrases.mockResolvedValue( successResponse );
+	} );
+
+	it( "calls getKeyphrases with the correct arguments on mount", async() => {
+		renderWithFetch();
+
+		await waitFor( () => expect( getKeyphrases ).toHaveBeenCalledTimes( 1 ) );
+		expect( getKeyphrases ).toHaveBeenCalledWith(
+			[ "seo" ],
+			"2024-01-01",
+			"https://example.com",
+			expect.any( AbortSignal )
+		);
+	} );
+
+	it( "calls setTrackedKeyphrases with the response results after a successful fetch", async() => {
+		const setTrackedKeyphrases = jest.fn();
+
+		renderWithFetch( { setTrackedKeyphrases } );
+
+		await waitFor( () => expect( setTrackedKeyphrases ).toHaveBeenCalledWith( successResponse.results ) );
+	} );
+
+	it( "calls getKeyphrases a second time and resolves setTrackedKeyphrases when keyphrases change", async() => {
+		const setTrackedKeyphrases = jest.fn();
+
+		const { rerender } = renderWithFetch( { setTrackedKeyphrases } );
+
+		await waitFor( () => expect( getKeyphrases ).toHaveBeenCalledTimes( 1 ) );
+
+		rerender( <WincherKeyphrasesTable
+			keyphrases={ [ "seo", "tools" ] }
+			trackedKeyphrases={ null }
+			onAuthentication={ noop }
+			addTrackingKeyphrase={ noop }
+			newRequest={ noop }
+			setKeyphraseLimitReached={ noop }
+			setTrackedKeyphrases={ setTrackedKeyphrases }
+			setRequestFailed={ noop }
+			setRequestSucceeded={ noop }
+			addTrackedKeyphrase={ noop }
+			removeTrackedKeyphrase={ noop }
+			setHasTrackedAll={ noop }
+			onSelectKeyphrases={ noop }
+			isLoggedIn={ true }
+			permalink="https://example.com"
+			startAt="2024-01-01"
+			selectedKeyphrases={ [] }
+		/> );
+
+		await waitFor( () => expect( getKeyphrases ).toHaveBeenCalledTimes( 2 ) );
+		await waitFor( () => expect( setTrackedKeyphrases ).toHaveBeenCalledTimes( 2 ) );
 	} );
 } );
 

--- a/packages/js/tests/containers/DocumentSidebar.test.js
+++ b/packages/js/tests/containers/DocumentSidebar.test.js
@@ -42,6 +42,26 @@ describe( "The DocumentSidebar container", () => {
 		expect( props.intro ).toEqual( undefined );
 	} );
 
+	it( "returns the same checklist reference when called twice with the same content", () => {
+		const select = mockSelectors();
+
+		const first = mapSelectToProps( select );
+		const second = mapSelectToProps( select );
+
+		expect( second.checklist ).toBe( first.checklist );
+	} );
+
+	it( "returns a new checklist reference when the content changes", () => {
+		const selectA = mockSelectors();
+		const selectB = mockSelectors();
+		selectB( "yoast-seo/editor" ).getResultsForFocusKeyword.mockReturnValue( { overallScore: 0 } );
+
+		const first = mapSelectToProps( selectA );
+		const second = mapSelectToProps( selectB );
+
+		expect( second.checklist ).not.toBe( first.checklist );
+	} );
+
 	it( "maps the dispatch function to props", () => {
 		const dispatchers = {
 			openGeneralSidebar: jest.fn(),

--- a/packages/js/tests/containers/PrePublish.test.js
+++ b/packages/js/tests/containers/PrePublish.test.js
@@ -25,6 +25,26 @@ describe( "The PrePublish container", () => {
 		} );
 	} );
 
+	it( "returns the same checklist reference when called twice with the same content", () => {
+		const select = mockSelectors();
+
+		const first = mapSelectToProps( select );
+		const second = mapSelectToProps( select );
+
+		expect( second.checklist ).toBe( first.checklist );
+	} );
+
+	it( "returns a new checklist reference when the content changes", () => {
+		const selectA = mockSelectors();
+		const selectB = mockSelectors();
+		selectB( "yoast-seo/editor" ).getResultsForFocusKeyword.mockReturnValue( { overallScore: 0 } );
+
+		const first = mapSelectToProps( selectA );
+		const second = mapSelectToProps( selectB );
+
+		expect( second.checklist ).not.toBe( first.checklist );
+	} );
+
 	it( "maps the dispatch function to props", () => {
 		const dispatchers = {
 			closePublishSidebar: jest.fn(),

--- a/packages/js/tests/containers/PrePublish.test.js
+++ b/packages/js/tests/containers/PrePublish.test.js
@@ -45,6 +45,59 @@ describe( "The PrePublish container", () => {
 		expect( second.checklist ).not.toBe( first.checklist );
 	} );
 
+	it( "returns the same isSeoDataDefault reference when the default-state booleans are unchanged", () => {
+		const select = mockSelectors();
+
+		const first = mapSelectToProps( select );
+		const second = mapSelectToProps( select );
+
+		expect( second.isSeoDataDefault ).toBe( first.isSeoDataDefault );
+	} );
+
+	it( "returns a new isSeoDataDefault reference when isAllTitlesDefault changes", () => {
+		const selectA = mockSelectors();
+
+		const selectB = mockSelectors();
+		selectB( "yoast-seo/editor" ).getPreferences.mockReturnValue( {
+			isKeywordAnalysisActive: true,
+			isContentAnalysisActive: true,
+			isRecentTitlesDefault: true,
+		} );
+		selectB( "yoast-seo/editor" ).getSnippetEditorData.mockReturnValue( {
+			title: "title template",
+			description: "",
+			slug: "",
+		} );
+
+		const first = mapSelectToProps( selectA );
+		const second = mapSelectToProps( selectB );
+
+		expect( second.isSeoDataDefault ).not.toBe( first.isSeoDataDefault );
+		expect( second.isSeoDataDefault.isAllTitlesDefault ).toBe( true );
+	} );
+
+	it( "returns a new isSeoDataDefault reference when isAllDescriptionsDefault changes", () => {
+		const selectA = mockSelectors();
+
+		const selectB = mockSelectors();
+		selectB( "yoast-seo/editor" ).getPreferences.mockReturnValue( {
+			isKeywordAnalysisActive: true,
+			isContentAnalysisActive: true,
+			isRecentDescriptionsDefault: true,
+		} );
+		selectB( "yoast-seo/editor" ).getSnippetEditorData.mockReturnValue( {
+			title: "",
+			description: "description template",
+			slug: "",
+		} );
+
+		const first = mapSelectToProps( selectA );
+		const second = mapSelectToProps( selectB );
+
+		expect( second.isSeoDataDefault ).not.toBe( first.isSeoDataDefault );
+		expect( second.isSeoDataDefault.isAllDescriptionsDefault ).toBe( true );
+	} );
+
 	it( "maps the dispatch function to props", () => {
 		const dispatchers = {
 			closePublishSidebar: jest.fn(),

--- a/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
+++ b/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
@@ -1,0 +1,84 @@
+import { makeWithSelectProps } from "../../src/containers/PrimaryTaxonomyPicker";
+
+const taxonomy = { name: "category", restBase: "categories" };
+
+/**
+ * Creates a mock select function for the PrimaryTaxonomyPicker container.
+ *
+ * @param {Object} overrides Override specific return values.
+ * @param {Array|null} overrides.termIds The term IDs to return from getEditedPostAttribute.
+ * @param {number|null} overrides.primaryId The primary taxonomy ID.
+ * @param {string} overrides.link The learn-more link.
+ *
+ * @returns {jest.Mock} A mock select function.
+ */
+const makeSelect = ( { termIds = [ 1, 2 ], primaryId = 5, link = "https://example.com" } = {} ) => {
+	return jest.fn( storeName => {
+		if ( storeName === "core/editor" ) {
+			return { getEditedPostAttribute: jest.fn().mockReturnValue( termIds ) };
+		}
+		if ( storeName === "yoast-seo/editor" ) {
+			return {
+				getPrimaryTaxonomyId: jest.fn().mockReturnValue( primaryId ),
+				selectLink: jest.fn().mockReturnValue( link ),
+			};
+		}
+	} );
+};
+
+describe( "PrimaryTaxonomyPicker container withSelect", () => {
+	it( "returns selectedTermIds, primaryTaxonomyId and learnMoreLink", () => {
+		const withSelectProps = makeWithSelectProps();
+
+		const props = withSelectProps( makeSelect(), { taxonomy } );
+
+		expect( props.selectedTermIds ).toEqual( [ 1, 2 ] );
+		expect( props.primaryTaxonomyId ).toBe( 5 );
+		expect( props.learnMoreLink ).toBe( "https://example.com" );
+	} );
+
+	it( "uses EMPTY_TERM_IDS when getEditedPostAttribute returns null", () => {
+		const withSelectProps = makeWithSelectProps();
+
+		const props = withSelectProps( makeSelect( { termIds: null } ), { taxonomy } );
+
+		expect( props.selectedTermIds ).toEqual( [] );
+	} );
+
+	it( "returns the same reference when called twice with the same content", () => {
+		const withSelectProps = makeWithSelectProps();
+		const select = makeSelect();
+
+		const first = withSelectProps( select, { taxonomy } );
+		const second = withSelectProps( select, { taxonomy } );
+
+		expect( second ).toBe( first );
+	} );
+
+	it( "returns a new reference when selectedTermIds changes", () => {
+		const withSelectProps = makeWithSelectProps();
+
+		const first = withSelectProps( makeSelect( { termIds: [ 1 ] } ), { taxonomy } );
+		const second = withSelectProps( makeSelect( { termIds: [ 2 ] } ), { taxonomy } );
+
+		expect( second ).not.toBe( first );
+	} );
+
+	it( "returns a new reference when primaryTaxonomyId changes", () => {
+		const withSelectProps = makeWithSelectProps();
+
+		const first = withSelectProps( makeSelect( { primaryId: 1 } ), { taxonomy } );
+		const second = withSelectProps( makeSelect( { primaryId: 2 } ), { taxonomy } );
+
+		expect( second ).not.toBe( first );
+	} );
+
+	it( "returns a new reference when learnMoreLink changes", () => {
+		const withSelectProps = makeWithSelectProps();
+
+		const first = withSelectProps( makeSelect( { link: "https://a.com" } ), { taxonomy } );
+		const second = withSelectProps( makeSelect( { link: "https://b.com" } ), { taxonomy } );
+
+		expect( second ).not.toBe( first );
+	} );
+} );

--- a/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
+++ b/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
@@ -64,6 +64,16 @@ describe( "PrimaryTaxonomyPicker container withSelect", () => {
 		expect( second ).not.toBe( first );
 	} );
 
+	it( "returns the same reference when primaryTaxonomyId is NaN on consecutive calls", () => {
+		const withSelectProps = makeWithSelectProps();
+		const select = makeSelect( { primaryId: NaN } );
+
+		const first = withSelectProps( select, { taxonomy } );
+		const second = withSelectProps( select, { taxonomy } );
+
+		expect( second ).toBe( first );
+	} );
+
 	it( "returns a new reference when primaryTaxonomyId changes", () => {
 		const withSelectProps = makeWithSelectProps();
 

--- a/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
+++ b/packages/js/tests/containers/PrimaryTaxonomyPicker.test.js
@@ -81,4 +81,17 @@ describe( "PrimaryTaxonomyPicker container withSelect", () => {
 
 		expect( second ).not.toBe( first );
 	} );
+
+	it( "keeps separate caches for different taxonomy names", () => {
+		const withSelectProps = makeWithSelectProps();
+		const categoryTaxonomy = { name: "category", restBase: "categories" };
+		const tagTaxonomy = { name: "post_tag", restBase: "tags" };
+
+		const categoryResult = withSelectProps( makeSelect( { primaryId: 1 } ), { taxonomy: categoryTaxonomy } );
+		// A call for a different taxonomy must not corrupt the category cache.
+		withSelectProps( makeSelect( { primaryId: 99 } ), { taxonomy: tagTaxonomy } );
+		const categoryResultAgain = withSelectProps( makeSelect( { primaryId: 1 } ), { taxonomy: categoryTaxonomy } );
+
+		expect( categoryResultAgain ).toBe( categoryResult );
+	} );
 } );

--- a/packages/js/tests/redux/selectors/WincherSEOPerformance.test.js
+++ b/packages/js/tests/redux/selectors/WincherSEOPerformance.test.js
@@ -1,0 +1,111 @@
+import { getWincherTrackableKeyphrases } from "../../../src/redux/selectors/WincherSEOPerformance";
+
+let windowSpy;
+
+beforeEach( () => {
+	windowSpy = jest.spyOn( global, "window", "get" );
+	// Default: free site, no premium store.
+	windowSpy.mockReturnValue( {
+		wpseoScriptData: { metabox: { isPremium: false } },
+	} );
+} );
+
+afterEach( () => {
+	windowSpy.mockRestore();
+} );
+
+describe( "getWincherTrackableKeyphrases", () => {
+	it( "trims, lowercases and sorts the focus keyword", () => {
+		const state = { focusKeyword: "  SEO  " };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo" ] );
+	} );
+
+	it( "filters out an empty focus keyword", () => {
+		const state = { focusKeyword: "" };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [] );
+	} );
+
+	it( "canonicalises quotes, colons and extra whitespace", () => {
+		const state = { focusKeyword: '"seo":tools' };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo tools" ] );
+	} );
+
+	it( "returns the same array reference when called twice with the same content", () => {
+		const state = { focusKeyword: "reference stability" };
+
+		const first = getWincherTrackableKeyphrases( state );
+		const second = getWincherTrackableKeyphrases( state );
+
+		expect( second ).toBe( first );
+	} );
+
+	it( "returns a new array reference when the focus keyword changes", () => {
+		const stateA = { focusKeyword: "keyword alpha" };
+		const stateB = { focusKeyword: "keyword beta" };
+
+		const first = getWincherTrackableKeyphrases( stateA );
+		const second = getWincherTrackableKeyphrases( stateB );
+
+		expect( second ).not.toBe( first );
+	} );
+
+	it( "includes premium keyphrases when the premium store is available", () => {
+		windowSpy.mockReturnValue( {
+			wpseoScriptData: { metabox: { isPremium: true } },
+			wp: {
+				data: {
+					select: () => ( {
+						getKeywords: () => [
+							{ keyword: "related keyphrase" },
+							{ keyword: "another one" },
+						],
+					} ),
+				},
+			},
+		} );
+
+		const state = { focusKeyword: "seo" };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "another one", "related keyphrase", "seo" ] );
+	} );
+
+	it( "ignores premium keywords whose keyword property is undefined", () => {
+		windowSpy.mockReturnValue( {
+			wpseoScriptData: { metabox: { isPremium: true } },
+			wp: {
+				data: {
+					select: () => ( {
+						getKeywords: () => [
+							{ keyword: "valid" },
+							{ keyword: undefined },
+						],
+					} ),
+				},
+			},
+		} );
+
+		const state = { focusKeyword: "seo" };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo", "valid" ] );
+	} );
+
+	it( "deduplicates keyphrases that canonicalise to the same value", () => {
+		windowSpy.mockReturnValue( {
+			wpseoScriptData: { metabox: { isPremium: true } },
+			wp: {
+				data: {
+					select: () => ( {
+						getKeywords: () => [ { keyword: "SEO" } ],
+					} ),
+				},
+			},
+		} );
+
+		const state = { focusKeyword: "seo" };
+
+		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo" ] );
+	} );
+} );

--- a/packages/js/tests/redux/selectors/WincherSEOPerformance.test.js
+++ b/packages/js/tests/redux/selectors/WincherSEOPerformance.test.js
@@ -1,4 +1,4 @@
-import { getWincherTrackableKeyphrases } from "../../../src/redux/selectors/WincherSEOPerformance";
+import { makeGetWincherTrackableKeyphrases } from "../../../src/redux/selectors/WincherSEOPerformance";
 
 let windowSpy;
 
@@ -16,38 +16,43 @@ afterEach( () => {
 
 describe( "getWincherTrackableKeyphrases", () => {
 	it( "trims, lowercases and sorts the focus keyword", () => {
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: "  SEO  " };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo" ] );
+		expect( selector( state ) ).toEqual( [ "seo" ] );
 	} );
 
 	it( "filters out an empty focus keyword", () => {
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: "" };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [] );
+		expect( selector( state ) ).toEqual( [] );
 	} );
 
 	it( "canonicalises quotes, colons and extra whitespace", () => {
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: '"seo":tools' };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo tools" ] );
+		expect( selector( state ) ).toEqual( [ "seo tools" ] );
 	} );
 
 	it( "returns the same array reference when called twice with the same content", () => {
-		const state = { focusKeyword: "reference stability" };
+		const selector = makeGetWincherTrackableKeyphrases();
+		const state = { focusKeyword: "seo" };
 
-		const first = getWincherTrackableKeyphrases( state );
-		const second = getWincherTrackableKeyphrases( state );
+		const first = selector( state );
+		const second = selector( state );
 
 		expect( second ).toBe( first );
 	} );
 
 	it( "returns a new array reference when the focus keyword changes", () => {
+		const selector = makeGetWincherTrackableKeyphrases();
 		const stateA = { focusKeyword: "keyword alpha" };
 		const stateB = { focusKeyword: "keyword beta" };
 
-		const first = getWincherTrackableKeyphrases( stateA );
-		const second = getWincherTrackableKeyphrases( stateB );
+		const first = selector( stateA );
+		const second = selector( stateB );
 
 		expect( second ).not.toBe( first );
 	} );
@@ -67,9 +72,10 @@ describe( "getWincherTrackableKeyphrases", () => {
 			},
 		} );
 
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: "seo" };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "another one", "related keyphrase", "seo" ] );
+		expect( selector( state ) ).toEqual( [ "another one", "related keyphrase", "seo" ] );
 	} );
 
 	it( "ignores premium keywords whose keyword property is undefined", () => {
@@ -87,9 +93,10 @@ describe( "getWincherTrackableKeyphrases", () => {
 			},
 		} );
 
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: "seo" };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo", "valid" ] );
+		expect( selector( state ) ).toEqual( [ "seo", "valid" ] );
 	} );
 
 	it( "deduplicates keyphrases that canonicalise to the same value", () => {
@@ -104,8 +111,9 @@ describe( "getWincherTrackableKeyphrases", () => {
 			},
 		} );
 
+		const selector = makeGetWincherTrackableKeyphrases();
 		const state = { focusKeyword: "seo" };
 
-		expect( getWincherTrackableKeyphrases( state ) ).toEqual( [ "seo" ] );
+		expect( selector( state ) ).toEqual( [ "seo" ] );
 	} );
 } );

--- a/packages/js/tests/redux/selectors/focusKeyPhrase.test.js
+++ b/packages/js/tests/redux/selectors/focusKeyPhrase.test.js
@@ -44,11 +44,22 @@ describe( "getFocusKeyphraseErrors", () => {
 		expect( second ).toBe( first );
 	} );
 
-	it( "returns a new array reference when the keyword changes", () => {
+	it( "returns the same array reference when the keyword changes but errors are identical", () => {
 		applyFilters.mockReturnValue( [ "An error." ] );
 
 		const first = getFocusKeyphraseErrors( { focusKeyword: "seo-new-a" } );
 		const second = getFocusKeyphraseErrors( { focusKeyword: "seo-new-b" } );
+
+		// Output memoization: reference only changes when error content changes, not when the keyword changes.
+		expect( second ).toBe( first );
+	} );
+
+	it( "returns a new array reference when the errors content changes", () => {
+		applyFilters.mockReturnValueOnce( [ "Error A." ] );
+		applyFilters.mockReturnValueOnce( [ "Error B." ] );
+
+		const first = getFocusKeyphraseErrors( { focusKeyword: "seo-change" } );
+		const second = getFocusKeyphraseErrors( { focusKeyword: "seo-change" } );
 
 		expect( second ).not.toBe( first );
 	} );

--- a/packages/js/tests/redux/selectors/focusKeyPhrase.test.js
+++ b/packages/js/tests/redux/selectors/focusKeyPhrase.test.js
@@ -1,0 +1,63 @@
+jest.mock( "@wordpress/hooks", () => ( {
+	applyFilters: jest.fn( ( _hook, defaultValue ) => defaultValue ),
+} ) );
+
+import { applyFilters } from "@wordpress/hooks";
+import { getFocusKeyphraseErrors } from "../../../src/redux/selectors/focusKeyPhrase";
+
+afterEach( () => {
+	applyFilters.mockReset();
+} );
+
+describe( "getFocusKeyphraseErrors", () => {
+	it( "returns an empty array when the filter adds no errors", () => {
+		applyFilters.mockReturnValue( [] );
+
+		expect( getFocusKeyphraseErrors( { focusKeyword: "seo-1" } ) ).toEqual( [] );
+	} );
+
+	it( "returns string errors provided by the filter", () => {
+		applyFilters.mockReturnValue( [ "Too short.", "Too generic." ] );
+
+		expect( getFocusKeyphraseErrors( { focusKeyword: "seo-2" } ) ).toEqual( [ "Too short.", "Too generic." ] );
+	} );
+
+	it( "filters out non-string values from the filter result", () => {
+		applyFilters.mockReturnValue( [ "Valid error.", 42, null, true ] );
+
+		expect( getFocusKeyphraseErrors( { focusKeyword: "seo-3" } ) ).toEqual( [ "Valid error." ] );
+	} );
+
+	it( "returns an empty array when the filter returns a non-array", () => {
+		applyFilters.mockReturnValue( "not an array" );
+
+		expect( getFocusKeyphraseErrors( { focusKeyword: "seo-4" } ) ).toEqual( [] );
+	} );
+
+	it( "returns the same array reference when called twice with the same keyword", () => {
+		applyFilters.mockReturnValue( [ "An error." ] );
+		const state = { focusKeyword: "seo-ref-stable" };
+
+		const first = getFocusKeyphraseErrors( state );
+		const second = getFocusKeyphraseErrors( state );
+
+		expect( second ).toBe( first );
+	} );
+
+	it( "returns a new array reference when the keyword changes", () => {
+		applyFilters.mockReturnValue( [ "An error." ] );
+
+		const first = getFocusKeyphraseErrors( { focusKeyword: "seo-new-a" } );
+		const second = getFocusKeyphraseErrors( { focusKeyword: "seo-new-b" } );
+
+		expect( second ).not.toBe( first );
+	} );
+
+	it( "passes the focus keyword to applyFilters", () => {
+		applyFilters.mockReturnValue( [] );
+
+		getFocusKeyphraseErrors( { focusKeyword: "yoast seo" } );
+
+		expect( applyFilters ).toHaveBeenCalledWith( "yoast.focusKeyphrase.errors", [], "yoast seo" );
+	} );
+} );


### PR DESCRIPTION
## Context

* We want to clear the performance console warnings.

## Summary

This PR can be summarized in the following changelog entry:

* Improves post editor rendering performance by stabilising Redux selector and `withSelect` references in multiple components to prevent unnecessary re-renders.
* Fixes a bug where NaN was set as the Primary taxonomy and triggered a console error.

## Relevant technical choices:

* `getFocusKeyphraseErrors` previously returned a new array on every call because `applyFilters` always produces a new reference. Wrapping it with RTK's `createSelector` memoises the output on the `focusKeyword` input, so `useSelect` only sees a new reference when the keyword actually changes.
* `getWincherTrackableKeyphrases` could not use `createSelector` alone because it reads from an external premium Redux store (`yoast-seo-premium/editor`) that is outside the local state tree. That store may return a new array reference on every call even when its contents are identical, which would always bust the input-equality check that `createSelector` relies on. Instead, the selector is wrapped in a closure (`makeGetWincherTrackableKeyphrases`) that keeps a `lastResult` reference and performs a shallow element-by-element comparison, returning the cached reference whenever the sorted, de-duped keyphrase list is unchanged.
* `DocumentSidebar` and `PrePublish` both built a fresh `checklist` array on every `withSelect` call, and `getIsSeoDataDefault` returned a new object literal on every call. Both containers now use an output-memoised closure (`makeMapSelectToProps`) that compares each checklist item individually (after a length check) and compares `isSeoDataDefault` properties directly, returning the previous reference when nothing has changed. Per-item comparison is preferred over a full `JSON.stringify` of the output to avoid silently dropping non-serializable values and to exit early on a length mismatch.
* `PrimaryTaxonomyPicker` had three issues: (1) `getEditedPostAttribute(...) || []` created a new array reference whenever the attribute was null/undefined, fixed with a stable `EMPTY_TERM_IDS` constant; (2) the full `withSelect` return object was recreated on every call, fixed with an output-memoised closure that compares term IDs element-by-element; (3) the equality check used `===` for `primaryTaxonomyId`, which fails for `NaN` (`NaN === NaN` is `false` in JS) — the component constructor calls `setPrimaryTaxonomyId` with `parseInt("", 10) = NaN` before the hidden field is populated, so the memoization always missed the cache during that transient state and returned a new object reference on every `withSelect` double-call in `SCRIPT_DEBUG` mode, triggering the "Non-equal value keys: primaryTaxonomyId" warning. Replaced with `Object.is()` which correctly treats `NaN` as equal to itself.
* `WincherKeyphrasesTable` called `getKeyphrases` through a module-level `debounce` (leading: true, 500 ms). When `getTrackedKeyphrases` was invoked twice within the debounce window the second call returned `undefined`, so `handleAPIResponse` exited without invoking any callback and `trackedKeyphrases` stayed `null` indefinitely — leaving the panel in a permanent loading state. The `AbortController` already cancels any in-flight request before each new call, making the debounce redundant; removing it ensures every call returns a real Promise that `handleAPIResponse` can resolve.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* In order to see those warnings, make sure your `wp-config.php` has:
```php
define( 'SCRIPT_DEBUG', true );
```

1. Open a WordPress post or page in the Block editor with Yoast SEO active.
2. Open the browser DevTools console and filter for warnings.
3. Enter or change the focus keyphrase in the Yoast SEO sidebar.
4. Confirm that no `useSelect` performance warnings appear in the console (e.g. "The 'useSelect' hook…returned a new reference").
5. Activate Yoast SEO Premium, add one or more related keyphrases and repeat step 4 ( useSelect error for `Non-equal value keys: relatedKeywords` is coming from the premium addon).
6. Connect Wincher, navigate to the SEO performance tab — verify the tracked keyphrases load correctly and the panel does not get stuck in a loading state. To exercise the fix specifically: trigger a keyphrase change twice in quick succession (within 500 ms) and confirm the panel still resolves and displays results.
7. Open the pre-publish panel and verify the checklist renders correctly with no console warnings.
8. On a post with a primary category configured, verify the primary taxonomy picker renders correctly with no console warnings. In particular confirm no "Non-equal value keys: primaryTaxonomyId" warning appears on initial load.
9. On a post where no primary taxonomy was configured, check there is no console error for Primary taxonomy being set with NaN.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — watch for `useSelect` performance/reference-equality warnings before and after.
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Wincher SEO Performance panel (keyphrase tracking list).
* Focus keyphrase error display in the Yoast SEO sidebar.
* Pre-publish checklist panel.
* Primary taxonomy picker (primary category/tag selector).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1209