### PR TITLE
fix(content-planner): skip syncing empty meta values to prevent overwriting the SEO title template

### DIFF
--- a/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
+++ b/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
@@ -25,6 +25,7 @@ export function useYoastMetaSync() {
 		};
 	}, [] );
 
+	// eslint-disable-next-line complexity
 	useEffect( () => {
 		// These meta keys are only registered for the 'post' subtype; bail on all other post types
 		// to avoid dispatching undefined values into yoast-seo/editor.
@@ -32,7 +33,21 @@ export function useYoastMetaSync() {
 			return;
 		}
 		const yoastEditor = dispatch( "yoast-seo/editor" );
-		yoastEditor?.updateData?.( { title: yoastTitle, description: yoastMetaDesc } );
-		yoastEditor?.setFocusKeyword?.( yoastFocusKw );
+		// Only sync non-empty values. An empty string means no custom value has been saved, in
+		// which case the snippet editor should keep showing the SEO title template instead of
+		// being overwritten with an empty string.
+		const dataToSync = {};
+		if ( yoastTitle ) {
+			dataToSync.title = yoastTitle;
+		}
+		if ( yoastMetaDesc ) {
+			dataToSync.description = yoastMetaDesc;
+		}
+		if ( Object.keys( dataToSync ).length > 0 ) {
+			yoastEditor?.updateData?.( dataToSync );
+		}
+		if ( yoastFocusKw ) {
+			yoastEditor?.setFocusKeyword?.( yoastFocusKw );
+		}
 	}, [ isPost, yoastTitle, yoastMetaDesc, yoastFocusKw ] );
 }

--- a/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
+++ b/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
@@ -7,10 +7,6 @@ import { useEffect } from "@wordpress/element";
  * Direct sidebar edits (yoast-seo/editor only) will be overwritten if core/editor meta
  * changes afterwards — accepted trade-off for correct undo behaviour.
  *
