### PR TITLE
Add filter to allow for short-circuiting a potentially expensive post…

### DIFF
--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -40,12 +40,27 @@ class WPSEO_Custom_Fields {
 		 *
 		 * @param int $limit Number of custom fields to retrieve. Default 30.
 		 */
-		$limit  = apply_filters( 'postmeta_form_limit', 30 );
-		$sql    = "SELECT DISTINCT meta_key
-			FROM $wpdb->postmeta
-			WHERE meta_key NOT BETWEEN '_' AND '_z' AND SUBSTRING(meta_key, 1, 1) != '_'
-			LIMIT %d";
-		$fields = $wpdb->get_col( $wpdb->prepare( $sql, $limit ) );
+		$limit = apply_filters( 'postmeta_form_limit', 30 );
+
+		/**
+		 * Filters the custom-fields lookup before the database query runs.
+		 *
+		 * Returning a non-null array short-circuits the default `SELECT DISTINCT meta_key`
+		 * query against `wp_postmeta`. On very large postmeta tables this is can be a way
+		 * to supply a pre-cached list or an alternative query to improve loading times.
+		 *
+		 * @param string[]|null $custom_fields Pre-computed list of meta_key names, or null to run the default query.
+		 * @param int           $limit         The configured result limit; honor it if running a custom query.
+		 */
+		$fields = apply_filters( 'wpseo_custom_fields_pre_query', null, $limit );
+
+		if ( ! is_array( $fields ) ) {
+			$sql    = "SELECT DISTINCT meta_key
+				FROM $wpdb->postmeta
+				WHERE meta_key NOT BETWEEN '_' AND '_z' AND SUBSTRING(meta_key, 1, 1) != '_'
+				LIMIT %d";
+			$fields = $wpdb->get_col( $wpdb->prepare( $sql, $limit ) );
+		}
 
 		/**
 		 * Filters the custom fields that are auto-completed and replaced as replacement variables

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -43,7 +43,7 @@ class WPSEO_Custom_Fields {
 		$limit = apply_filters( 'postmeta_form_limit', 30 );
 
 		/**
-		 * Filters the custom-fields lookup before the database query runs.
+		 * Filter: 'wpseo_custom_fields_pre_query' - Filters the custom-fields lookup before the database query runs.
 		 *
 		 * Returning a non-null array short-circuits the default `SELECT DISTINCT meta_key`
 		 * query against `wp_postmeta`. On very large postmeta tables this is can be a way

--- a/inc/class-wpseo-custom-fields.php
+++ b/inc/class-wpseo-custom-fields.php
@@ -46,7 +46,7 @@ class WPSEO_Custom_Fields {
 		 * Filter: 'wpseo_custom_fields_pre_query' - Filters the custom-fields lookup before the database query runs.
 		 *
 		 * Returning a non-null array short-circuits the default `SELECT DISTINCT meta_key`
-		 * query against `wp_postmeta`. On very large postmeta tables this is can be a way
+		 * query against `wp_postmeta`. On very large postmeta tables this can be a way
 		 * to supply a pre-cached list or an alternative query to improve loading times.
 		 *
 		 * @param string[]|null $custom_fields Pre-computed list of meta_key names, or null to run the default query.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* On sites with very large `wp_postmeta` tables (e.g. 80M+ rows), the query in `WPSEO_Custom_Fields::get_custom_fields()` can become a significant bottleneck. The query runs whenever the replacement-variable autocomplete is initialized (Search Appearance settings, the post editor sidebar, etc.) and on such large tables takes many seconds to complete each time.
* This PR adds an escape hatch: a filter that lets site owners short-circuit the query with a curated list or a custom, schema-aware query of their own.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the `wpseo_custom_fields_pre_query` filter, allowing sites to short-circuit the potentially expensive custom-fields lookup in Yoast settings, with a pre-computed list or a custom query.

## Relevant technical choices:

* The query that was proposed in the original issue is dependent on the setup of the database, so we would have expected varying results. Instead we'll give power users the ability to short-circuit the query to hook their custom one, in case their customized setup allows for optimization.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Activate Yoast SEO and a plugin that adds custom fields to posts (eg. Fakerpress). Also install Query Monitor
* Go to Yoast settings
* Run `wpseoScriptData.replacementVariables.specific.post` in the console and take a note of the result. It should also have the custom field that the plugin you have active registers (in the case of Fakerpress, `cf_fakerpress_flag`)
  * Do the same without this PR and confirm that you see the same result
  * In both cases, Query Monitor shows a query being performed by the `WPSEO_Custom_Fields::get_custom_fields` caller
* Add the following snippet:
```
add_filter( 'wpseo_custom_fields_pre_query', static function ( $fields, $limit ) {
      global $wpdb;

      // Tightly bounded range on the meta_key index — no leading wildcard, no SUBSTRING.
      $sql = "SELECT DISTINCT meta_key
          FROM $wpdb->postmeta
          WHERE meta_key NOT LIKE '\_%'
          LIMIT %d";

      return $wpdb->get_col( $wpdb->prepare( $sql, $limit ) );
  }, 10, 2 );
```
* This filter is supposed to perform a custom query to find out the replacements
* Reload run `wpseoScriptData.replacementVariables.specific.post` in the console and confirm that you get the same results with before
* Also, the Query Monitor doesn't shows a query being performed by the `WPSEO_Custom_Fields::get_custom_fields` caller, but rather one from `{closure}` and it's like the one we filtered in:
```
SELECT DISTINCT meta_key
FROM wp_postmeta
WHERE meta_key NOT LIKE '\_%'
LIMIT 30
```
* Remove the above snippet and add the following snippet:
```
  <?php
  add_filter( 'wpseo_custom_fields_pre_query', static function ( $fields, $limit ) {
      return [ 'pr_test_one', 'pr_test_two', 'pr_test_three' ];
  }, 10, 2 );
```
* Reload the page, run `wpseoScriptData.replacementVariables.specific.post` in the console and confirm that those values are added in the result and `cf_fakerpress_flag` is now removed
* Also, the Query Monitor no longer shows a query being performed by the `WPSEO_Custom_Fields::get_custom_fields` caller

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
