### PR TITLE
feat: restore EditorIntro section in classic and Elementor editors

### DIFF
--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -22,10 +22,7 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 	const helperTextId = "yoast-content-planner-min-posts-notice-" + location;
 
 	return <Root><div
-		className={ classNames(
-			"yst-p-4",
-			location === "metabox" && "yst-flex yst-items-center yst-gap-3"
-		) }
+		className={ location === "metabox" ? "yst-flex yst-items-center yst-gap-3" : null }
 	>
 		<Button
 			variant="ai-secondary"

--- a/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
+++ b/packages/js/src/ai-content-planner/components/content-planner-editor-item.js
@@ -22,7 +22,7 @@ export const ContentPlannerEditorItem = ( { location, setFeatureModalStatus } ) 
 	const helperTextId = "yoast-content-planner-min-posts-notice-" + location;
 
 	return <Root><div
-		className={ location === "metabox" ? "yst-flex yst-items-center yst-gap-3" : null }
+		className={ classNames( location === "metabox" && "yst-flex yst-items-center yst-gap-3" ) }
 	>
 		<Button
 			variant="ai-secondary"

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -14,14 +14,12 @@ import classNames from "classnames";
  *
  * @param {string} store The store to use. Defaults to {@code yoast-seo/editor}
  * @param {string} location Where the notice will be shown. Defaults to {@code sidebar}
