### PR TITLE
Add unit tests for Content_Planner_Integration

### DIFF
--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Abstract_Content_Planner_Integration_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Abstract_Content_Planner_Integration_Test.php
@@ -1,0 +1,80 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use Mockery;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Planner_Endpoints_Repository;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Base class for the Content_Planner_Integration tests.
+ *
+ * @group ai-content-planner
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Content_Planner_Integration_Test extends TestCase {
+
+	/**
+	 * Holds the asset manager mock.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
+	 * Holds the endpoints repository mock.
+	 *
+	 * @var Mockery\MockInterface|Content_Planner_Endpoints_Repository
+	 */
+	protected $endpoints_repository;
+
+	/**
+	 * Holds the indexable repository mock.
+	 *
+	 * @var Mockery\MockInterface|Indexable_Repository
+	 */
+	protected $indexable_repository;
+
+	/**
+	 * Holds the user helper mock.
+	 *
+	 * @var Mockery\MockInterface|User_Helper
+	 */
+	protected $user_helper;
+
+	/**
+	 * Holds the instance under test.
+	 *
+	 * @var Content_Planner_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->asset_manager        = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->endpoints_repository = Mockery::mock( Content_Planner_Endpoints_Repository::class );
+		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
+		$this->user_helper          = Mockery::mock( User_Helper::class );
+
+		$this->instance = new Content_Planner_Integration(
+			$this->asset_manager,
+			$this->endpoints_repository,
+			$this->indexable_repository,
+			$this->user_helper,
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Constructor_Test.php
@@ -1,0 +1,47 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Planner_Endpoints_Repository;
+use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Repositories\Indexable_Repository;
+
+/**
+ * Tests the Content_Planner_Integration constructor.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::__construct
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Constructor_Test extends Abstract_Content_Planner_Integration_Test {
+
+	/**
+	 * Tests if the constructor sets properties correctly.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'asset_manager' ),
+		);
+		$this->assertInstanceOf(
+			Content_Planner_Endpoints_Repository::class,
+			$this->getPropertyValue( $this->instance, 'endpoints_repository' ),
+		);
+		$this->assertInstanceOf(
+			Indexable_Repository::class,
+			$this->getPropertyValue( $this->instance, 'indexable_repository' ),
+		);
+		$this->assertInstanceOf(
+			User_Helper::class,
+			$this->getPropertyValue( $this->instance, 'user_helper' ),
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Enqueue_Assets_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Enqueue_Assets_Test.php
@@ -1,0 +1,67 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use Mockery;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+use Yoast\WP\SEO\Routes\Endpoint\Endpoint_List;
+
+/**
+ * Tests the Content_Planner_Integration enqueue_assets method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::enqueue_assets
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Enqueue_Assets_Test extends Abstract_Content_Planner_Integration_Test {
+
+	/**
+	 * Tests that enqueue_assets enqueues the script and localizes it with the script data.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_assets() {
+		$endpoints = [
+			'get_outline' => '/yoast/v1/ai_content_planner/outline',
+		];
+
+		$endpoint_list = Mockery::mock( Endpoint_List::class );
+		$endpoint_list->expects( 'to_paths_array' )->once()->andReturn( $endpoints );
+		$this->endpoints_repository->expects( 'get_all_endpoints' )->once()->andReturn( $endpoint_list );
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', Content_Planner_Integration::MIN_PUBLISHED_POSTS, false )
+			->andReturn( \array_fill( 0, Content_Planner_Integration::MIN_PUBLISHED_POSTS, 'post' ) );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper
+			->expects( 'get_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '1' );
+
+		$this->asset_manager->expects( 'enqueue_script' )->once()->with( 'ai-content-planner' );
+		$this->asset_manager
+			->expects( 'localize_script' )
+			->once()
+			->with(
+				'ai-content-planner',
+				'wpseoContentPlanner',
+				[
+					'endpoints'                    => $endpoints,
+					'minPostsMet'                  => true,
+					'isBannerPermanentlyDismissed' => true,
+				],
+			);
+
+		$this->instance->enqueue_assets();
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Conditionals_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Conditionals_Test.php
@@ -1,0 +1,35 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use Yoast\WP\SEO\Conditionals\AI_Conditional;
+use Yoast\WP\SEO\Conditionals\AI_Editor_Conditional;
+
+/**
+ * Tests the Content_Planner_Integration get_conditionals method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::get_conditionals
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Conditionals_Test extends Abstract_Content_Planner_Integration_Test {
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$expected = [
+			AI_Conditional::class,
+			AI_Editor_Conditional::class,
+		];
+
+		$this->assertSame( $expected, $this->instance::get_conditionals() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Script_Data_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Script_Data_Test.php
@@ -16,6 +16,8 @@ use Yoast\WP\SEO\Routes\Endpoint\Endpoint_List;
  * @group ai-content-planner
  *
  * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::get_script_data
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::is_minimum_posts_met
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::is_banner_permanently_dismissed
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Script_Data_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Get_Script_Data_Test.php
@@ -1,0 +1,146 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use Mockery;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Banner_Permanent_Dismissal_Route;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+use Yoast\WP\SEO\Routes\Endpoint\Endpoint_List;
+
+/**
+ * Tests the Content_Planner_Integration get_script_data method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::get_script_data
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Script_Data_Test extends Abstract_Content_Planner_Integration_Test {
+
+	/**
+	 * Tests that get_script_data returns all expected keys when the threshold is met and the banner is dismissed.
+	 *
+	 * @return void
+	 */
+	public function test_get_script_data_returns_expected_shape_when_threshold_met_and_banner_dismissed() {
+		$endpoints = [
+			'get_outline' => '/yoast/v1/ai_content_planner/outline',
+		];
+
+		$endpoint_list = Mockery::mock( Endpoint_List::class );
+		$endpoint_list->expects( 'to_paths_array' )->once()->andReturn( $endpoints );
+		$this->endpoints_repository->expects( 'get_all_endpoints' )->once()->andReturn( $endpoint_list );
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', Content_Planner_Integration::MIN_PUBLISHED_POSTS, false )
+			->andReturn( \array_fill( 0, Content_Planner_Integration::MIN_PUBLISHED_POSTS, 'post' ) );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper
+			->expects( 'get_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '1' );
+
+		$expected = [
+			'endpoints'                    => $endpoints,
+			'minPostsMet'                  => true,
+			'isBannerPermanentlyDismissed' => true,
+		];
+
+		$this->assertSame( $expected, $this->instance->get_script_data() );
+	}
+
+	/**
+	 * Tests that minPostsMet is false when the number of recently modified posts is below the threshold.
+	 *
+	 * @return void
+	 */
+	public function test_get_script_data_returns_min_posts_met_false_when_below_threshold() {
+		$endpoint_list = Mockery::mock( Endpoint_List::class );
+		$endpoint_list->expects( 'to_paths_array' )->once()->andReturn( [] );
+		$this->endpoints_repository->expects( 'get_all_endpoints' )->once()->andReturn( $endpoint_list );
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', Content_Planner_Integration::MIN_PUBLISHED_POSTS, false )
+			->andReturn( \array_fill( 0, ( Content_Planner_Integration::MIN_PUBLISHED_POSTS - 1 ), 'post' ) );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 1 );
+		$this->user_helper
+			->expects( 'get_meta' )
+			->once()
+			->with( 1, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '' );
+
+		$result = $this->instance->get_script_data();
+
+		$this->assertFalse( $result['minPostsMet'] );
+		$this->assertFalse( $result['isBannerPermanentlyDismissed'] );
+		$this->assertSame( [], $result['endpoints'] );
+	}
+
+	/**
+	 * Tests that isBannerPermanentlyDismissed is false when user meta is the string "0".
+	 *
+	 * @return void
+	 */
+	public function test_get_script_data_returns_banner_dismissed_false_when_meta_is_string_zero() {
+		$endpoint_list = Mockery::mock( Endpoint_List::class );
+		$endpoint_list->expects( 'to_paths_array' )->once()->andReturn( [] );
+		$this->endpoints_repository->expects( 'get_all_endpoints' )->once()->andReturn( $endpoint_list );
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', Content_Planner_Integration::MIN_PUBLISHED_POSTS, false )
+			->andReturn( \array_fill( 0, Content_Planner_Integration::MIN_PUBLISHED_POSTS, 'post' ) );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 7 );
+		$this->user_helper
+			->expects( 'get_meta' )
+			->once()
+			->with( 7, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '0' );
+
+		$result = $this->instance->get_script_data();
+
+		$this->assertFalse( $result['isBannerPermanentlyDismissed'] );
+	}
+
+	/**
+	 * Tests that isBannerPermanentlyDismissed is false when no user meta exists.
+	 *
+	 * @return void
+	 */
+	public function test_get_script_data_returns_banner_dismissed_false_when_no_meta() {
+		$endpoint_list = Mockery::mock( Endpoint_List::class );
+		$endpoint_list->expects( 'to_paths_array' )->once()->andReturn( [] );
+		$this->endpoints_repository->expects( 'get_all_endpoints' )->once()->andReturn( $endpoint_list );
+
+		$this->indexable_repository
+			->expects( 'get_recently_modified_posts' )
+			->once()
+			->with( 'post', Content_Planner_Integration::MIN_PUBLISHED_POSTS, false )
+			->andReturn( \array_fill( 0, Content_Planner_Integration::MIN_PUBLISHED_POSTS, 'post' ) );
+
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 42 );
+		$this->user_helper
+			->expects( 'get_meta' )
+			->once()
+			->with( 42, Banner_Permanent_Dismissal_Route::USER_META_KEY, true )
+			->andReturn( '' );
+
+		$result = $this->instance->get_script_data();
+
+		$this->assertFalse( $result['isBannerPermanentlyDismissed'] );
+		$this->assertTrue( $result['minPostsMet'] );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Register_Hooks_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Content_Planner_Integration/Register_Hooks_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Content_Planner_Integration;
+
+use Brain\Monkey;
+
+/**
+ * Tests the Content_Planner_Integration register_hooks method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Content_Planner_Integration::register_hooks
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Register_Hooks_Test extends Abstract_Content_Planner_Integration_Test {
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Actions\expectAdded( 'admin_enqueue_scripts' )
+			->once()
+			->with( [ $this->instance, 'enqueue_assets' ] );
+
+		Monkey\Actions\expectAdded( 'elementor/editor/before_enqueue_scripts' )
+			->once()
+			->with( [ $this->instance, 'enqueue_assets' ], 11 );
+
+		$this->instance->register_hooks();
+	}
+}


### PR DESCRIPTION
## Context

The`Content_Planner_Integration` class (`src/ai/content-planner/user-interface/content-planner-integration.php`) shipped without unit tests. This PR backfills the coverage. 

## Summary

- Adds unit tests for the `Content_Planner_Integration` class.

## Relevant technical choices

- Pins the priority `11` on `elementor/editor/before_enqueue_scripts` so the "after Elementor_Premium re-registers assets" ordering can't drift silently.
- Covers the `(bool)` cast in `is_banner_permanently_dismissed()` against the `"0"` string that WordPress can return from `get_user_meta`, which would be truthy under a naive check.

## Test instructions for the acceptance test before the PR gets merged

1. Fetch and check out the branch: `git fetch && git checkout cp/add-unit-tests-for-content_planner_integration`.
2. Run `composer test -- --filter=Content_Planner_Integration`.
3. Confirm the output reports **8 tests, 57 assertions, OK** with no failures, errors, risky tests, or warnings.
4. Run `composer check-branch-cs` and confirm there are no new Yoast coding-standard errors introduced by this branch.
5. Run the full unit-test suite with `composer test` and confirm the overall count has gone up (by 8 tests / 57 assertions) compared to `trunk`, with no other tests failing.

## Relevant test scenarios

_None — this PR adds tests only and does not change runtime behaviour._

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- `Content_Planner_Integration` (tests only; no runtime change).

## Other environments

- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [x] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run `grunt build:images` and committed the results, if my PR introduces new images or SVGs.

## Innovation

- [ ] No innovation project is applicable for this PR.
- [x] This PR falls under an innovation project. I have attached the innovation label.
- [x] I have added my hours to the WBSO document.

Fixes [#1206](https://github.com/Yoast/reserved-tasks/issues/1206)