### PR TITLE
Adds a new RelatedKeyphraseInputField component 

### DIFF
--- a/packages/js/src/components/contentAnalysis/RelatedKeyphraseInputField.js
+++ b/packages/js/src/components/contentAnalysis/RelatedKeyphraseInputField.js
@@ -1,0 +1,37 @@
+import { TextField } from "@yoast/ui-library";
+import PropTypes from "prop-types";
+
+/**
+ * Renders the related keyphrase input field.
+ *
+ * Props that are not consumed by this component are forwarded to the underlying TextField.
+ *
+ * @param {Object} props The component props.
+ * @param {string} props.id The id of the input.
+ * @param {string} props.label The label of the input.
+ * @param {JSX.node} [props.description=""] The description of the input.
+ * @param {Function} props.onChange The change handler. Receives the raw change event.
+ *
+ * @returns {JSX.Element} The related keyphrase input field.
+ */
+const RelatedKeyphraseInputField = ( { id, label, description = "", onChange, ...inputProps } ) => (
+	<div className="yst-root">
+		<TextField
+			id={ id }
+			label={ label }
+			onChange={ onChange }
+			autoComplete="off"
+			description={ description }
+			{ ...inputProps }
+		/>
+	</div>
+);
+
+RelatedKeyphraseInputField.propTypes = {
+	id: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+	onChange: PropTypes.func.isRequired,
+	description: PropTypes.node,
+};
+
+export default RelatedKeyphraseInputField;

--- a/packages/js/src/components/contentAnalysis/RelatedKeyphraseInputField.js
+++ b/packages/js/src/components/contentAnalysis/RelatedKeyphraseInputField.js
@@ -1,4 +1,4 @@
-import { TextField } from "@yoast/ui-library";
+import { Root, TextField } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 
 /**
@@ -15,7 +15,7 @@ import PropTypes from "prop-types";
  * @returns {JSX.Element} The related keyphrase input field.
  */
 const RelatedKeyphraseInputField = ( { id, label, description = "", onChange, ...inputProps } ) => (
-	<div className="yst-root">
+	<Root>
 		<TextField
 			id={ id }
 			label={ label }
@@ -24,7 +24,7 @@ const RelatedKeyphraseInputField = ( { id, label, description = "", onChange, ..
 			description={ description }
 			{ ...inputProps }
 		/>
-	</div>
+	</Root>
 );
 
 RelatedKeyphraseInputField.propTypes = {

--- a/packages/js/src/editor-modules.js
+++ b/packages/js/src/editor-modules.js
@@ -6,6 +6,7 @@ import getL10nObject from "./analysis/getL10nObject";
 import * as refreshAnalysis from "./analysis/refreshAnalysis";
 import KeywordInput from "./components/contentAnalysis/KeywordInputComponent";
 import * as mapResults from "./components/contentAnalysis/mapResults";
+import RelatedKeyphraseInputField from "./components/contentAnalysis/RelatedKeyphraseInputField";
 import HelpLink from "./components/HelpLink";
 import withYoastSidebarPriority from "./components/higherorder/withYoastSidebarPriority";
 import MetaboxCollapsible from "./components/MetaboxCollapsible";
@@ -68,6 +69,7 @@ window.yoast.editorModules = {
 		},
 		contentAnalysis: {
 			KeywordInput,
+			RelatedKeyphraseInputField,
 			SynonymsInputField,
 			mapResults,
 		},


### PR DESCRIPTION
## Context

After we changed the focus keyphrase and synonyms fields design, we want to update the same for the related keyphrases for consistancy.

## Summary

* Adds a new `RelatedKeyphraseInputField` component to the editor modules to render the updated related keyphrase input field in YoasSEO Premium.

## Relevant technical choices

- **New component instead of refactoring `KeywordInputComponent`.** The legacy `KeywordInputComponent` is still mounted by the SEMrush wrapper for the focus keyphrase, and its API differs from `TextField`. Adding a new component mirrors how PR [#23233](https://github.com/Yoast/wordpress-seo/pull/23233)  introduced `SynonymsInputField` alongside the legacy synonyms component and lets consumers migrate incrementally.

## Test instructions for the acceptance test before the PR gets merged

1. Test together with the Premium PR [#4959](https://github.com/Yoast/wordpress-seo-premium/pull/4959) 
2. In a post or page, open the browser console and run `typeof window.yoast.editorModules.components.contentAnalysis.RelatedKeyphraseInputField` — expected output: `"function"`.
3. In the same console, run `window.yoast.editorModules.components.contentAnalysis.RelatedKeyphraseInputField({ id: "x", label: "y", onChange: () => {} })` and confirm it returns a React element whose root is a `div` with `className: "yst-root"` wrapping a `TextField`.

## Relevant test scenarios

- [x] Changes should be tested with the browser console open
- [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
- [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
- [ ] Changes should be tested on different browsers
- [ ] Changes should be tested on multisite

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- `packages/js/src/components/contentAnalysis/` — new `RelatedKeyphraseInputField` component.
- `packages/js/src/editor-modules.js` — adds an export under `window.yoast.editorModules.components.contentAnalysis`.

## Other environments

- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [ ] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

- [x] No innovation project is applicable for this PR.
- [ ] This PR falls under an innovation project. I have attached the innovation label.
- [ ] I have added my hours to the WBSO document.

Fixes [#1216](https://github.com/Yoast/reserved-tasks/issues/1216)