- * dispatch() is called inside the effect (not via useDispatch) because yoast-seo/editor
- * is registered after the Gutenberg store and may not be available at component mount;
- * resolving it lazily avoids the need for a conditional hook.
- *
  * @returns {void}
  */
 export function useYoastMetaSync() {

--- a/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
+++ b/packages/js/src/ai-content-planner/hooks/use-yoast-meta-sync.js
@@ -1,4 +1,4 @@
-import { dispatch, useSelect } from "@wordpress/data";
+import { useDispatch, useSelect } from "@wordpress/data";
 import { useEffect } from "@wordpress/element";
 
 /**
@@ -14,40 +14,41 @@ import { useEffect } from "@wordpress/element";
  * @returns {void}
  */
 export function useYoastMetaSync() {
-	const { yoastTitle, yoastMetaDesc, yoastFocusKw, isPost } = useSelect( select => {
+	const { yoastTitle, yoastMetaDesc, yoastFocusKw, isPost, titleTemplate, descTemplate } = useSelect( select => {
 		const editor = select( "core/editor" );
 		const meta = editor.getEditedPostAttribute( "meta" );
+		const { title, description } = select( "yoast-seo/editor" ).getSnippetEditorTemplates();
 		return {
 			yoastTitle: meta?._yoast_wpseo_title,
 			yoastMetaDesc: meta?._yoast_wpseo_metadesc,
 			yoastFocusKw: meta?._yoast_wpseo_focuskw,
 			isPost: editor.getCurrentPostType() === "post",
+			titleTemplate: title,
+			descTemplate: description,
 		};
 	}, [] );
+	const { updateData, setFocusKeyword } = useDispatch( "yoast-seo/editor" );
 
-	// eslint-disable-next-line complexity
 	useEffect( () => {
 		// These meta keys are only registered for the 'post' subtype; bail on all other post types
 		// to avoid dispatching undefined values into yoast-seo/editor.
 		if ( ! isPost ) {
 			return;
 		}
-		const yoastEditor = dispatch( "yoast-seo/editor" );
 		// Only sync non-empty values. An empty string means no custom value has been saved, in
 		// which case the snippet editor should keep showing the SEO title template instead of
 		// being overwritten with an empty string.
-		const dataToSync = {};
+		const dataToSync = {
+			title: titleTemplate,
+			description: descTemplate,
+		};
 		if ( yoastTitle ) {
 			dataToSync.title = yoastTitle;
 		}
 		if ( yoastMetaDesc ) {
 			dataToSync.description = yoastMetaDesc;
 		}
-		if ( Object.keys( dataToSync ).length > 0 ) {
-			yoastEditor?.updateData?.( dataToSync );
-		}
-		if ( yoastFocusKw ) {
-			yoastEditor?.setFocusKeyword?.( yoastFocusKw );
-		}
-	}, [ isPost, yoastTitle, yoastMetaDesc, yoastFocusKw ] );
+		updateData( dataToSync );
+		setFocusKeyword( yoastFocusKw || "" );
+	}, [ isPost, yoastTitle, yoastMetaDesc, yoastFocusKw, titleTemplate, descTemplate ] );
 }

--- a/packages/js/src/initializers/editor-store.js
+++ b/packages/js/src/initializers/editor-store.js
@@ -45,11 +45,8 @@ const populateStore = store => {
 	store.dispatch( actions.setWistiaEmbedPermissionValue( get( window, "wpseoScriptData.wistiaEmbedPermission", false ) === "1" ) );
 	store.dispatch( actions.loadSnippetEditorData(
 		{
-			data: {
-				title: "",
-				description: "",
-				slug: "",
-			},
+			// The post scraper will update the data later. This prevents throwing errors for missing data in the meantime.
+			data: { title: "", description: "", slug: "" },
 			templates: {
 				title: get( window, "wpseoScriptData.metabox.title_template", "" ),
 				description: get( window, "wpseoScriptData.metabox.metadesc_template", "" ),

--- a/packages/js/src/initializers/editor-store.js
+++ b/packages/js/src/initializers/editor-store.js
@@ -43,6 +43,19 @@ const populateStore = store => {
 	store.dispatch( actions.setLinkParams( get( window, "wpseoScriptData.linkParams", {} ) ) );
 	store.dispatch( actions.setPluginUrl( get( window, "wpseoScriptData.pluginUrl", "" ) ) );
 	store.dispatch( actions.setWistiaEmbedPermissionValue( get( window, "wpseoScriptData.wistiaEmbedPermission", false ) === "1" ) );
+	store.dispatch( actions.loadSnippetEditorData(
+		{
+			data: {
+				title: "",
+				description: "",
+				slug: "",
+			},
+			templates: {
+				title: get( window, "wpseoScriptData.metabox.title_template", "" ),
+				description: get( window, "wpseoScriptData.metabox.metadesc_template", "" ),
+			},
+		}
+	) );
 };
 
 /**

--- a/packages/js/src/redux/actions/snippetEditor.js
+++ b/packages/js/src/redux/actions/snippetEditor.js
@@ -154,3 +154,17 @@ export function hideReplacementVariables( replacementVariableNamesToBeHidden ) {
 		data: replacementVariableNamesToBeHidden,
 	};
 }
+
+/**
+ * Updates the snippet editor data in redux.
+ *
+ * @param {Object} data The snippet editor data.
+ *
+ * @returns {Object} An action for redux.
+ */
+export function loadSnippetEditorData( data ) {
+	return {
+		type: LOAD_SNIPPET_EDITOR_DATA,
+		...data,
+	};
+}

--- a/packages/js/src/redux/selectors/snippetEditor.js
+++ b/packages/js/src/redux/selectors/snippetEditor.js
@@ -14,7 +14,7 @@ export const getReplaceVars = state => get( state, "snippetEditor.replacementVar
  *
  * @param {Object} state The state object.
  *
- * @returns {string} The snippet editor templates.
+ * @returns {Object} The snippet editor templates.
  */
 export const getSnippetEditorTemplates = state => get( state, "snippetEditor.templates", {
 	title: "",

--- a/packages/js/tests/ai-content-planner/hooks/use-yoast-meta-sync.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-yoast-meta-sync.test.js
@@ -35,13 +35,31 @@ beforeEach( () => {
 } );
 
 describe( "useYoastMetaSync", () => {
-	it( "calls updateData with title and description from meta", () => {
+	it( "calls updateData with title and description from meta when both are non-empty", () => {
 		// eslint-disable-next-line camelcase
 		setupUseSelect( { _yoast_wpseo_title: "My title", _yoast_wpseo_metadesc: "My desc" } );
 
 		renderHook( () => useYoastMetaSync() );
 
 		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "My title", description: "My desc" } );
+	} );
+
+	it( "calls updateData with only title when description is empty", () => {
+		// eslint-disable-next-line camelcase
+		setupUseSelect( { _yoast_wpseo_title: "My title", _yoast_wpseo_metadesc: "" } );
+
+		renderHook( () => useYoastMetaSync() );
+
+		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "My title" } );
+	} );
+
+	it( "calls updateData with only description when title is empty", () => {
+		// eslint-disable-next-line camelcase
+		setupUseSelect( { _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "My desc" } );
+
+		renderHook( () => useYoastMetaSync() );
+
+		expect( mockUpdateData ).toHaveBeenCalledWith( { description: "My desc" } );
 	} );
 
 	it( "calls setFocusKeyword with the focus keyword from meta", () => {
@@ -53,11 +71,23 @@ describe( "useYoastMetaSync", () => {
 		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "my keyword" );
 	} );
 
-	it( "passes undefined when meta fields are absent on a post", () => {
+	it( "does not dispatch when meta fields are absent on a post", () => {
 		renderHook( () => useYoastMetaSync() );
 
-		expect( mockUpdateData ).toHaveBeenCalledWith( { title: undefined, description: undefined } );
-		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( undefined );
+		expect( mockUpdateData ).not.toHaveBeenCalled();
+		expect( mockSetFocusKeyword ).not.toHaveBeenCalled();
+	} );
+
+	it( "does not dispatch when meta fields are empty strings (REST API default when no custom value is saved)", () => {
+		// The REST API returns "" for registered meta keys that have no saved value.
+		// Dispatching an empty string would overwrite the SEO title template in the snippet editor.
+		// eslint-disable-next-line camelcase
+		setupUseSelect( { _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "", _yoast_wpseo_focuskw: "" } );
+
+		renderHook( () => useYoastMetaSync() );
+
+		expect( mockUpdateData ).not.toHaveBeenCalled();
+		expect( mockSetFocusKeyword ).not.toHaveBeenCalled();
 	} );
 
 	it( "does not dispatch when the post type is not 'post'", () => {

--- a/packages/js/tests/ai-content-planner/hooks/use-yoast-meta-sync.test.js
+++ b/packages/js/tests/ai-content-planner/hooks/use-yoast-meta-sync.test.js
@@ -1,9 +1,9 @@
-import { renderHook } from "@testing-library/react";
-import { dispatch, useSelect } from "@wordpress/data";
+import { renderHook, act } from "@testing-library/react";
+import { useDispatch, useSelect } from "@wordpress/data";
 import { useYoastMetaSync } from "../../../src/ai-content-planner/hooks/use-yoast-meta-sync";
 
 jest.mock( "@wordpress/data", () => ( {
-	dispatch: jest.fn(),
+	useDispatch: jest.fn(),
 	useSelect: jest.fn(),
 } ) );
 
@@ -11,17 +11,23 @@ const mockUpdateData = jest.fn();
 const mockSetFocusKeyword = jest.fn();
 
 /**
- * Sets up useSelect to return meta fields from a fake core/editor store.
+ * Sets up useSelect to return meta fields and templates from fake stores.
  *
- * @param {Object} meta     The meta object to return from getEditedPostAttribute.
- * @param {string} postType The post type to return from getCurrentPostType.
+ * @param {Object} meta      The meta object to return from getEditedPostAttribute.
+ * @param {string} postType  The post type to return from getCurrentPostType.
+ * @param {Object} templates The templates to return from getSnippetEditorTemplates.
  */
-const setupUseSelect = ( meta = {}, postType = "post" ) => {
+const setupUseSelect = ( meta = {}, postType = "post", templates = { title: "", description: "" } ) => {
 	useSelect.mockImplementation( ( selector ) => selector( ( storeName ) => {
 		if ( storeName === "core/editor" ) {
 			return {
 				getEditedPostAttribute: ( attr ) => attr === "meta" ? meta : null,
 				getCurrentPostType: () => postType,
+			};
+		}
+		if ( storeName === "yoast-seo/editor" ) {
+			return {
+				getSnippetEditorTemplates: () => templates,
 			};
 		}
 	} ) );
@@ -30,7 +36,7 @@ const setupUseSelect = ( meta = {}, postType = "post" ) => {
 beforeEach( () => {
 	mockUpdateData.mockClear();
 	mockSetFocusKeyword.mockClear();
-	dispatch.mockReturnValue( { updateData: mockUpdateData, setFocusKeyword: mockSetFocusKeyword } );
+	useDispatch.mockReturnValue( { updateData: mockUpdateData, setFocusKeyword: mockSetFocusKeyword } );
 	setupUseSelect();
 } );
 
@@ -44,22 +50,48 @@ describe( "useYoastMetaSync", () => {
 		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "My title", description: "My desc" } );
 	} );
 
-	it( "calls updateData with only title when description is empty", () => {
-		// eslint-disable-next-line camelcase
-		setupUseSelect( { _yoast_wpseo_title: "My title", _yoast_wpseo_metadesc: "" } );
+	it( "falls back to title template when yoast title meta is empty", () => {
+		// The REST API returns "" when no custom SEO title is saved; the template should show instead.
+		setupUseSelect(
+			// eslint-disable-next-line camelcase
+			{ _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "My desc" },
+			"post",
+			{ title: "%%title%% %%sep%% %%sitename%%", description: "" }
+		);
 
 		renderHook( () => useYoastMetaSync() );
 
-		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "My title" } );
+		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "%%title%% %%sep%% %%sitename%%", description: "My desc" } );
 	} );
 
-	it( "calls updateData with only description when title is empty", () => {
-		// eslint-disable-next-line camelcase
-		setupUseSelect( { _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "My desc" } );
+	it( "falls back to description template when yoast description meta is empty", () => {
+		setupUseSelect(
+			// eslint-disable-next-line camelcase
+			{ _yoast_wpseo_title: "My title", _yoast_wpseo_metadesc: "" },
+			"post",
+			{ title: "", description: "%%excerpt%%" }
+		);
 
 		renderHook( () => useYoastMetaSync() );
 
-		expect( mockUpdateData ).toHaveBeenCalledWith( { description: "My desc" } );
+		expect( mockUpdateData ).toHaveBeenCalledWith( { title: "My title", description: "%%excerpt%%" } );
+	} );
+
+	it( "falls back to both templates when all meta fields are empty (initial load, no custom values saved)", () => {
+		setupUseSelect(
+			// eslint-disable-next-line camelcase
+			{ _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "", _yoast_wpseo_focuskw: "" },
+			"post",
+			{ title: "%%title%% %%sep%% %%sitename%%", description: "%%excerpt%%" }
+		);
+
+		renderHook( () => useYoastMetaSync() );
+
+		expect( mockUpdateData ).toHaveBeenCalledWith( {
+			title: "%%title%% %%sep%% %%sitename%%",
+			description: "%%excerpt%%",
+		} );
+		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "" );
 	} );
 
 	it( "calls setFocusKeyword with the focus keyword from meta", () => {
@@ -71,23 +103,55 @@ describe( "useYoastMetaSync", () => {
 		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "my keyword" );
 	} );
 
-	it( "does not dispatch when meta fields are absent on a post", () => {
+	it( "calls setFocusKeyword with empty string when focus keyword is absent", () => {
 		renderHook( () => useYoastMetaSync() );
 
-		expect( mockUpdateData ).not.toHaveBeenCalled();
-		expect( mockSetFocusKeyword ).not.toHaveBeenCalled();
+		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "" );
 	} );
 
-	it( "does not dispatch when meta fields are empty strings (REST API default when no custom value is saved)", () => {
-		// The REST API returns "" for registered meta keys that have no saved value.
-		// Dispatching an empty string would overwrite the SEO title template in the snippet editor.
+	it( "restores templates after undo reverts title and description to empty", () => {
+		// Simulate the content planner setting values, then the user undoing.
+		setupUseSelect(
+			// eslint-disable-next-line camelcase
+			{ _yoast_wpseo_title: "Generated title", _yoast_wpseo_metadesc: "Generated desc" },
+			"post",
+			{ title: "%%title%% %%sep%% %%sitename%%", description: "%%excerpt%%" }
+		);
+		const { rerender } = renderHook( () => useYoastMetaSync() );
+
+		mockUpdateData.mockClear();
+
+		// Undo reverts both fields back to empty.
+		setupUseSelect(
+			// eslint-disable-next-line camelcase
+			{ _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "" },
+			"post",
+			{ title: "%%title%% %%sep%% %%sitename%%", description: "%%excerpt%%" }
+		);
+		act( () => {
+			rerender();
+		} );
+
+		expect( mockUpdateData ).toHaveBeenCalledWith( {
+			title: "%%title%% %%sep%% %%sitename%%",
+			description: "%%excerpt%%",
+		} );
+	} );
+
+	it( "calls setFocusKeyword with empty string after undo reverts focus keyword to empty", () => {
 		// eslint-disable-next-line camelcase
-		setupUseSelect( { _yoast_wpseo_title: "", _yoast_wpseo_metadesc: "", _yoast_wpseo_focuskw: "" } );
+		setupUseSelect( { _yoast_wpseo_focuskw: "my keyword" } );
+		const { rerender } = renderHook( () => useYoastMetaSync() );
 
-		renderHook( () => useYoastMetaSync() );
+		mockSetFocusKeyword.mockClear();
 
-		expect( mockUpdateData ).not.toHaveBeenCalled();
-		expect( mockSetFocusKeyword ).not.toHaveBeenCalled();
+		// eslint-disable-next-line camelcase
+		setupUseSelect( { _yoast_wpseo_focuskw: "" } );
+		act( () => {
+			rerender();
+		} );
+
+		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "" );
 	} );
 
 	it( "does not dispatch when the post type is not 'post'", () => {
@@ -99,21 +163,27 @@ describe( "useYoastMetaSync", () => {
 		expect( mockSetFocusKeyword ).not.toHaveBeenCalled();
 	} );
 
-	it( "dispatches to yoast-seo/editor", () => {
+	it( "uses non-empty suggestion values over templates when content planner applies suggestions", () => {
+		// Simulate the content planner writing generated values to core/editor meta.
+		setupUseSelect(
+			{
+				// eslint-disable-next-line camelcase
+				_yoast_wpseo_title: "Generated title",
+				// eslint-disable-next-line camelcase
+				_yoast_wpseo_metadesc: "Generated description",
+				// eslint-disable-next-line camelcase
+				_yoast_wpseo_focuskw: "generated keyword",
+			},
+			"post",
+			{ title: "%%title%% %%sep%% %%sitename%%", description: "%%excerpt%%" }
+		);
+
 		renderHook( () => useYoastMetaSync() );
 
-		expect( dispatch ).toHaveBeenCalledWith( "yoast-seo/editor" );
-	} );
-
-	it( "does not throw when the yoast-seo/editor store is not available", () => {
-		dispatch.mockReturnValue( null );
-
-		expect( () => renderHook( () => useYoastMetaSync() ) ).not.toThrow();
-	} );
-
-	it( "does not throw when the yoast-seo/editor store has no updateData method", () => {
-		dispatch.mockReturnValue( { setFocusKeyword: mockSetFocusKeyword } );
-
-		expect( () => renderHook( () => useYoastMetaSync() ) ).not.toThrow();
+		expect( mockUpdateData ).toHaveBeenCalledWith( {
+			title: "Generated title",
+			description: "Generated description",
+		} );
+		expect( mockSetFocusKeyword ).toHaveBeenCalledWith( "generated keyword" );
 	} );
 } );

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -7,17 +7,31 @@ jest.mock( "@wordpress/data", () => ( {
 		updateData: jest.fn(),
 		setFocusKeyword: jest.fn(),
 	} ) ),
-	useSelect: jest.fn( () => ( {
-		isNewPost: false,
-		postType: "post",
-		blocks: [],
-		minPostsMet: false,
-		isBannerRendered: false,
-		yoastTitle: "",
-		yoastMetaDesc: "",
-		yoastFocusKw: "",
+	useSelect: jest.fn( ( selector ) => selector( ( storeName ) => {
+		if ( storeName === "core/editor" ) {
+			return {
+				getEditedPostAttribute: () => ( {} ),
+				getCurrentPostType: () => "post",
+				isEditedPostNew: () => false,
+			};
+		}
+		if ( storeName === "core/block-editor" ) {
+			return { getBlocks: () => [] };
+		}
+		if ( storeName === "yoast-seo/editor" ) {
+			return { getSnippetEditorTemplates: () => ( { title: "", description: "" } ) };
+		}
+		// Content planner store and any other store.
+		return {
+			selectIsMinPostsMet: () => false,
+			selectIsBannerRendered: () => false,
+		};
 	} ) ),
-	useDispatch: jest.fn( () => ( { insertBlock: jest.fn() } ) ),
+	useDispatch: jest.fn( () => ( {
+		insertBlock: jest.fn(),
+		updateData: jest.fn(),
+		setFocusKeyword: jest.fn(),
+	} ) ),
 	select: jest.fn( () => ( {
 		getBlocks: () => [],
 		isEditedPostNew: () => true,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* useYoastMetaSync was unconditionally dispatching updateData with the values from core/editor meta, including empty strings. When a post has no custom SEO title saved, the REST API returns "" for _yoast_wpseo_title, which overwrote the SEO title template that the store had correctly initialised during boot.
* Only sync non-empty values so the snippet editor keeps showing the template when no custom value has been saved. Tests are updated to assert this behaviour and cover the empty-string case that was missing.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the SEO title field in the block editor appeared empty instead of showing the title template when no custom SEO title had been saved.  

## Relevant technical choices:

* The hook previously called `dispatch("yoast-seo/editor")` lazily inside `useEffect` to guard against the store not being registered at component mount. The fix switches to `useDispatch("yoast-seo/editor")` at the top level, which is the correct React pattern. This is safe because `initEditorStore()` registers `yoast-seo/editor` synchronously during plugin boot — before the block editor's React tree mounts — so the store is guaranteed to exist at render time. The `useSelect` call was already making the same assumption by reading from `yoast-seo/editor` during render; `useDispatch` now brings the dispatch half in line with that.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to Yoast SEo -> Settings -> Content Types -> Posts
* Check you have replacement variables in the seo title and meta descriptions.
* Create a new post in the block editor.
* Check the template is applied to the seo title and meta description in the Search appearance.
* Use the Content planner to generate content and apply it. 
* Check the focus keyphrase, seo title and meta description are applied.
* Undo the changes using the block editor undo button.
* Check the seo title and meta descriptions are restored to the templated and the focus keyphrase is empty.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1225