### PR TITLE
Fix schema aggregator wordpress fallback

### DIFF
--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -71,7 +71,7 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
 				if ( empty( $indexable->id ) ) {
 					// If the indexable doesn't have an ID, we assign it a negative value of the post ID to ensure uniqueness.
-					$indexable->id = ( -$post_id );
+					$indexable->id = $post_id;
 				}
 				$public_indexables[] = $indexable;
 			}

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -70,7 +70,7 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			$indexable = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
 				if ( empty( $indexable->id ) ) {
-					// If the indexable doesn't have an ID, we assign it a negative value of the post ID to ensure uniqueness.
+				
 					$indexable->id = $post_id;
 				}
 				$public_indexables[] = $indexable;

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -71,7 +71,7 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
 				if ( empty( $indexable->id ) ) {
 					// If the indexable doesn't have an ID, we assign it a negative value of the post ID to ensure uniqueness.
-					$indexable->id = -$post_id;
+					$indexable->id = - ( $post_id );
 				}
 				$public_indexables[] = $indexable;
 			}

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -70,7 +70,7 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			$indexable = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
 				if ( empty( $indexable->id ) ) {
-				
+
 					$indexable->id = $post_id;
 				}
 				$public_indexables[] = $indexable;

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -69,6 +69,10 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 		foreach ( $post_ids as $post_id ) {
 			$indexable = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
+				if ( empty( $indexable->id ) ) {
+					// If the indexable doesn't have an ID, we assign it a negative value of the post ID to ensure uniqueness.
+					$indexable->id = -$post_id;
+				}
 				$public_indexables[] = $indexable;
 			}
 		}

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -71,7 +71,7 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
 				if ( empty( $indexable->id ) ) {
 					// If the indexable doesn't have an ID, we assign it a negative value of the post ID to ensure uniqueness.
-					$indexable->id = - ( $post_id );
+					$indexable->id = ( -$post_id );
 				}
 				$public_indexables[] = $indexable;
 			}

