### PR TITLE
fix: update wpseo_sitemap_entry documentation

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -217,9 +217,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				/**
 				 * Filter URL entry before it gets added to the sitemap.
 				 *
-				 * @param array  $url  Array of URL parts.
-				 * @param string $type URL type.
-				 * @param object $post Data object for the URL.
+				 * @param array   $url  Sitemap URL entry.
+				 * @param string  $type Post type.
+				 * @param WP_Post $post Post object.
 				 */
 				$url = apply_filters( 'wpseo_sitemap_entry', $url, 'post', $post );
 


### PR DESCRIPTION
## Context

The `wpseo_sitemap_entry` filter docblock in `class-post-type-sitemap-provider.php` currently describes the parameters in a way that does not clearly match the values passed to the filter.

Fixes #23148.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `wpseo_sitemap_entry` filter parameters were inaccurately documented.

## Relevant technical choices:

* Updates only the inline documentation for the existing filter.
* Does not change runtime behavior.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

* Review the updated docblock for the `wpseo_sitemap_entry` filter in `inc/sitemaps/class-post-type-sitemap-provider.php`.
* Confirm that the filter parameters are documented as a sitemap URL entry, post type, and post object.

#### Relevant test scenarios

* Not applicable; this is a documentation-only change.

### Test instructions for QA when the code is in the RC

Not applicable.

QA can test this PR by following these steps:

* Not applicable.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Sitemaps inline developer documentation only.

## Other environments

* Not applicable.

## Documentation

* I have updated the inline documentation for the existing filter.

## Quality assurance

* `composer lint-branch` passed.
* `composer install` failed locally during dependency prefixing with a Symfony Finder return type compatibility error on PHP 8.5.6.
* `composer check-branch-cs` could not complete because Composer dependencies were not fully installed.
* This is a documentation-only change and does not change runtime behavior.

## Innovation

* No innovation project is applicable for this PR.

Fixes #23148