### PR TITLE
1155 cache get recently modified posts results

### DIFF
--- a/packages/js/src/ai-content-planner/hooks/use-fetch-content-outline.js
+++ b/packages/js/src/ai-content-planner/hooks/use-fetch-content-outline.js
@@ -16,12 +16,13 @@ import { removesLocaleVariantSuffixes } from "../../shared-admin/helpers";
  * @returns {(contentSuggestion: Suggestion) => void} Callback to trigger the content outline fetch.
  */
 export const useFetchContentOutline = () => {
-	const { endpoint, postType, contentLocale, editorApiValue, selectContentOutlineCache } = useSelect( ( select ) => {
+	const { endpoint, postType, contentLocale, editorApiValue, recentContent, selectContentOutlineCache } = useSelect( ( select ) => {
 		return {
 			endpoint: select( CONTENT_PLANNER_STORE ).selectContentOutlineEndpoint(),
 			postType: select( "yoast-seo/editor" ).getPostType(),
 			contentLocale: select( "yoast-seo/editor" ).getContentLocale(),
 			editorApiValue: select( "yoast-seo/editor" ).getEditorTypeApiValue(),
+			recentContent: select( CONTENT_PLANNER_STORE ).selectRecentContent(),
 			selectContentOutlineCache: select( CONTENT_PLANNER_STORE ).selectContentOutlineCache,
 		};
 	}, [] );
@@ -42,6 +43,7 @@ export const useFetchContentOutline = () => {
 			postType,
 			language,
 			editor: editorApiValue,
+			recentContent,
 			suggestion: {
 				...contentSuggestion,
 			},
@@ -50,6 +52,7 @@ export const useFetchContentOutline = () => {
 		postType,
 		contentLocale,
 		editorApiValue,
+		recentContent,
 		fetchContentOutline,
 		restoreContentOutlineFromCache,
 		selectContentOutlineCache,

--- a/packages/js/src/ai-content-planner/store/content-outline.js
+++ b/packages/js/src/ai-content-planner/store/content-outline.js
@@ -107,15 +107,16 @@ export const contentOutlineSelectors = {
 };
 
 /**
- * @param {string} endpoint The endpoint to fetch the content outline from.
- * @param {string} postType The type of the post.
- * @param {string} language The language of the post.
- * @param {string} editor The editor instance.
- * @param {Suggestion} suggestion The suggestion object containing details for the content outline.
+ * @param {string}   endpoint      The endpoint to fetch the content outline from.
+ * @param {string}   postType      The type of the post.
+ * @param {string}   language      The language of the post.
+ * @param {string}   editor        The editor instance.
+ * @param {Suggestion} suggestion  The suggestion object containing details for the content outline.
+ * @param {Object[]} recentContent The recent content from the suggestions response.
  * @returns {Object} Success or error action object.
  */
 export function* fetchContentOutline( {
-	endpoint, postType, language, editor, suggestion,
+	endpoint, postType, language, editor, suggestion, recentContent,
 } ) {
 	yield{ type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, payload: { suggestion } };
 	try {
@@ -124,6 +125,7 @@ export function* fetchContentOutline( {
 			postType,
 			language,
 			editor,
+			recentContent,
 			...suggestion,
 		} };
 		yield{ type: `${ FETCH_CONTENT_OUTLINE_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, payload };
@@ -156,6 +158,8 @@ export const contentOutlineControls = {
 			// eslint-disable-next-line camelcase
 			meta_description: payload.meta_description,
 			category: payload.category,
+			// eslint-disable-next-line camelcase
+			recent_content: payload.recentContent,
 		},
 	} ),
 };

--- a/packages/js/src/ai-content-planner/store/content-suggestions.js
+++ b/packages/js/src/ai-content-planner/store/content-suggestions.js
@@ -19,6 +19,7 @@ const slice = createSlice( {
 		endpoint: "",
 		status: ASYNC_ACTION_STATUS.idle,
 		suggestions: [],
+		recentContent: [],
 		error: ERROR_DEFAULT,
 	},
 	reducers: {
@@ -43,11 +44,13 @@ const slice = createSlice( {
 		builder.addCase( `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.request }`, ( state ) => {
 			state.status = ASYNC_ACTION_STATUS.loading;
 			state.suggestions = [];
+			state.recentContent = [];
 			state.error = ERROR_DEFAULT;
 		} );
 		builder.addCase( `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`, ( state, { payload } ) => {
 			state.status = ASYNC_ACTION_STATUS.success;
-			state.suggestions = payload;
+			state.suggestions = payload.suggestions;
+			state.recentContent = payload.recentContent;
 			state.error = ERROR_DEFAULT;
 		} );
 		builder.addCase( `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.error }`, ( state, { payload } ) => {
@@ -63,6 +66,7 @@ export const contentSuggestionsSelectors = {
 	selectContentSuggestionsEndpoint: ( state ) => get( state, [ CONTENT_SUGGESTIONS_NAME, "endpoint" ], slice.getInitialState().endpoint ),
 	selectSuggestionsStatus: ( state ) => get( state, [ CONTENT_SUGGESTIONS_NAME, "status" ], slice.getInitialState().status ),
 	selectSuggestions: ( state ) => get( state, [ CONTENT_SUGGESTIONS_NAME, "suggestions" ], slice.getInitialState().suggestions ),
+	selectRecentContent: ( state ) => get( state, [ CONTENT_SUGGESTIONS_NAME, "recentContent" ], slice.getInitialState().recentContent ),
 	selectSuggestionsError: ( state ) => get( state, [ CONTENT_SUGGESTIONS_NAME, "error" ], slice.getInitialState().error ),
 };
 /**
@@ -70,7 +74,7 @@ export const contentSuggestionsSelectors = {
  *
  * @param {Object} result The raw API response.
  *
- * @returns {Suggestion[]} The validated and transformed suggestions array.
+ * @returns {{ suggestions: Suggestion[], recentContent: Object[] }} The validated and transformed response.
  */
 const validateSuggestionsResponse = ( result ) => {
 	const suggestions = get( result, "suggestions", null );
@@ -79,16 +83,19 @@ const validateSuggestionsResponse = ( result ) => {
 		throw new Error( "Invalid suggestions response: expected an array of suggestions." );
 	}
 
-	return suggestions.map( ( suggestion ) => ( {
-		title: suggestion.title,
-		intent: suggestion.intent,
-		keyphrase: suggestion.keyphrase,
-		// eslint-disable-next-line camelcase
-		meta_description: suggestion.meta_description,
-		category: suggestion.category,
-		explanation: suggestion.explanation,
-		id: `suggestion-${ suggestion.keyphrase }-${ suggestion.title }`,
-	} ) );
+	return {
+		suggestions: suggestions.map( ( suggestion ) => ( {
+			title: suggestion.title,
+			intent: suggestion.intent,
+			keyphrase: suggestion.keyphrase,
+			// eslint-disable-next-line camelcase
+			meta_description: suggestion.meta_description,
+			category: suggestion.category,
+			explanation: suggestion.explanation,
+			id: `suggestion-${ suggestion.keyphrase }-${ suggestion.title }`,
+		} ) ),
+		recentContent: get( result, "recent_content", [] ),
+	};
 };
 /**
  * Generator action to fetch content planner suggestions from the REST API.

--- a/packages/js/tests/ai-content-planner/hooks/use-fetch-content-outline.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-fetch-content-outline.test.js
@@ -23,6 +23,7 @@ const defaultStoreValues = {
 	postType: "post",
 	contentLocale: "en_US",
 	editorApiValue: "classic",
+	recentContent: [],
 	selectContentOutlineCache: jest.fn( () => null ),
 };
 
@@ -37,6 +38,7 @@ const setupUseSelect = ( overrides = {} ) => {
 		if ( storeName === "yoast-seo/content-planner" ) {
 			return {
 				selectContentOutlineEndpoint: () => values.endpoint,
+				selectRecentContent: () => values.recentContent,
 				selectContentOutlineCache: values.selectContentOutlineCache,
 			};
 		}
@@ -139,6 +141,21 @@ describe( "useFetchContentOutline", () => {
 			} );
 
 			expect( setFeatureModalStatus ).not.toHaveBeenCalled();
+		} );
+
+		it( "passes recentContent from the store to fetchContentOutline", () => {
+			const recentContent = [ { title: "My Post", description: "A description." } ];
+			setupUseSelect( { recentContent } );
+
+			const { result } = renderHook( () => useFetchContentOutline() );
+
+			act( () => {
+				result.current( mockSuggestion );
+			} );
+
+			expect( fetchContentOutline ).toHaveBeenCalledWith( expect.objectContaining( {
+				recentContent,
+			} ) );
 		} );
 	} );
 

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -284,12 +284,14 @@ describe( "content outline store", () => {
 	} );
 
 	describe( "fetchContentOutline", () => {
+		const mockRecentContent = [ { title: "My Post", description: "A description." } ];
 		const params = {
 			endpoint: "yoast/v1/ai_content_planner/get_outline",
 			postType: "post",
 			language: "en",
 			editor: "gutenberg",
 			suggestion: mockSuggestion,
+			recentContent: mockRecentContent,
 		};
 
 		it( "should yield a request action, a control action, a success action, then complete", () => {
@@ -312,6 +314,7 @@ describe( "content outline store", () => {
 					postType: params.postType,
 					language: params.language,
 					editor: params.editor,
+					recentContent: mockRecentContent,
 					...mockSuggestion,
 				},
 			} );
@@ -370,6 +373,7 @@ describe( "content outline store", () => {
 		} );
 
 		it( "should call contentPlannerFetch with POST method and correct data fields", async() => {
+			const mockRecentContent = [ { title: "My Post", description: "A description." } ];
 			const payload = {
 				endpoint: "yoast/v1/ai_content_planner/get_outline",
 				postType: "post",
@@ -382,6 +386,7 @@ describe( "content outline store", () => {
 				// eslint-disable-next-line camelcase
 				meta_description: mockSuggestion.meta_description,
 				category: mockSuggestion.category,
+				recentContent: mockRecentContent,
 			};
 			contentPlannerFetch.mockResolvedValue( { outline: [] } );
 
@@ -402,6 +407,7 @@ describe( "content outline store", () => {
 						keyphrase: payload.keyphrase,
 						meta_description: payload.meta_description,
 						category: payload.category,
+						recent_content: mockRecentContent,
 					} ),
 				} )
 			);

--- a/packages/js/tests/ai-content-planner/store/outline.test.js
+++ b/packages/js/tests/ai-content-planner/store/outline.test.js
@@ -29,6 +29,8 @@ const mockSuggestion = {
 };
 /* eslint-enable camelcase */
 
+const mockRecentContent = [ { title: "My Post", description: "A description." } ];
+
 describe( "content outline store", () => {
 	describe( "getInitialContentOutlineState", () => {
 		it( "should return the initial state", () => {
@@ -284,7 +286,6 @@ describe( "content outline store", () => {
 	} );
 
 	describe( "fetchContentOutline", () => {
-		const mockRecentContent = [ { title: "My Post", description: "A description." } ];
 		const params = {
 			endpoint: "yoast/v1/ai_content_planner/get_outline",
 			postType: "post",
@@ -373,7 +374,6 @@ describe( "content outline store", () => {
 		} );
 
 		it( "should call contentPlannerFetch with POST method and correct data fields", async() => {
-			const mockRecentContent = [ { title: "My Post", description: "A description." } ];
 			const payload = {
 				endpoint: "yoast/v1/ai_content_planner/get_outline",
 				postType: "post",

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -102,7 +102,6 @@ describe( "suggestions store", () => {
 		} );
 
 		it( "should set suggestions and status to success on success", () => {
-			/* eslint-disable camelcase */
 			const recentContent = [ { title: "My Post", description: "A description." } ];
 			const result = contentSuggestionsReducer(
 				getInitialContentSuggestionsState(),
@@ -111,7 +110,6 @@ describe( "suggestions store", () => {
 					payload: { suggestions: transformedSuggestions, recentContent },
 				}
 			);
-			/* eslint-enable camelcase */
 
 			expect( result ).toEqual( {
 				endpoint: "",

--- a/packages/js/tests/ai-content-planner/store/suggestions.test.js
+++ b/packages/js/tests/ai-content-planner/store/suggestions.test.js
@@ -71,6 +71,7 @@ describe( "suggestions store", () => {
 				endpoint: "",
 				status: ASYNC_ACTION_STATUS.idle,
 				suggestions: [],
+				recentContent: [],
 				error: ERROR_DEFAULT,
 			} );
 		} );
@@ -82,6 +83,7 @@ describe( "suggestions store", () => {
 				endpoint: "",
 				status: ASYNC_ACTION_STATUS.success,
 				suggestions: transformedSuggestions,
+				recentContent: [ { title: "Old post" } ],
 				error: ERROR_DEFAULT,
 			};
 
@@ -94,23 +96,28 @@ describe( "suggestions store", () => {
 				endpoint: "",
 				status: ASYNC_ACTION_STATUS.loading,
 				suggestions: [],
+				recentContent: [],
 				error: ERROR_DEFAULT,
 			} );
 		} );
 
 		it( "should set suggestions and status to success on success", () => {
+			/* eslint-disable camelcase */
+			const recentContent = [ { title: "My Post", description: "A description." } ];
 			const result = contentSuggestionsReducer(
 				getInitialContentSuggestionsState(),
 				{
 					type: `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
-					payload: transformedSuggestions,
+					payload: { suggestions: transformedSuggestions, recentContent },
 				}
 			);
+			/* eslint-enable camelcase */
 
 			expect( result ).toEqual( {
 				endpoint: "",
 				status: ASYNC_ACTION_STATUS.success,
 				suggestions: transformedSuggestions,
+				recentContent,
 				error: ERROR_DEFAULT,
 			} );
 		} );
@@ -134,6 +141,7 @@ describe( "suggestions store", () => {
 				endpoint: "",
 				status: ASYNC_ACTION_STATUS.error,
 				suggestions: [],
+				recentContent: [],
 				error: {
 					errorCode: 403,
 					errorIdentifier: "forbidden",
@@ -289,6 +297,24 @@ describe( "suggestions store", () => {
 		it( "should return the default error when state is missing", () => {
 			expect( contentSuggestionsSelectors.selectSuggestionsError( {} ) ).toEqual( ERROR_DEFAULT );
 		} );
+
+		it( "should return recent content from state", () => {
+			const recentContent = [ { title: "My Post", description: "A description." } ];
+			const state = {
+				[ CONTENT_SUGGESTIONS_NAME ]: {
+					status: ASYNC_ACTION_STATUS.success,
+					suggestions: [],
+					recentContent,
+					error: ERROR_DEFAULT,
+				},
+			};
+
+			expect( contentSuggestionsSelectors.selectRecentContent( state ) ).toEqual( recentContent );
+		} );
+
+		it( "should return an empty array for recent content when state is missing", () => {
+			expect( contentSuggestionsSelectors.selectRecentContent( {} ) ).toEqual( [] );
+		} );
 	} );
 
 	describe( "fetchContentPlannerSuggestions", () => {
@@ -316,10 +342,11 @@ describe( "suggestions store", () => {
 			} );
 
 			// Simulate the API response being returned from the control.
-			const result = generator.next( { suggestions: mockApiSuggestions } );
+			// eslint-disable-next-line camelcase
+			const result = generator.next( { suggestions: mockApiSuggestions, recent_content: [] } );
 			expect( result.value ).toEqual( {
 				type: `${ FETCH_CONTENT_SUGGESTIONS_ACTION_NAME }/${ ASYNC_ACTION_NAMES.success }`,
-				payload: transformedSuggestions,
+				payload: { suggestions: transformedSuggestions, recentContent: [] },
 			} );
 			expect( result.done ).toBe( true );
 		} );

--- a/src/ai/content-planner/application/content-outline-command-handler.php
+++ b/src/ai/content-planner/application/content-outline-command-handler.php
@@ -82,10 +82,9 @@ class Content_Outline_Command_Handler {
 		Content_Outline_Command $command,
 		bool $retry_on_unauthorized = true
 	): Section_List {
-		$recent_content = $this->recent_content_collector->collect( $command->get_post_type() );
+		$recent_content = $command->get_recent_content();
 		$about_page     = $this->recent_content_collector->collect_about_page( $command->get_post_type() );
 		$token          = $this->token_manager->get_or_request_access_token( $command->get_user() );
-		$recent_content = $recent_content->to_array();
 
 		$existing_posts = \array_map(
 			static function ( $post ) {

--- a/src/ai/content-planner/application/content-outline-command.php
+++ b/src/ai/content-planner/application/content-outline-command.php
@@ -91,17 +91,17 @@ class Content_Outline_Command {
 	/**
 	 * The constructor.
 	 *
-	 * @param WP_User $user             The user.
-	 * @param string  $post_type        The post type.
-	 * @param string  $language         The language.
-	 * @param string  $editor           The editor.
-	 * @param string  $title            The title.
-	 * @param string  $intent           The intent.
-	 * @param string  $explanation      The explanation.
-	 * @param string  $keyphrase        The keyphrase.
-	 * @param string  $meta_description The meta description.
-	 * @param string                      $category_name    The category name.
-	 * @param int                         $category_id      The category ID.
+	 * @param WP_User                                              $user             The user.
+	 * @param string                                               $post_type        The post type.
+	 * @param string                                               $language         The language.
+	 * @param string                                               $editor           The editor.
+	 * @param string                                               $title            The title.
+	 * @param string                                               $intent           The intent.
+	 * @param string                                               $explanation      The explanation.
+	 * @param string                                               $keyphrase        The keyphrase.
+	 * @param string                                               $meta_description The meta description.
+	 * @param string                                               $category_name    The category name.
+	 * @param int                                                  $category_id      The category ID.
 	 * @param array<array<string, string|bool|array<string, int>>> $recent_content   The recent content from the suggestions response.
 	 */
 	public function __construct(

--- a/src/ai/content-planner/application/content-outline-command.php
+++ b/src/ai/content-planner/application/content-outline-command.php
@@ -82,6 +82,13 @@ class Content_Outline_Command {
 	private $category;
 
 	/**
+	 * The recent content from the suggestions response.
+	 *
+	 * @var array<array<string, string|bool|array<string, int>>>
+	 */
+	private $recent_content;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param WP_User $user             The user.
@@ -93,8 +100,9 @@ class Content_Outline_Command {
 	 * @param string  $explanation      The explanation.
 	 * @param string  $keyphrase        The keyphrase.
 	 * @param string  $meta_description The meta description.
-	 * @param string  $category_name    The category name.
-	 * @param int     $category_id      The category ID.
+	 * @param string                      $category_name    The category name.
+	 * @param int                         $category_id      The category ID.
+	 * @param array<array<string, string|bool|array<string, int>>> $recent_content   The recent content from the suggestions response.
 	 */
 	public function __construct(
 		WP_User $user,
@@ -107,7 +115,8 @@ class Content_Outline_Command {
 		string $keyphrase,
 		string $meta_description,
 		string $category_name,
-		int $category_id
+		int $category_id,
+		array $recent_content
 	) {
 		$this->user             = $user;
 		$this->post_type        = $post_type;
@@ -119,6 +128,7 @@ class Content_Outline_Command {
 		$this->keyphrase        = $keyphrase;
 		$this->meta_description = $meta_description;
 		$this->category         = new Category( $category_name, $category_id );
+		$this->recent_content   = $recent_content;
 	}
 
 	/**
@@ -209,5 +219,14 @@ class Content_Outline_Command {
 	 */
 	public function get_category(): Category {
 		return $this->category;
+	}
+
+	/**
+	 * Returns the recent content from the suggestions response.
+	 *
+	 * @return array<array<string, string|bool|array<string, int>>> The recent content.
+	 */
+	public function get_recent_content(): array {
+		return $this->recent_content;
 	}
 }

--- a/src/ai/content-planner/application/content-suggestion-command-handler.php
+++ b/src/ai/content-planner/application/content-suggestion-command-handler.php
@@ -7,6 +7,8 @@ use Yoast\WP\SEO\AI\Authorization\Application\Token_Manager;
 use Yoast\WP\SEO\AI\Consent\Application\Consent_Handler;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
 use Yoast\WP\SEO\AI\Content_Planner\Infrastructure\Recent_Content\Recent_Content_Collector;
 use Yoast\WP\SEO\AI\HTTP_Request\Application\Request_Handler;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Forbidden_Exception;
@@ -86,16 +88,16 @@ class Content_Suggestion_Command_Handler {
 	 * @throws Unauthorized_Exception When the API returns an unauthorized response and retry is exhausted.
 	 * @throws Forbidden_Exception    When consent has been revoked.
 	 *
-	 * @return Content_Suggestion_List A list of content suggestions.
+	 * @return Content_Suggestion_Response The response containing suggestions and recent content.
 	 */
 	public function handle(
 		Content_Suggestion_Command $command,
 		bool $retry_on_unauthorized = true
-	): Content_Suggestion_List {
-		$recent_content = $this->recent_content_collector->collect( $command->get_post_type() );
+	): Content_Suggestion_Response {
+		$post_list      = $this->recent_content_collector->collect( $command->get_post_type() );
 		$about_page     = $this->recent_content_collector->collect_about_page( $command->get_post_type() );
 		$token          = $this->token_manager->get_or_request_access_token( $command->get_user() );
-		$recent_content = $recent_content->to_array();
+		$recent_content = $post_list->to_array();
 
 		$content = [
 			'posts' => $recent_content,
@@ -136,7 +138,22 @@ class Content_Suggestion_Command_Handler {
 			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
 		}
 
-		return $this->build_suggestions_array( $response );
+		return $this->build_response( $response, $post_list );
+	}
+
+	/**
+	 * Builds a response object bundling the content suggestions with the recent content used to generate them.
+	 *
+	 * @param Response  $response       The API response.
+	 * @param Post_List $recent_content The recent content passed to the AI API.
+	 *
+	 * @return Content_Suggestion_Response The response containing suggestions and recent content.
+	 */
+	public function build_response( Response $response, Post_List $recent_content ): Content_Suggestion_Response {
+		return new Content_Suggestion_Response(
+			$this->build_suggestions_array( $response ),
+			$recent_content,
+		);
 	}
 
 	/**

--- a/src/ai/content-planner/domain/content-suggestion-response.php
+++ b/src/ai/content-planner/domain/content-suggestion-response.php
@@ -1,0 +1,63 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
+
+/**
+ * The response to a content suggestion request, bundling suggestions with the recent content used to generate them.
+ */
+class Content_Suggestion_Response {
+
+	/**
+	 * The content suggestions.
+	 *
+	 * @var Content_Suggestion_List
+	 */
+	private $suggestions;
+
+	/**
+	 * The recent content used to generate the suggestions.
+	 *
+	 * @var Post_List
+	 */
+	private $recent_content;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Content_Suggestion_List $suggestions    The content suggestions.
+	 * @param Post_List               $recent_content The recent content.
+	 */
+	public function __construct( Content_Suggestion_List $suggestions, Post_List $recent_content ) {
+		$this->suggestions    = $suggestions;
+		$this->recent_content = $recent_content;
+	}
+
+	/**
+	 * Returns the content suggestions.
+	 *
+	 * @return Content_Suggestion_List The content suggestions.
+	 */
+	public function get_suggestions(): Content_Suggestion_List {
+		return $this->suggestions;
+	}
+
+	/**
+	 * Returns the recent content.
+	 *
+	 * @return Post_List The recent content.
+	 */
+	public function get_recent_content(): Post_List {
+		return $this->recent_content;
+	}
+
+	/**
+	 * Returns this object in array format.
+	 *
+	 * @return array<string, mixed> The response as an array.
+	 */
+	public function to_array(): array {
+		$result                   = $this->suggestions->to_array();
+		$result['recent_content'] = $this->recent_content->to_array();
+		return $result;
+	}
+}

--- a/src/ai/content-planner/domain/content-suggestion-response.php
+++ b/src/ai/content-planner/domain/content-suggestion-response.php
@@ -53,7 +53,7 @@ class Content_Suggestion_Response {
 	/**
 	 * Returns this object in array format.
 	 *
-	 * @return array<string, mixed> The response as an array.
+	 * @return array<string, array<array<string, string|bool|array<string, int>>>> The response as an array.
 	 */
 	public function to_array(): array {
 		$result                   = $this->suggestions->to_array();

--- a/src/ai/content-planner/domain/content-suggestion-response.php
+++ b/src/ai/content-planner/domain/content-suggestion-response.php
@@ -53,11 +53,15 @@ class Content_Suggestion_Response {
 	/**
 	 * Returns this object in array format.
 	 *
-	 * @return array<string, array<array<string, string|bool|array<string, int>>>> The response as an array.
+	 * Uses the minimal Post representation so editor-only metadata
+	 * (focus keyphrase, cornerstone flag, schema type) never crosses
+	 * the REST boundary into the browser.
+	 *
+	 * @return array<string, array<array<string, string>>> The response as an array.
 	 */
 	public function to_array(): array {
 		$result                   = $this->suggestions->to_array();
-		$result['recent_content'] = $this->recent_content->to_array();
+		$result['recent_content'] = $this->recent_content->to_minimal_array();
 		return $result;
 	}
 }

--- a/src/ai/content-planner/domain/post-list.php
+++ b/src/ai/content-planner/domain/post-list.php
@@ -38,4 +38,18 @@ class Post_List {
 
 		return $result;
 	}
+
+	/**
+	 * Returns the minimal array representation suitable for the REST response.
+	 *
+	 * @return array<array<string, string>> The posts as minimal arrays.
+	 */
+	public function to_minimal_array(): array {
+		$result = [];
+		foreach ( $this->posts as $post ) {
+			$result[] = $post->to_minimal_array();
+		}
+
+		return $result;
+	}
 }

--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -105,4 +105,20 @@ class Post {
 
 		return $data;
 	}
+
+	/**
+	 * Returns the minimal array representation suitable for the REST response.
+	 *
+	 * Only includes fields the frontend round-trips into the get_outline call.
+	 * Excludes editor-only metadata (focus keyphrase, cornerstone, schema type)
+	 * that must not cross the REST boundary.
+	 *
+	 * @return array<string, string> The minimal post payload.
+	 */
+	public function to_minimal_array(): array {
+		return [
+			'title'       => $this->title,
+			'description' => $this->description,
+		];
+	}
 }

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -137,6 +137,12 @@ class Get_Outline_Route implements Route_Interface {
 						],
 						'description' => 'The category of the chosen content suggestion. Use name "" and id -1 to indicate no category.',
 					],
+					'recent_content'   => [
+						'required'    => true,
+						'type'        => 'array',
+						'items'       => [ 'type' => 'object' ],
+						'description' => 'The recent content returned by the get_suggestions response.',
+					],
 				],
 				'callback'            => [ $this, 'get_outline' ],
 				'permission_callback' => [ $this, 'check_permissions' ],
@@ -169,6 +175,7 @@ class Get_Outline_Route implements Route_Interface {
 				$request->get_param( 'meta_description' ),
 				$category_param['name'],
 				(int) $category_param['id'],
+				$request->get_param( 'recent_content' ),
 			);
 			$data    = $this->command_handler->handle( $command );
 		} catch ( Remote_Request_Exception $e ) {

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -18,7 +18,7 @@ use Yoast\WP\SEO\Routes\Route_Interface;
 /**
  * Registers a route to get a content outline from the AI API.
  *
- * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the `edit_posts` capability (see {@see self::check_permissions()}), and may change at any time without notice.
+ * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the capability to edit posts of the requested post type (see {@see self::check_permissions()}), and may change at any time without notice.
  *
  * @makePublic
  *

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -214,16 +214,29 @@ class Get_Outline_Route implements Route_Interface {
 	}
 
 	/**
-	 * Checks if the user is logged in and can edit posts.
+	 * Checks if the user is logged in and can edit posts of the requested post type.
 	 *
-	 * @return bool Whether the user is logged in and can edit posts.
+	 * The requested post_type is caller-controlled, so the permission must be evaluated
+	 * against that post type's own edit_posts meta-capability — not the generic
+	 * 'edit_posts' string, which would let a user with edit_posts but no edit_pages
+	 * (e.g. an Author) trigger outline generation for pages or arbitrary CPTs.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool Whether the user can edit posts of the requested post type.
 	 */
-	public function check_permissions(): bool {
+	public function check_permissions( WP_REST_Request $request ): bool {
 		$user = \wp_get_current_user();
 		if ( $user === null || $user->ID < 1 ) {
 			return false;
 		}
 
-		return \user_can( $user, 'edit_posts' );
+		$post_type        = $request->get_param( 'post_type' );
+		$post_type_object = \get_post_type_object( $post_type );
+		if ( $post_type_object === null ) {
+			return false;
+		}
+
+		return \user_can( $user, $post_type_object->cap->edit_posts );
 	}
 }

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -145,12 +145,14 @@ class Get_Outline_Route implements Route_Interface {
 							'type'                 => 'object',
 							'properties'           => [
 								'title'       => [
-									'type'     => 'string',
-									'required' => true,
+									'type'      => 'string',
+									'required'  => true,
+									'maxLength' => 500,
 								],
 								'description' => [
-									'type'     => 'string',
-									'required' => true,
+									'type'      => 'string',
+									'required'  => true,
+									'maxLength' => 1000,
 								],
 							],
 							'additionalProperties' => false,

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -143,16 +143,14 @@ class Get_Outline_Route implements Route_Interface {
 						'maxItems'    => 100,
 						'items'       => [
 							'type'                 => 'object',
-							'required'             => [
-								'title',
-								'description',
-							],
 							'properties'           => [
 								'title'       => [
-									'type' => 'string',
+									'type'     => 'string',
+									'required' => true,
 								],
 								'description' => [
-									'type' => 'string',
+									'type'     => 'string',
+									'required' => true,
 								],
 							],
 							'additionalProperties' => false,

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -140,7 +140,23 @@ class Get_Outline_Route implements Route_Interface {
 					'recent_content'   => [
 						'required'    => true,
 						'type'        => 'array',
-						'items'       => [ 'type' => 'object' ],
+						'maxItems'    => 100,
+						'items'       => [
+							'type'                 => 'object',
+							'required'             => [
+								'title',
+								'description',
+							],
+							'properties'           => [
+								'title'       => [
+									'type' => 'string',
+								],
+								'description' => [
+									'type' => 'string',
+								],
+							],
+							'additionalProperties' => false,
+						],
 						'description' => 'The recent content returned by the get_suggestions response.',
 					],
 				],

--- a/src/ai/content-planner/user-interface/get-suggestions-route.php
+++ b/src/ai/content-planner/user-interface/get-suggestions-route.php
@@ -142,16 +142,29 @@ class Get_Suggestions_Route implements Route_Interface {
 	}
 
 	/**
-	 * Checks if the user is logged in and can edit posts.
+	 * Checks if the user is logged in and can edit posts of the requested post type.
 	 *
-	 * @return bool Whether the user is logged in and can edit posts.
+	 * The requested post_type is caller-controlled, so the permission must be evaluated
+	 * against that post type's own edit_posts meta-capability — not the generic
+	 * 'edit_posts' string, which would let a user with edit_posts but no edit_pages
+	 * (e.g. an Author) pull metadata for pages or arbitrary CPTs.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool Whether the user can edit posts of the requested post type.
 	 */
-	public function check_permissions(): bool {
+	public function check_permissions( WP_REST_Request $request ): bool {
 		$user = \wp_get_current_user();
 		if ( $user === null || $user->ID < 1 ) {
 			return false;
 		}
 
-		return \user_can( $user, 'edit_posts' );
+		$post_type        = $request->get_param( 'post_type' );
+		$post_type_object = \get_post_type_object( $post_type );
+		if ( $post_type_object === null ) {
+			return false;
+		}
+
+		return \user_can( $user, $post_type_object->cap->edit_posts );
 	}
 }

--- a/src/ai/content-planner/user-interface/get-suggestions-route.php
+++ b/src/ai/content-planner/user-interface/get-suggestions-route.php
@@ -18,7 +18,7 @@ use Yoast\WP\SEO\Routes\Route_Interface;
 /**
  * Registers a route to get content suggestions from the AI API.
  *
- * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the `edit_posts` capability (see {@see self::check_permissions()}), and may change at any time without notice.
+ * @internal This route powers the Yoast SEO admin UI's Content Planner feature. It is not part of the plugin's public REST API surface, requires the capability to edit posts of the requested post type (see {@see self::check_permissions()}), and may change at any time without notice.
  *
  * @makePublic
  *

--- a/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command/Content_Outline_Command_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command/Content_Outline_Command_Test.php
@@ -38,7 +38,12 @@ final class Content_Outline_Command_Test extends TestCase {
 	public function test_constructor_populates_all_fields() {
 		$user = Mockery::mock( WP_User::class );
 
-		$recent_content = [ [ 'title' => 'My Post', 'description' => 'A description.' ] ];
+		$recent_content = [
+			[
+				'title'       => 'My Post',
+				'description' => 'A description.',
+			],
+		];
 
 		$command = new Content_Outline_Command(
 			$user,

--- a/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command/Content_Outline_Command_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command/Content_Outline_Command_Test.php
@@ -26,6 +26,7 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
  * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command::get_keyphrase
  * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command::get_meta_description
  * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command::get_category
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command::get_recent_content
  */
 final class Content_Outline_Command_Test extends TestCase {
 
@@ -36,6 +37,8 @@ final class Content_Outline_Command_Test extends TestCase {
 	 */
 	public function test_constructor_populates_all_fields() {
 		$user = Mockery::mock( WP_User::class );
+
+		$recent_content = [ [ 'title' => 'My Post', 'description' => 'A description.' ] ];
 
 		$command = new Content_Outline_Command(
 			$user,
@@ -49,6 +52,7 @@ final class Content_Outline_Command_Test extends TestCase {
 			'Learn how to use AI effectively.',
 			'Tech',
 			5,
+			$recent_content,
 		);
 
 		$this->assertSame( $user, $command->get_user() );
@@ -67,6 +71,7 @@ final class Content_Outline_Command_Test extends TestCase {
 			],
 			$command->get_category()->to_array(),
 		);
+		$this->assertSame( $recent_content, $command->get_recent_content() );
 	}
 
 	/**
@@ -95,6 +100,7 @@ final class Content_Outline_Command_Test extends TestCase {
 			'Meta description',
 			'Tech',
 			5,
+			[],
 		);
 
 		$this->assertSame( $post_type, $command->get_post_type() );

--- a/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command_Handler/Handle_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Outline_Command_Handler/Handle_Test.php
@@ -7,7 +7,6 @@ namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Application\Content_Outline
 use Mockery;
 use WP_User;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command;
-use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Section_List;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Forbidden_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Unauthorized_Exception;
@@ -54,6 +53,12 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 			'Learn how to use AI effectively.',
 			'Tech',
 			5,
+			[
+				[
+					'title'       => 'Existing post',
+					'description' => 'Existing description',
+				],
+			],
 		);
 	}
 
@@ -65,23 +70,11 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_happy_path_with_about_page() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn(
-			[
-				[
-					'title'       => 'Existing post',
-					'description' => 'Existing description',
-					'extra'       => 'ignored',
-				],
-			],
-		);
-
 		$about_page = [
 			'title'       => 'About us',
 			'description' => 'All about us',
 		];
 
-		$this->recent_content_collector->expects( 'collect' )->once()->with( 'post' )->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->with( 'post' )->andReturn( $about_page );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->with( $command->get_user() )->andReturn( 'JWT' );
 
@@ -121,10 +114,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_happy_path_without_about_page() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 
@@ -158,10 +147,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_retries_on_unauthorized() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->twice()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->twice()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->twice()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->twice()->andReturn( 'JWT' );
 		$this->token_manager->expects( 'clear_tokens' )->once()->with( 1 );
@@ -194,10 +179,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_rethrows_unauthorized_when_retry_disabled() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 		$this->token_manager->expects( 'clear_tokens' )->once()->with( 1 );
@@ -217,10 +198,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_revokes_consent_on_forbidden() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 
@@ -242,10 +219,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_returns_empty_section_list_on_invalid_json() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 		$this->request_handler->expects( 'handle' )->once()->andReturn( new Response( 'not json', 200, '' ) );
@@ -263,10 +236,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_returns_empty_section_list_on_missing_choices_key() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 		$this->request_handler->expects( 'handle' )->once()->andReturn( new Response( '{"something_else":[]}', 200, '' ) );
@@ -284,10 +253,6 @@ final class Handle_Test extends Abstract_Content_Outline_Command_Handler_Test {
 	public function test_handle_falls_back_gracefully_on_partial_choice_fields() {
 		$command = $this->build_command();
 
-		$post_list = Mockery::mock( Post_List::class );
-		$post_list->expects( 'to_array' )->once()->andReturn( [] );
-
-		$this->recent_content_collector->expects( 'collect' )->once()->andReturn( $post_list );
 		$this->recent_content_collector->expects( 'collect_about_page' )->once()->andReturn( false );
 		$this->token_manager->expects( 'get_or_request_access_token' )->once()->andReturn( 'JWT' );
 		$this->request_handler

--- a/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Build_Response_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Build_Response_Test.php
@@ -1,0 +1,89 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Application\Content_Suggestion_Command_Handler;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Response;
+
+/**
+ * Tests Content_Suggestion_Command_Handler::build_response.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command_Handler::build_response
+ */
+final class Build_Response_Test extends Abstract_Content_Suggestion_Command_Handler_Test {
+
+	/**
+	 * Tests that build_response returns a Content_Suggestion_Response bundling suggestions and recent content.
+	 *
+	 * @return void
+	 */
+	public function test_build_response_returns_response_with_suggestions_and_recent_content() {
+		$body = [
+			'choices' => [
+				[
+					'title'            => 'How to use AI',
+					'intent'           => 'informational',
+					'explanation'      => 'This article explains AI usage.',
+					'keyphrase'        => 'AI usage',
+					'meta_description' => 'Learn how to use AI effectively.',
+					'category'         => [ 'name' => 'Tech', 'id' => 5 ],
+				],
+			],
+		];
+
+		$resolved_category = new Category( 'Tech', 5 );
+		$this->category_repository
+			->expects( 'find_by_name' )
+			->once()
+			->with( 'Tech' )
+			->andReturn( $resolved_category );
+
+		$response       = new Response( (string) \wp_json_encode( $body ), 200, 'OK' );
+		$recent_content = new Post_List();
+
+		$result = $this->instance->build_response( $response, $recent_content );
+
+		$this->assertInstanceOf( Content_Suggestion_Response::class, $result );
+		$this->assertSame( $recent_content, $result->get_recent_content() );
+		$this->assertSame(
+			[
+				'suggestions' => [
+					[
+						'title'            => 'How to use AI',
+						'intent'           => 'informational',
+						'explanation'      => 'This article explains AI usage.',
+						'keyphrase'        => 'AI usage',
+						'meta_description' => 'Learn how to use AI effectively.',
+						'category'         => [
+							'name' => 'Tech',
+							'id'   => 5,
+						],
+					],
+				],
+			],
+			$result->get_suggestions()->to_array(),
+		);
+	}
+
+	/**
+	 * Tests that build_response with an empty API body returns a response with empty suggestions.
+	 *
+	 * @return void
+	 */
+	public function test_build_response_with_empty_body_returns_empty_suggestions() {
+		$response       = new Response( (string) \wp_json_encode( [] ), 200, 'OK' );
+		$recent_content = new Post_List();
+
+		$result = $this->instance->build_response( $response, $recent_content );
+
+		$this->assertInstanceOf( Content_Suggestion_Response::class, $result );
+		$this->assertSame( $recent_content, $result->get_recent_content() );
+		$this->assertSame( [ 'suggestions' => [] ], $result->get_suggestions()->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Build_Response_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Build_Response_Test.php
@@ -32,7 +32,10 @@ final class Build_Response_Test extends Abstract_Content_Suggestion_Command_Hand
 					'explanation'      => 'This article explains AI usage.',
 					'keyphrase'        => 'AI usage',
 					'meta_description' => 'Learn how to use AI effectively.',
-					'category'         => [ 'name' => 'Tech', 'id' => 5 ],
+					'category'         => [
+						'name' => 'Tech',
+						'id'   => 5,
+					],
 				],
 			],
 		];

--- a/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Handle_Test.php
+++ b/tests/Unit/AI/Content_Planner/Application/Content_Suggestion_Command_Handler/Handle_Test.php
@@ -1,0 +1,122 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Application\Content_Suggestion_Command_Handler;
+
+use Mockery;
+use WP_User;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Request;
+use Yoast\WP\SEO\AI\HTTP_Request\Domain\Response;
+
+/**
+ * Tests the Content_Suggestion_Command_Handler::handle method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command_Handler::handle
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Handle_Test extends Abstract_Content_Suggestion_Command_Handler_Test {
+
+	/**
+	 * Builds a Content_Suggestion_Command with a WP_User mock whose ID is 1.
+	 *
+	 * @return Content_Suggestion_Command The command.
+	 */
+	private function build_command(): Content_Suggestion_Command {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+
+		return new Content_Suggestion_Command( $user, 'post', 'en_US', 'gutenberg' );
+	}
+
+	/**
+	 * Builds a Post_List with a single Post for use as collector output.
+	 *
+	 * @return Post_List The post list.
+	 */
+	private function build_post_list(): Post_List {
+		$post_list = new Post_List();
+		$post_list->add(
+			new Post(
+				'Existing post',
+				'Existing description',
+				new Category( 'Tech', 5 ),
+				'AI usage',
+				1,
+				'2026-05-19 12:00:00',
+				'Article',
+			),
+		);
+
+		return $post_list;
+	}
+
+	/**
+	 * Tests that on the happy path handle() returns a Content_Suggestion_Response whose
+	 * recent content is the exact Post_List that was returned by the collector and forwarded
+	 * to the suggestions API, so the frontend receives the same recent-content payload that
+	 * the AI request was built from (no double collection).
+	 *
+	 * @return void
+	 */
+	public function test_handle_returns_same_post_list_that_was_collected_and_sent() {
+		$command   = $this->build_command();
+		$post_list = $this->build_post_list();
+
+		$this->recent_content_collector
+			->expects( 'collect' )
+			->once()
+			->with( 'post' )
+			->andReturn( $post_list );
+
+		$this->recent_content_collector
+			->expects( 'collect_about_page' )
+			->once()
+			->with( 'post' )
+			->andReturn( false );
+
+		$this->token_manager
+			->expects( 'get_or_request_access_token' )
+			->once()
+			->with( $command->get_user() )
+			->andReturn( 'JWT' );
+
+		$this->request_handler
+			->expects( 'handle' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $request ) use ( $post_list ) {
+						if ( ! $request instanceof Request ) {
+							return false;
+						}
+						if ( $request->get_action_path() !== '/content-planner/next-post-suggestions' ) {
+							return false;
+						}
+
+						$content = ( $request->get_body()['subject']['content'] ?? [] );
+
+						return ( $content['posts'] ?? null ) === $post_list->to_array();
+					},
+				),
+			)
+			->andReturn( new Response( (string) \wp_json_encode( [ 'choices' => [] ] ), 200, 'OK' ) );
+
+		$result = $this->instance->handle( $command );
+
+		$this->assertInstanceOf( Content_Suggestion_Response::class, $result );
+		$this->assertSame(
+			$post_list,
+			$result->get_recent_content(),
+			'handle() must return the same Post_List instance that was collected and sent to the suggestions API.',
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Abstract_Content_Suggestion_Response.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Abstract_Content_Suggestion_Response.php
@@ -1,0 +1,39 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_Response;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for Content_Suggestion_Response tests.
+ *
+ * @group ai-content-planner
+ */
+abstract class Abstract_Content_Suggestion_Response extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Content_Suggestion_Response
+	 */
+	protected $instance;
+
+	/**
+	 * Setup the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		$this->instance = new Content_Suggestion_Response(
+			new Content_Suggestion_List(),
+			new Post_List(),
+		);
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Constructor_Test.php
@@ -1,0 +1,38 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_Response;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+
+/**
+ * Tests the Content_Suggestion_Response constructor and getters.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response::__construct
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response::get_suggestions
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response::get_recent_content
+ */
+final class Constructor_Test extends Abstract_Content_Suggestion_Response {
+
+	/**
+	 * Tests that the constructor stores the suggestions and recent content and the getters return them.
+	 *
+	 * @return void
+	 */
+	public function test_constructor_stores_suggestions_and_recent_content() {
+		$suggestions    = new Content_Suggestion_List();
+		$recent_content = new Post_List();
+
+		$instance = new \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response(
+			$suggestions,
+			$recent_content,
+		);
+
+		$this->assertSame( $suggestions, $instance->get_suggestions() );
+		$this->assertSame( $recent_content, $instance->get_recent_content() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Constructor_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/Constructor_Test.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_Response;
 
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
 
 /**
@@ -27,7 +28,7 @@ final class Constructor_Test extends Abstract_Content_Suggestion_Response {
 		$suggestions    = new Content_Suggestion_List();
 		$recent_content = new Post_List();
 
-		$instance = new \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response(
+		$instance = new Content_Suggestion_Response(
 			$suggestions,
 			$recent_content,
 		);

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
@@ -60,7 +60,7 @@ final class To_Array_Test extends Abstract_Content_Suggestion_Response {
 			'BlogPosting',
 		);
 
-		$suggestions    = new Content_Suggestion_List();
+		$suggestions = new Content_Suggestion_List();
 		$suggestions->add( $suggestion );
 
 		$recent_content = new Post_List();

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
@@ -1,0 +1,103 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Content_Suggestion_Response;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_List;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post_List;
+
+/**
+ * Tests the Content_Suggestion_Response::to_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Content_Suggestion_Response::to_array
+ */
+final class To_Array_Test extends Abstract_Content_Suggestion_Response {
+
+	/**
+	 * Tests that to_array returns the correct structure when both lists are empty.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_empty() {
+		$this->assertSame(
+			[
+				'suggestions'    => [],
+				'recent_content' => [],
+			],
+			$this->instance->to_array(),
+		);
+	}
+
+	/**
+	 * Tests that to_array merges suggestions and recent content into the expected structure.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_with_data() {
+		$category   = new Category( 'Tech', 5 );
+		$suggestion = new Content_Suggestion(
+			'How to use AI',
+			'informational',
+			'This article explains AI usage.',
+			'AI usage',
+			'Learn how to use AI effectively.',
+			$category,
+		);
+		$post       = new Post(
+			'My Post Title',
+			'A description of the post.',
+			$category,
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$suggestions    = new Content_Suggestion_List();
+		$suggestions->add( $suggestion );
+
+		$recent_content = new Post_List();
+		$recent_content->add( $post );
+
+		$instance = new Content_Suggestion_Response( $suggestions, $recent_content );
+
+		$expected = [
+			'suggestions'    => [
+				[
+					'title'            => 'How to use AI',
+					'intent'           => 'informational',
+					'explanation'      => 'This article explains AI usage.',
+					'keyphrase'        => 'AI usage',
+					'meta_description' => 'Learn how to use AI effectively.',
+					'category'         => [
+						'name' => 'Tech',
+						'id'   => 5,
+					],
+				],
+			],
+			'recent_content' => [
+				[
+					'title'                 => 'My Post Title',
+					'description'           => 'A description of the post.',
+					'category'              => [
+						'name' => 'Tech',
+						'id'   => 5,
+					],
+					'primary_focus_keyword' => 'focus keyword',
+					'is_cornerstone'        => 1,
+					'last_modified'         => '2024-01-15',
+					'schema_article_type'   => 'BlogPosting',
+				],
+			],
+		];
+
+		$this->assertSame( $expected, $instance->to_array() );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Content_Suggestion_Response/To_Array_Test.php
@@ -84,16 +84,8 @@ final class To_Array_Test extends Abstract_Content_Suggestion_Response {
 			],
 			'recent_content' => [
 				[
-					'title'                 => 'My Post Title',
-					'description'           => 'A description of the post.',
-					'category'              => [
-						'name' => 'Tech',
-						'id'   => 5,
-					],
-					'primary_focus_keyword' => 'focus keyword',
-					'is_cornerstone'        => 1,
-					'last_modified'         => '2024-01-15',
-					'schema_article_type'   => 'BlogPosting',
+					'title'       => 'My Post Title',
+					'description' => 'A description of the post.',
 				],
 			],
 		];

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
@@ -6,6 +6,8 @@ namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Get_Outline_
 
 use Brain\Monkey\Functions;
 use Mockery;
+use stdClass;
+use WP_REST_Request;
 use WP_User;
 
 /**
@@ -20,6 +22,35 @@ use WP_User;
 final class Check_Permissions_Test extends Abstract_Get_Outline_Route_Test {
 
 	/**
+	 * Builds a request whose `post_type` parameter returns the given value.
+	 *
+	 * @param string $post_type The post type to return from get_param.
+	 *
+	 * @return Mockery\MockInterface|WP_REST_Request The request mock.
+	 */
+	private function build_request( string $post_type ) {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'post_type' )->andReturn( $post_type );
+
+		return $request;
+	}
+
+	/**
+	 * Builds a fake post-type object whose cap->edit_posts is the given capability.
+	 *
+	 * @param string $edit_posts_cap The edit_posts capability for this post type.
+	 *
+	 * @return stdClass The post-type object.
+	 */
+	private function build_post_type_object( string $edit_posts_cap ): stdClass {
+		$post_type_object             = new stdClass();
+		$post_type_object->cap        = new stdClass();
+		$post_type_object->cap->edit_posts = $edit_posts_cap;
+
+		return $post_type_object;
+	}
+
+	/**
 	 * Tests check_permissions returns false for an anonymous user.
 	 *
 	 * @return void
@@ -29,34 +60,50 @@ final class Check_Permissions_Test extends Abstract_Get_Outline_Route_Test {
 		$user->ID = 0;
 		Functions\when( 'wp_get_current_user' )->justReturn( $user );
 
-		$this->assertFalse( $this->instance->check_permissions() );
+		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'post' ) ) );
 	}
 
 	/**
-	 * Tests check_permissions returns true for a logged-in user with the edit_posts capability.
+	 * Tests check_permissions returns false when the requested post type does not exist.
 	 *
 	 * @return void
 	 */
-	public function test_check_permissions_logged_in_user_with_edit_posts() {
+	public function test_check_permissions_unknown_post_type() {
 		$user     = Mockery::mock( WP_User::class );
 		$user->ID = 1;
 		Functions\when( 'wp_get_current_user' )->justReturn( $user );
-		Functions\when( 'user_can' )->justReturn( true );
+		Functions\when( 'get_post_type_object' )->justReturn( null );
 
-		$this->assertTrue( $this->instance->check_permissions() );
+		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'does_not_exist' ) ) );
 	}
 
 	/**
-	 * Tests check_permissions returns false for a logged-in user without the edit_posts capability.
+	 * Tests check_permissions returns true when the user holds the post-type-specific edit_posts cap.
 	 *
 	 * @return void
 	 */
-	public function test_check_permissions_logged_in_user_without_edit_posts() {
+	public function test_check_permissions_user_with_post_type_cap() {
 		$user     = Mockery::mock( WP_User::class );
 		$user->ID = 1;
 		Functions\when( 'wp_get_current_user' )->justReturn( $user );
-		Functions\when( 'user_can' )->justReturn( false );
+		Functions\when( 'get_post_type_object' )->justReturn( $this->build_post_type_object( 'edit_pages' ) );
+		Functions\expect( 'user_can' )->with( $user, 'edit_pages' )->andReturn( true );
 
-		$this->assertFalse( $this->instance->check_permissions() );
+		$this->assertTrue( $this->instance->check_permissions( $this->build_request( 'page' ) ) );
+	}
+
+	/**
+	 * Tests check_permissions returns false when the user lacks the post-type-specific edit_posts cap.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions_user_without_post_type_cap() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+		Functions\when( 'wp_get_current_user' )->justReturn( $user );
+		Functions\when( 'get_post_type_object' )->justReturn( $this->build_post_type_object( 'edit_pages' ) );
+		Functions\expect( 'user_can' )->with( $user, 'edit_pages' )->andReturn( false );
+
+		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'page' ) ) );
 	}
 }

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
@@ -51,7 +51,7 @@ final class Check_Permissions_Test extends Abstract_Get_Outline_Route_Test {
 	}
 
 	/**
-	 * Tests check_permissions returns false for an anonymous user.
+	 * Tests check_permissions returns false for an anonymous user without inspecting the request.
 	 *
 	 * @return void
 	 */
@@ -60,7 +60,9 @@ final class Check_Permissions_Test extends Abstract_Get_Outline_Route_Test {
 		$user->ID = 0;
 		Functions\when( 'wp_get_current_user' )->justReturn( $user );
 
-		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'post' ) ) );
+		$request = Mockery::mock( WP_REST_Request::class );
+
+		$this->assertFalse( $this->instance->check_permissions( $request ) );
 	}
 
 	/**

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Check_Permissions_Test.php
@@ -43,8 +43,8 @@ final class Check_Permissions_Test extends Abstract_Get_Outline_Route_Test {
 	 * @return stdClass The post-type object.
 	 */
 	private function build_post_type_object( string $edit_posts_cap ): stdClass {
-		$post_type_object             = new stdClass();
-		$post_type_object->cap        = new stdClass();
+		$post_type_object                  = new stdClass();
+		$post_type_object->cap             = new stdClass();
 		$post_type_object->cap->edit_posts = $edit_posts_cap;
 
 		return $post_type_object;

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Get_Outline_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Outline_Route/Get_Outline_Test.php
@@ -49,6 +49,7 @@ final class Get_Outline_Test extends Abstract_Get_Outline_Route_Test {
 		$request->expects( 'get_param' )->with( 'explanation' )->andReturn( 'Explanation' );
 		$request->expects( 'get_param' )->with( 'keyphrase' )->andReturn( 'AI usage' );
 		$request->expects( 'get_param' )->with( 'meta_description' )->andReturn( 'Meta description' );
+		$request->expects( 'get_param' )->with( 'recent_content' )->andReturn( [] );
 
 		return $request;
 	}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Suggestions_Route/Abstract_Get_Suggestions_Route_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Suggestions_Route/Abstract_Get_Suggestions_Route_Test.php
@@ -1,0 +1,47 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Get_Suggestions_Route;
+
+use Mockery;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Suggestion_Command_Handler;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Get_Suggestions_Route;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Base class for the Get_Suggestions_Route tests.
+ *
+ * @group ai-content-planner
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Get_Suggestions_Route_Test extends TestCase {
+
+	/**
+	 * Holds the command handler mock.
+	 *
+	 * @var Mockery\MockInterface|Content_Suggestion_Command_Handler
+	 */
+	protected $command_handler;
+
+	/**
+	 * Holds the instance under test.
+	 *
+	 * @var Get_Suggestions_Route
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->command_handler = Mockery::mock( Content_Suggestion_Command_Handler::class );
+
+		$this->instance = new Get_Suggestions_Route( $this->command_handler );
+	}
+}

--- a/tests/Unit/AI/Content_Planner/User_Interface/Get_Suggestions_Route/Check_Permissions_Test.php
+++ b/tests/Unit/AI/Content_Planner/User_Interface/Get_Suggestions_Route/Check_Permissions_Test.php
@@ -1,0 +1,111 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\User_Interface\Get_Suggestions_Route;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use stdClass;
+use WP_REST_Request;
+use WP_User;
+
+/**
+ * Tests the Get_Suggestions_Route check_permissions method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Get_Suggestions_Route::check_permissions
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Check_Permissions_Test extends Abstract_Get_Suggestions_Route_Test {
+
+	/**
+	 * Builds a request whose `post_type` parameter returns the given value.
+	 *
+	 * @param string $post_type The post type to return from get_param.
+	 *
+	 * @return Mockery\MockInterface|WP_REST_Request The request mock.
+	 */
+	private function build_request( string $post_type ) {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'post_type' )->andReturn( $post_type );
+
+		return $request;
+	}
+
+	/**
+	 * Builds a fake post-type object whose cap->edit_posts is the given capability.
+	 *
+	 * @param string $edit_posts_cap The edit_posts capability for this post type.
+	 *
+	 * @return stdClass The post-type object.
+	 */
+	private function build_post_type_object( string $edit_posts_cap ): stdClass {
+		$post_type_object                  = new stdClass();
+		$post_type_object->cap             = new stdClass();
+		$post_type_object->cap->edit_posts = $edit_posts_cap;
+
+		return $post_type_object;
+	}
+
+	/**
+	 * Tests check_permissions returns false for an anonymous user without inspecting the request.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions_anonymous_user() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 0;
+		Functions\when( 'wp_get_current_user' )->justReturn( $user );
+
+		$request = Mockery::mock( WP_REST_Request::class );
+
+		$this->assertFalse( $this->instance->check_permissions( $request ) );
+	}
+
+	/**
+	 * Tests check_permissions returns false when the requested post type does not exist.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions_unknown_post_type() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+		Functions\when( 'wp_get_current_user' )->justReturn( $user );
+		Functions\when( 'get_post_type_object' )->justReturn( null );
+
+		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'does_not_exist' ) ) );
+	}
+
+	/**
+	 * Tests check_permissions returns true when the user holds the post-type-specific edit_posts cap.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions_user_with_post_type_cap() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+		Functions\when( 'wp_get_current_user' )->justReturn( $user );
+		Functions\when( 'get_post_type_object' )->justReturn( $this->build_post_type_object( 'edit_pages' ) );
+		Functions\expect( 'user_can' )->with( $user, 'edit_pages' )->andReturn( true );
+
+		$this->assertTrue( $this->instance->check_permissions( $this->build_request( 'page' ) ) );
+	}
+
+	/**
+	 * Tests check_permissions returns false when the user lacks the post-type-specific edit_posts cap.
+	 *
+	 * @return void
+	 */
+	public function test_check_permissions_user_without_post_type_cap() {
+		$user     = Mockery::mock( WP_User::class );
+		$user->ID = 1;
+		Functions\when( 'wp_get_current_user' )->justReturn( $user );
+		Functions\when( 'get_post_type_object' )->justReturn( $this->build_post_type_object( 'edit_pages' ) );
+		Functions\expect( 'user_can' )->with( $user, 'edit_pages' )->andReturn( false );
+
+		$this->assertFalse( $this->instance->check_permissions( $this->build_request( 'page' ) ) );
+	}
+}

--- a/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
+++ b/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
@@ -1,0 +1,262 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- This namespace should reflect the namespace of the original class.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\WP\AI\Content_Planner\User_Interface;
+
+use Mockery;
+use WP_REST_Request;
+use WP_REST_Response;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command;
+use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command_Handler;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Section;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Section_List;
+use Yoast\WP\SEO\AI\Content_Planner\User_Interface\Get_Outline_Route;
+use Yoast\WP\SEO\Tests\WP\TestCase;
+
+/**
+ * Integration tests for Get_Outline_Route.
+ *
+ * Exercises the WordPress REST schema validation on the
+ * POST /yoast/v1/ai_content_planner/get_outline endpoint, with focus on the
+ * required `recent_content` request body parameter.
+ *
+ * @group ai-content-planner
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\AI\Content_Planner\User_Interface\Get_Outline_Route
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Get_Outline_Route_Test extends TestCase {
+
+	/**
+	 * The route under test.
+	 *
+	 * @var Get_Outline_Route
+	 */
+	private $instance;
+
+	/**
+	 * The command handler mock.
+	 *
+	 * @var Content_Outline_Command_Handler|Mockery\MockInterface
+	 */
+	private $command_handler;
+
+	/**
+	 * Sets up the route on the live REST server and authenticates as an admin.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->command_handler = Mockery::mock( Content_Outline_Command_Handler::class );
+		$this->instance        = new Get_Outline_Route( $this->command_handler );
+		$this->instance->register_routes();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		\wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Builds a valid request body, optionally with overrides or removed keys.
+	 *
+	 * @param array<string, mixed> $overrides Values to override on the default body.
+	 * @param array<int, string>   $unset     Top-level keys to remove from the default body.
+	 *
+	 * @return array<string, mixed> The request body.
+	 */
+	private function valid_body( array $overrides = [], array $unset = [] ): array {
+		$body = [
+			'post_type'        => 'post',
+			'language'         => 'en_US',
+			'editor'           => 'gutenberg',
+			'title'            => 'How to use AI',
+			'intent'           => 'informational',
+			'explanation'      => 'Explanation',
+			'keyphrase'        => 'AI usage',
+			'meta_description' => 'Meta description',
+			'category'         => [
+				'name' => 'Tech',
+				'id'   => 5,
+			],
+			'recent_content'   => [
+				[
+					'title'       => 'An earlier post',
+					'description' => 'A short description of that earlier post.',
+				],
+			],
+		];
+
+		foreach ( $unset as $key ) {
+			unset( $body[ $key ] );
+		}
+
+		return \array_merge( $body, $overrides );
+	}
+
+	/**
+	 * Dispatches a POST request with a JSON body to the get_outline endpoint.
+	 *
+	 * @param array<string, mixed> $body The request body.
+	 *
+	 * @return WP_REST_Response The REST response.
+	 */
+	private function dispatch( array $body ): WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/yoast/v1/ai_content_planner/get_outline' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( (string) \wp_json_encode( $body ) );
+
+		return \rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Tests that the route is registered on the REST server.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_route_is_registered() {
+		$routes = \rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey(
+			'/yoast/v1/ai_content_planner/get_outline',
+			$routes,
+			'Expected the get_outline route to be registered on the REST server.',
+		);
+	}
+
+	/**
+	 * Tests that a fully valid payload — including a populated recent_content array —
+	 * passes schema validation and is forwarded to the command handler.
+	 *
+	 * @covers ::get_outline
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_valid_payload_is_dispatched_to_handler() {
+		$section_list = new Section_List();
+		$section_list->add( new Section( [ 'note 1' ], 'Section A' ) );
+
+		$this->command_handler
+			->expects( 'handle' )
+			->once()
+			->with( Mockery::type( Content_Outline_Command::class ) )
+			->andReturn( $section_list );
+
+		$response = $this->dispatch( $this->valid_body() );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $section_list->to_array(), $response->get_data() );
+	}
+
+	/**
+	 * Tests that an empty recent_content array is accepted (the schema sets no minItems).
+	 *
+	 * @covers ::get_outline
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_empty_recent_content_is_accepted() {
+		$this->command_handler
+			->expects( 'handle' )
+			->once()
+			->andReturn( new Section_List() );
+
+		$response = $this->dispatch( $this->valid_body( [ 'recent_content' => [] ] ) );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Tests that omitting recent_content is rejected by REST schema validation.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_missing_recent_content_returns_400() {
+		$this->command_handler->expects( 'handle' )->never();
+
+		$response = $this->dispatch( $this->valid_body( [], [ 'recent_content' ] ) );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Tests that a recent_content item without the required title is rejected.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_recent_content_item_without_title_returns_400() {
+		$this->command_handler->expects( 'handle' )->never();
+
+		$response = $this->dispatch(
+			$this->valid_body(
+				[
+					'recent_content' => [
+						[ 'description' => 'No title here.' ],
+					],
+				],
+			),
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Tests that a recent_content item without the required description is rejected.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_recent_content_item_without_description_returns_400() {
+		$this->command_handler->expects( 'handle' )->never();
+
+		$response = $this->dispatch(
+			$this->valid_body(
+				[
+					'recent_content' => [
+						[ 'title' => 'Only a title.' ],
+					],
+				],
+			),
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Tests that a recent_content item with an unexpected property is rejected,
+	 * because the schema declares additionalProperties: false on each item.
+	 *
+	 * @covers ::register_routes
+	 *
+	 * @return void
+	 */
+	public function test_recent_content_item_with_extra_property_returns_400() {
+		$this->command_handler->expects( 'handle' )->never();
+
+		$response = $this->dispatch(
+			$this->valid_body(
+				[
+					'recent_content' => [
+						[
+							'title'       => 'A title',
+							'description' => 'A description',
+							'unexpected'  => 'should be rejected',
+						],
+					],
+				],
+			),
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+}

--- a/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
+++ b/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
@@ -66,9 +66,8 @@ final class Get_Outline_Route_Test extends TestCase {
 		\add_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
 
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- $wp_rest_server is a WP core global.
-		global $wp_rest_server;
-		$wp_rest_server = new WP_REST_Server();
-		\do_action( 'rest_api_init', $wp_rest_server );
+		$GLOBALS['wp_rest_server'] = new WP_REST_Server();
+		\do_action( 'rest_api_init', $GLOBALS['wp_rest_server'] );
 
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		\wp_set_current_user( $user_id );
@@ -83,8 +82,7 @@ final class Get_Outline_Route_Test extends TestCase {
 		\remove_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
 
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- $wp_rest_server is a WP core global.
-		global $wp_rest_server;
-		$wp_rest_server = null;
+		$GLOBALS['wp_rest_server'] = null;
 
 		parent::tear_down();
 	}

--- a/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
+++ b/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
@@ -90,11 +90,11 @@ final class Get_Outline_Route_Test extends TestCase {
 	 * Builds a valid request body, optionally with overrides or removed keys.
 	 *
 	 * @param array<string, mixed> $overrides Values to override on the default body.
-	 * @param array<int, string>   $unset     Top-level keys to remove from the default body.
+	 * @param array<int, string>   $remove     Top-level keys to remove from the default body.
 	 *
 	 * @return array<string, mixed> The request body.
 	 */
-	private function valid_body( array $overrides = [], array $unset = [] ): array {
+	private function valid_body( array $overrides = [], array $remove = [] ): array {
 		$body = [
 			'post_type'        => 'post',
 			'language'         => 'en_US',
@@ -116,7 +116,7 @@ final class Get_Outline_Route_Test extends TestCase {
 			],
 		];
 
-		foreach ( $unset as $key ) {
+		foreach ( $remove as $key ) {
 			unset( $body[ $key ] );
 		}
 

--- a/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
+++ b/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
@@ -45,17 +45,45 @@ final class Get_Outline_Route_Test extends TestCase {
 	/**
 	 * Sets up the route on the live REST server and authenticates as an admin.
 	 *
+	 * Disables the AI conditional so the plugin's loader skips its own
+	 * registration of Get_Outline_Route, then registers a mocked instance on
+	 * rest_api_init and re-fires the action against a fresh REST server. This
+	 * keeps register_rest_route inside the rest_api_init context (no
+	 * _doing_it_wrong) and guarantees the mocked handler — not the real one — is
+	 * what dispatch reaches.
+	 *
 	 * @return void
 	 */
 	public function set_up() {
 		parent::set_up();
 
+		\YoastSEO()->helpers->options->set( 'enable_ai_generator', false );
+
 		$this->command_handler = Mockery::mock( Content_Outline_Command_Handler::class );
 		$this->instance        = new Get_Outline_Route( $this->command_handler );
-		$this->instance->register_routes();
+
+		\add_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		\do_action( 'rest_api_init', $wp_rest_server );
 
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		\wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Removes the route hook and resets the REST server so the next test starts clean.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		\remove_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
+++ b/tests/WP/AI/Content_Planner/User_Interface/Get_Outline_Route_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\WP\AI\Content_Planner\User_Interface;
 use Mockery;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_REST_Server;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command_Handler;
 use Yoast\WP\SEO\AI\Content_Planner\Domain\Section;
@@ -64,8 +65,9 @@ final class Get_Outline_Route_Test extends TestCase {
 
 		\add_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- $wp_rest_server is a WP core global.
 		global $wp_rest_server;
-		$wp_rest_server = new \WP_REST_Server();
+		$wp_rest_server = new WP_REST_Server();
 		\do_action( 'rest_api_init', $wp_rest_server );
 
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
@@ -80,6 +82,7 @@ final class Get_Outline_Route_Test extends TestCase {
 	public function tear_down() {
 		\remove_action( 'rest_api_init', [ $this->instance, 'register_routes' ] );
 
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- $wp_rest_server is a WP core global.
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
@@ -90,7 +93,7 @@ final class Get_Outline_Route_Test extends TestCase {
 	 * Builds a valid request body, optionally with overrides or removed keys.
 	 *
 	 * @param array<string, mixed> $overrides Values to override on the default body.
-	 * @param array<int, string>   $remove     Top-level keys to remove from the default body.
+	 * @param array<int, string>   $remove    Top-level keys to remove from the default body.
 	 *
 	 * @return array<string, mixed> The request body.
 	 */


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The Content Planner performs two different REST requests: the first to fetch possible topics suggestions, the second when the user selects a suggestion to fetch the summary structure. Both the requests query the database for the recently modified posts. We want to cache that data the first time it is fetched.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the recently modified posts were fetched twice when using the Content Planner.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit a post (or create a new one) in the block editor
* Open the `Network` tab of you browser's developer console
* Click on `Get content suggestions`
* Once you get the topics suggestions, look in the `Network` tab for the `get_suggestions` request
  * Inspect the response and verify you get a `recent_content` array along the `suggestions` one
* Select a topic 
  * In the `Network` tab look for the `get_outline` request
  * Inspect the request and verify the `recent_content` array is present and has the same data returned by the `get_suggestions` request

#### Devs only - test the REST route can't be used to access data about post types the user cannot edit
* Create a new user and assign to it the `author` role
* Publish at least five posts with that user
* Make sure you have some public pages in your blog
* Edit a post and open the browser's development console
* In the console, copy-paste this snippet and press `Enter`
  ```
  await fetch('/wp-json/yoast/v1/ai_content_planner/get_suggestions?post_type=post&language=en-US&editor=gutenberg', {
    headers: { 'X-WP-Nonce': wpApiSettings.nonce }
  }).then(r => r.status).then(console.log)
  ``` 
  * You should get a `200` in the console, as authors have permission to edit posts
* Now copy-paste this snippet and press `Enter`
  ```
  await fetch('/wp-json/yoast/v1/ai_content_planner/get_suggestions?post_type=page&language=en-US&editor=gutenberg', {
    headers: { 'X-WP-Nonce': wpApiSettings.nonce }
  }).then(r => r.status).then(console.log)
  ``` 
  * You should get a `403` in the console, as authors do not have permission to edit pages

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [C] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [C] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [C] I have written this PR in accordance with my team's definition of done.
* [C] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1155