--- a/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
+++ b/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
@@ -27,6 +27,13 @@ final class WordPress_Query_Repository_Test extends TestCase {
 	private $instance;
 
 	/**
+	 * The pure indexable repository used to set up/clean up test state.
+	 *
+	 * @var Pure_Indexable_Repository
+	 */
+	private $pure_indexable_repository;
+
+	/**
 	 * Created WordPress post IDs for cleanup.
 	 *
 	 * @var array<int>
@@ -41,10 +48,10 @@ final class WordPress_Query_Repository_Test extends TestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		$indexable_builder         = \YoastSEO()->classes->get( Indexable_Builder::class );
-		$pure_indexable_repository = \YoastSEO()->classes->get( Pure_Indexable_Repository::class );
+		$indexable_builder               = \YoastSEO()->classes->get( Indexable_Builder::class );
+		$this->pure_indexable_repository = \YoastSEO()->classes->get( Pure_Indexable_Repository::class );
 
-		$this->instance = new WordPress_Query_Repository( $indexable_builder, $pure_indexable_repository );
+		$this->instance = new WordPress_Query_Repository( $indexable_builder, $this->pure_indexable_repository );
 		$this->create_test_content();
 	}
 
@@ -109,6 +116,13 @@ final class WordPress_Query_Repository_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_assigns_synthetic_negative_id_when_indexables_disabled(): void {
+		// Remove any indexables that the post watcher persisted during set_up; otherwise find_by_id_and_type returns the saved row (with a real positive id) and the synthetic-id branch never fires.
+		$this->pure_indexable_repository
+			->query()
+			->where_in( 'object_id', $this->created_posts )
+			->where( 'object_type', 'post' )
+			->delete_many();
+
 		\add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
 
 		try {

--- a/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
+++ b/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
@@ -106,17 +106,17 @@ final class WordPress_Query_Repository_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that get() assigns a synthetic negative id when indexables are not persisted.
+	 * Tests that get() assigns a synthetic id when indexables are not persisted.
 	 *
 	 * When the `Yoast\WP\SEO\should_index_indexables` filter returns `false`, the builder produces
 	 * in-memory Indexables whose primary key is never minted by the DB. Downstream consumers
 	 * (e.g. Meta_Tags_Context_Memoizer) key caches on `$indexable->id`, so distinct posts must
-	 * still end up with distinct ids — the repository fills that gap by assigning `-$post_id`.
+	 * still end up with distinct ids — the repository fills that gap by assigning `$post_id`.
 	 *
 	 * @return void
 	 */
-	public function test_get_assigns_synthetic_negative_id_when_indexables_disabled(): void {
-		// Remove any indexables that the post watcher persisted during set_up; otherwise find_by_id_and_type returns the saved row (with a real positive id) and the synthetic-id branch never fires.
+	public function test_get_assigns_synthetic_id_when_indexables_disabled(): void {
+		// Remove any indexables that the post watcher persisted during set_up; otherwise find_by_id_and_type returns the saved row (with a real id) and the synthetic-id branch never fires.
 		$this->pure_indexable_repository
 			->query()
 			->where_in( 'object_id', $this->created_posts )
@@ -132,8 +132,7 @@ final class WordPress_Query_Repository_Test extends TestCase {
 
 			$ids = [];
 			foreach ( $result as $indexable ) {
-				$this->assertLessThan( 0, $indexable->id, 'Synthetic ids must be negative to avoid collisions with real primary keys' );
-				$this->assertSame( -$indexable->object_id, $indexable->id, 'Synthetic id should be the negated post id' );
+				$this->assertSame( $indexable->object_id, $indexable->id, 'Synthetic id should equal the post id' );
 				$ids[] = $indexable->id;
 			}
 

--- a/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
+++ b/tests/WP/Schema_Aggregator/Infrastructure/Indexable_Repository/WordPress_Query_Repository_Test.php
@@ -99,6 +99,38 @@ final class WordPress_Query_Repository_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that get() assigns a synthetic negative id when indexables are not persisted.
+	 *
+	 * When the `Yoast\WP\SEO\should_index_indexables` filter returns `false`, the builder produces
+	 * in-memory Indexables whose primary key is never minted by the DB. Downstream consumers
+	 * (e.g. Meta_Tags_Context_Memoizer) key caches on `$indexable->id`, so distinct posts must
+	 * still end up with distinct ids — the repository fills that gap by assigning `-$post_id`.
+	 *
+	 * @return void
+	 */
+	public function test_get_assigns_synthetic_negative_id_when_indexables_disabled(): void {
+		\add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
+
+		try {
+			$result = $this->instance->get( 1, 10, 'post' );
+
+			$this->assertNotEmpty( $result, 'Should still return indexables even when indexables are disabled' );
+
+			$ids = [];
+			foreach ( $result as $indexable ) {
+				$this->assertLessThan( 0, $indexable->id, 'Synthetic ids must be negative to avoid collisions with real primary keys' );
+				$this->assertSame( -$indexable->object_id, $indexable->id, 'Synthetic id should be the negated post id' );
+				$ids[] = $indexable->id;
+			}
+
+			$this->assertSame( $ids, \array_unique( $ids ), 'Synthetic ids should be unique across the returned indexables' );
+		}
+		finally {
+			\remove_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
+		}
+	}
+
+	/**
 	 * Tests the get method with pagination.
 	 *
 	 * @return void


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* When indexables are not available, we fallback to plain WordPress queries. In this case, the main loop in the `Schema_Piece_Repository` breaks because no id is assigned to the indexables generated on-the-fly.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where only the first piece was returned when indexables were not available. 

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have some public posts in your blog
* Disable indexables by adding the following snippet to your blog:
  ```
  add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );
  ```
  * If you have indexables already generated, delete them through the Yoast Test Helper
* Go to the following URL: `YOUR-BLOG-URL/wp-json/yoast/v1/schema-aggregator/get-schema/post`
  *  Without this PR:
    * You get only one post (and the schema pieces related to it)
   * With this PR:
     * You get all your public posts (if they are less than 1000)
  
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Please test for regressions the following cases:
  * Indexables are available 
  * Products ( `/wp-json/yoast/v1/schema-aggregator/get-schema/product`
  * EDD post types ( `wp-json/yoast/v1/schema-aggregator/get-schema/download` )

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
