### PR TITLE
1203 replace multiple find by id and type usages with find by multiple ids and type in the schema aggregator

### DIFF
--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -64,17 +64,21 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 			return [];
 		}
 
-		$post_ids          = isset( $query->posts ) && \is_array( $query->posts ) ? $query->posts : [];
-		$public_indexables = [];
-		foreach ( $post_ids as $post_id ) {
-			$indexable = $this->indexable_repository->find_by_id_and_type( $post_id, 'post' );
-			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
-				if ( empty( $indexable->id ) ) {
+		$post_ids = isset( $query->posts ) && \is_array( $query->posts ) ? $query->posts : [];
 
-					$indexable->id = $post_id;
-				}
-				$public_indexables[] = $indexable;
+		$indexables        = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post' );
+		$public_indexables = [];
+		foreach ( $indexables as $indexable ) {
+			if ( $indexable === null ) {
+				continue;
 			}
+			if ( $indexable->is_public !== true && $indexable->is_public !== null ) {
+				continue;
+			}
+			if ( empty( $indexable->id ) ) {
+				$indexable->id = $indexable->object_id;
+			}
+			$public_indexables[] = $indexable;
 		}
 		return $public_indexables;
 	}

--- a/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
+++ b/src/schema-aggregator/infrastructure/indexable-repository/wordpress-query-repository.php
@@ -69,16 +69,13 @@ class WordPress_Query_Repository implements Indexable_Repository_Interface {
 		$indexables        = $this->indexable_repository->find_by_multiple_ids_and_type( $post_ids, 'post' );
 		$public_indexables = [];
 		foreach ( $indexables as $indexable ) {
-			if ( $indexable === null ) {
-				continue;
+			if ( $indexable !== null && ( $indexable->is_public === true || $indexable->is_public === null ) ) {
+				if ( empty( $indexable->id ) ) {
+
+					$indexable->id = $indexable->object_id;
+				}
+				$public_indexables[] = $indexable;
 			}
-			if ( $indexable->is_public !== true && $indexable->is_public !== null ) {
-				continue;
-			}
-			if ( empty( $indexable->id ) ) {
-				$indexable->id = $indexable->object_id;
-			}
-			$public_indexables[] = $indexable;
 		}
 		return $public_indexables;
 	}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Instead of doing 1 SELECT per post when fetching them to be output in the schema aggregator, we gather all IDs from posts in the batch (1000 at most) and SELECT them within one query. This saves 999 roundtrips to the DB per batch (so if a site has 5000 posts, it saves 4996 roundtrips upon building the schema aggregator output)
  * The downside would be a possibility of exceeding allocated memory, but SEOO is batched into chunks of 1000 posts at most, so that's not a problem here.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Makes the schema aggregator faster by drastically reducing the roundtrips to the database, when indexables are disabled.

## Relevant technical choices:

* I considered removing the `find_*()` function altogether and go straight into building the indexables, because 99& of the time there will be no indexables and the `SELECT`s will just be redundant. But it would mean that for the edge cases of sites that have indexables built but disabled, we would decrease performance instead of improving it.
 
## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Reset indexables and then disable them
* Have a couple of posts that are:
  * draft
  * private
  * no-indexed
  * public
* GET the `http://example.com/wp-json/yoast/v1/schema-aggregator/get-schema/post` endpoint and compare results with this PR and without (make sure to delete all transients between requests)
  * confirm the output stays the same.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* https://github.com/Yoast/wordpress-seo/pull/23255

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