- * @param {boolean} [inEditorIntro=false] Whether rendered inside EditorIntro. Tightens margins.
  *
  * @returns {JSX.Element} The BlackFridayPromotion component.
  */
 export const BlackFridayPromotion = ( {
 	store = "yoast-seo/editor",
 	location = "sidebar",
-	inEditorIntro = false,
 } ) => {
 	const alertKey = "black-friday-promotion";
 	const isPremium = useSelect( select => select( store ).getIsPremium(), [ store ] );
@@ -29,7 +27,6 @@ export const BlackFridayPromotion = ( {
 	const promotionActive = useSelect( select => select( store ).isPromotionActive( alertKey ), [ store ] );
 	const isWooCommerceActive = useSelect( select => select( store ).getIsWooCommerceActive(), [ store ] );
 	const isAlertDismissed = useSelect( select => select( store ).isAlertDismissed( alertKey ), [ store ] );
-	const isElementorEditor = useSelect( select => select( store ).getIsElementorEditor(), [ store ] );
 
 	const onDismiss = useCallback( () => {
 		dispatch( store ).dismissAlert( alertKey );
@@ -50,13 +47,7 @@ export const BlackFridayPromotion = ( {
 			<div
 				className={
 					classNames(
-						inEditorIntro
-							? "yst-mx-0 yst-mt-3"
-							: [
-								location === "sidebar" && ! isElementorEditor ? "yst-mx-0" : "yst-mx-4",
-								"yst-mt-6",
-							],
-						"yst-border yst-rounded-lg yst-p-4 yst-max-w-md yst-relative yst-shadow-sm",
+						"yst-border yst-rounded-lg yst-p-4 yst-max-w-md yst-relative yst-shadow-sm yst-mt-2",
 						isWooCommerceActive ? "yst-border-woo-light" : "yst-border-primary-200" ) }
 			>
 				<Badge size="small"className="yst-text-[10px] yst-bg-black yst-text-amber-300 yst-absolute yst--top-2">

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -50,7 +50,7 @@ export const BlackFridayPromotion = ( {
 						"yst-border yst-rounded-lg yst-p-4 yst-max-w-md yst-relative yst-shadow-sm yst-mt-2",
 						isWooCommerceActive ? "yst-border-woo-light" : "yst-border-primary-200" ) }
 			>
-				<Badge size="small"className="yst-text-[10px] yst-bg-black yst-text-amber-300 yst-absolute yst--top-2">
+				<Badge size="small" className="yst-text-[10px] yst-bg-black yst-text-amber-300 yst-absolute yst--top-2">
 					{ __( "BLACK FRIDAY", "wordpress-seo" ) } </Badge>
 				<button className="yst-absolute yst-top-4 yst-end-4" onClick={ onDismiss }>
 					<XIcon className="yst-w-4 yst-text-slate-400 yst-shrink-0 yst--mt-0.5" />

--- a/packages/js/src/components/EditorIntro.js
+++ b/packages/js/src/components/EditorIntro.js
@@ -2,21 +2,6 @@ import { ReactComponent as Yoast } from "../../images/yoast.svg";
 import { __ } from "@wordpress/i18n";
 
 /**
- * Editor intro text.
- *
- * @param {Object} props The component props.
- * @param {boolean} props.withPromptForContentSuggestions Whether to show the prompt for content suggestions.
- * @param {string} props.className Additional class names to apply to the component.
- * @returns {JSX.Element} The editor introduction text component.
- */
-export const EditorIntroText = ( { withPromptForContentSuggestions, className } ) => {
-	return <p className={ classNames( "yst-text-slate-600 yst-my-3", className ) }>
-		{ withPromptForContentSuggestions ? __( "Optimize your content for discovery or get new content suggestions.", "wordpress-seo" )
-			: __( "Optimize your content for discovery.", "wordpress-seo" ) }
-	</p>;
-};
-
-/**
  * The introduction component for the editor.
  *
  * @param {Object} props The component props.
@@ -28,6 +13,21 @@ export const EditorIntro = ( { children } ) => {
 		<Yoast className="yst-w-14 yst-text-primary-500" />
 		{ children }
 	</div>;
+};
+
+/**
+ * Editor intro text.
+ *
+ * @param {Object} props The component props.
+ * @param {boolean} props.withPromptForContentSuggestions Whether to show the prompt for content suggestions.
+ * @param {string} props.className Additional class names to apply to the component.
+ * @returns {JSX.Element} The editor introduction text component.
+ */
+export const EditorIntroText = ( { withPromptForContentSuggestions, className } ) => {
+	return <p className={ classNames( "yst-text-slate-600 yst-my-0", className ) }>
+		{ withPromptForContentSuggestions ? __( "Optimize your content for discovery or get new content suggestions.", "wordpress-seo" )
+			: __( "Optimize your content for discovery.", "wordpress-seo" ) }
+	</p>;
 };
 
 

--- a/packages/js/src/components/EditorIntro.js
+++ b/packages/js/src/components/EditorIntro.js
@@ -2,20 +2,32 @@ import { ReactComponent as Yoast } from "../../images/yoast.svg";
 import { __ } from "@wordpress/i18n";
 
 /**
- * The introduction component for the editor.
+ * Editor intro text.
  *
  * @param {Object} props The component props.
  * @param {boolean} props.withPromptForContentSuggestions Whether to show the prompt for content suggestions.
+ * @param {string} props.className Additional class names to apply to the component.
+ * @returns {JSX.Element} The editor introduction text component.
+ */
+export const EditorIntroText = ( { withPromptForContentSuggestions, className } ) => {
+	return <p className={ classNames( "yst-text-slate-600 yst-my-3", className ) }>
+		{ withPromptForContentSuggestions ? __( "Optimize your content for discovery or get new content suggestions.", "wordpress-seo" )
+			: __( "Optimize your content for discovery.", "wordpress-seo" ) }
+	</p>;
+};
+
+/**
+ * The introduction component for the editor.
+ *
+ * @param {Object} props The component props.
  * @param {string} props.children The children to render inside the component.
  * @returns {JSX.Element} The editor introduction component.
  */
 export const EditorIntro = ( { children } ) => {
-	return <div className="yst-p-4 yst-flex yst-flex-col yst-gap-3">
+	return <div className="yst-p-4">
 		<Yoast className="yst-w-14 yst-text-primary-500" />
 		{ children }
-		<p className="yst-text-slate-600 yst-mb-0 yst-mt-3">
-			{ withPromptForContentSuggestions ? __( "Optimize your content for discovery or get new content suggestions.", "wordpress-seo" )
-				: __( "Optimize your content for discovery.", "wordpress-seo" ) }
-		</p>
 	</div>;
 };
+
+

--- a/packages/js/src/components/EditorIntro.js
+++ b/packages/js/src/components/EditorIntro.js
@@ -9,8 +9,8 @@ import { __ } from "@wordpress/i18n";
  * @param {string} props.children The children to render inside the component.
  * @returns {JSX.Element} The editor introduction component.
  */
-export const EditorIntro = ( { withPromptForContentSuggestions, children } ) => {
-	return <div className="yst-px-4 yst-pt-4">
+export const EditorIntro = ( { children } ) => {
+	return <div className="yst-p-4 yst-flex yst-flex-col yst-gap-3">
 		<Yoast className="yst-w-14 yst-text-primary-500" />
 		{ children }
 		<p className="yst-text-slate-600 yst-mb-0 yst-mt-3">

--- a/packages/js/src/components/EditorIntro.js
+++ b/packages/js/src/components/EditorIntro.js
@@ -1,5 +1,6 @@
 import { ReactComponent as Yoast } from "../../images/yoast.svg";
 import { __ } from "@wordpress/i18n";
+import classNames from "classnames";
 
 /**
  * The introduction component for the editor.
@@ -9,7 +10,7 @@ import { __ } from "@wordpress/i18n";
  * @returns {JSX.Element} The editor introduction component.
  */
 export const EditorIntro = ( { children } ) => {
-	return <div className="yst-p-4">
+	return <div className="yst-p-4 yst-flex yst-flex-col yst-gap-3">
 		<Yoast className="yst-w-14 yst-text-primary-500" />
 		{ children }
 	</div>;

--- a/packages/js/src/components/EditorIntro.js
+++ b/packages/js/src/components/EditorIntro.js
@@ -6,7 +6,7 @@ import classNames from "classnames";
  * The introduction component for the editor.
  *
  * @param {Object} props The component props.
- * @param {string} props.children The children to render inside the component.
+ * @param {React.ReactNode} props.children The children to render inside the component.
  * @returns {JSX.Element} The editor introduction component.
  */
 export const EditorIntro = ( { children } ) => {
@@ -30,5 +30,3 @@ export const EditorIntroText = ( { withPromptForContentSuggestions, className } 
 			: __( "Optimize your content for discovery.", "wordpress-seo" ) }
 	</p>;
 };
-
-

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -59,26 +59,18 @@ export default function MetaboxFill( { settings } ) {
 				>
 					<Warning />
 				</SidebarItem>
-				{ isBlockEditorActive ? (
-					<SidebarItem
-						key="editor-intro"
-						renderPriority={ 1 }
-					>
-						<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isPost }>
-							<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } inEditorIntro={ true } />
-						</EditorIntro>
-					</SidebarItem>
-				) : (
-					<SidebarItem
-						key="time-constrained-notification"
-						renderPriority={ 1 }
-					>
+				<SidebarItem
+					key="editor-intro"
+					renderPriority={ 1 }
+				>
+					<EditorIntro>
 						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
-					</SidebarItem>
-				) }
-				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>
-					<ContentPlannerEditorItem location="metabox" />
-				</SidebarItem> }
+						<EditorIntroText
+							withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }
+						/>
+						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="metabox" /> }
+					</EditorIntro>
+				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 					<KeywordInput
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -64,10 +64,9 @@ export default function MetaboxFill( { settings } ) {
 					renderPriority={ 1 }
 				>
 					<EditorIntro>
-						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } inEditorIntro={ true } />
+						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
 						<EditorIntroText
 							withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }
-							className={ isAiFeatureActive && isBlockEditorActive && isPost ? "yst-my-3" : "yst-mt-3" }
 						/>
 						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="metabox" /> }
 					</EditorIntro>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -65,7 +65,10 @@ export default function MetaboxFill( { settings } ) {
 				>
 					<EditorIntro>
 						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } inEditorIntro={ true } />
-						<EditorIntroText withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost } />
+						<EditorIntroText
+							withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }
+							className={ isAiFeatureActive && isBlockEditorActive && isPost ? "yst-my-3" : "yst-mt-3" }
+						/>
 						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="metabox" /> }
 					</EditorIntro>
 				</SidebarItem>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -25,7 +25,7 @@ import { withMetaboxWarningsCheck } from "../higherorder/withMetaboxWarningsChec
 import isBlockEditor from "../../helpers/isBlockEditor";
 import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
 import ContentPlannerEditorItem from "../../ai-content-planner/containers/content-planner-editor-item";
-import { EditorIntro } from "../EditorIntro";
+import { EditorIntro, EditorIntroText } from "../EditorIntro";
 
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
 
@@ -64,10 +64,8 @@ export default function MetaboxFill( { settings } ) {
 					renderPriority={ 1 }
 				>
 					<EditorIntro>
-						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } />
-						<EditorIntroText
-							withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }
-						/>
+						<BlackFridayPromotionWithMetaboxWarningsCheck location={ "metabox" } inEditorIntro={ true } />
+						<EditorIntroText withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost } />
 						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="metabox" /> }
 					</EditorIntro>
 				</SidebarItem>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -63,8 +63,11 @@ export default function SidebarFill( { settings } ) {
 				>
 					<EditorIntro>
 						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
-						<EditorIntroText withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost } />
-						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
+						<EditorIntroText
+							withPromptForContentSuggestions={ isAiFeatureActive && isPost }
+							className={ isAiFeatureActive && isPost ? "yst-my-3" : "yst-mt-3" }
+						/>
+						{ isPost && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
 					</EditorIntro>
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -62,10 +62,9 @@ export default function SidebarFill( { settings } ) {
 					renderPriority={ 1 }
 				>
 					<EditorIntro>
-						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
 						<EditorIntroText
 							withPromptForContentSuggestions={ isAiFeatureActive && isPost }
-							className={ isAiFeatureActive && isPost ? "yst-my-3" : "yst-mt-3" }
 						/>
 						{ isPost && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
 					</EditorIntro>

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -24,7 +24,7 @@ import KeywordUpsell from "../modals/KeywordUpsell";
 import isBlockEditor from "../../helpers/isBlockEditor";
 import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
 import ContentPlannerEditorItem from "../../ai-content-planner/containers/content-planner-editor-item";
-import { EditorIntro } from "../EditorIntro";
+import { EditorIntro, EditorIntroText } from "../EditorIntro";
 
 /* eslint-disable complexity */
 /**
@@ -62,16 +62,11 @@ export default function SidebarFill( { settings } ) {
 					renderPriority={ 1 }
 				>
 					<EditorIntro>
-						{ FirstEligibleNotification && <FirstEligibleNotification /> }
-						<EditorIntroText
-							withPromptForContentSuggestions={ isAiFeatureActive && isPost }
-						/>
-						{ isPost && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
+						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
+						<EditorIntroText withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost } />
+						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
 					</EditorIntro>
 				</SidebarItem>
-				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>
-					<ContentPlannerEditorItem location="sidebar" />
-				</SidebarItem> }
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>
 					<KeywordInput
 						isSEMrushIntegrationActive={ settings.isSEMrushIntegrationActive }

--- a/packages/js/src/components/fills/SidebarFill.js
+++ b/packages/js/src/components/fills/SidebarFill.js
@@ -61,8 +61,12 @@ export default function SidebarFill( { settings } ) {
 					key="editor-intro"
 					renderPriority={ 1 }
 				>
-					<EditorIntro withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }>
-						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
+					<EditorIntro>
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
+						<EditorIntroText
+							withPromptForContentSuggestions={ isAiFeatureActive && isPost }
+						/>
+						{ isPost && isAiFeatureActive && <ContentPlannerEditorItem location="sidebar" /> }
 					</EditorIntro>
 				</SidebarItem>
 				{ isPost && isBlockEditorActive && isAiFeatureActive && <SidebarItem key="content-planner" renderPriority={ 2 }>

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -1,4 +1,3 @@
-import classNames from "classnames";
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import withPersistentDismiss from "./withPersistentDismiss";
@@ -10,11 +9,10 @@ import withPersistentDismiss from "./withPersistentDismiss";
  * @param {JSX.Element|null} image The image or null if no image.
  * @param {boolean} isAlertDismissed Whether or not the notification is dismissed.
  * @param {Function} onDismissed The dismissal prop to be renamed for Notification component.
- * @param {boolean} [inEditorIntro=false] Whether rendered inside EditorIntro. Adds a small top margin under the logo.
  *
  * @returns {Component} The composed Notification component.
  */
-/* eslint-disable-next-line complexity */
+
 export const PersistentDismissableNotification = ( {
 	children,
 	id,
@@ -23,10 +21,9 @@ export const PersistentDismissableNotification = ( {
 	image: Image = null,
 	isAlertDismissed,
 	onDismissed,
-	inEditorIntro = false,
 } ) => {
 	return isAlertDismissed ? null : (
-		<div id={ id } className={ classNames( "notice-yoast yoast is-dismissible yoast-webinar-dashboard yoast-general-page-notices", inEditorIntro && "yst-mt-3" ) }>
+		<div id={ id } className="notice-yoast yoast is-dismissible yoast-webinar-dashboard yoast-general-page-notices yst-m-0">
 			<div className="notice-yoast__container">
 				<div>
 					<div className="notice-yoast__header">
@@ -59,7 +56,6 @@ PersistentDismissableNotification.propTypes = {
 	image: PropTypes.elementType,
 	isAlertDismissed: PropTypes.bool.isRequired,
 	onDismissed: PropTypes.func.isRequired,
-	inEditorIntro: PropTypes.bool,
 };
 
 export default withPersistentDismiss( PersistentDismissableNotification );

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -21,6 +21,7 @@ import AdvancedSettings from "../../../containers/AdvancedSettings";
 import SEMrushRelatedKeyphrases from "../../../containers/SEMrushRelatedKeyphrases";
 import WincherSEOPerformanceModal from "../../../containers/WincherSEOPerformanceModal";
 import KeywordUpsell from "../../../components/modals/KeywordUpsell";
+import { EditorIntro, EditorIntroText } from "../../../components/EditorIntro";
 
 /* eslint-disable complexity */
 /**
@@ -56,8 +57,8 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 					renderPriority={ 0 }
 				>
 					<EditorIntro>
-						{ FirstEligibleNotification && <FirstEligibleNotification /> }
-						<EditorIntroText withPromptForContentSuggestions={ false } />
+						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
+						<EditorIntroText withPromptForContentSuggestions={ false } className="yst-mb-0" />
 					</EditorIntro>
 				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -51,6 +51,15 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 	return (
 		<>
 			<Fill name="YoastElementor">
+				<SidebarItem
+					key="editor-intro"
+					renderPriority={ 0 }
+				>
+					<EditorIntro>
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
+						<EditorIntroText withPromptForContentSuggestions={ false } />
+					</EditorIntro>
+				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
 					{ FirstEligibleNotification && (

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -57,8 +57,8 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 					renderPriority={ 0 }
 				>
 					<EditorIntro>
-						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
-						<EditorIntroText withPromptForContentSuggestions={ false } className="yst-mt-3" />
+						{ FirstEligibleNotification && <FirstEligibleNotification /> }
+						<EditorIntroText withPromptForContentSuggestions={ false } />
 					</EditorIntro>
 				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -58,7 +58,7 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 				>
 					<EditorIntro>
 						{ FirstEligibleNotification && <FirstEligibleNotification inEditorIntro={ true } /> }
-						<EditorIntroText withPromptForContentSuggestions={ false } className="yst-mb-0" />
+						<EditorIntroText withPromptForContentSuggestions={ false } className="yst-mt-3" />
 					</EditorIntro>
 				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>

--- a/packages/js/src/elementor/components/fills/ElementorFill.js
+++ b/packages/js/src/elementor/components/fills/ElementorFill.js
@@ -63,11 +63,6 @@ export default function ElementorFill( { isLoading, onLoad, settings } ) {
 				</SidebarItem>
 				<SidebarItem renderPriority={ 1 }>
 					<Alert />
-					{ FirstEligibleNotification && (
-						<div className="yst-inline-block yst-px-1.5">
-							<FirstEligibleNotification />
-						</div>
-					) }
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem renderPriority={ 8 }>
 					<KeywordInput

--- a/packages/js/tests/components/EditorIntroText.test.js
+++ b/packages/js/tests/components/EditorIntroText.test.js
@@ -1,0 +1,14 @@
+import { EditorIntroText } from "../../src/components/EditorIntro";
+import { render, screen } from "../test-utils";
+
+describe( "EditorIntroText", () => {
+	it( "renders the content suggestions copy when withPromptForContentSuggestions is true", () => {
+		render( <EditorIntroText withPromptForContentSuggestions={ true } /> );
+		expect( screen.getByText( "Optimize your content for discovery or get new content suggestions." ) ).toBeInTheDocument();
+	} );
+
+	it( "renders the discovery-only copy when withPromptForContentSuggestions is false", () => {
+		render( <EditorIntroText withPromptForContentSuggestions={ false } /> );
+		expect( screen.getByText( "Optimize your content for discovery." ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to restore the editor intro.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds the editor intro of the Yoast Icon and intro text to Yoast Elementor integration and in Yoast editor in classic editor.

## Relevant technical choices:

* Centralizes spacing in one place, the Editor intro section using flex.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Testing overview for the editor Intro section:

* We want to test the Yoast editor intro section in different editors:
  * Classic editor
  * Elementor editor
  * Block editor - sidebar and metabox

Key tests:
* ADS TEST - We want to test with ads - ad appears between Yoast icon and intro text.
    * Black friday ad
    * Webinar ad
* SPACING - We want to test the spacing between elements in the intro section are 12 px.
* INTRO LOGO - Test the intro section has Yoast logo.
* INTRO TEXT - We want to test the intro text changes to `Optimize your content for discovery.` and no "Get content suggestions" and we have INTRO LOGO.
* AI INTRO - We want to test the intro text changes to `Optimize your content for discovery or get new content suggestions.` with "Get content suggestions" button under it.

#### Block editor
* [x] Deactivate Premium.
* [x] Edit a post in block editor and open yoast editor in sidebar and check AI INTRO TEXT.
* [x] Check metabox has AI INTRO and SPACING.
* [x] Edit a page and open the block editor sidebar and check INTRO TEXT and check SPACING.
* [x] Check metabox INTRO TEXT and check SPACING.
* [x] Enable the Webinar ad by changing the user meta `_yoast_alerts_dismissed` to:
`a:1:{s:26:"webinar-promo-notification";b:0;}`
* [x] Edit the page again open the yoast editor in the sidebar and check ADS TEST and SPACING and INTRO TEXT.
* [ ] Edit a post and open the yoast editor in the sidebar, check ADS TEST and SPACING and AI INTRO.
* [x] Trigger the Black Friday ad by changing the date in `src/promotions/domain/black-friday-promotion.php`, change only the year in the second date to 2027:
```php
new Time_Interval( \gmmktime( 10, 00, 00, 3, 20, 2025 ), \gmmktime( 10, 00, 00, 3, 30, 2027 ) ),                           
```
* [x] Edit the page again open the yoast editor in the sidebar and check ADS TEST and SPACING and INTRO TEXT.
* [x] Check metabox ADS TEST and INTRO TEXT and SPACING.
* [x] Edit a post and open the yoast editor in the sidebar, check ADS TEST and SPACING and AI INTRO.
* [x] Check metabox ADS TEST and AI INTRO and SPACING.

#### Classic editor
* [x] Deactivate Premium edit a post in classic editor.
* [x] Check metabox has INTRO LOGO, INTRO TEXT and check SPACING.
* [x] Trigger the Black Friday ad by changing the date in `src/promotions/domain/black-friday-promotion.php`, change only the year in the second date to 2027:
```php
new Time_Interval( \gmmktime( 10, 00, 00, 3, 20, 2025 ), \gmmktime( 10, 00, 00, 3, 30, 2027 ) ),                           
```
* [x] Check metabox ADS TEST and INTRO TEXT and SPACING.

#### Elementor editor
* [x] Deactivate Premium edit a post in elementor.
* [x] Check elementor sidebar for INTRO LOGO, INTRO TEXT and check SPACING.
* [x] Trigger the Black Friday ad by changing the date in `src/promotions/domain/black-friday-promotion.php`, change only the year in the second date to 2027:
```php
new Time_Interval( \gmmktime( 10, 00, 00, 3, 20, 2025 ), \gmmktime( 10, 00, 00, 3, 30, 2027 ) ),                           
```
* [x] Check elementor sidebar ADS TEST and INTRO TEXT and SPACING.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1215
