### PR TITLE
fix(content-planner): hide inline banner when editing templates or in nested block contexts

### DIFF
--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -177,15 +177,22 @@ const FirstBlockWithBanner = ( { BlockListBlock, props, hasConsent } ) => {
  * persists "1" on the next save.
  */
 export const withInlineBanner = createHigherOrderComponent( ( BlockListBlock ) => function WithInlineBanner( props ) {
-	const isFirstBlock = useSelect( ( select ) => {
-		return select( "core/block-editor" ).getBlockOrder()[ 0 ] === props.clientId;
+	const { isFirstBlock, isEditingTemplate } = useSelect( ( select ) => {
+		const postType = select( "core/editor" ).getCurrentPostType();
+		return {
+			// getBlockOrder() with no arguments returns root-level block IDs only, so nested
+			// blocks (inside core/query, core/comment-template, etc.) never match here.
+			isFirstBlock: select( "core/block-editor" ).getBlockOrder()[ 0 ] === props.clientId,
+			// Banner should not appear when editing a template or template part in the Site Editor.
+			isEditingTemplate: postType === "wp_template" || postType === "wp_template_part",
+		};
 	}, [ props.clientId ] );
 	const aiGeneratorSelectors = useSelect( select => select( STORE_NAME_AI ) );
 	const hasConsent = useSelect( select => select( STORE_NAME_AI )?.selectHasAiGeneratorConsent() ?? false );
 	const BannerFallback = useCallback( () => <BlockListBlock { ...props } />, [ BlockListBlock, props ] );
 
-	// Non-first blocks or missing AI generator selectors: zero additional overhead.
-	if ( ! isFirstBlock || ! isObject( aiGeneratorSelectors ) ) {
+	// Non-first blocks, missing AI generator selectors, or template editing: zero additional overhead.
+	if ( ! isFirstBlock || ! isObject( aiGeneratorSelectors ) || isEditingTemplate ) {
 		return <BlockListBlock { ...props } />;
 	}
 

--- a/packages/js/src/ai-content-planner/components/with-inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/with-inline-banner.js
@@ -178,13 +178,15 @@ const FirstBlockWithBanner = ( { BlockListBlock, props, hasConsent } ) => {
  */
 export const withInlineBanner = createHigherOrderComponent( ( BlockListBlock ) => function WithInlineBanner( props ) {
 	const { isFirstBlock, isEditingTemplate } = useSelect( ( select ) => {
-		const postType = select( "core/editor" ).getCurrentPostType();
+		const editor = select( "core/editor" );
+		const postType = editor.getCurrentPostType();
 		return {
 			// getBlockOrder() with no arguments returns root-level block IDs only, so nested
 			// blocks (inside core/query, core/comment-template, etc.) never match here.
 			isFirstBlock: select( "core/block-editor" ).getBlockOrder()[ 0 ] === props.clientId,
-			// Banner should not appear when editing a template or template part in the Site Editor.
-			isEditingTemplate: postType === "wp_template" || postType === "wp_template_part",
+			// Banner should not appear when editing a template or template part in the Site Editor,
+			// or when template-locked mode is active (Settings > Template > Show template in the post editor).
+			isEditingTemplate: postType === "wp_template" || postType === "wp_template_part" || editor.getRenderingMode() === "template-locked",
 		};
 	}, [ props.clientId ] );
 	const aiGeneratorSelectors = useSelect( select => select( STORE_NAME_AI ) );

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -124,6 +124,7 @@ const mockDismissBannerPermanently = jest.fn();
  * @param {Object}  [overrides]                           Per-test store value overrides.
  * @param {boolean} [overrides.isFirstBlock=true]         Whether the rendered block is the first in the canvas.
  * @param {boolean} [overrides.isNewPost=true]            Whether the post is new (not yet saved).
+ * @param {string}  [overrides.postType="post"]           The current post type (e.g. "post", "wp_template").
  * @param {boolean} [overrides.isBannerDismissed=false]   Whether the banner has been dismissed for this session.
  * @param {boolean} [overrides.isBannerPermanentlyDismissed=false] Whether the banner has been permanently dismissed.
  * @param {boolean} [overrides.isBannerRendered=false]    Whether the banner has been persisted to the post meta.
@@ -137,6 +138,7 @@ const setupMocks = ( overrides = {} ) => {
 	const defaults = {
 		isFirstBlock: true,
 		isNewPost: true,
+		postType: "post",
 		isBannerDismissed: false,
 		isBannerPermanentlyDismissed: false,
 		isBannerRendered: false,
@@ -153,7 +155,7 @@ const setupMocks = ( overrides = {} ) => {
 			return { getBlockOrder: () => values.isFirstBlock ? [ "client-1" ] : [ "other" ] };
 		}
 		if ( storeName === "core/editor" ) {
-			return { isEditedPostNew: () => values.isNewPost };
+			return { isEditedPostNew: () => values.isNewPost, getCurrentPostType: () => values.postType };
 		}
 		if ( storeName === "yoast-seo/content-planner" ) {
 			return {
@@ -226,6 +228,20 @@ describe( "withInlineBanner", () => {
 
 	test( "does not render the banner when not the first block", () => {
 		setupMocks( { isFirstBlock: false } );
+		const { queryByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
+	} );
+
+	test( "does not render the banner when editing a wp_template", () => {
+		setupMocks( { postType: "wp_template" } );
+		const { queryByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
+	} );
+
+	test( "does not render the banner when editing a wp_template_part", () => {
+		setupMocks( { postType: "wp_template_part" } );
 		const { queryByTestId } = render( <WithInlineBanner clientId="client-1" /> );
 
 		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
@@ -694,7 +710,7 @@ describe( "withInlineBanner", () => {
 					return { getBlockOrder: () => [ "client-1" ] };
 				}
 				if ( storeName === "core/editor" ) {
-					return { isEditedPostNew: () => true };
+					return { isEditedPostNew: () => true, getCurrentPostType: () => "post" };
 				}
 				if ( storeName === "yoast-seo/content-planner" ) {
 					return {
@@ -783,7 +799,7 @@ describe( "withInlineBanner", () => {
 					return { getBlockOrder: () => [ "client-1" ] };
 				}
 				if ( storeName === "core/editor" ) {
-					return { isEditedPostNew: () => true };
+					return { isEditedPostNew: () => true, getCurrentPostType: () => "post" };
 				}
 				if ( storeName === "yoast-seo/content-planner" ) {
 					return {

--- a/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
+++ b/packages/js/tests/ai-content-planner/components/with-inline-banner.test.js
@@ -125,6 +125,7 @@ const mockDismissBannerPermanently = jest.fn();
  * @param {boolean} [overrides.isFirstBlock=true]         Whether the rendered block is the first in the canvas.
  * @param {boolean} [overrides.isNewPost=true]            Whether the post is new (not yet saved).
  * @param {string}  [overrides.postType="post"]           The current post type (e.g. "post", "wp_template").
+ * @param {string}  [overrides.renderingMode="post-only"] The editor rendering mode (e.g. "post-only", "template-locked").
  * @param {boolean} [overrides.isBannerDismissed=false]   Whether the banner has been dismissed for this session.
  * @param {boolean} [overrides.isBannerPermanentlyDismissed=false] Whether the banner has been permanently dismissed.
  * @param {boolean} [overrides.isBannerRendered=false]    Whether the banner has been persisted to the post meta.
@@ -139,6 +140,7 @@ const setupMocks = ( overrides = {} ) => {
 		isFirstBlock: true,
 		isNewPost: true,
 		postType: "post",
+		renderingMode: "post-only",
 		isBannerDismissed: false,
 		isBannerPermanentlyDismissed: false,
 		isBannerRendered: false,
@@ -155,7 +157,11 @@ const setupMocks = ( overrides = {} ) => {
 			return { getBlockOrder: () => values.isFirstBlock ? [ "client-1" ] : [ "other" ] };
 		}
 		if ( storeName === "core/editor" ) {
-			return { isEditedPostNew: () => values.isNewPost, getCurrentPostType: () => values.postType };
+			return {
+				isEditedPostNew: () => values.isNewPost,
+				getCurrentPostType: () => values.postType,
+				getRenderingMode: () => values.renderingMode,
+			};
 		}
 		if ( storeName === "yoast-seo/content-planner" ) {
 			return {
@@ -242,6 +248,13 @@ describe( "withInlineBanner", () => {
 
 	test( "does not render the banner when editing a wp_template_part", () => {
 		setupMocks( { postType: "wp_template_part" } );
+		const { queryByTestId } = render( <WithInlineBanner clientId="client-1" /> );
+
+		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
+	} );
+
+	test( "does not render the banner when the rendering mode is template-locked (Settings > Template > Show template)", () => {
+		setupMocks( { renderingMode: "template-locked" } );
 		const { queryByTestId } = render( <WithInlineBanner clientId="client-1" /> );
 
 		expect( queryByTestId( "inline-banner" ) ).not.toBeInTheDocument();
@@ -710,7 +723,7 @@ describe( "withInlineBanner", () => {
 					return { getBlockOrder: () => [ "client-1" ] };
 				}
 				if ( storeName === "core/editor" ) {
-					return { isEditedPostNew: () => true, getCurrentPostType: () => "post" };
+					return { isEditedPostNew: () => true, getCurrentPostType: () => "post", getRenderingMode: () => "post-only" };
 				}
 				if ( storeName === "yoast-seo/content-planner" ) {
 					return {
@@ -799,7 +812,7 @@ describe( "withInlineBanner", () => {
 					return { getBlockOrder: () => [ "client-1" ] };
 				}
 				if ( storeName === "core/editor" ) {
-					return { isEditedPostNew: () => true, getCurrentPostType: () => "post" };
+					return { isEditedPostNew: () => true, getCurrentPostType: () => "post", getRenderingMode: () => "post-only" };
 				}
 				if ( storeName === "yoast-seo/content-planner" ) {
 					return {


### PR DESCRIPTION
Suppresses the banner when the current post type is wp_template or wp_template_part (Site Editor). Also documents that getBlockOrder() with no arguments returns only root-level IDs, meaning blocks nested inside core/query or core/comment-template are already excluded by the isFirstBlock check without additional parent traversal.

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Content Planner inline banner was displayed when editing a template or template part.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Prerequisites:** Make sure the Content Planner feature is active and the inline banner is visible. You can confirm this by going to **Posts > Add New** — the banner should appear above the first block in the editor.

**Verify the fix — banner should NOT appear in templates or template parts:**
In site editor:
1. In the WordPress admin, go to **Appearance > Editor** to open the Site Editor.
2. In the left sidebar, navigate to **Templates** and open any template (e.g. "Single Post").
3. Confirm that the Content Planner inline banner does **not** appear above the first block in the editor canvas.
4. Go back and navigate to **Template Parts**, then open any template part (e.g. "Header").
5. Confirm that the Content Planner inline banner does **not** appear there either.

In New post:
* Add new post in the block editor and in the sidebar click on Templates: Single template, edit template.
* Check you don't see the inline banner when editing the single template from a post.
* Check the banner is not at the top of the template, not in the comments, and not in a posts block.
* Edit in template-locked mode:Go to Settings > Template > Show template
* Check the banner is not at the top of the template, not in the comments, and not in a posts block.

**Regression check — banner should still appear on normal posts:**
7. Go to **Posts > Add New**.
8. Confirm that the Content Planner inline banner **does** appear above the first block as expected.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/branch should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23281