### PR TITLE
feat(myyoast-client): add `wp yoast auth reset` command and clear-state action

### DIFF
--- a/src/myyoast-client/user-interface/auth-command.php
+++ b/src/myyoast-client/user-interface/auth-command.php
@@ -1,7 +1,5 @@
 <?php
 
-// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
-
 namespace Yoast\WP\SEO\MyYoast_Client\User_Interface;
 
 use Exception;
@@ -13,6 +11,7 @@ use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
 use Yoast\WP\SEO\Loadable_Interface;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client;
+use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client_Cleanup;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
@@ -63,6 +62,13 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	private $user_token_storage;
 
 	/**
+	 * The cleanup service.
+	 *
+	 * @var MyYoast_Client_Cleanup
+	 */
+	private $cleanup;
+
+	/**
 	 * Auth_Command constructor.
 	 *
 	 * @param MyYoast_Client                $myyoast_client      The MyYoast client facade.
@@ -70,19 +76,22 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @param Issuer_Config                 $issuer_config       The issuer configuration.
 	 * @param Token_Storage_Interface       $token_storage       The site-level token storage port.
 	 * @param User_Token_Storage_Interface  $user_token_storage  The user-level token storage port.
+	 * @param MyYoast_Client_Cleanup        $cleanup             The cleanup service.
 	 */
 	public function __construct(
 		MyYoast_Client $myyoast_client,
 		Client_Registration_Interface $client_registration,
 		Issuer_Config $issuer_config,
 		Token_Storage_Interface $token_storage,
-		User_Token_Storage_Interface $user_token_storage
+		User_Token_Storage_Interface $user_token_storage,
+		MyYoast_Client_Cleanup $cleanup
 	) {
 		$this->myyoast_client      = $myyoast_client;
 		$this->client_registration = $client_registration;
 		$this->issuer_config       = $issuer_config;
 		$this->token_storage       = $token_storage;
 		$this->user_token_storage  = $user_token_storage;
+		$this->cleanup             = $cleanup;
 	}
 
 	/**
@@ -334,6 +343,40 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		else {
 			WP_CLI::warning( 'Server-side deregistration failed (network error). Local token was cleared but client credentials remain.' );
 		}
+	}
+
+	/**
+	 * Resets all MyYoast OAuth client state on this site.
+	 *
+	 * Performs the same cleanup as plugin uninstall: best-effort server-side
+	 * deregistration, then deletes all site/user tokens, registered client
+	 * credentials, key pairs, and OIDC/JWKS/DPoP caches. Intended for
+	 * development environments that need to start from a clean slate without
+	 * uninstalling the plugin.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Skip confirmation prompt.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp yoast auth reset
+	 *     wp yoast auth reset --yes
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>|null    $args       The arguments.
+	 * @param array<string, string>|null $assoc_args The associative arguments.
+	 *
+	 * @return void
+	 */
+	public function reset( $args = null, $assoc_args = null ): void {
+		WP_CLI::confirm( 'This will wipe all MyYoast OAuth client state on this site (registered client, site/user tokens, key pairs, OIDC/JWKS/DPoP caches). Proceed?', $assoc_args );
+
+		$this->cleanup->execute();
+
+		WP_CLI::success( 'MyYoast OAuth client state cleared.' );
 	}
 
 	/**

--- a/src/myyoast-client/user-interface/myyoast-cleanup-integration.php
+++ b/src/myyoast-client/user-interface/myyoast-cleanup-integration.php
@@ -7,7 +7,7 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client_Cleanup;
 
 /**
- * Handles cleanup of all MyYoast client data on plugin uninstall.
+ * Handles cleanup of all MyYoast client data on plugin uninstall or through Yoast Test Helper.
  */
 class MyYoast_Cleanup_Integration implements Integration_Interface {
 

--- a/src/myyoast-client/user-interface/myyoast-cleanup-integration.php
+++ b/src/myyoast-client/user-interface/myyoast-cleanup-integration.php
@@ -43,6 +43,18 @@ class MyYoast_Cleanup_Integration implements Integration_Interface {
 	 */
 	public function register_hooks(): void {
 		\add_action( 'uninstall_' . \WPSEO_BASENAME, [ $this, 'cleanup' ] );
+
+		/**
+		 * Public action that wipes all local MyYoast OAuth client state
+		 * (registered client, site/user tokens, key pairs, OIDC/JWKS/DPoP caches).
+		 *
+		 * Intended for development tooling that needs to reset state without
+		 * uninstalling the plugin. The handler is the same one that runs on
+		 * uninstall, so the effect is identical.
+		 *
+		 * @internal
+		 */
+		\add_action( 'wpseo_myyoast_clear_client_state', [ $this, 'cleanup' ] );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/User_Interface/MyYoast_Cleanup_Integration_Test.php
+++ b/tests/Unit/MyYoast_Client/User_Interface/MyYoast_Cleanup_Integration_Test.php
@@ -57,7 +57,7 @@ final class MyYoast_Cleanup_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that register_hooks registers the uninstall hook.
+	 * Tests that register_hooks registers the uninstall hook and the public clear-state action.
 	 *
 	 * @covers ::register_hooks
 	 *
@@ -66,6 +66,9 @@ final class MyYoast_Cleanup_Integration_Test extends TestCase {
 	public function test_register_hooks() {
 		Functions\expect( 'add_action' )
 			->with( 'uninstall_' . \WPSEO_BASENAME, [ $this->instance, 'cleanup' ] )
+			->once();
+		Functions\expect( 'add_action' )
+			->with( 'wpseo_myyoast_clear_client_state', [ $this->instance, 'cleanup' ] )
 			->once();
 
 		$this->instance->register_hooks();


### PR DESCRIPTION
## Context

The MyYoast OAuth client already wipes its full local state (registered client, site/user tokens, key pairs, OIDC/JWKS/DPoP caches) on plugin uninstall via `MyYoast_Client_Cleanup::execute()`. The same cleanup is useful during development — switching MyYoast environments, recovering from a broken handshake, or letting the Yoast test helper offer a "Clear OAuth state" button — but until now it could only be reached by uninstalling the plugin.

This PR opens two ergonomic entry points on top of that existing service:

1. A public WordPress action `wpseo_myyoast_clear_client_state` that runs the same cleanup handler.
2. A `wp yoast auth reset` WP-CLI subcommand alongside the existing `wp yoast auth {status,register,verify,deregister,authorize,revoke,rotate-keys}` family.

Both reuse `MyYoast_Client_Cleanup::execute()`, so the CLI command, the dev-tooling action, and the uninstall hook all go through one cleanup path.

## Summary
This PR can be summarized in the following changelog entry:

* Adds a `wp yoast auth reset` WP-CLI command that wipes all MyYoast OAuth client state on the current site.
* Adds an internal `wpseo_myyoast_clear_client_state` action that triggers the same cleanup without uninstalling the plugin (fired by the test helper plugin).

## Relevant technical choices:

* The `wpseo_myyoast_clear_client_state` action is marked `@internal` — it exists for Yoast development tooling, not as a long-term public extension point. 
* It's an action to decouple the intended use (test helper plugin) from the implementation. The alternative would be to add the reset to the facade, and have a hard dependency on the facade through DI in the test helper.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. In `wp-config.php`, add `define( 'YOAST_SEO_MYYOAST_CONNECTION', true );`.
2. From the plugin folder, run `wp yoast auth register` to register the site as an OAuth client.
3. Run `wp yoast auth status` and confirm `registered: yes`, a `client_id`, and (optionally) a site/user token.
4. Run `wp yoast auth reset` — confirm that a prompt appears asking to wipe all MyYoast OAuth client state.
5. Type `y` to confirm and verify the success message: `MyYoast OAuth client state cleared.`.
6. Run `wp yoast auth status` again and confirm `registered: no`, `client_id: -`, and `site_token: none`.
7. Repeat from step 2, then run `wp yoast auth reset --yes` and verify the command runs without a prompt.
8. Repeat from step 2 again. In `wp shell` (or any PHP context inside WP), run `do_action( 'wpseo_myyoast_clear_client_state' );` and verify the same cleanup happens.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.


## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The test hepler's Clear OAuth State button

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [] I have written documentation for this change.