### PR TITLE
Switch to checking for authors with published posts when updating use…

### DIFF
--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -88,30 +88,20 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 */
 	protected function get_users( $arguments = [] ) {
 
-		global $wpdb;
-
 		$defaults = [
 			'meta_key'   => '_yoast_wpseo_profile_updated',
 			'orderby'    => 'meta_value_num',
 			'order'      => 'DESC',
 			'meta_query' => [
-				'relation' => 'AND',
+				'relation' => 'OR',
 				[
-					'key'     => $wpdb->get_blog_prefix() . 'user_level',
-					'value'   => '0',
+					'key'     => 'wpseo_noindex_author',
+					'value'   => 'on',
 					'compare' => '!=',
 				],
 				[
-					'relation' => 'OR',
-					[
-						'key'     => 'wpseo_noindex_author',
-						'value'   => 'on',
-						'compare' => '!=',
-					],
-					[
-						'key'     => 'wpseo_noindex_author',
-						'compare' => 'NOT EXISTS',
-					],
+					'key'     => 'wpseo_noindex_author',
+					'compare' => 'NOT EXISTS',
 				],
 			],
 		];

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -127,9 +127,9 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	 * Centralises the `noindex-author-noposts-wpseo` branching so the sitemap query and its
 	 * backfill counterpart always agree on which users are considered eligible.
 	 *
-	 * @param array $criteria The get_users() criteria array to extend.
+	 * @param array<string, array<array<string, string>>> $criteria The get_users() criteria array to extend.
 	 *
-	 * @return array The criteria array with the eligibility clause applied.
+	 * @return array<string, array<array<string, string>>> The criteria array with the eligibility clause applied.
 	 */
 	protected function apply_author_eligibility_filter( array $criteria ) {
 		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {

--- a/inc/sitemaps/class-author-sitemap-provider.php
+++ b/inc/sitemaps/class-author-sitemap-provider.php
@@ -91,7 +91,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		global $wpdb;
 
 		$defaults = [
-			'capability' => [ 'edit_posts' ],
 			'meta_key'   => '_yoast_wpseo_profile_updated',
 			'orderby'    => 'meta_value_num',
 			'order'      => 'DESC',
@@ -117,12 +116,31 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			],
 		];
 
-		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
-			unset( $defaults['capability'] ); // Otherwise it cancels out next argument.
-			$defaults['has_published_posts'] = YoastSEO()->helpers->author_archive->get_author_archive_post_types();
-		}
+		$defaults = $this->apply_author_eligibility_filter( $defaults );
 
 		return get_users( array_merge( $defaults, $arguments ) );
+	}
+
+	/**
+	 * Applies the author-eligibility clause (capability or has_published_posts) to a get_users() criteria array.
+	 *
+	 * Centralises the `noindex-author-noposts-wpseo` branching so the sitemap query and its
+	 * backfill counterpart always agree on which users are considered eligible.
+	 *
+	 * @param array $criteria The get_users() criteria array to extend.
+	 *
+	 * @return array The criteria array with the eligibility clause applied.
+	 */
+	protected function apply_author_eligibility_filter( array $criteria ) {
+		if ( WPSEO_Options::get( 'noindex-author-noposts-wpseo', true ) ) {
+			$criteria['has_published_posts'] = YoastSEO()->helpers->author_archive->get_author_archive_post_types();
+
+			return $criteria;
+		}
+
+		$criteria['capability'] = [ 'edit_posts' ];
+
+		return $criteria;
 	}
 
 	/**
@@ -205,7 +223,6 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 	protected function update_user_meta() {
 
 		$user_criteria = [
-			'capability' => [ 'edit_posts' ],
 			'meta_query' => [
 				[
 					'key'     => '_yoast_wpseo_profile_updated',
@@ -213,6 +230,8 @@ class WPSEO_Author_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				],
 			],
 		];
+
+		$user_criteria = $this->apply_author_eligibility_filter( $user_criteria );
 
 		$users = get_users( $user_criteria );
 

--- a/tests/WP/Sitemaps/Author_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Author_Sitemap_Provider_Test.php
@@ -234,4 +234,157 @@ final class Author_Sitemap_Provider_Test extends TestCase {
 		// Checks which users are in the sitemap, there should be none.
 		self::$class_instance->get_sitemap_links( 'author', 10, 1 );
 	}
+
+	/**
+	 * Tests that the backfill (triggered by get_index_links) stamps `_yoast_wpseo_profile_updated`
+	 * only for users that have published posts when `noindex-author-noposts-wpseo` is enabled.
+	 *
+	 * Mirrors the "Normal flow" preparation from PR #23256: delete the meta, render the index,
+	 * then verify the set of stamped users matches the set that will appear in the sitemap.
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+	 * @covers WPSEO_Author_Sitemap_Provider::update_user_meta
+	 * @covers WPSEO_Author_Sitemap_Provider::apply_author_eligibility_filter
+	 *
+	 * @return void
+	 */
+	public function test_backfill_stamps_only_authors_with_posts_when_noposts_option_is_true() {
+		// Removes authors with no posts from the sitemap.
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
+
+		// Creates one author with published posts and one without any.
+		$author_with_posts_id    = $this->factory->user->create( [ 'role' => 'author' ] );
+		$author_without_posts_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$this->factory->post->create_many( 2, [ 'post_author' => $author_with_posts_id ] );
+
+		// Resets meta so the backfill has a clean slate (user_register may have stamped it).
+		\delete_user_meta( $author_with_posts_id, '_yoast_wpseo_profile_updated' );
+		\delete_user_meta( $author_without_posts_id, '_yoast_wpseo_profile_updated' );
+
+		// Renders the index, which triggers the backfill internally.
+		self::$class_instance->get_index_links( 100 );
+
+		// Only the author with posts should have been stamped.
+		$this->assertNotEmpty( \get_user_meta( $author_with_posts_id, '_yoast_wpseo_profile_updated', true ) );
+		$this->assertEmpty( \get_user_meta( $author_without_posts_id, '_yoast_wpseo_profile_updated', true ) );
+	}
+
+	/**
+	 * Tests that the backfill stamps every user with the `edit_posts` capability — regardless of
+	 * whether they have posts — when `noindex-author-noposts-wpseo` is disabled.
+	 *
+	 * Mirrors the "Enable the setting and repeat" branch of PR #23256.
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+	 * @covers WPSEO_Author_Sitemap_Provider::update_user_meta
+	 * @covers WPSEO_Author_Sitemap_Provider::apply_author_eligibility_filter
+	 *
+	 * @return void
+	 */
+	public function test_backfill_stamps_all_edit_posts_users_when_noposts_option_is_false() {
+		// Allows authors with no posts in the sitemap.
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', false );
+
+		$author_id     = $this->factory->user->create( [ 'role' => 'author' ] );
+		$admin_id      = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		// Resets meta so the backfill has a clean slate.
+		\delete_user_meta( $author_id, '_yoast_wpseo_profile_updated' );
+		\delete_user_meta( $admin_id, '_yoast_wpseo_profile_updated' );
+		\delete_user_meta( $subscriber_id, '_yoast_wpseo_profile_updated' );
+
+		// Renders the index, which triggers the backfill internally.
+		self::$class_instance->get_index_links( 100 );
+
+		// Author and admin have `edit_posts` and should be stamped.
+		$this->assertNotEmpty( \get_user_meta( $author_id, '_yoast_wpseo_profile_updated', true ) );
+		$this->assertNotEmpty( \get_user_meta( $admin_id, '_yoast_wpseo_profile_updated', true ) );
+
+		// Subscribers do not have `edit_posts` and should remain unstamped.
+		$this->assertEmpty( \get_user_meta( $subscriber_id, '_yoast_wpseo_profile_updated', true ) );
+	}
+
+	/**
+	 * Tests that the per-page author sitemap emits a `<lastmod>` equal to the backfill timestamp
+	 * for a user whose meta was unset before the index render.
+	 *
+	 * Mirrors the PR #23256 step "Last Mods of authors sitemap should be the time of when you
+	 * visit the root sitemap page" — i.e. fresh stamps from the immediately-preceding index render.
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 * @covers WPSEO_Author_Sitemap_Provider::update_user_meta
+	 *
+	 * @return void
+	 */
+	public function test_sitemap_lastmod_reflects_backfill_time_when_option_is_true() {
+		// Removes authors with no posts from the sitemap.
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
+
+		$author_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		$this->factory->post->create( [ 'post_author' => $author_id ] );
+
+		// Resets meta to ensure the backfill writes a fresh stamp.
+		\delete_user_meta( $author_id, '_yoast_wpseo_profile_updated' );
+
+		$time_before = \time();
+		self::$class_instance->get_index_links( 100 );
+		$time_after = \time();
+
+		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+
+		// One author should be present.
+		$this->assertCount( 1, $sitemap_links );
+
+		// The author's <lastmod> value must match a stamp written during the backfill above.
+		$stamp = (int) \get_user_meta( $author_id, '_yoast_wpseo_profile_updated', true );
+		$this->assertGreaterThanOrEqual( $time_before, $stamp );
+		$this->assertLessThanOrEqual( $time_after, $stamp );
+		$this->assertSame( \gmdate( \DATE_W3C, $stamp ), $sitemap_links[0]['mod'] );
+	}
+
+	/**
+	 * Tests the "first-publish freshness" property called out in the PR description: an author who
+	 * has no posts at first index render gets no stamp; once they publish their first post, the
+	 * next index render stamps them with the current time, and that stamp surfaces as their
+	 * `<lastmod>` in the per-page sitemap.
+	 *
+	 * @covers WPSEO_Author_Sitemap_Provider::get_index_links
+	 * @covers WPSEO_Author_Sitemap_Provider::get_sitemap_links
+	 * @covers WPSEO_Author_Sitemap_Provider::update_user_meta
+	 *
+	 * @return void
+	 */
+	public function test_first_publish_triggers_fresh_lastmod_on_next_index_render() {
+		// Removes authors with no posts from the sitemap.
+		WPSEO_Options::set( 'noindex-author-noposts-wpseo', true );
+
+		$author_id = $this->factory->user->create( [ 'role' => 'author' ] );
+		\delete_user_meta( $author_id, '_yoast_wpseo_profile_updated' );
+
+		// First render — author has no posts, so the backfill must skip them.
+		self::$class_instance->get_index_links( 100 );
+		$this->assertEmpty(
+			\get_user_meta( $author_id, '_yoast_wpseo_profile_updated', true ),
+			'Author without posts should not be stamped on the first index render.',
+		);
+
+		// Author publishes their first post.
+		$this->factory->post->create( [ 'post_author' => $author_id ] );
+
+		// Second render — backfill should now stamp the author with a fresh timestamp.
+		$time_before = \time();
+		self::$class_instance->get_index_links( 100 );
+		$time_after = \time();
+
+		$stamp = (int) \get_user_meta( $author_id, '_yoast_wpseo_profile_updated', true );
+		$this->assertGreaterThanOrEqual( $time_before, $stamp );
+		$this->assertLessThanOrEqual( $time_after, $stamp );
+
+		// Per-page sitemap should now contain the author with the fresh stamp.
+		$sitemap_links = self::$class_instance->get_sitemap_links( 'author', 10, 1 );
+		$this->assertCount( 1, $sitemap_links );
+		$this->assertSame( \gmdate( \DATE_W3C, $stamp ), $sitemap_links[0]['mod'] );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* 2 separate query optimizations:
  * About the **root sitemap** - We basically unify the query that updates the `_yoast_wpseo_profile_updated` usermeta on the root sitemap (which is required for an author to be shown in the author sitemap) with the query that actually retrieves authors on the author sitemap.
    * As a result we manage to have a much more optimized query while keeping most of the functionality intact. 
    * There's two subtle changes and can be summed up like: 
      * When an author that was created while Yoast wasn't active publishes their first post after the sitemap is first rendered, they will have a LAST_MOD indicating a time after the first post, whereas before they had a LAST_MOD indicating the time the sitemap was first rendered - We provide test instructions for this, below
      * Users with published posts but no `edit_posts` capability start appearing in the sitemap. We're ok with this because
        * it's an actual improvement
        * it requires a very customized role that makes little sense, that is a site having a user role where users can publish but not edit posts
   * About the **author sitemap** -We simplify the query that runs on the author sitemap itself by removing the clause that's about user level because user levels [have been deprecated since WP 3.0](https://codex.wordpress.org/User_Levels)
     * Further explanation on why I think this is safe, [here](https://yoast.slack.com/archives/C03KU0EHCNQ/p1778837383632239?thread_ts=1778760580.529479&cid=C03KU0EHCNQ) for anyone interested. 
 

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Significantly reduces loading times of the root sitemap on sites with many users.
* Reduces loading times of the author sitemap on sites with many users.

## Relevant technical choices:

* We expect the new query about the root sitemap to have massive improvements on sites with a large number of users (on a test site with over 100k users, it ran in 23ms where the old one ran in 347s). We also expect it to have marginal differences on a site with a large number of posts (on a test site with over 100k posts, it ran in 25ms where the old one ran in 2.5ms)
* We expect the new query about the author sitemap to have smaller but still significant improvements on sites with a large number of users (on a test site with over 100k users, it ran in 221s where the old one ran in 319s).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Preparation**:
* The test instructions are basically regression tests, we have confirmed that we optimize the queries by testing them in a large test site with lots of users.
* Have at least two users for all roles (subscriber, contributor, editor, admin etc.) 
* One of the user for each role should have published a post (wherever possible, eg. for subscribers that's not possible) and and the other shouldn't

**Optimization of root sitemap**:
* Have `Show author archives without posts in search results` setting disabled which is the default
* Delete `_yoast_wpseo_profile_updated` usermeta for all users, if there are any. That way, we avoid previous renders of the sitemap affect our tests.
* Visit `/sitemap_index.xml` with this PR 
  * Keep that tab open
* Visit `/author-sitemap.xml` with this PR 
  * Keep that tab open
* Delete the `_yoast_wpseo_profile_updated` usermeta and switch to a branch/RC without this PR
* Visit `/sitemap_index.xml` 
  * Confirm that you see the same results with the opened tab, except the Last Mod of the author sitemap which should be the time of when you visit that page
* Visit `/author-sitemap.xml` 
  * Confirm that you see the same results with the opened tab, except the Last Mods of authors sitemap which should be the time of when you visit the root sitemap page.
* Enable the `Show author archives without posts in search results` setting and repeat the tests

**Optimization of author sitemap**:
* Create a subscriber and two authors, author1 and author2
* Make sure that for all three users, there's its `wp_user_level` usermeta counterpart
  * Basically, for subscriber (eg. with user ID 2), there needs to be a row in usermeta with `user_id=2` and `wp_user_level=0`
  * For authors (eg. with user ID 3 and 4), there needs to be a row in usermeta with `user_id=3` (or 4) and `wp_user_level=2`
* Have `Show author archives without posts in search results` setting disabled which is the default
* Create a post with author1
* Go to the root sitemap and then to the author sitemap
* Confirm that you see only author1 there
* Have `Show author archives without posts in search results` setting enabled 
* Go to the author sitemap
* Confirm that you now see also the author2 there but NOT the subscriber

**Subtle change**:
* Switch to a branch/RC without this PR.
* Have a site with at least one author user (e.g. user `author-fresh`) that has no published posts.
* Have the `Show author archives without posts in search results` setting disabled (the default).
* Delete the `_yoast_wpseo_profile_updated usermeta` for author-fresh, to make sure no stale stamp from a previous render affects the test.
* Switch to a branch/RC without this PR.
* Visit `/sitemap_index.xml` and take a note at the time you did, let's call it SITEMAP_RENDER_TIME_1
  * Keep that tab open
* Visit `/author-sitemap.xml`
  * Keep that tab open
  * Confirm that author-fresh does not appear yet (they have no published posts).
* Log in as author-fresh and publish their first post.
* Wait for the time to change its minutes (so, at least one minute) and then visit `/sitemap_index.xml` and `/author-sitemap.xml` again.
  * Confirm that `author-fresh` now appears.
  * Note the `<lastmod>` value of author-fresh's `<url>` entry. Call this LASTMOD_1.
  * Notice that `LASTMOD_1` is basically equal to `SITEMAP_RENDER_TIME_1` — it reflects the moment we visited the root sitemap even before the new author published anything.
* **Switch to this PR** and do the same steps with above. In detail:
* Delete the `_yoast_wpseo_profile_updated usermeta` for author-fresh again and delete its post
* Switch to this PR and visit `/sitemap_index.xml` and take a note at the time you did, let's call it SITEMAP_RENDER_TIME_2
  * Keep that tab open
* Visit `/author-sitemap.xml`
  * Keep that tab open
  * Confirm that author-fresh does not appear yet (they have no published posts).
* Log in as author-fresh and publish their first post. 
* Wait for the time to change its minutes (so, at least one minute) and then visit `/sitemap_index.xml` and `/author-sitemap.xml` again.
  * Confirm that `author-fresh` now appears.
  * Note the `<lastmod>` value of author-fresh's `<url>` entry. Call this LASTMOD_2.
  * Notice that `LASTMOD_2` is now NOT equal to `SITEMAP_RENDER_TIME_2` — instead it reflects the moment we visited the root sitemap while the user had a published post, not before

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Author sitemaps

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
