### PR TITLE
feat(myyoast-client): add RFC 8707 resource indicator support

### DIFF
--- a/src/myyoast-client/application/authorization-code-handler.php
+++ b/src/myyoast-client/application/authorization-code-handler.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Expiring_Store\Domain\Key_Not_Found_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Authorization_Flow_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Discovery_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\ID_Token_Validation_Exception;
+use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Invalid_Resource_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Registration_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Server_Capability_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Request_Failed_Exception;
@@ -19,6 +20,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Discovery_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\ID_Token_Validator_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Auth_Flow_State;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Encoding\Base64url;
 use YoastSEO_Vendor\Psr\Log\LoggerAwareInterface;
@@ -101,16 +103,17 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 	 *
 	 * Generates PKCE challenge, state, and nonce, and stores them in the expiring store.
 	 *
-	 * @param int         $user_id      The WordPress user ID.
-	 * @param string      $redirect_uri The callback redirect URI.
-	 * @param string[]    $scopes       The scopes to request.
-	 * @param string|null $return_url   The URL to return the user to after authorization completes.
+	 * @param int                $user_id            The WordPress user ID.
+	 * @param string             $redirect_uri       The callback redirect URI.
+	 * @param string[]           $scopes             The scopes to request.
+	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the issued token should be bound to.
+	 * @param string|null        $return_url         The URL to return the user to after authorization completes.
 	 *
 	 * @return string The authorization URL to redirect the user to.
 	 *
 	 * @throws Authorization_Flow_Exception If any of the auth flow prerequisites (registration, discovery, random number generation, or state parameter validation) fails.
 	 */
-	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes = [], ?string $return_url = null ): string {
+	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes, Resource_Indicator $resource_indicator, ?string $return_url = null ): string {
 		if ( $user_id <= 0 ) {
 			throw new Authorization_Flow_Exception( 'invalid_user', 'A valid WordPress user ID is required to start the authorization flow.' );
 		}
@@ -146,7 +149,7 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 		}
 
 		try {
-			$flow_state = new Auth_Flow_State( $code_verifier, $state, $nonce, $redirect_uri, $return_url );
+			$flow_state = new Auth_Flow_State( $code_verifier, $state, $nonce, $redirect_uri, $return_url, $resource_indicator );
 		} catch ( InvalidArgumentException $e ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
 			throw new Authorization_Flow_Exception( 'invalid_state', $e->getMessage(), 0, $e );
@@ -172,6 +175,10 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 
 		if ( $nonce !== null ) {
 			$params['nonce'] = $nonce;
+		}
+
+		if ( ! $resource_indicator->is_default() ) {
+			$params['resource'] = $resource_indicator->value();
 		}
 
 		return $auth_endpoint . '?' . \http_build_query( $params, '', '&', \PHP_QUERY_RFC3986 );
@@ -208,8 +215,9 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 		// Clean up the stored flow state.
 		$this->expiring_store->delete_for_user( self::CURRENT_AUTH_FLOW_STATE_KEY, $user_id );
 
-		$grant     = new Authorization_Code_Grant( $code, $flow_state->get_redirect_uri(), $flow_state->get_code_verifier() );
-		$token_set = $this->grant_handler->request_token( $grant );
+		$resource_indicator = $flow_state->get_resource_indicator();
+		$grant              = new Authorization_Code_Grant( $code, $flow_state->get_redirect_uri(), $flow_state->get_code_verifier() );
+		$token_set          = $this->grant_handler->request_token( $grant, $resource_indicator );
 
 		// Validate ID token nonce (replay protection) if an ID token was returned.
 		$this->validate_id_token_nonce( $token_set, $flow_state );

--- a/src/myyoast-client/application/authorization-code-handler.php
+++ b/src/myyoast-client/application/authorization-code-handler.php
@@ -11,7 +11,6 @@ use Yoast\WP\SEO\Expiring_Store\Domain\Key_Not_Found_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Authorization_Flow_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Discovery_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\ID_Token_Validation_Exception;
-use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Invalid_Resource_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Registration_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Server_Capability_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Request_Failed_Exception;

--- a/src/myyoast-client/application/myyoast-client-cleanup.php
+++ b/src/myyoast-client/application/myyoast-client-cleanup.php
@@ -73,8 +73,8 @@ class MyYoast_Client_Cleanup implements LoggerAwareInterface {
 			$this->logger->warning( 'MyYoast client deregistration failed during cleanup: {error}', [ 'error' => $e->getMessage() ] );
 		}
 
-		$this->user_token_storage->delete_all();
-		$this->token_storage->delete_all();
+		$this->user_token_storage->delete_all_issuers();
+		$this->token_storage->delete_all_issuers();
 		$this->client_registration->delete_local_data();
 	}
 }

--- a/src/myyoast-client/application/myyoast-client-cleanup.php
+++ b/src/myyoast-client/application/myyoast-client-cleanup.php
@@ -74,7 +74,7 @@ class MyYoast_Client_Cleanup implements LoggerAwareInterface {
 		}
 
 		$this->user_token_storage->delete_all();
-		$this->token_storage->delete();
+		$this->token_storage->delete_all();
 		$this->client_registration->delete_local_data();
 	}
 }

--- a/src/myyoast-client/application/myyoast-client.php
+++ b/src/myyoast-client/application/myyoast-client.php
@@ -17,8 +17,10 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\OAuth_Server_Client_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Site_URL_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Exceptions\Invalid_Resource_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Domain\HTTP_Response;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Type_Hint;
 use YoastSEO_Vendor\Psr\Log\LoggerAwareInterface;
@@ -204,17 +206,19 @@ class MyYoast_Client implements LoggerAwareInterface {
 	/**
 	 * Builds the authorization URL for the user authorization flow.
 	 *
-	 * @param int         $user_id      The WordPress user ID.
-	 * @param string      $redirect_uri The callback redirect URI.
-	 * @param string[]    $scopes       The scopes to request.
-	 * @param string|null $return_url   The URL to return the user to after authorization completes.
+	 * @param int         $user_id            The WordPress user ID.
+	 * @param string      $redirect_uri       The callback redirect URI.
+	 * @param string[]    $scopes             The scopes to request.
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator the issued token should be bound to.
+	 * @param string|null $return_url         The URL to return the user to after authorization completes.
 	 *
 	 * @return string The authorization URL.
 	 *
 	 * @throws Authorization_Flow_Exception If registration, discovery, or parameter validation fails.
+	 * @throws Invalid_Resource_Exception     If the resource indicator is malformed.
 	 */
-	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes = [], ?string $return_url = null ): string {
-		return $this->auth_code_handler->get_authorization_url( $user_id, $redirect_uri, $scopes, $return_url );
+	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes = [], ?string $resource_indicator = null, ?string $return_url = null ): string {
+		return $this->auth_code_handler->get_authorization_url( $user_id, $redirect_uri, $scopes, new Resource_Indicator( $resource_indicator ), $return_url );
 	}
 
 	/**
@@ -238,21 +242,24 @@ class MyYoast_Client implements LoggerAwareInterface {
 	/**
 	 * Returns a valid site-level access token (client_credentials).
 	 *
-	 * @param string[] $scopes The service:* scopes to request.
+	 * @param string[]    $scopes             The service:* scopes to request.
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator the token should be bound to, or null for the default resource.
 	 *
 	 * @return Token_Set The site-level token set.
 	 *
-	 * @throws Token_Request_Failed_Exception If the token request fails.
-	 * @throws Token_Storage_Exception        If encrypting the token set for storage fails.
+	 * @throws Invalid_Resource_Exception     If the resource indicator is malformed.
+	 * @throws Token_Request_Failed_Exception If the token request fails. May also throw Token_Storage_Exception when encrypting the token set for storage fails.
 	 */
-	public function get_site_token( array $scopes = [] ): Token_Set {
-		$cached = $this->token_storage->get();
+	public function get_site_token( array $scopes = [], ?string $resource_indicator = null ): Token_Set {
+		$indicator = new Resource_Indicator( $resource_indicator );
+
+		$cached = $this->token_storage->get( $indicator );
 		if ( $cached !== null && ! $cached->is_expired() && $cached->has_scopes( $scopes ) ) {
 			return $cached;
 		}
 
 		$grant     = new Client_Credentials_Grant( $scopes, $this->site_url_provider->get() );
-		$token_set = $this->grant_handler->request_token( $grant );
+		$token_set = $this->grant_handler->request_token( $grant, $indicator );
 		$this->token_storage->store( $token_set );
 
 		return $token_set;
@@ -261,14 +268,18 @@ class MyYoast_Client implements LoggerAwareInterface {
 	/**
 	 * Returns a valid user-level access token, auto-refreshing if expired.
 	 *
-	 * @param int      $user_id         The WordPress user ID.
-	 * @param string[] $required_scopes Optional scopes required for the token; if provided, no token will be returned unless it has at least these scopes.
-	 *                                  This is to avoid refreshing a token that would trigger an immediate re-authorization due to missing scopes.
+	 * @param int         $user_id            The WordPress user ID.
+	 * @param string[]    $required_scopes    Optional scopes required for the token; if provided, no token will be returned unless it has at least these scopes.
+	 *                                        This is to avoid refreshing a token that would trigger an immediate re-authorization due to missing scopes.
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator the token should be bound to, or null for the default resource.
 	 *
 	 * @return Token_Set|null The user token set, or null if the user hasn't authorized.
+	 *
+	 * @throws Invalid_Resource_Exception If the resource indicator is malformed.
 	 */
-	public function get_user_token( int $user_id, array $required_scopes = [] ): ?Token_Set {
-		$token_set = $this->user_token_storage->get( $user_id );
+	public function get_user_token( int $user_id, array $required_scopes = [], ?string $resource_indicator = null ): ?Token_Set {
+		$indicator = new Resource_Indicator( $resource_indicator );
+		$token_set = $this->user_token_storage->get( $user_id, $indicator );
 		if ( $token_set === null ) {
 			return null;
 		}
@@ -287,26 +298,22 @@ class MyYoast_Client implements LoggerAwareInterface {
 			return null;
 		}
 
+		// Refresh must keep the audience binding (RFC 8707 §2); pull it from the stored token.
+		$bound_resource = $token_set->get_resource_indicator();
+
+		// If the client was just re-registered, this refresh will fail with invalid_grant.
+		// error_count is 0 on first attempt; after one invalid_grant it becomes 1.
+		// On the second consecutive invalid_grant (error_count >= 1), clear and give up.
+		$grant    = new Refresh_Token_Grant( $refresh_token );
+		$lock_key = 'wpseo_myyoast_refresh:' . \hash( 'sha256', $refresh_token );
 		try {
-			// If the client was just re-registered, this refresh will fail with invalid_grant.
-			// error_count is 0 on first attempt; after one invalid_grant it becomes 1.
-			// On the second consecutive invalid_grant (error_count >= 1), clear and give up.
-			$grant         = new Refresh_Token_Grant( $refresh_token );
-			$lock_key      = 'wpseo_myyoast_refresh:' . \hash( 'sha256', $refresh_token );
 			$new_token_set = $this->lock_helper->execute(
 				$lock_key,
-				function () use ( $grant ) {
-					return $this->grant_handler->request_token( $grant );
+				function () use ( $grant, $bound_resource ) {
+					return $this->grant_handler->request_token( $grant, $bound_resource );
 				},
 				self::REFRESH_LOCK_TTL_IN_SECONDS,
 			);
-			try {
-				$this->user_token_storage->store( $user_id, $new_token_set );
-			} catch ( Token_Storage_Exception $e ) {
-				// Next request will re-refresh from the old stored token.
-				$this->logger->warning( 'Failed to persist refreshed token: {error}', [ 'error' => $e->getMessage() ] );
-			}
-			return $new_token_set;
 		} catch ( Lock_Timeout_Exception $e ) {
 			// Concurrent refresh in progress, treat as transient failure.
 			$this->logger->debug( 'Skipping token refresh for user {user_id}: concurrent refresh in progress.', [ 'user_id' => $user_id ] );
@@ -315,7 +322,7 @@ class MyYoast_Client implements LoggerAwareInterface {
 			if ( $e->get_error_code() === 'invalid_grant' ) {
 				if ( $token_set->get_error_count() >= 1 ) {
 					$this->logger->warning( 'Repeated invalid_grant for user {user_id}, clearing stored tokens.', [ 'user_id' => $user_id ] );
-					$this->user_token_storage->delete( $user_id );
+					$this->user_token_storage->delete( $user_id, $indicator );
 					return null;
 				}
 
@@ -329,28 +336,42 @@ class MyYoast_Client implements LoggerAwareInterface {
 
 			return null;
 		}
+		try {
+			$this->user_token_storage->store( $user_id, $new_token_set );
+		} catch ( Token_Storage_Exception $e ) {
+			// Next request will re-refresh from the old stored token.
+			$this->logger->warning( 'Failed to persist refreshed token: {error}', [ 'error' => $e->getMessage() ] );
+		}
+		return $new_token_set;
 	}
 
 	/**
-	 * Whether the given user has authorized with MyYoast.
+	 * Whether the given user has authorized with MyYoast for a resource.
 	 *
-	 * @param int $user_id The WordPress user ID.
+	 * @param int         $user_id            The WordPress user ID.
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator, or null for the default resource.
 	 *
 	 * @return bool
+	 *
+	 * @throws Invalid_Resource_Exception If the resource indicator is malformed.
 	 */
-	public function has_user_token( int $user_id ): bool {
-		return $this->user_token_storage->get( $user_id ) !== null;
+	public function has_user_token( int $user_id, ?string $resource_indicator = null ): bool {
+		return $this->user_token_storage->get( $user_id, new Resource_Indicator( $resource_indicator ) ) !== null;
 	}
 
 	/**
-	 * Revokes the user's tokens and clears storage.
+	 * Revokes the user's tokens for a resource and clears storage.
 	 *
-	 * @param int $user_id The WordPress user ID.
+	 * @param int         $user_id            The WordPress user ID.
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator, or null for the default resource.
 	 *
 	 * @return void
+	 *
+	 * @throws Invalid_Resource_Exception If the resource indicator is malformed.
 	 */
-	public function revoke_user_token( int $user_id ): void {
-		$token_set = $this->user_token_storage->get( $user_id );
+	public function revoke_user_token( int $user_id, ?string $resource_indicator = null ): void {
+		$indicator = new Resource_Indicator( $resource_indicator );
+		$token_set = $this->user_token_storage->get( $user_id, $indicator );
 		if ( $token_set === null ) {
 			return;
 		}
@@ -360,7 +381,25 @@ class MyYoast_Client implements LoggerAwareInterface {
 			$this->revocation_handler->revoke( $token_set->get_refresh_token(), Token_Type_Hint::REFRESH_TOKEN );
 		}
 
-		$this->user_token_storage->delete( $user_id );
+		$this->user_token_storage->delete( $user_id, $indicator );
+	}
+
+	/**
+	 * Revokes every user token across all resource buckets ("log out everywhere").
+	 *
+	 * @param int $user_id The WordPress user ID.
+	 *
+	 * @return void
+	 */
+	public function revoke_all_user_tokens( int $user_id ): void {
+		$tokens = $this->user_token_storage->get_all( $user_id );
+		foreach ( $tokens as $token_set ) {
+			$this->revocation_handler->revoke( $token_set->get_access_token(), Token_Type_Hint::ACCESS_TOKEN );
+			if ( $token_set->get_refresh_token() !== null ) {
+				$this->revocation_handler->revoke( $token_set->get_refresh_token(), Token_Type_Hint::REFRESH_TOKEN );
+			}
+			$this->user_token_storage->delete( $user_id, $token_set->get_resource_indicator() );
+		}
 	}
 
 	/**
@@ -381,12 +420,25 @@ class MyYoast_Client implements LoggerAwareInterface {
 	}
 
 	/**
-	 * Clears the site-level token.
+	 * Clears the site-level token for a resource bucket.
+	 *
+	 * @param string|null $resource_indicator The RFC 8707 resource indicator, or null for the default resource.
+	 *
+	 * @return void
+	 *
+	 * @throws Invalid_Resource_Exception If the resource indicator is malformed.
+	 */
+	public function clear_site_token( ?string $resource_indicator = null ): void {
+		$this->token_storage->delete( new Resource_Indicator( $resource_indicator ) );
+	}
+
+	/**
+	 * Clears every site-level token across resource buckets.
 	 *
 	 * @return void
 	 */
-	public function clear_site_token(): void {
-		$this->token_storage->delete();
+	public function clear_all_site_tokens(): void {
+		$this->token_storage->delete_all();
 	}
 
 	/**

--- a/src/myyoast-client/application/oauth-grant-handler.php
+++ b/src/myyoast-client/application/oauth-grant-handler.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Authenticator_Interface
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Discovery_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\OAuth_Server_Client_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use YoastSEO_Vendor\Psr\Log\LoggerAwareInterface;
 use YoastSEO_Vendor\Psr\Log\LoggerAwareTrait;
@@ -81,15 +82,19 @@ class OAuth_Grant_Handler implements LoggerAwareInterface {
 	 * Executes a token endpoint request using the provided grant strategy.
 	 *
 	 * Ensures the client is registered, creates a client assertion, merges
-	 * grant-specific parameters, and sends the request.
+	 * grant-specific parameters, and sends the request. The resource indicator
+	 * is added to the body (unless it's the default-resource instance) and
+	 * stamped onto the resulting Token_Set so storage and audit code can
+	 * introspect the audience.
 	 *
-	 * @param Grant_Interface $grant The grant strategy providing grant-specific parameters.
+	 * @param Grant_Interface    $grant              The grant strategy providing grant-specific parameters.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (RFC 8707) the grant targets. Use Resource_Indicator::default() for the default resource.
 	 *
 	 * @return Token_Set The token set from the response.
 	 *
 	 * @throws Token_Request_Failed_Exception If the token request fails.
 	 */
-	public function request_token( Grant_Interface $grant ): Token_Set {
+	public function request_token( Grant_Interface $grant, Resource_Indicator $resource_indicator ): Token_Set {
 		$registered_client = $this->client_registration->ensure_registered();
 
 		try {
@@ -117,6 +122,12 @@ class OAuth_Grant_Handler implements LoggerAwareInterface {
 			],
 			$grant->get_grant_params(),
 		);
+
+		// RFC 8707 resource indicator is cross-cutting — independent of grant type.
+		// The Resource_Indicator value object proves the value is already canonical.
+		if ( ! $resource_indicator->is_default() ) {
+			$body['resource'] = $resource_indicator->value();
+		}
 
 		$result = $this->oauth_server_client->request(
 			'POST',
@@ -156,10 +167,15 @@ class OAuth_Grant_Handler implements LoggerAwareInterface {
 		}
 
 		try {
-			return Token_Set::from_response( $body );
+			$token_set = Token_Set::from_response( $body );
 		} catch ( InvalidArgumentException $e ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
 			throw new Token_Request_Failed_Exception( 'invalid_token_response', $e->getMessage(), 0, $e );
 		}
+
+		// Per RFC 8707's trust model (§2, §4), the client is authoritative for the
+		// canonical resource indicator. We always stamp the requested value on the
+		// result rather than honouring any echoed `resource` field from the AS.
+		return $token_set->with_resource_indicator( $resource_indicator );
 	}
 }

--- a/src/myyoast-client/application/ports/token-storage-interface.php
+++ b/src/myyoast-client/application/ports/token-storage-interface.php
@@ -4,22 +4,28 @@
 namespace Yoast\WP\SEO\MyYoast_Client\Application\Ports;
 
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Storage_Exception;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 
 /**
  * Port for site-level token persistence.
+ *
+ * Tokens are bucketed by RFC 8707 resource indicator so a site can hold one
+ * token per resource server. The null bucket is the default resource.
  */
 interface Token_Storage_Interface {
 
 	/**
-	 * Retrieves the stored token set.
+	 * Retrieves the stored token set for a resource bucket.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return Token_Set|null The token set, or null if not stored.
 	 */
-	public function get(): ?Token_Set;
+	public function get( Resource_Indicator $resource_indicator ): ?Token_Set;
 
 	/**
-	 * Stores a token set.
+	 * Stores a token set. The resource bucket is derived from the token's own resource indicator.
 	 *
 	 * @param Token_Set $token_set The token set to store.
 	 *
@@ -30,9 +36,25 @@ interface Token_Storage_Interface {
 	public function store( Token_Set $token_set ): void;
 
 	/**
-	 * Deletes the stored token set.
+	 * Deletes the stored token set for a resource bucket.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return void
 	 */
-	public function delete(): void;
+	public function delete( Resource_Indicator $resource_indicator ): void;
+
+	/**
+	 * Returns every stored token set across resource buckets.
+	 *
+	 * @return Token_Set[] The stored token sets.
+	 */
+	public function get_all(): array;
+
+	/**
+	 * Deletes every stored token set across resource buckets.
+	 *
+	 * @return void
+	 */
+	public function delete_all(): void;
 }

--- a/src/myyoast-client/application/ports/token-storage-interface.php
+++ b/src/myyoast-client/application/ports/token-storage-interface.php
@@ -52,9 +52,19 @@ interface Token_Storage_Interface {
 	public function get_all(): array;
 
 	/**
-	 * Deletes every stored token set across resource buckets.
+	 * Deletes every stored token set across resource buckets for the current issuer.
 	 *
 	 * @return void
 	 */
 	public function delete_all(): void;
+
+	/**
+	 * Deletes every stored token set across all issuers and resource buckets.
+	 *
+	 * Intended for full plugin cleanup on uninstall, where any token bucket
+	 * for any issuer that this site ever connected to should be purged.
+	 *
+	 * @return void
+	 */
+	public function delete_all_issuers(): void;
 }

--- a/src/myyoast-client/application/ports/user-token-storage-interface.php
+++ b/src/myyoast-client/application/ports/user-token-storage-interface.php
@@ -57,9 +57,19 @@ interface User_Token_Storage_Interface {
 	public function get_all( int $user_id ): array;
 
 	/**
-	 * Deletes all stored user token sets across all users and resource buckets.
+	 * Deletes every stored user token set across all users and resource buckets for the current issuer.
 	 *
 	 * @return void
 	 */
 	public function delete_all(): void;
+
+	/**
+	 * Deletes every stored user token set across all users, issuers, and resource buckets.
+	 *
+	 * Intended for full plugin cleanup on uninstall, where any token bucket
+	 * for any issuer that this site ever connected to should be purged.
+	 *
+	 * @return void
+	 */
+	public function delete_all_issuers(): void;
 }

--- a/src/myyoast-client/application/ports/user-token-storage-interface.php
+++ b/src/myyoast-client/application/ports/user-token-storage-interface.php
@@ -4,24 +4,29 @@
 namespace Yoast\WP\SEO\MyYoast_Client\Application\Ports;
 
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Storage_Exception;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 
 /**
  * Port for per-user token persistence.
+ *
+ * Tokens are bucketed by RFC 8707 resource indicator so a user can hold one
+ * token per resource server. The null bucket is the default resource.
  */
 interface User_Token_Storage_Interface {
 
 	/**
-	 * Retrieves the stored token set for a user.
+	 * Retrieves the stored token set for a user and resource bucket.
 	 *
-	 * @param int $user_id The user ID.
+	 * @param int                $user_id            The user ID.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return Token_Set|null The token set, or null if not stored.
 	 */
-	public function get( int $user_id ): ?Token_Set;
+	public function get( int $user_id, Resource_Indicator $resource_indicator ): ?Token_Set;
 
 	/**
-	 * Stores a token set for a user.
+	 * Stores a token set for a user. The resource bucket is derived from the token's own resource indicator.
 	 *
 	 * @param int       $user_id   The user ID.
 	 * @param Token_Set $token_set The token set to store.
@@ -33,16 +38,26 @@ interface User_Token_Storage_Interface {
 	public function store( int $user_id, Token_Set $token_set ): void;
 
 	/**
-	 * Deletes the stored token set for a user.
+	 * Deletes the stored token set for a user and resource bucket.
 	 *
-	 * @param int $user_id The user ID.
+	 * @param int                $user_id            The user ID.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return void
 	 */
-	public function delete( int $user_id ): void;
+	public function delete( int $user_id, Resource_Indicator $resource_indicator ): void;
 
 	/**
-	 * Deletes all stored user token sets.
+	 * Returns every stored token set across resource buckets for a user.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return Token_Set[] The stored token sets.
+	 */
+	public function get_all( int $user_id ): array;
+
+	/**
+	 * Deletes all stored user token sets across all users and resource buckets.
 	 *
 	 * @return void
 	 */

--- a/src/myyoast-client/domain/auth-flow-state.php
+++ b/src/myyoast-client/domain/auth-flow-state.php
@@ -48,13 +48,21 @@ class Auth_Flow_State {
 	private $return_url;
 
 	/**
+	 * The RFC 8707 resource indicator this flow targets.
+	 *
+	 * @var Resource_Indicator
+	 */
+	private $resource_indicator;
+
+	/**
 	 * Auth_Flow_State constructor.
 	 *
-	 * @param string      $code_verifier The PKCE code verifier.
-	 * @param string      $state         The CSRF state parameter.
-	 * @param string|null $nonce         The nonce for ID token validation (only when openid scope is requested).
-	 * @param string      $redirect_uri  The callback redirect URI.
-	 * @param string|null $return_url    The URL to return the user to after authorization.
+	 * @param string             $code_verifier      The PKCE code verifier.
+	 * @param string             $state              The CSRF state parameter.
+	 * @param string|null        $nonce              The nonce for ID token validation (only when openid scope is requested).
+	 * @param string             $redirect_uri       The callback redirect URI.
+	 * @param string|null        $return_url         The URL to return the user to after authorization.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (RFC 8707) this flow targets. Use Resource_Indicator::default() for the default resource.
 	 *
 	 * @throws InvalidArgumentException If required fields are empty.
 	 */
@@ -63,17 +71,19 @@ class Auth_Flow_State {
 		string $state,
 		?string $nonce,
 		string $redirect_uri,
-		?string $return_url = null
+		?string $return_url,
+		Resource_Indicator $resource_indicator
 	) {
 		if ( $code_verifier === '' || $state === '' || $redirect_uri === '' ) {
 			throw new InvalidArgumentException( 'Auth_Flow_State requires non-empty code_verifier, state, and redirect_uri.' );
 		}
 
-		$this->code_verifier = $code_verifier;
-		$this->state         = $state;
-		$this->nonce         = $nonce;
-		$this->redirect_uri  = $redirect_uri;
-		$this->return_url    = $return_url;
+		$this->code_verifier      = $code_verifier;
+		$this->state              = $state;
+		$this->nonce              = $nonce;
+		$this->redirect_uri       = $redirect_uri;
+		$this->return_url         = $return_url;
+		$this->resource_indicator = $resource_indicator;
 	}
 
 	/**
@@ -122,17 +132,27 @@ class Auth_Flow_State {
 	}
 
 	/**
+	 * Returns the RFC 8707 resource indicator this flow targets.
+	 *
+	 * @return Resource_Indicator
+	 */
+	public function get_resource_indicator(): Resource_Indicator {
+		return $this->resource_indicator;
+	}
+
+	/**
 	 * Converts the state to an associative array for storage.
 	 *
 	 * @return array<string, string|null>
 	 */
 	public function to_array(): array {
 		return [
-			'code_verifier' => $this->code_verifier,
-			'state'         => $this->state,
-			'nonce'         => $this->nonce,
-			'redirect_uri'  => $this->redirect_uri,
-			'return_url'    => $this->return_url,
+			'code_verifier'      => $this->code_verifier,
+			'state'              => $this->state,
+			'nonce'              => $this->nonce,
+			'redirect_uri'       => $this->redirect_uri,
+			'return_url'         => $this->return_url,
+			'resource_indicator' => $this->resource_indicator->value(),
 		];
 	}
 
@@ -153,7 +173,7 @@ class Auth_Flow_State {
 				throw new InvalidArgumentException( "Auth_Flow_State::from_array() requires a string value for '{$key}'." );
 			}
 		}
-		$optional_strings = [ 'nonce', 'return_url' ];
+		$optional_strings = [ 'nonce', 'return_url', 'resource_indicator' ];
 		foreach ( $optional_strings as $key ) {
 			if ( isset( $data[ $key ] ) && ! \is_string( $data[ $key ] ) ) {
 				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
@@ -161,12 +181,15 @@ class Auth_Flow_State {
 			}
 		}
 
+		$stored_indicator = ( $data['resource_indicator'] ?? null );
+
 		return new self(
 			$data['code_verifier'],
 			$data['state'],
 			( $data['nonce'] ?? null ),
 			$data['redirect_uri'],
 			( $data['return_url'] ?? null ),
+			new Resource_Indicator( ( \is_string( $stored_indicator ) && $stored_indicator !== '' ) ? $stored_indicator : null ),
 		);
 	}
 }

--- a/src/myyoast-client/domain/exceptions/invalid-resource-exception.php
+++ b/src/myyoast-client/domain/exceptions/invalid-resource-exception.php
@@ -1,0 +1,16 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\MyYoast_Client\Domain\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Exception thrown when a resource indicator (RFC 8707) is malformed.
+ *
+ * Callers translate this into their flow-specific exception
+ * (Authorization_Flow_Exception or Token_Request_Failed_Exception).
+ */
+class Invalid_Resource_Exception extends InvalidArgumentException {
+
+}

--- a/src/myyoast-client/domain/resource-indicator.php
+++ b/src/myyoast-client/domain/resource-indicator.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Yoast\WP\SEO\MyYoast_Client\Domain;
+
+use Yoast\WP\SEO\MyYoast_Client\Domain\Exceptions\Invalid_Resource_Exception;
+
+/**
+ * Immutable value object representing an RFC 8707 resource indicator.
+ *
+ * A resource indicator is an absolute URI (RFC 3986 §4.3) without a fragment
+ * that identifies a target resource server. RFC 8707 does not restrict the
+ * scheme — http, https, urn, did, etc. are all valid. The authorization
+ * server decides which specific values it accepts via the OAuth
+ * `invalid_target` error.
+ *
+ * Per the spec's trust model (RFC 8707 §2 and §4), the client is the source
+ * of truth for the canonical form. Every value we put on the wire — including
+ * on refresh — must satisfy §2. The constructor enforces this, and there is
+ * no path that wraps an unvalidated string in this class.
+ *
+ * Null-object pattern: passing null (or calling ::default()) yields an
+ * instance representing "the default resource" — no `resource` parameter
+ * goes on the wire, and storage uses the default bucket. Callers don't
+ * need to null-check; ask is_default() instead.
+ */
+class Resource_Indicator {
+
+	/**
+	 * RFC 3986 §3.1 scheme: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
+	 *
+	 * @var string
+	 */
+	private const SCHEME_PATTERN = '[A-Za-z][A-Za-z0-9+.\-]*';
+
+	/**
+	 * RFC 3986 character set permitted in the rest of a URI, excluding the
+	 * fragment delimiter "#" — RFC 8707 §2 forbids fragments and we reject
+	 * them explicitly with a more specific error.
+	 *
+	 * Includes: unreserved / pct-encoded / sub-delims / ":" / "/" / "?" / "[" / "]" / "@".
+	 *
+	 * @var string
+	 */
+	private const URI_TAIL_PATTERN = '[A-Za-z0-9\-._~:\/?\[\]@!$&\'()*+,;=%]+';
+
+	/**
+	 * The canonical string form, or null when this instance represents the default resource.
+	 *
+	 * @var string|null
+	 */
+	private $value;
+
+	/**
+	 * Resource_Indicator constructor.
+	 *
+	 * Null yields the default-resource instance — no validation, no wire
+	 * parameter, default storage bucket. Non-null is validated per RFC 8707 §2
+	 * (absolute URI per RFC 3986 §4.3, no fragment) and has its trailing slash
+	 * canonicalized for storage-key stability.
+	 *
+	 * @param string|null $value The resource indicator string, or null for the default resource.
+	 *
+	 * @throws Invalid_Resource_Exception When the value is non-null but malformed.
+	 */
+	public function __construct( ?string $value ) {
+		if ( $value === null ) {
+			$this->value = null;
+			return;
+		}
+
+		$trimmed = \trim( $value );
+		if ( $trimmed === '' ) {
+			throw new Invalid_Resource_Exception( 'Resource indicator must not be empty.' );
+		}
+
+		// Fragment forbidden by RFC 8707 §2. Checked before the absolute-URI
+		// regex so the caller gets a more specific error message.
+		if ( \strpos( $trimmed, '#' ) !== false ) {
+			throw new Invalid_Resource_Exception( 'Resource indicator must not contain a fragment (RFC 8707 §2).' );
+		}
+
+		// RFC 3986 §4.3 absolute-URI: scheme ":" hier-part [ "?" query ].
+		// We don't deeply validate hier-part — the authorization server will
+		// reject unrecognized formats via OAuth `invalid_target`.
+		//
+		// Anchors are \A (start-of-string) and \z (end-of-string), NOT ^ and $.
+		// ^/$ are line-aware: $ matches before a trailing \n by default, and
+		// with /m both match at every line boundary. That lets a two-line
+		// input smuggle a second URI past the check while still appearing to
+		// "match the whole string". \A and \z always mean literal start/end of
+		// the entire input regardless of newlines or regex flags, which is
+		// what we need when validating untrusted input that goes on the wire.
+		$absolute_uri_pattern = '/\A' . self::SCHEME_PATTERN . ':' . self::URI_TAIL_PATTERN . '\z/';
+		if ( \preg_match( $absolute_uri_pattern, $trimmed ) !== 1 ) {
+			throw new Invalid_Resource_Exception( 'Resource indicator must be an absolute URI (RFC 3986 §4.3, RFC 8707 §2).' );
+		}
+
+		$this->value = self::normalize_trailing_slash( $trimmed );
+	}
+
+	/**
+	 * Returns an instance representing the default resource.
+	 *
+	 * Equivalent to `new Resource_Indicator( null )` — provided for readability
+	 * at call sites that want to express the intent explicitly.
+	 *
+	 * @return self
+	 */
+	public static function default(): self {
+		return new self( null );
+	}
+
+	/**
+	 * Returns the canonical string form, or null when this is the default resource.
+	 *
+	 * @return string|null
+	 */
+	public function value(): ?string {
+		return $this->value;
+	}
+
+	/**
+	 * Whether this instance represents the default resource.
+	 *
+	 * @return bool
+	 */
+	public function is_default(): bool {
+		return $this->value === null;
+	}
+
+	/**
+	 * Returns the canonical string form, or empty string for the default resource.
+	 *
+	 * @return string
+	 */
+	public function __toString(): string {
+		return ( $this->value ?? '' );
+	}
+
+	/**
+	 * Returns true when the other indicator has the same canonical value.
+	 *
+	 * @param self $other The other indicator.
+	 *
+	 * @return bool
+	 */
+	public function equals( self $other ): bool {
+		return $this->value === $other->value;
+	}
+
+	/**
+	 * Strips a single trailing slash from URIs that have an authority and a
+	 * root-only path, so "https://host/" and "https://host" map to the same
+	 * canonical form. URIs without an authority (urn:, did:, etc.) are left
+	 * alone.
+	 *
+	 * @param string $uri A validated absolute URI.
+	 *
+	 * @return string The URI, with the root-path trailing slash trimmed when applicable.
+	 */
+	private static function normalize_trailing_slash( string $uri ): string {
+		if ( \strpos( $uri, '://' ) === false ) {
+			return $uri;
+		}
+
+		$after_authority = \substr( $uri, ( \strpos( $uri, '://' ) + 3 ) );
+		$query_pos       = \strpos( $after_authority, '?' );
+		$path_segment    = ( $query_pos === false ) ? $after_authority : \substr( $after_authority, 0, $query_pos );
+
+		$slash_pos = \strpos( $path_segment, '/' );
+		if ( $slash_pos === false ) {
+			return $uri;
+		}
+
+		$path = \substr( $path_segment, $slash_pos );
+		if ( $path === '/' ) {
+			$prefix_end = \strpos( $uri, '/', ( \strpos( $uri, '://' ) + 3 ) );
+
+			return \substr( $uri, 0, $prefix_end ) . ( ( $query_pos === false ) ? '' : \substr( $after_authority, $query_pos ) );
+		}
+
+		return $uri;
+	}
+}

--- a/src/myyoast-client/domain/token-set.php
+++ b/src/myyoast-client/domain/token-set.php
@@ -70,15 +70,23 @@ class Token_Set {
 	private $error_count;
 
 	/**
+	 * The RFC 8707 resource indicator this token was minted for.
+	 *
+	 * @var Resource_Indicator
+	 */
+	private $resource_indicator;
+
+	/**
 	 * Token_Set constructor.
 	 *
-	 * @param string      $access_token  The access token.
-	 * @param int         $expires_at    Unix timestamp of token expiry.
-	 * @param string      $token_type    An Auth_Token_Type constant.
-	 * @param string|null $refresh_token The refresh token.
-	 * @param string|null $id_token      The OIDC ID token.
-	 * @param string|null $scope         The granted scope.
-	 * @param int         $error_count   The number of consecutive refresh errors.
+	 * @param string                  $access_token       The access token.
+	 * @param int                     $expires_at         Unix timestamp of token expiry.
+	 * @param string                  $token_type         An Auth_Token_Type constant.
+	 * @param string|null             $refresh_token      The refresh token.
+	 * @param string|null             $id_token           The OIDC ID token.
+	 * @param string|null             $scope              The granted scope.
+	 * @param int                     $error_count        The number of consecutive refresh errors.
+	 * @param Resource_Indicator|null $resource_indicator The resource indicator (RFC 8707) the token was minted for. Null is treated as Resource_Indicator::default().
 	 *
 	 * @throws InvalidArgumentException If required fields are empty or invalid.
 	 */
@@ -93,7 +101,8 @@ class Token_Set {
 		?string $refresh_token = null,
 		?string $id_token = null,
 		?string $scope = null,
-		int $error_count = 0
+		int $error_count = 0,
+		?Resource_Indicator $resource_indicator = null
 	) {
 		if ( $access_token === '' ) {
 			throw new InvalidArgumentException( 'Token_Set requires a non-empty access_token.' );
@@ -105,13 +114,14 @@ class Token_Set {
 			throw new InvalidArgumentException( 'Token_Set requires a non-empty token_type.' );
 		}
 
-		$this->access_token  = $access_token;
-		$this->expires_at    = $expires_at;
-		$this->token_type    = $token_type;
-		$this->refresh_token = $refresh_token;
-		$this->id_token      = $id_token;
-		$this->scope         = $scope;
-		$this->error_count   = $error_count;
+		$this->access_token       = $access_token;
+		$this->expires_at         = $expires_at;
+		$this->token_type         = $token_type;
+		$this->refresh_token      = $refresh_token;
+		$this->id_token           = $id_token;
+		$this->scope              = $scope;
+		$this->error_count        = $error_count;
+		$this->resource_indicator = ( $resource_indicator ?? new Resource_Indicator( null ) );
 	}
 
 	/**
@@ -194,6 +204,35 @@ class Token_Set {
 	}
 
 	/**
+	 * Returns the RFC 8707 resource indicator this token was minted for.
+	 *
+	 * @return Resource_Indicator
+	 */
+	public function get_resource_indicator(): Resource_Indicator {
+		return $this->resource_indicator;
+	}
+
+	/**
+	 * Returns a new Token_Set bound to the given resource indicator.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator.
+	 *
+	 * @return self
+	 */
+	public function with_resource_indicator( Resource_Indicator $resource_indicator ): self {
+		return new self(
+			$this->access_token,
+			$this->expires_at,
+			$this->token_type,
+			$this->refresh_token,
+			$this->id_token,
+			$this->scope,
+			$this->error_count,
+			$resource_indicator,
+		);
+	}
+
+	/**
 	 * Returns a new Token_Set with an incremented error count.
 	 *
 	 * @return self
@@ -207,6 +246,7 @@ class Token_Set {
 			$this->id_token,
 			$this->scope,
 			$this->error_count + 1,
+			$this->resource_indicator,
 		);
 	}
 
@@ -228,13 +268,14 @@ class Token_Set {
 	 */
 	public function to_array(): array {
 		return [
-			'access_token'  => $this->access_token,
-			'expires_at'    => $this->expires_at,
-			'token_type'    => $this->token_type,
-			'refresh_token' => $this->refresh_token,
-			'id_token'      => $this->id_token,
-			'scope'         => $this->scope,
-			'error_count'   => $this->error_count,
+			'access_token'       => $this->access_token,
+			'expires_at'         => $this->expires_at,
+			'token_type'         => $this->token_type,
+			'refresh_token'      => $this->refresh_token,
+			'id_token'           => $this->id_token,
+			'scope'              => $this->scope,
+			'error_count'        => $this->error_count,
+			'resource_indicator' => $this->resource_indicator->value(),
 		];
 	}
 
@@ -246,6 +287,8 @@ class Token_Set {
 	 * @return self
 	 */
 	public static function from_array( array $data ): self {
+		$stored_indicator = ( $data['resource_indicator'] ?? null );
+
 		return new self(
 			(string) ( $data['access_token'] ?? '' ),
 			(int) ( $data['expires_at'] ?? 0 ),
@@ -254,11 +297,18 @@ class Token_Set {
 			( $data['id_token'] ?? null ),
 			( $data['scope'] ?? null ),
 			(int) ( $data['error_count'] ?? 0 ),
+			new Resource_Indicator( ( \is_string( $stored_indicator ) && $stored_indicator !== '' ) ? $stored_indicator : null ),
 		);
 	}
 
 	/**
 	 * Creates a Token_Set from a token endpoint response.
+	 *
+	 * Per RFC 8707 §3 the AS may echo a `resource` field to confirm the audience
+	 * it minted the token for. The spec does not require the client to honour
+	 * the echo, and trusting an unverified echo into storage could later violate
+	 * §2 on refresh. We deliberately ignore the echoed field; the caller is
+	 * expected to stamp the requested indicator via with_resource_indicator().
 	 *
 	 * @param array<string, string|int|null> $response The parsed JSON response from the token endpoint.
 	 *

--- a/src/myyoast-client/infrastructure/token/token-storage.php
+++ b/src/myyoast-client/infrastructure/token/token-storage.php
@@ -135,22 +135,38 @@ class Token_Storage implements Token_Storage_Interface, LoggerAwareInterface {
 	}
 
 	/**
-	 * Deletes every stored token set across resource buckets.
+	 * Deletes every stored token set across resource buckets for the current issuer.
 	 *
 	 * @return void
 	 */
 	public function delete_all(): void {
-		global $wpdb;
+		$this->bulk_delete_by_prefix( $this->get_option_key_prefix_for_current_issuer() );
+	}
 
-		if ( ! isset( $wpdb ) ) {
-			return;
-		}
+	/**
+	 * Deletes every stored token set across all issuers and resource buckets.
+	 *
+	 * @return void
+	 */
+	public function delete_all_issuers(): void {
+		$this->bulk_delete_by_prefix( self::OPTION_KEY_PREFIX );
+	}
+
+	/**
+	 * Deletes every option whose name starts with the given prefix.
+	 *
+	 * @param string $prefix The option-name prefix.
+	 *
+	 * @return void
+	 */
+	private function bulk_delete_by_prefix( string $prefix ): void {
+		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk cleanup.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-				$wpdb->esc_like( $this->get_option_key_prefix_for_current_issuer() ) . '%',
+				$wpdb->esc_like( $prefix ) . '%',
 			),
 		);
 	}

--- a/src/myyoast-client/infrastructure/token/token-storage.php
+++ b/src/myyoast-client/infrastructure/token/token-storage.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\MyYoast_Client\Infrastructure\Token;
 use Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Storage_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption_Exception;
@@ -15,11 +16,16 @@ use YoastSEO_Vendor\Psr\Log\LoggerAwareTrait;
 use YoastSEO_Vendor\Psr\Log\NullLogger;
 
 /**
- * Stores and retrieves encrypted site-level tokens as a WordPress option.
+ * Stores and retrieves encrypted site-level tokens as WordPress options.
  *
- * Used for client_credentials tokens (site-level, no user context).
- * The option key is scoped by issuer so that switching issuers
- * isolates all stored data.
+ * Used for client_credentials tokens (site-level, no user context). Tokens
+ * are bucketed per RFC 8707 resource indicator so a site can hold one token
+ * per resource server. Each (issuer, resource bucket) pair maps to a
+ * separate option row.
+ *
+ * Key layout:
+ *   - Default bucket:  wpseo_myyoast_site_tokens_{issuer_key}
+ *   - Resource bucket: wpseo_myyoast_site_tokens_{issuer_key}_{sha1_prefix}
  */
 class Token_Storage implements Token_Storage_Interface, LoggerAwareInterface {
 	use LoggerAwareTrait;
@@ -54,7 +60,7 @@ class Token_Storage implements Token_Storage_Interface, LoggerAwareInterface {
 	}
 
 	/**
-	 * Stores a token set (encrypted).
+	 * Stores a token set (encrypted). The resource bucket is derived from the token's own resource indicator.
 	 *
 	 * @param Token_Set $token_set The token set to store.
 	 *
@@ -77,16 +83,86 @@ class Token_Storage implements Token_Storage_Interface, LoggerAwareInterface {
 			throw new Token_Storage_Exception( 'Failed to encrypt token set for storage: ' . $e->getMessage(), 0, $e );
 		}
 
-		\update_option( $this->get_option_key(), $encrypted, false );
+		\update_option( $this->get_option_key( $token_set->get_resource_indicator() ), $encrypted, false );
 	}
 
 	/**
-	 * Retrieves the stored token set.
+	 * Retrieves the stored token set for a resource bucket.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return Token_Set|null The token set, or null if not stored or decryption fails.
 	 */
-	public function get(): ?Token_Set {
-		$stored = \get_option( $this->get_option_key(), '' );
+	public function get( Resource_Indicator $resource_indicator ): ?Token_Set {
+		return $this->decrypt_and_decode( \get_option( $this->get_option_key( $resource_indicator ), '' ) );
+	}
+
+	/**
+	 * Deletes the stored token set for a resource bucket.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
+	 *
+	 * @return void
+	 */
+	public function delete( Resource_Indicator $resource_indicator ): void {
+		\delete_option( $this->get_option_key( $resource_indicator ) );
+	}
+
+	/**
+	 * Returns every stored token set across resource buckets.
+	 *
+	 * @return Token_Set[] The stored token sets.
+	 */
+	public function get_all(): array {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Accuracy over performance.
+		$rows   = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT option_value FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( $this->get_option_key_prefix_for_current_issuer() ) . '%',
+			),
+			\ARRAY_A,
+		);
+		$tokens = [];
+		foreach ( ( \is_array( $rows ) ? $rows : [] ) as $row ) {
+			$token = $this->decrypt_and_decode( ( $row['option_value'] ?? '' ) );
+			if ( $token !== null ) {
+				$tokens[] = $token;
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Deletes every stored token set across resource buckets.
+	 *
+	 * @return void
+	 */
+	public function delete_all(): void {
+		global $wpdb;
+
+		if ( ! isset( $wpdb ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk cleanup.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$wpdb->esc_like( $this->get_option_key_prefix_for_current_issuer() ) . '%',
+			),
+		);
+	}
+
+	/**
+	 * Decrypts and decodes a stored option value into a Token_Set.
+	 *
+	 * @param string|false|null $stored The stored value.
+	 *
+	 * @return Token_Set|null The token set, or null on absence/failure.
+	 */
+	private function decrypt_and_decode( $stored ): ?Token_Set {
 		if ( ! \is_string( $stored ) || $stored === '' ) {
 			return null;
 		}
@@ -108,20 +184,31 @@ class Token_Storage implements Token_Storage_Interface, LoggerAwareInterface {
 	}
 
 	/**
-	 * Deletes the stored token set.
+	 * Returns the option key prefix for the current issuer.
 	 *
-	 * @return void
+	 * @return string The option key prefix.
 	 */
-	public function delete(): void {
-		\delete_option( $this->get_option_key() );
+	private function get_option_key_prefix_for_current_issuer(): string {
+		return self::OPTION_KEY_PREFIX . $this->issuer_config->get_issuer_key();
 	}
 
 	/**
-	 * Returns the issuer-scoped option key.
+	 * Returns the option key for a resource bucket.
+	 *
+	 * The default bucket has no suffix and shares its key with pre-RFC-8707
+	 * installs. Explicit resource indicators get a sha1-hash suffix joined
+	 * by an underscore.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator.
 	 *
 	 * @return string The option key.
 	 */
-	private function get_option_key(): string {
-		return self::OPTION_KEY_PREFIX . $this->issuer_config->get_issuer_key();
+	private function get_option_key( Resource_Indicator $resource_indicator ): string {
+		$key = $this->get_option_key_prefix_for_current_issuer();
+		if ( $resource_indicator->is_default() ) {
+			return $key;
+		}
+
+		return $key . '_' . \substr( \sha1( $resource_indicator->value() ), 0, 12 );
 	}
 }

--- a/src/myyoast-client/infrastructure/token/user-token-storage.php
+++ b/src/myyoast-client/infrastructure/token/user-token-storage.php
@@ -7,6 +7,7 @@ use Exception;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Storage_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption_Exception;
@@ -18,7 +19,14 @@ use YoastSEO_Vendor\Psr\Log\NullLogger;
 /**
  * Stores and retrieves encrypted user-level tokens in wp_usermeta.
  *
- * Used for authorization code flow tokens (user-specific).
+ * Used for authorization code flow tokens (user-specific). Tokens are
+ * bucketed per RFC 8707 resource indicator so a user can hold one token per
+ * resource server. Each (issuer, user, resource bucket) maps to a separate
+ * usermeta row.
+ *
+ * Key layout:
+ *   - Default bucket:  _wpseo_myyoast_user_tokens_{issuer_key}
+ *   - Resource bucket: _wpseo_myyoast_user_tokens_{issuer_key}_{sha1_prefix}
  */
 class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInterface {
 	use LoggerAwareTrait;
@@ -62,16 +70,7 @@ class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInt
 	}
 
 	/**
-	 * Returns the issuer-scoped user meta key.
-	 *
-	 * @return string The meta key.
-	 */
-	private function get_meta_key(): string {
-		return self::META_KEY_PREFIX . $this->issuer_config->get_issuer_key();
-	}
-
-	/**
-	 * Stores a token set for a user (encrypted).
+	 * Stores a token set for a user (encrypted). The resource bucket is derived from the token's own resource indicator.
 	 *
 	 * @param int       $user_id   The user ID.
 	 * @param Token_Set $token_set The token set to store.
@@ -89,24 +88,94 @@ class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInt
 			}
 
 			$encrypted = $this->encryption->encrypt( $json, self::ENCRYPTION_CONTEXT );
-		}
-		catch ( Encryption_Exception $e ) {
+		} catch ( Encryption_Exception $e ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
 			throw new Token_Storage_Exception( 'Failed to encrypt token set for storage: ' . $e->getMessage(), 0, $e );
 		}
 
-		$this->user_helper->update_meta( $user_id, $this->get_meta_key(), $encrypted );
+		$this->user_helper->update_meta( $user_id, $this->get_meta_key( $token_set->get_resource_indicator() ), $encrypted );
 	}
 
 	/**
-	 * Retrieves the stored token set for a user.
+	 * Retrieves the stored token set for a user and resource bucket.
 	 *
-	 * @param int $user_id The user ID.
+	 * @param int                $user_id            The user ID.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
 	 *
 	 * @return Token_Set|null The token set, or null if not stored or decryption fails.
 	 */
-	public function get( int $user_id ): ?Token_Set {
-		$stored = $this->user_helper->get_meta( $user_id, $this->get_meta_key(), true );
+	public function get( int $user_id, Resource_Indicator $resource_indicator ): ?Token_Set {
+		return $this->decrypt_and_decode( $user_id, $this->user_helper->get_meta( $user_id, $this->get_meta_key( $resource_indicator ), true ) );
+	}
+
+	/**
+	 * Deletes the stored token set for a user and resource bucket.
+	 *
+	 * @param int                $user_id            The user ID.
+	 * @param Resource_Indicator $resource_indicator The resource indicator (use Resource_Indicator::default() for the default bucket).
+	 *
+	 * @return void
+	 */
+	public function delete( int $user_id, Resource_Indicator $resource_indicator ): void {
+		$this->user_helper->delete_meta( $user_id, $this->get_meta_key( $resource_indicator ) );
+	}
+
+	/**
+	 * Returns every stored token set across resource buckets for a user.
+	 *
+	 * @param int $user_id The user ID.
+	 *
+	 * @return Token_Set[] The stored token sets.
+	 */
+	public function get_all( int $user_id ): array {
+		$tokens   = [];
+		$all_meta = $this->user_helper->get_meta( $user_id );
+		if ( ! \is_array( $all_meta ) ) {
+			return $tokens;
+		}
+		$prefix = $this->get_meta_key_prefix_for_current_issuer();
+		foreach ( $all_meta as $key => $values ) {
+			if ( \strpos( (string) $key, $prefix ) !== 0 ) {
+				continue;
+			}
+			$stored = \is_array( $values ) ? ( $values[0] ?? '' ) : $values;
+			$token  = $this->decrypt_and_decode( $user_id, $stored );
+			if ( $token !== null ) {
+				$tokens[] = $token;
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Deletes all stored user token sets across all users and resource buckets.
+	 * Used for cleanup on uninstall.
+	 *
+	 * @return void
+	 */
+	public function delete_all(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete query.
+		$wpdb->query(
+			$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Bulk cleanup on uninstall.
+				"DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s",
+				$wpdb->esc_like( $this->get_meta_key_prefix_for_current_issuer() ) . '%',
+			),
+		);
+	}
+
+	/**
+	 * Decrypts and decodes a stored meta value into a Token_Set.
+	 *
+	 * @param int               $user_id The user ID (for logging context).
+	 * @param string|false|null $stored  The stored value.
+	 *
+	 * @return Token_Set|null The token set, or null on absence/failure.
+	 */
+	private function decrypt_and_decode( int $user_id, $stored ): ?Token_Set {
 		if ( ! \is_string( $stored ) || $stored === '' ) {
 			return null;
 		}
@@ -120,8 +189,7 @@ class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInt
 			}
 
 			return Token_Set::from_array( $data );
-		}
-		catch ( Exception $e ) {
+		} catch ( Exception $e ) {
 			$this->logger->error(
 				'Failed to decrypt stored user token for user {user_id}: {error}',
 				[
@@ -129,40 +197,37 @@ class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInt
 					'error'   => $e->getMessage(),
 				],
 			);
+
 			return null;
 		}
 	}
 
 	/**
-	 * Deletes the stored token set for a user.
+	 * Returns the meta key prefix for the current issuer.
 	 *
-	 * @param int $user_id The user ID.
-	 *
-	 * @return void
+	 * @return string The meta key prefix.
 	 */
-	public function delete( int $user_id ): void {
-		$this->user_helper->delete_meta( $user_id, $this->get_meta_key() );
+	private function get_meta_key_prefix_for_current_issuer(): string {
+		return self::META_KEY_PREFIX . $this->issuer_config->get_issuer_key();
 	}
 
 	/**
-	 * Deletes all stored user token sets across all issuers.
-	 * This is used for cleanup on uninstall, as we cannot know which users had tokens stored.
-	 * Uses a LIKE match on the meta key prefix to ensure tokens from all issuers are removed.
+	 * Returns the meta key for a resource bucket.
 	 *
-	 * @return void
+	 * The default bucket has no suffix and shares its key with pre-RFC-8707
+	 * installs. Explicit resource indicators get a sha1-hash suffix joined
+	 * by an underscore.
+	 *
+	 * @param Resource_Indicator $resource_indicator The resource indicator.
+	 *
+	 * @return string The meta key.
 	 */
-	public function delete_all(): void {
-		global $wpdb;
-
-		if ( isset( $wpdb ) ) {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk cleanup on uninstall.
-			$wpdb->query(
-				$wpdb->prepare(
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Bulk cleanup on uninstall.
-					"DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s",
-					$wpdb->esc_like( self::META_KEY_PREFIX ) . '%',
-				),
-			);
+	private function get_meta_key( Resource_Indicator $resource_indicator ): string {
+		$key = $this->get_meta_key_prefix_for_current_issuer();
+		if ( $resource_indicator->is_default() ) {
+			return $key;
 		}
+
+		return $key . '_' . \substr( \sha1( $resource_indicator->value() ), 0, 12 );
 	}
 }

--- a/src/myyoast-client/infrastructure/token/user-token-storage.php
+++ b/src/myyoast-client/infrastructure/token/user-token-storage.php
@@ -149,20 +149,39 @@ class User_Token_Storage implements User_Token_Storage_Interface, LoggerAwareInt
 	}
 
 	/**
-	 * Deletes all stored user token sets across all users and resource buckets.
-	 * Used for cleanup on uninstall.
+	 * Deletes every stored user token set across all users and resource buckets for the current issuer.
 	 *
 	 * @return void
 	 */
 	public function delete_all(): void {
+		$this->bulk_delete_by_prefix( $this->get_meta_key_prefix_for_current_issuer() );
+	}
+
+	/**
+	 * Deletes every stored user token set across all users, issuers, and resource buckets.
+	 *
+	 * @return void
+	 */
+	public function delete_all_issuers(): void {
+		$this->bulk_delete_by_prefix( self::META_KEY_PREFIX );
+	}
+
+	/**
+	 * Deletes every usermeta row whose meta_key starts with the given prefix.
+	 *
+	 * @param string $prefix The meta_key prefix.
+	 *
+	 * @return void
+	 */
+	private function bulk_delete_by_prefix( string $prefix ): void {
 		global $wpdb;
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Delete query.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Bulk cleanup.
 		$wpdb->query(
 			$wpdb->prepare(
-			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Bulk cleanup on uninstall.
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Bulk cleanup.
 				"DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE %s",
-				$wpdb->esc_like( $this->get_meta_key_prefix_for_current_issuer() ) . '%',
+				$wpdb->esc_like( $prefix ) . '%',
 			),
 		);
 	}

--- a/src/myyoast-client/user-interface/auth-command.php
+++ b/src/myyoast-client/user-interface/auth-command.php
@@ -7,6 +7,7 @@ namespace Yoast\WP\SEO\MyYoast_Client\User_Interface;
 use Exception;
 use WP_CLI;
 use WP_CLI\ExitException;
+use WP_CLI\Utils;
 use Yoast\WP\SEO\Commands\Command_Interface;
 use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
 use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
@@ -16,6 +17,8 @@ use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Exceptions\Invalid_Resource_Exception;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\OIDC\Issuer_Config;
 
@@ -112,6 +115,12 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 *
 	 * ## OPTIONS
 	 *
+	 * [--resource=<uri>]
+	 * : Show status for a specific RFC 8707 resource indicator. Omit to target the default resource. Cannot be combined with --all-resources.
+	 *
+	 * [--all-resources]
+	 * : Show status for every stored resource bucket. Cannot be combined with --resource.
+	 *
 	 * [--format=<format>]
 	 * : Output format.
 	 * ---
@@ -125,6 +134,8 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 *
 	 *     wp yoast auth status
 	 *     wp yoast auth status --user=admin
+	 *     wp yoast auth status --resource=https://ai.yoa.st
+	 *     wp yoast auth status --all-resources
 	 *     wp yoast auth status --format=json
 	 *
 	 * @when after_wp_load
@@ -148,11 +159,31 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 			$client_id = $registered_client->get_client_id();
 		}
 
-		$site_token      = $this->token_storage->get();
-		$site_token_info = $this->build_token_info( $site_token );
+		$has_all  = (bool) Utils\get_flag_value( $assoc_args, 'all-resources', false );
+		$resource = Utils\get_flag_value( $assoc_args, 'resource' );
 
-		$user_token      = ( $user_id > 0 ) ? $this->user_token_storage->get( $user_id ) : null;
-		$user_token_info = $this->build_token_info( $user_token );
+		if ( $has_all && $resource !== null && $resource !== '' ) {
+			WP_CLI::error( '--all-resources and --resource cannot be combined.' );
+		}
+
+		if ( $has_all ) {
+			$user_tokens = ( $user_id > 0 ) ? $this->user_token_storage->get_all( $user_id ) : [];
+			$site_tokens = $this->token_storage->get_all();
+		}
+		else {
+			try {
+				$resource_filter = new Resource_Indicator( ( $resource !== null && $resource !== '' ) ? (string) $resource : null );
+			}
+			catch ( Invalid_Resource_Exception $e ) {
+				WP_CLI::error( 'Invalid resource indicator: ' . $e->getMessage() );
+				return;
+			}
+
+			$user_tokens = ( $user_id > 0 ) ? \array_filter( [ $this->user_token_storage->get( $user_id, $resource_filter ) ] ) : [];
+			$site_tokens = \array_filter( [ $this->token_storage->get( $resource_filter ) ] );
+		}
+
+		$format = Utils\get_flag_value( $assoc_args, 'format', 'table' );
 
 		$data = [
 			'issuer_url'           => $issuer_url,
@@ -160,17 +191,12 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 			'initial_access_token' => ( $has_iat ) ? 'configured' : 'not configured',
 			'registered'           => ( $is_registered ) ? 'yes' : 'no',
 			'client_id'            => ( $client_id ?? '-' ),
-			'site_token'           => $site_token_info['status'],
-			'site_token_expires'   => $site_token_info['expires'],
-			'site_token_scopes'    => $site_token_info['scopes'],
 			'user_id'              => ( $user_id > 0 ) ? $user_id : 'none (use --user flag)',
-			'user_token'           => $user_token_info['status'],
-			'user_token_expires'   => $user_token_info['expires'],
-			'user_token_scopes'    => $user_token_info['scopes'],
-			'user_token_errors'    => $user_token_info['error_count'],
+			'user_tokens'          => $this->build_token_inventory( $user_tokens ),
+			'site_tokens'          => $this->build_token_inventory( $site_tokens ),
 		];
 
-		$this->output( $data, $assoc_args['format'] );
+		$this->output( $data, $format );
 	}
 
 	/**
@@ -208,7 +234,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @throws ExitException When registration fails.
 	 */
 	public function register( $args = null, $assoc_args = null ): void {
-		if ( isset( $assoc_args['force'] ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'force', false ) ) {
 			$this->myyoast_client->deregister();
 			WP_CLI::log( 'Deregistered existing client.' );
 		}
@@ -226,7 +252,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 				'client_id' => $client->get_client_id(),
 				'status'    => 'registered',
 			],
-			$assoc_args['format'],
+			Utils\get_flag_value( $assoc_args, 'format', 'table' ),
 		);
 
 		WP_CLI::success( 'Client registered: ' . $client->get_client_id() );
@@ -278,7 +304,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		// Redact sensitive fields.
 		unset( $metadata['registration_access_token'] );
 
-		$this->output( $this->flatten_for_display( $metadata ), $assoc_args['format'] );
+		$this->output( $metadata, Utils\get_flag_value( $assoc_args, 'format', 'table' ) );
 
 		WP_CLI::success( 'Registration is valid.' );
 	}
@@ -318,15 +344,15 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 
 		WP_CLI::confirm( 'This will deregister this site from MyYoast and clear all cached tokens. Proceed?', $assoc_args );
 
-		if ( isset( $assoc_args['local-only'] ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'local-only', false ) ) {
 			$this->client_registration->delete_local_data();
-			$this->myyoast_client->clear_site_token();
+			$this->myyoast_client->clear_all_site_tokens();
 			WP_CLI::success( 'Local registration data cleared.' );
 			return;
 		}
 
 		$result = $this->myyoast_client->deregister();
-		$this->myyoast_client->clear_site_token();
+		$this->myyoast_client->clear_all_site_tokens();
 
 		if ( $result ) {
 			WP_CLI::success( 'Client deregistered.' );
@@ -355,6 +381,9 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * [--scopes=<scopes>]
 	 * : Comma-separated scopes to request.
 	 *
+	 * [--resource=<uri>]
+	 * : RFC 8707 resource indicator to bind the token to (e.g. https://ai.yoa.st). Omit for the default resource.
+	 *
 	 * [--code=<code>]
 	 * : Authorization code from the callback URL (user flow phase 2).
 	 *
@@ -378,6 +407,9 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 *     # Site-level token (client_credentials):
 	 *     wp yoast auth authorize --site --scopes=service:analytics
 	 *
+	 *     # Site-level token for a non-default resource:
+	 *     wp yoast auth authorize --site --resource=https://ai.yoa.st --scopes=service:ai:consume
+	 *
 	 *     # User authorization code flow, phase 1 - get the URL:
 	 *     wp yoast auth authorize --user=admin --scopes=openid,profile
 	 *
@@ -394,14 +426,17 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @throws ExitException When authorization fails.
 	 */
 	public function authorize( $args = null, $assoc_args = null ): void {
-		$scopes = $this->parse_scopes( $assoc_args );
+		$scopes             = $this->parse_scopes( $assoc_args );
+		$format             = Utils\get_flag_value( $assoc_args, 'format', 'table' );
+		$resource           = Utils\get_flag_value( $assoc_args, 'resource' );
+		$resource_indicator = ( $resource !== null && $resource !== '' ) ? (string) $resource : null;
 
-		if ( isset( $assoc_args['site'] ) ) {
-			$this->authorize_site( $scopes, $assoc_args['format'] );
+		if ( Utils\get_flag_value( $assoc_args, 'site', false ) ) {
+			$this->authorize_site( $scopes, $resource_indicator, $format );
 			return;
 		}
 
-		$this->authorize_user( $assoc_args, $scopes, $assoc_args['format'] );
+		$this->authorize_user( $assoc_args, $scopes, $resource_indicator, $format );
 	}
 
 	/**
@@ -416,6 +451,12 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * [--site]
 	 * : Clear the cached site-level token.
 	 *
+	 * [--resource=<uri>]
+	 * : Limit revocation to a single RFC 8707 resource indicator. Omit to target the default resource.
+	 *
+	 * [--all-resources]
+	 * : Revoke every stored token across all resource indicators. Cannot be combined with --resource.
+	 *
 	 * [--yes]
 	 * : Skip confirmation prompt.
 	 *
@@ -424,6 +465,8 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 *     wp yoast auth revoke --user=admin
 	 *     wp yoast auth revoke --site
 	 *     wp yoast auth revoke --user=admin --site --yes
+	 *     wp yoast auth revoke --user=admin --resource=https://ai.yoa.st
+	 *     wp yoast auth revoke --user=admin --site --all-resources
 	 *
 	 * @when after_wp_load
 	 *
@@ -433,24 +476,60 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @return void
 	 */
 	public function revoke( $args = null, $assoc_args = null ): void {
-		$user_id  = \get_current_user_id();
-		$has_site = isset( $assoc_args['site'] );
-		$has_user = ( $user_id > 0 );
+		$user_id           = \get_current_user_id();
+		$has_user          = ( $user_id > 0 );
+		$has_site          = (bool) Utils\get_flag_value( $assoc_args, 'site', false );
+		$has_all_resources = (bool) Utils\get_flag_value( $assoc_args, 'all-resources', false );
+		$resource          = Utils\get_flag_value( $assoc_args, 'resource' );
 
 		if ( ! $has_site && ! $has_user ) {
 			WP_CLI::error( 'Specify --site and/or use the global --user flag.' );
 		}
 
-		WP_CLI::confirm( 'This will revoke the specified tokens. Proceed?', $assoc_args );
-
-		if ( $has_user ) {
-			$this->myyoast_client->revoke_user_token( $user_id );
-			WP_CLI::log( \sprintf( 'User %d tokens revoked.', $user_id ) );
+		if ( $has_all_resources && $resource !== null && $resource !== '' ) {
+			WP_CLI::error( '--all-resources and --resource cannot be combined.' );
 		}
 
-		if ( $has_site ) {
-			$this->myyoast_client->clear_site_token();
-			WP_CLI::log( 'Site token cleared.' );
+		$resource_indicator = null;
+		if ( $resource !== null && $resource !== '' ) {
+			$resource_indicator = (string) $resource;
+			try {
+				new Resource_Indicator( $resource_indicator );
+			}
+			catch ( Invalid_Resource_Exception $e ) {
+				WP_CLI::error( 'Invalid resource indicator: ' . $e->getMessage() );
+				return;
+			}
+		}
+
+		WP_CLI::confirm( 'This will revoke the specified tokens. Proceed?', $assoc_args );
+
+		try {
+			if ( $has_user ) {
+				if ( $has_all_resources ) {
+					$this->myyoast_client->revoke_all_user_tokens( $user_id );
+					WP_CLI::log( \sprintf( 'User %d tokens revoked across all resources.', $user_id ) );
+				}
+				else {
+					$this->myyoast_client->revoke_user_token( $user_id, $resource_indicator );
+					WP_CLI::log( \sprintf( 'User %d tokens revoked.', $user_id ) );
+				}
+			}
+
+			if ( $has_site ) {
+				if ( $has_all_resources ) {
+					$this->myyoast_client->clear_all_site_tokens();
+					WP_CLI::log( 'All site tokens cleared.' );
+				}
+				else {
+					$this->myyoast_client->clear_site_token( $resource_indicator );
+					WP_CLI::log( 'Site token cleared.' );
+				}
+			}
+		}
+		catch ( Exception $e ) {
+			WP_CLI::error( 'Revocation failed: ' . $e->getMessage() );
+			return;
 		}
 
 		WP_CLI::success( 'Done.' );
@@ -492,8 +571,9 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @throws ExitException When key rotation fails.
 	 */
 	public function rotate_keys( $args = null, $assoc_args = null ): void {
-		$rotate_registration = isset( $assoc_args['registration'] ) || isset( $assoc_args['all'] );
-		$rotate_dpop         = isset( $assoc_args['dpop'] ) || isset( $assoc_args['all'] );
+		$rotate_all          = (bool) Utils\get_flag_value( $assoc_args, 'all', false );
+		$rotate_registration = ( $rotate_all || (bool) Utils\get_flag_value( $assoc_args, 'registration', false ) );
+		$rotate_dpop         = ( $rotate_all || (bool) Utils\get_flag_value( $assoc_args, 'dpop', false ) );
 
 		if ( ! $rotate_registration && ! $rotate_dpop ) {
 			WP_CLI::error( 'Specify --registration, --dpop, or --all.' );
@@ -526,16 +606,17 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	/**
 	 * Performs a client_credentials grant for a site-level token.
 	 *
-	 * @param string[] $scopes The scopes to request.
-	 * @param string   $format The output format.
+	 * @param string[]    $scopes             The scopes to request.
+	 * @param string|null $resource_indicator The resource indicator (RFC 8707), or null for the default resource.
+	 * @param string      $format             The output format.
 	 *
 	 * @return void
 	 *
 	 * @throws ExitException When the token request fails.
 	 */
-	private function authorize_site( array $scopes, string $format ): void {
+	private function authorize_site( array $scopes, ?string $resource_indicator, string $format ): void {
 		try {
-			$token_set = $this->myyoast_client->get_site_token( $scopes );
+			$token_set = $this->myyoast_client->get_site_token( $scopes, $resource_indicator );
 		} catch ( Exception $e ) {
 			WP_CLI::error( 'Site token request failed: ' . $e->getMessage() );
 			return;
@@ -549,30 +630,31 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	/**
 	 * Handles the user authorization code flow.
 	 *
-	 * @param array<string, string> $assoc_args The associative arguments.
-	 * @param string[]              $scopes     The scopes to request.
-	 * @param string                $format     The output format.
+	 * @param array<string, string> $assoc_args         The associative arguments.
+	 * @param string[]              $scopes             The scopes to request.
+	 * @param string|null           $resource_indicator The resource indicator (RFC 8707), or null for the default resource.
+	 * @param string                $format             The output format.
 	 *
 	 * @return void
 	 *
 	 * @throws ExitException When authorization fails.
 	 */
-	private function authorize_user( array $assoc_args, array $scopes, string $format ): void {
+	private function authorize_user( array $assoc_args, array $scopes, ?string $resource_indicator, string $format ): void {
 		$user_id = \get_current_user_id();
 		if ( $user_id <= 0 ) {
 			WP_CLI::error( 'User authorization requires the global --user flag.' );
 		}
 
-		$has_code  = isset( $assoc_args['code'] );
-		$has_state = isset( $assoc_args['state'] );
+		$code  = Utils\get_flag_value( $assoc_args, 'code' );
+		$state = Utils\get_flag_value( $assoc_args, 'state' );
 
-		// Phase 2: exchange the code.
-		if ( $has_code && $has_state ) {
+		// Phase 2: exchange the code. The resource was persisted in the flow state during phase 1.
+		if ( $code !== null && $state !== null ) {
 			try {
 				$token_set = $this->myyoast_client->exchange_authorization_code(
 					$user_id,
-					$assoc_args['code'],
-					$assoc_args['state'],
+					(string) $code,
+					(string) $state,
 				);
 			} catch ( Exception $e ) {
 				WP_CLI::error( 'Code exchange failed: ' . $e->getMessage() );
@@ -585,7 +667,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 			return;
 		}
 
-		if ( $has_code || $has_state ) {
+		if ( $code !== null || $state !== null ) {
 			WP_CLI::error( 'Both --code and --state are required for code exchange.' );
 		}
 
@@ -593,13 +675,13 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		$redirect_uri = \get_admin_url( null, 'admin.php?page=' . General_Page_Integration::PAGE . '&yoast_myyoast_oauth_callback=1' );
 
 		try {
-			$url = $this->myyoast_client->get_authorization_url( $user_id, $redirect_uri, $scopes );
+			$url = $this->myyoast_client->get_authorization_url( $user_id, $redirect_uri, $scopes, $resource_indicator );
 		} catch ( Exception $e ) {
 			WP_CLI::error( 'Failed to generate authorization URL: ' . $e->getMessage() );
 			return;
 		}
 
-		if ( isset( $assoc_args['url-only'] ) ) {
+		if ( Utils\get_flag_value( $assoc_args, 'url-only', false ) ) {
 			WP_CLI::log( $url );
 			return;
 		}
@@ -629,6 +711,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	private function build_token_info( ?Token_Set $token_set ): array {
 		if ( $token_set === null ) {
 			return [
+				'resource'    => '-',
 				'status'      => 'none',
 				'expires'     => '-',
 				'scopes'      => '-',
@@ -637,11 +720,27 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		}
 
 		return [
+			'resource'    => ( $token_set->get_resource_indicator()->is_default() ? '(default)' : $token_set->get_resource_indicator()->value() ),
 			'status'      => ( $token_set->is_expired() ) ? 'expired' : 'valid',
 			'expires'     => \gmdate( 'Y-m-d H:i:s', $token_set->get_expires_at() ) . ' UTC',
 			'scopes'      => ( $token_set->get_scope() ?? '-' ),
 			'error_count' => $token_set->get_error_count(),
 		];
+	}
+
+	/**
+	 * Builds a display-safe inventory of tokens across resource buckets.
+	 *
+	 * @param Token_Set[] $token_sets The token sets.
+	 *
+	 * @return array<int, array<string, string|int>>|string The inventory, or a placeholder when empty.
+	 */
+	private function build_token_inventory( array $token_sets ) {
+		$inventory = [];
+		foreach ( $token_sets as $token_set ) {
+			$inventory[] = $this->build_token_info( $token_set );
+		}
+		return $inventory;
 	}
 
 	/**
@@ -652,11 +751,12 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 * @return string[] The parsed scopes.
 	 */
 	private function parse_scopes( $assoc_args ): array {
-		if ( ! isset( $assoc_args['scopes'] ) || $assoc_args['scopes'] === '' ) {
+		$scopes = Utils\get_flag_value( $assoc_args, 'scopes', '' );
+		if ( $scopes === '' ) {
 			return [];
 		}
 
-		return \array_values( \array_filter( \array_map( 'trim', \explode( ',', $assoc_args['scopes'] ) ) ) );
+		return \array_values( \array_filter( \array_map( 'trim', \explode( ',', (string) $scopes ) ) ) );
 	}
 
 	/**
@@ -671,7 +771,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		foreach ( $data as $key => $value ) {
 			if ( \is_array( $value ) ) {
 				// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- WP-CLI display output, not user-facing HTML.
-				$result[ $key ] = ( \wp_json_encode( $value ) ?? '[]' );
+				$result[ $key ] = ( \wp_json_encode( $value ) ?? 'err' );
 			}
 			elseif ( \is_bool( $value ) ) {
 				$result[ $key ] = ( $value ) ? 'true' : 'false';
@@ -699,11 +799,12 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 			return;
 		}
 
-		$items = [];
-		foreach ( $data as $key => $value ) {
+		$flat_data = $this->flatten_for_display( $data );
+		$items     = [];
+		foreach ( $flat_data as $key => $value ) {
 			$items[] = [
 				'field' => $key,
-				'value' => (string) $value,
+				'value' => $value,
 			];
 		}
 

--- a/src/myyoast-client/user-interface/auth-command.php
+++ b/src/myyoast-client/user-interface/auth-command.php
@@ -733,9 +733,9 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 	 *
 	 * @param Token_Set[] $token_sets The token sets.
 	 *
-	 * @return array<int, array<string, string|int>>|string The inventory, or a placeholder when empty.
+	 * @return array<int, array<string, string|int>> The inventory.
 	 */
-	private function build_token_inventory( array $token_sets ) {
+	private function build_token_inventory( array $token_sets ): array {
 		$inventory = [];
 		foreach ( $token_sets as $token_set ) {
 			$inventory[] = $this->build_token_info( $token_set );

--- a/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Discovery_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\ID_Token_Validator_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Discovery_Document;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -114,7 +115,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 			->once()
 			->with( 'myyoast_current_authorization_state', Mockery::type( 'array' ), 600, 1 );
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ] );
+		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], Resource_Indicator::default() );
 
 		$this->assertStringStartsWith( 'https://my.yoast.com/api/oauth/auth?', $url );
 		$this->assertStringContainsString( 'response_type=code', $url );
@@ -123,6 +124,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->assertStringContainsString( 'prompt=consent', $url );
 		$this->assertStringContainsString( 'state=', $url );
 		$this->assertStringNotContainsString( 'nonce=', $url );
+		$this->assertStringNotContainsString( 'resource=', $url );
 	}
 
 	/**
@@ -161,7 +163,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 				1,
 			);
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'openid', 'profile' ] );
+		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'openid', 'profile' ], Resource_Indicator::default() );
 
 		$this->assertStringContainsString( 'nonce=', $url );
 	}
@@ -201,7 +203,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 				1,
 			);
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], 'https://example.com/settings' );
+		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], Resource_Indicator::default(), 'https://example.com/settings' );
 
 		$this->assertStringStartsWith( 'https://my.yoast.com/api/oauth/auth?', $url );
 	}
@@ -337,7 +339,14 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->grant_handler
 			->expects( 'request_token' )
 			->once()
-			->with( Mockery::type( Authorization_Code_Grant::class ) )
+			->with(
+				Mockery::type( Authorization_Code_Grant::class ),
+				Mockery::on(
+					static function ( $indicator ) {
+						return $indicator instanceof Resource_Indicator && $indicator->is_default();
+					},
+				),
+			)
 			->andReturn( $token_set );
 
 		$result = $this->instance->exchange_code( 1, 'auth-code', 'the-state' );
@@ -379,7 +388,14 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->grant_handler
 			->expects( 'request_token' )
 			->once()
-			->with( Mockery::type( Authorization_Code_Grant::class ) )
+			->with(
+				Mockery::type( Authorization_Code_Grant::class ),
+				Mockery::on(
+					static function ( $indicator ) {
+						return $indicator instanceof Resource_Indicator && $indicator->is_default();
+					},
+				),
+			)
 			->andReturn( $token_set );
 
 		$result = $this->instance->exchange_code( 1, 'auth-code', 'the-state' );
@@ -421,7 +437,14 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->grant_handler
 			->expects( 'request_token' )
 			->once()
-			->with( Mockery::type( Authorization_Code_Grant::class ) )
+			->with(
+				Mockery::type( Authorization_Code_Grant::class ),
+				Mockery::on(
+					static function ( $indicator ) {
+						return $indicator instanceof Resource_Indicator && $indicator->is_default();
+					},
+				),
+			)
 			->andReturn( $token_set );
 
 		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
@@ -440,6 +463,87 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$result = $this->instance->exchange_code( 1, 'auth-code', 'the-state' );
 
 		$this->assertSame( $token_set, $result );
+	}
+
+	/**
+	 * Tests that get_authorization_url includes the resource indicator in the URL and persists it.
+	 *
+	 * @covers ::get_authorization_url
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_url_with_resource_indicator() {
+		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
+
+		$this->client_registration
+			->expects( 'ensure_registered' )
+			->andReturn( $registered_client );
+
+		$document = new Discovery_Document( $this->get_valid_discovery_response() );
+		$this->discovery->expects( 'get_document' )->andReturn( $document );
+
+		$this->expiring_store
+			->expects( 'persist_for_user' )
+			->once()
+			->with(
+				'myyoast_current_authorization_state',
+				Mockery::on(
+					static function ( $value ) {
+						return \is_array( $value )
+							&& ( $value['resource_indicator'] ?? null ) === 'https://ai.yoa.st';
+					},
+				),
+				600,
+				1,
+			);
+
+		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->assertStringContainsString( 'resource=https%3A%2F%2Fai.yoa.st', $url );
+	}
+
+	/**
+	 * Tests that exchange_code forwards the stored resource indicator to the grant and grant handler.
+	 *
+	 * @covers ::exchange_code
+	 *
+	 * @return void
+	 */
+	public function test_exchange_code_forwards_resource_indicator() {
+		$this->expiring_store
+			->expects( 'get_for_user' )
+			->once()
+			->andReturn(
+				[
+					'state'              => 'the-state',
+					'code_verifier'      => 'the-verifier',
+					'nonce'              => null,
+					'redirect_uri'       => 'https://example.com/callback',
+					'return_url'         => null,
+					'resource_indicator' => 'https://ai.yoa.st',
+				],
+			);
+
+		$this->expiring_store->expects( 'delete_for_user' )->once();
+
+		$token_set = ( new Token_Set( 'access-tok', ( \time() + 3600 ), 'DPoP', 'refresh-tok' ) )
+			->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->grant_handler
+			->expects( 'request_token' )
+			->once()
+			->withArgs(
+				static function ( $grant, $indicator ) {
+					return $grant instanceof Authorization_Code_Grant
+						&& $indicator instanceof Resource_Indicator
+						&& $indicator->value() === 'https://ai.yoa.st';
+				},
+			)
+			->andReturn( $token_set );
+
+		$result = $this->instance->exchange_code( 1, 'auth-code', 'the-state' );
+
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Application/Grants/Authorization_Code_Grant_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Grants/Authorization_Code_Grant_Test.php
@@ -42,5 +42,6 @@ final class Authorization_Code_Grant_Test extends TestCase {
 		$this->assertSame( 'code-123', $params['code'] );
 		$this->assertSame( 'https://example.com/callback', $params['redirect_uri'] );
 		$this->assertSame( 'verifier-abc', $params['code_verifier'] );
+		$this->assertArrayNotHasKey( 'resource', $params );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Application/Grants/Client_Credentials_Grant_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Grants/Client_Credentials_Grant_Test.php
@@ -57,5 +57,6 @@ final class Client_Credentials_Grant_Test extends TestCase {
 
 		$this->assertSame( 'https://example.com/', $params['site_url'] );
 		$this->assertArrayNotHasKey( 'scope', $params );
+		$this->assertArrayNotHasKey( 'resource', $params );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Application/Grants/Refresh_Token_Grant_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Grants/Refresh_Token_Grant_Test.php
@@ -40,5 +40,6 @@ final class Refresh_Token_Grant_Test extends TestCase {
 		$params = $grant->get_grant_params();
 
 		$this->assertSame( 'rt-abc-123', $params['refresh_token'] );
+		$this->assertArrayNotHasKey( 'resource', $params );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Cleanup_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Cleanup_Test.php
@@ -78,11 +78,11 @@ final class MyYoast_Client_Cleanup_Test extends TestCase {
 			->andReturn( true );
 
 		$this->user_token_storage
-			->expects( 'delete_all' )
+			->expects( 'delete_all_issuers' )
 			->once();
 
 		$this->token_storage
-			->expects( 'delete_all' )
+			->expects( 'delete_all_issuers' )
 			->once();
 
 		$this->client_registration
@@ -106,11 +106,11 @@ final class MyYoast_Client_Cleanup_Test extends TestCase {
 			->andThrow( new Exception( 'Network error' ) );
 
 		$this->user_token_storage
-			->expects( 'delete_all' )
+			->expects( 'delete_all_issuers' )
 			->once();
 
 		$this->token_storage
-			->expects( 'delete_all' )
+			->expects( 'delete_all_issuers' )
 			->once();
 
 		$this->client_registration

--- a/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Cleanup_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Cleanup_Test.php
@@ -82,7 +82,7 @@ final class MyYoast_Client_Cleanup_Test extends TestCase {
 			->once();
 
 		$this->token_storage
-			->expects( 'delete' )
+			->expects( 'delete_all' )
 			->once();
 
 		$this->client_registration
@@ -110,7 +110,7 @@ final class MyYoast_Client_Cleanup_Test extends TestCase {
 			->once();
 
 		$this->token_storage
-			->expects( 'delete' )
+			->expects( 'delete_all' )
 			->once();
 
 		$this->client_registration

--- a/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
@@ -18,6 +18,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Token_Revocation_Handler;
 use Yoast\WP\SEO\MyYoast_Client\Domain\HTTP_Response;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -125,6 +126,19 @@ final class MyYoast_Client_Test extends TestCase {
 	}
 
 	/**
+	 * Mockery matcher for "is the default Resource_Indicator".
+	 *
+	 * @return Mockery\Matcher\MatcherAbstract
+	 */
+	private function default_indicator() {
+		return Mockery::on(
+			static function ( $indicator ) {
+				return $indicator instanceof Resource_Indicator && $indicator->is_default();
+			},
+		);
+	}
+
+	/**
 	 * Tests that is_registered delegates to client_registration.
 	 *
 	 * @covers ::is_registered
@@ -152,7 +166,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->once()
 			->andReturn( $token_set );
 
@@ -174,7 +188,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $expired );
 
 		$this->lock_helper
@@ -250,7 +264,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'delete' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->once();
 
 		$this->assertNull( $this->instance->get_user_token( 42 ) );
@@ -290,7 +304,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $token_set );
 
 		$this->revocation_handler
@@ -307,7 +321,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'delete' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->once();
 
 		$this->instance->revoke_user_token( 42 );
@@ -323,7 +337,7 @@ final class MyYoast_Client_Test extends TestCase {
 	public function test_has_user_token() {
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( new Token_Set( 'access', ( \time() + 3600 ) ) );
 
 		$this->assertTrue( $this->instance->has_user_token( 42 ) );
@@ -390,7 +404,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $expired );
 
 		$this->assertNull( $this->instance->get_user_token( 42 ) );
@@ -409,7 +423,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $expired );
 
 		$this->lock_helper
@@ -438,7 +452,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $expired );
 
 		$this->lock_helper
@@ -463,7 +477,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $token_set );
 
 		$this->assertNull( $this->instance->get_user_token( 42, [ 'profile', 'email' ] ) );
@@ -481,7 +495,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $token_set );
 
 		$result = $this->instance->get_user_token( 42, [ 'profile' ] );
@@ -532,7 +546,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( $token_set );
 
 		$this->revocation_handler
@@ -543,7 +557,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->user_token_storage
 			->expects( 'delete' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->once();
 
 		$this->instance->revoke_user_token( 42 );
@@ -559,7 +573,7 @@ final class MyYoast_Client_Test extends TestCase {
 	public function test_revoke_user_token_noop_when_no_token() {
 		$this->user_token_storage
 			->expects( 'get' )
-			->with( 42 )
+			->with( 42, $this->default_indicator() )
 			->andReturn( null );
 
 		$this->revocation_handler->expects( 'revoke' )->never();
@@ -712,5 +726,197 @@ final class MyYoast_Client_Test extends TestCase {
 			->andReturn( true );
 
 		$this->assertTrue( $this->instance->revoke_token( 'some-token', 'access_token' ) );
+	}
+
+	/**
+	 * Tests that get_site_token forwards the resource indicator to storage and grant.
+	 *
+	 * @covers ::get_site_token
+	 *
+	 * @return void
+	 */
+	public function test_get_site_token_with_resource_indicator() {
+		$indicator_matches = static function ( $indicator ) {
+			return $indicator instanceof Resource_Indicator
+				&& $indicator->value() === 'https://ai.yoa.st';
+		};
+
+		$this->token_storage
+			->expects( 'get' )
+			->withArgs(
+				static function ( $indicator ) use ( $indicator_matches ) {
+					return $indicator_matches( $indicator );
+				},
+			)
+			->andReturn( null );
+
+		$fresh = ( new Token_Set( 'ai-tok', ( \time() + 900 ) ) )->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->grant_handler
+			->expects( 'request_token' )
+			->withArgs(
+				static function ( $grant, $requested_resource ) use ( $indicator_matches ) {
+					return $indicator_matches( $requested_resource );
+				},
+			)
+			->andReturn( $fresh );
+
+		$this->token_storage
+			->expects( 'store' )
+			->with( $fresh )
+			->once();
+
+		$result = $this->instance->get_site_token( [ 'service:ai:consume' ], 'https://ai.yoa.st' );
+
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that get_user_token refresh keeps the resource indicator binding.
+	 *
+	 * @covers ::get_user_token
+	 *
+	 * @return void
+	 */
+	public function test_get_user_token_refresh_preserves_resource_indicator() {
+		$indicator_matches = static function ( $indicator ) {
+			return $indicator instanceof Resource_Indicator
+				&& $indicator->value() === 'https://ai.yoa.st';
+		};
+
+		$expired = ( new Token_Set( 'old', ( \time() - 100 ), 'DPoP', 'refresh-tok' ) )
+			->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+		$fresh   = ( new Token_Set( 'new', ( \time() + 900 ), 'DPoP', 'new-refresh' ) )
+			->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->user_token_storage
+			->expects( 'get' )
+			->withArgs(
+				static function ( $user_id, $indicator ) use ( $indicator_matches ) {
+					return $user_id === 42 && $indicator_matches( $indicator );
+				},
+			)
+			->andReturn( $expired );
+
+		$this->lock_helper
+			->expects( 'execute' )
+			->andReturnUsing(
+				static function ( $key, $callback ) {
+					return $callback();
+				},
+			);
+
+		$this->grant_handler
+			->expects( 'request_token' )
+			->withArgs(
+				static function ( $grant, $requested_resource ) use ( $indicator_matches ) {
+					return $indicator_matches( $requested_resource );
+				},
+			)
+			->andReturn( $fresh );
+
+		$this->user_token_storage
+			->expects( 'store' )
+			->with( 42, $fresh )
+			->once();
+
+		$result = $this->instance->get_user_token( 42, [], 'https://ai.yoa.st' );
+
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that revoke_user_token targets only the requested resource bucket.
+	 *
+	 * @covers ::revoke_user_token
+	 *
+	 * @return void
+	 */
+	public function test_revoke_user_token_targets_resource_bucket() {
+		$indicator_matches = static function ( $indicator ) {
+			return $indicator instanceof Resource_Indicator
+				&& $indicator->value() === 'https://ai.yoa.st';
+		};
+
+		$token_set = ( new Token_Set( 'ai-access', ( \time() + 3600 ), 'DPoP', 'ai-refresh' ) )
+			->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->user_token_storage
+			->expects( 'get' )
+			->withArgs(
+				static function ( $user_id, $indicator ) use ( $indicator_matches ) {
+					return $user_id === 42 && $indicator_matches( $indicator );
+				},
+			)
+			->andReturn( $token_set );
+
+		$this->revocation_handler->expects( 'revoke' )->with( 'ai-access', 'access_token' )->andReturn( true );
+		$this->revocation_handler->expects( 'revoke' )->with( 'ai-refresh', 'refresh_token' )->andReturn( true );
+
+		$this->user_token_storage
+			->expects( 'delete' )
+			->withArgs(
+				static function ( $user_id, $indicator ) use ( $indicator_matches ) {
+					return $user_id === 42 && $indicator_matches( $indicator );
+				},
+			)
+			->once();
+
+		$this->instance->revoke_user_token( 42, 'https://ai.yoa.st' );
+	}
+
+	/**
+	 * Tests that clear_site_token forwards the resource indicator to storage.
+	 *
+	 * @covers ::clear_site_token
+	 *
+	 * @return void
+	 */
+	public function test_clear_site_token_with_resource_indicator() {
+		$this->token_storage
+			->expects( 'delete' )
+			->withArgs(
+				static function ( $indicator ) {
+					return $indicator instanceof Resource_Indicator
+						&& $indicator->value() === 'https://ai.yoa.st';
+				},
+			)
+			->once();
+
+		$this->instance->clear_site_token( 'https://ai.yoa.st' );
+	}
+
+	/**
+	 * Tests that revoke_all_user_tokens revokes every stored bucket.
+	 *
+	 * @covers ::revoke_all_user_tokens
+	 *
+	 * @return void
+	 */
+	public function test_revoke_all_user_tokens() {
+		$default_token = new Token_Set( 'default-access', ( \time() + 3600 ), 'DPoP', 'default-refresh' );
+		$ai_token      = ( new Token_Set( 'ai-access', ( \time() + 3600 ), 'DPoP', 'ai-refresh' ) )
+			->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->user_token_storage
+			->expects( 'get_all' )
+			->with( 42 )
+			->andReturn( [ $default_token, $ai_token ] );
+
+		$this->revocation_handler->expects( 'revoke' )->with( 'default-access', 'access_token' )->andReturn( true );
+		$this->revocation_handler->expects( 'revoke' )->with( 'default-refresh', 'refresh_token' )->andReturn( true );
+		$this->revocation_handler->expects( 'revoke' )->with( 'ai-access', 'access_token' )->andReturn( true );
+		$this->revocation_handler->expects( 'revoke' )->with( 'ai-refresh', 'refresh_token' )->andReturn( true );
+
+		$this->user_token_storage->expects( 'delete' )->with( 42, $this->default_indicator() )->once();
+		$this->user_token_storage->expects( 'delete' )->withArgs(
+			static function ( $user_id, $indicator ) {
+				return $user_id === 42
+					&& $indicator instanceof Resource_Indicator
+					&& $indicator->value() === 'https://ai.yoa.st';
+			},
+		)->once();
+
+		$this->instance->revoke_all_user_tokens( 42 );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Application/OAuth_Grant_Handler_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/OAuth_Grant_Handler_Test.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Ports\OAuth_Server_Client_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Discovery_Document;
 use Yoast\WP\SEO\MyYoast_Client\Domain\HTTP_Response;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -133,9 +134,141 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 				),
 			);
 
-		$result = $this->instance->request_token( $grant );
+		$result = $this->instance->request_token( $grant, Resource_Indicator::default() );
 
 		$this->assertSame( 'new-token', $result->get_access_token() );
+	}
+
+	/**
+	 * Tests that request_token sends the resource indicator in the body and stamps it on the result.
+	 *
+	 * @covers ::request_token
+	 *
+	 * @return void
+	 */
+	public function test_request_token_sends_resource_indicator_in_body_and_stamps_result() {
+		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
+		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
+
+		$grant = Mockery::mock( Grant_Interface::class );
+		$grant->expects( 'get_grant_type' )->andReturn( 'client_credentials' );
+		$grant->expects( 'get_grant_params' )->andReturn( [ 'site_url' => 'https://example.com/' ] );
+
+		$this->token_endpoint_client
+			->expects( 'request' )
+			->once()
+			->with(
+				'POST',
+				'https://my.yoast.com/api/oauth/token',
+				Mockery::on(
+					static function ( $options ) {
+						$body = ( $options['body'] ?? [] );
+						return ( $body['resource'] ?? null ) === 'https://ai.yoa.st';
+					},
+				),
+			)
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'access_token' => 'tok',
+						'token_type'   => 'DPoP',
+						'expires_in'   => 900,
+					],
+				),
+			);
+
+		$result = $this->instance->request_token( $grant, new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that request_token omits 'resource' from the body when no resource indicator is given.
+	 *
+	 * @covers ::request_token
+	 *
+	 * @return void
+	 */
+	public function test_request_token_omits_resource_when_null() {
+		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
+		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
+
+		$grant = Mockery::mock( Grant_Interface::class );
+		$grant->expects( 'get_grant_type' )->andReturn( 'client_credentials' );
+		$grant->expects( 'get_grant_params' )->andReturn( [ 'site_url' => 'https://example.com/' ] );
+
+		$this->token_endpoint_client
+			->expects( 'request' )
+			->once()
+			->with(
+				'POST',
+				'https://my.yoast.com/api/oauth/token',
+				Mockery::on(
+					static function ( $options ) {
+						$body = ( $options['body'] ?? [] );
+						return ! \array_key_exists( 'resource', $body );
+					},
+				),
+			)
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'access_token' => 'tok',
+						'token_type'   => 'DPoP',
+						'expires_in'   => 900,
+					],
+				),
+			);
+
+		$result = $this->instance->request_token( $grant, Resource_Indicator::default() );
+
+		$this->assertTrue( $result->get_resource_indicator()->is_default() );
+	}
+
+	/**
+	 * Tests that an AS-echoed resource field in the response is ignored.
+	 *
+	 * Per RFC 8707's trust model the client is authoritative for the canonical
+	 * resource indicator. The handler stamps the requested indicator on the
+	 * result rather than honouring an unverified echo from the AS.
+	 *
+	 * @covers ::request_token
+	 *
+	 * @return void
+	 */
+	public function test_request_token_ignores_as_echoed_resource() {
+		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
+		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
+
+		$grant = Mockery::mock( Grant_Interface::class );
+		$grant->expects( 'get_grant_type' )->andReturn( 'client_credentials' );
+		$grant->expects( 'get_grant_params' )->andReturn( [] );
+
+		$this->token_endpoint_client
+			->expects( 'request' )
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'access_token' => 'tok',
+						'token_type'   => 'DPoP',
+						'expires_in'   => 900,
+						'resource'     => 'https://ai.yoa.st/v2',
+					],
+				),
+			);
+
+		$result = $this->instance->request_token( $grant, new Resource_Indicator( 'https://ai.yoa.st' ) );
+
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
 	}
 
 	/**
@@ -171,7 +304,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 			);
 
 		$this->expectException( Token_Request_Failed_Exception::class );
-		$this->instance->request_token( $grant );
+		$this->instance->request_token( $grant, Resource_Indicator::default() );
 	}
 
 	/**
@@ -205,7 +338,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 
 		$this->expectException( Token_Request_Failed_Exception::class );
 		$this->expectExceptionMessage( 'HTTP 500' );
-		$this->instance->request_token( $grant );
+		$this->instance->request_token( $grant, Resource_Indicator::default() );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Domain/Auth_Flow_State_Test.php
+++ b/tests/Unit/MyYoast_Client/Domain/Auth_Flow_State_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Domain;
 
 use InvalidArgumentException;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Auth_Flow_State;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -26,7 +27,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_getters() {
-		$state = new Auth_Flow_State( 'verifier', 'csrf-state', 'nonce-123', 'https://example.com/callback', 'https://example.com/settings' );
+		$state = new Auth_Flow_State( 'verifier', 'csrf-state', 'nonce-123', 'https://example.com/callback', 'https://example.com/settings', Resource_Indicator::default() );
 
 		$this->assertSame( 'verifier', $state->get_code_verifier() );
 		$this->assertSame( 'csrf-state', $state->get_state() );
@@ -43,8 +44,8 @@ final class Auth_Flow_State_Test extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_return_url_defaults_to_null() {
-		$state = new Auth_Flow_State( 'verifier', 'csrf-state', 'nonce', 'https://example.com/callback' );
+	public function test_accepts_null_return_url() {
+		$state = new Auth_Flow_State( 'verifier', 'csrf-state', 'nonce', 'https://example.com/callback', null, Resource_Indicator::default() );
 
 		$this->assertNull( $state->get_return_url() );
 	}
@@ -58,7 +59,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_to_array_from_array_round_trip() {
-		$original = new Auth_Flow_State( 'verifier', 'state', 'nonce', 'https://example.com/cb', 'https://example.com/return' );
+		$original = new Auth_Flow_State( 'verifier', 'state', 'nonce', 'https://example.com/cb', 'https://example.com/return', Resource_Indicator::default() );
 		$restored = Auth_Flow_State::from_array( $original->to_array() );
 
 		$this->assertSame( $original->get_code_verifier(), $restored->get_code_verifier() );
@@ -77,7 +78,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_to_array_from_array_without_return_url() {
-		$original = new Auth_Flow_State( 'verifier', 'state', 'nonce', 'https://example.com/cb' );
+		$original = new Auth_Flow_State( 'verifier', 'state', 'nonce', 'https://example.com/cb', null, Resource_Indicator::default() );
 		$restored = Auth_Flow_State::from_array( $original->to_array() );
 
 		$this->assertNull( $restored->get_return_url() );
@@ -93,7 +94,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	public function test_throws_on_empty_code_verifier() {
 		$this->expectException( InvalidArgumentException::class );
 
-		new Auth_Flow_State( '', 'state', 'nonce', 'https://example.com/cb' );
+		new Auth_Flow_State( '', 'state', 'nonce', 'https://example.com/cb', null, Resource_Indicator::default() );
 	}
 
 	/**
@@ -106,7 +107,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	public function test_throws_on_empty_state() {
 		$this->expectException( InvalidArgumentException::class );
 
-		new Auth_Flow_State( 'verifier', '', 'nonce', 'https://example.com/cb' );
+		new Auth_Flow_State( 'verifier', '', 'nonce', 'https://example.com/cb', null, Resource_Indicator::default() );
 	}
 
 	/**
@@ -118,7 +119,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_accepts_null_nonce() {
-		$state = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/cb' );
+		$state = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/cb', null, Resource_Indicator::default() );
 
 		$this->assertNull( $state->get_nonce() );
 	}
@@ -132,7 +133,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_to_array_from_array_without_nonce() {
-		$original = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/cb' );
+		$original = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/cb', null, Resource_Indicator::default() );
 		$restored = Auth_Flow_State::from_array( $original->to_array() );
 
 		$this->assertNull( $restored->get_nonce() );
@@ -148,7 +149,7 @@ final class Auth_Flow_State_Test extends TestCase {
 	public function test_throws_on_empty_redirect_uri() {
 		$this->expectException( InvalidArgumentException::class );
 
-		new Auth_Flow_State( 'verifier', 'state', 'nonce', '' );
+		new Auth_Flow_State( 'verifier', 'state', 'nonce', '', null, Resource_Indicator::default() );
 	}
 
 	/**
@@ -162,5 +163,27 @@ final class Auth_Flow_State_Test extends TestCase {
 		$this->expectException( InvalidArgumentException::class );
 
 		Auth_Flow_State::from_array( [] );
+	}
+
+	/**
+	 * Tests that the resource indicator defaults to null and round-trips through serialization.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_resource_indicator
+	 * @covers ::to_array
+	 * @covers ::from_array
+	 *
+	 * @return void
+	 */
+	public function test_resource_indicator_round_trip() {
+		$default = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/callback', null, Resource_Indicator::default() );
+		$this->assertTrue( $default->get_resource_indicator()->is_default() );
+
+		$indicator = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bound     = new Auth_Flow_State( 'verifier', 'state', null, 'https://example.com/callback', null, $indicator );
+		$this->assertSame( 'https://ai.yoa.st', $bound->get_resource_indicator()->value() );
+
+		$restored = Auth_Flow_State::from_array( $bound->to_array() );
+		$this->assertSame( 'https://ai.yoa.st', $restored->get_resource_indicator()->value() );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Domain/Resource_Indicator_Test.php
+++ b/tests/Unit/MyYoast_Client/Domain/Resource_Indicator_Test.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Domain;
+
+use Yoast\WP\SEO\MyYoast_Client\Domain\Exceptions\Invalid_Resource_Exception;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Resource_Indicator value object.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator
+ */
+final class Resource_Indicator_Test extends TestCase {
+
+	/**
+	 * Tests that an absolute URI is accepted.
+	 *
+	 * @covers ::__construct
+	 * @covers ::value
+	 *
+	 * @return void
+	 */
+	public function test_construct_accepts_absolute_uri() {
+		$this->assertSame( 'https://ai.yoa.st', ( new Resource_Indicator( 'https://ai.yoa.st' ) )->value() );
+		$this->assertSame( 'https://api.example.com/v2', ( new Resource_Indicator( 'https://api.example.com/v2' ) )->value() );
+	}
+
+	/**
+	 * Tests that absolute URIs with non-URL schemes (urn, did) are accepted.
+	 *
+	 * RFC 8707 does not restrict the scheme; the AS decides what to accept via invalid_target.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_accepts_non_url_absolute_uri() {
+		$this->assertSame( 'urn:example:resource', ( new Resource_Indicator( 'urn:example:resource' ) )->value() );
+		$this->assertSame( 'did:web:example.com', ( new Resource_Indicator( 'did:web:example.com' ) )->value() );
+	}
+
+	/**
+	 * Tests that a trailing root slash is trimmed for storage-key stability.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_trims_root_trailing_slash() {
+		$this->assertSame( 'https://ai.yoa.st', ( new Resource_Indicator( 'https://ai.yoa.st/' ) )->value() );
+	}
+
+	/**
+	 * Tests that a non-root trailing slash is preserved.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_preserves_non_root_path_trailing_slash() {
+		$this->assertSame( 'https://api.example.com/v2/', ( new Resource_Indicator( 'https://api.example.com/v2/' ) )->value() );
+	}
+
+	/**
+	 * Tests that a fragment is rejected per RFC 8707 §2.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_rejects_fragment() {
+		$this->expectException( Invalid_Resource_Exception::class );
+
+		new Resource_Indicator( 'https://ai.yoa.st#frag' );
+	}
+
+	/**
+	 * Tests that a relative URI is rejected.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_rejects_relative_uri() {
+		$this->expectException( Invalid_Resource_Exception::class );
+
+		new Resource_Indicator( '/api/v2' );
+	}
+
+	/**
+	 * Tests that an invalid scheme syntax (RFC 3986 §3.1) is rejected.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_rejects_invalid_scheme_syntax() {
+		$this->expectException( Invalid_Resource_Exception::class );
+
+		new Resource_Indicator( '1https://example.com' );
+	}
+
+	/**
+	 * Tests that a string with no scheme is rejected.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_rejects_string_without_scheme() {
+		$this->expectException( Invalid_Resource_Exception::class );
+
+		new Resource_Indicator( 'example.com/path' );
+	}
+
+	/**
+	 * Tests that an empty string is rejected.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_construct_rejects_empty_string() {
+		$this->expectException( Invalid_Resource_Exception::class );
+
+		new Resource_Indicator( '' );
+	}
+
+	/**
+	 * Tests __toString.
+	 *
+	 * @covers ::__toString
+	 *
+	 * @return void
+	 */
+	public function test_to_string() {
+		$indicator = new Resource_Indicator( 'https://ai.yoa.st' );
+
+		$this->assertSame( 'https://ai.yoa.st', (string) $indicator );
+	}
+
+	/**
+	 * Tests equals() identifies same canonical values.
+	 *
+	 * @covers ::equals
+	 *
+	 * @return void
+	 */
+	public function test_equals_returns_true_for_same_value() {
+		$a = new Resource_Indicator( 'https://ai.yoa.st' );
+		$b = new Resource_Indicator( 'https://ai.yoa.st/' );
+
+		$this->assertTrue( $a->equals( $b ) );
+	}
+
+	/**
+	 * Tests equals() distinguishes different canonical values.
+	 *
+	 * @covers ::equals
+	 *
+	 * @return void
+	 */
+	public function test_equals_returns_false_for_different_value() {
+		$a = new Resource_Indicator( 'https://ai.yoa.st' );
+		$b = new Resource_Indicator( 'https://my.yoast.com' );
+
+		$this->assertFalse( $a->equals( $b ) );
+	}
+}

--- a/tests/Unit/MyYoast_Client/Domain/Token_Set_Test.php
+++ b/tests/Unit/MyYoast_Client/Domain/Token_Set_Test.php
@@ -3,6 +3,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Domain;
 
 use InvalidArgumentException;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -360,5 +361,84 @@ final class Token_Set_Test extends TestCase {
 		$token_set = new Token_Set( 'token', ( \time() + 3600 ) );
 
 		$this->assertFalse( $token_set->has_scopes( [ 'openid' ] ) );
+	}
+
+	/**
+	 * Tests that the resource indicator defaults to null and round-trips through serialization.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_resource_indicator
+	 * @covers ::to_array
+	 * @covers ::from_array
+	 *
+	 * @return void
+	 */
+	public function test_resource_indicator_round_trip() {
+		$default = new Token_Set( 'token', ( \time() + 3600 ) );
+		$this->assertTrue( $default->get_resource_indicator()->is_default() );
+
+		$indicator = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bound     = new Token_Set( 'token', ( \time() + 3600 ), 'DPoP', null, null, null, 0, $indicator );
+		$this->assertSame( 'https://ai.yoa.st', $bound->get_resource_indicator()->value() );
+
+		$restored = Token_Set::from_array( $bound->to_array() );
+		$this->assertSame( 'https://ai.yoa.st', $restored->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that with_resource_indicator returns a new bound instance.
+	 *
+	 * @covers ::with_resource_indicator
+	 * @covers ::get_resource_indicator
+	 *
+	 * @return void
+	 */
+	public function test_with_resource_indicator() {
+		$original  = new Token_Set( 'token', ( \time() + 3600 ) );
+		$indicator = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bound     = $original->with_resource_indicator( $indicator );
+
+		$this->assertTrue( $original->get_resource_indicator()->is_default() );
+		$this->assertSame( 'https://ai.yoa.st', $bound->get_resource_indicator()->value() );
+		$this->assertNotSame( $original, $bound );
+	}
+
+	/**
+	 * Tests that with_incremented_error_count preserves the resource indicator.
+	 *
+	 * @covers ::with_incremented_error_count
+	 *
+	 * @return void
+	 */
+	public function test_with_incremented_error_count_preserves_resource_indicator() {
+		$indicator   = new Resource_Indicator( 'https://ai.yoa.st' );
+		$original    = new Token_Set( 'token', ( \time() + 3600 ), 'DPoP', 'refresh', null, null, 0, $indicator );
+		$incremented = $original->with_incremented_error_count();
+
+		$this->assertSame( 'https://ai.yoa.st', $incremented->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that from_response ignores any AS-echoed resource field.
+	 *
+	 * Per RFC 8707's trust model the client is authoritative for the canonical
+	 * resource indicator. The caller (OAuth_Grant_Handler) stamps the
+	 * requested indicator on the result rather than trusting the AS echo.
+	 *
+	 * @covers ::from_response
+	 * @covers ::get_resource_indicator
+	 *
+	 * @return void
+	 */
+	public function test_from_response_ignores_echoed_resource_field() {
+		$token_set = Token_Set::from_response(
+			[
+				'access_token' => 'tok',
+				'expires_in'   => 900,
+				'resource'     => 'https://ai.yoa.st',
+			],
+		);
+
+		$this->assertTrue( $token_set->get_resource_indicator()->is_default() );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Infrastructure/Token/Token_Storage_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Token/Token_Storage_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Infrastructure\Token;
 use Brain\Monkey\Functions;
 use Mockery;
 use RuntimeException;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\OIDC\Issuer_Config;
@@ -27,11 +28,14 @@ final class Token_Storage_Test extends TestCase {
 	private const ISSUER_KEY = 'a1b2c3d4';
 
 	/**
-	 * The expected option key.
+	 * The option key for the default resource bucket.
+	 *
+	 * This shares the key with pre-RFC-8707 installs by design so existing
+	 * tokens keep working without a data migration.
 	 *
 	 * @var string
 	 */
-	private const OPTION_KEY = 'wpseo_myyoast_site_tokens_' . self::ISSUER_KEY;
+	private const OPTION_KEY_DEFAULT = 'wpseo_myyoast_site_tokens_' . self::ISSUER_KEY;
 
 	/**
 	 * The encryption mock.
@@ -62,14 +66,14 @@ final class Token_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Tests storing and retrieving a token set.
+	 * Tests storing and retrieving a token set in the default resource bucket.
 	 *
 	 * @covers ::store
 	 * @covers ::get
 	 *
 	 * @return void
 	 */
-	public function test_store_and_get() {
+	public function test_store_and_get_default_bucket() {
 		$token_set = new Token_Set( 'access-token', ( \time() + 900 ), 'DPoP' );
 
 		$this->encryption
@@ -79,15 +83,14 @@ final class Token_Storage_Test extends TestCase {
 
 		Functions\expect( 'update_option' )
 			->once()
-			->with( self::OPTION_KEY, 'encrypted-data', false )
+			->with( self::OPTION_KEY_DEFAULT, 'encrypted-data', false )
 			->andReturn( true );
 
 		$this->instance->store( $token_set );
 
-		// Now test get.
 		Functions\expect( 'get_option' )
 			->once()
-			->with( self::OPTION_KEY, '' )
+			->with( self::OPTION_KEY_DEFAULT, '' )
 			->andReturn( 'encrypted-data' );
 
 		$this->encryption
@@ -96,14 +99,48 @@ final class Token_Storage_Test extends TestCase {
 			->once()
 			->andReturn( \wp_json_encode( $token_set->to_array() ) );
 
-		$result = $this->instance->get();
+		$result = $this->instance->get( Resource_Indicator::default() );
 
 		$this->assertNotNull( $result );
 		$this->assertSame( 'access-token', $result->get_access_token() );
 	}
 
 	/**
-	 * Tests that get returns null when no token is stored.
+	 * Tests that a per-resource bucket uses a hashed key suffix.
+	 *
+	 * @covers ::store
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_store_and_get_per_resource_bucket() {
+		$indicator    = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bucket_key   = \substr( \sha1( $indicator->value() ), 0, 12 );
+		$expected_key = self::OPTION_KEY_DEFAULT . '_' . $bucket_key;
+		$token_set    = new Token_Set( 'access-token', ( \time() + 900 ), 'DPoP', null, null, null, 0, $indicator );
+
+		$this->encryption->expects( 'encrypt' )->once()->andReturn( 'encrypted-data' );
+		Functions\expect( 'update_option' )
+			->once()
+			->with( $expected_key, 'encrypted-data', false )
+			->andReturn( true );
+
+		$this->instance->store( $token_set );
+
+		Functions\expect( 'get_option' )
+			->once()
+			->with( $expected_key, '' )
+			->andReturn( 'encrypted-data' );
+		$this->encryption->expects( 'decrypt' )->once()->andReturn( \wp_json_encode( $token_set->to_array() ) );
+
+		$result = $this->instance->get( $indicator );
+
+		$this->assertNotNull( $result );
+		$this->assertSame( 'https://ai.yoa.st', $result->get_resource_indicator()->value() );
+	}
+
+	/**
+	 * Tests that get returns null when no token is stored in the default bucket.
 	 *
 	 * @covers ::get
 	 *
@@ -112,10 +149,10 @@ final class Token_Storage_Test extends TestCase {
 	public function test_get_returns_null_when_empty() {
 		Functions\expect( 'get_option' )
 			->once()
-			->with( self::OPTION_KEY, '' )
+			->with( self::OPTION_KEY_DEFAULT, '' )
 			->andReturn( '' );
 
-		$this->assertNull( $this->instance->get() );
+		$this->assertNull( $this->instance->get( Resource_Indicator::default() ) );
 	}
 
 	/**
@@ -128,29 +165,49 @@ final class Token_Storage_Test extends TestCase {
 	public function test_get_returns_null_on_decryption_failure() {
 		Functions\expect( 'get_option' )
 			->once()
-			->with( self::OPTION_KEY, '' )
+			->with( self::OPTION_KEY_DEFAULT, '' )
 			->andReturn( 'corrupted-data' );
 
 		$this->encryption
 			->expects( 'decrypt' )
 			->andThrow( new RuntimeException( 'Decryption failed' ) );
 
-		$this->assertNull( $this->instance->get() );
+		$this->assertNull( $this->instance->get( Resource_Indicator::default() ) );
 	}
 
 	/**
-	 * Tests that delete clears the stored token.
+	 * Tests that delete clears the default bucket.
 	 *
 	 * @covers ::delete
 	 *
 	 * @return void
 	 */
-	public function test_delete() {
+	public function test_delete_default_bucket() {
 		Functions\expect( 'delete_option' )
 			->once()
-			->with( self::OPTION_KEY )
+			->with( self::OPTION_KEY_DEFAULT )
 			->andReturn( true );
 
-		$this->instance->delete();
+		$this->instance->delete( Resource_Indicator::default() );
+	}
+
+	/**
+	 * Tests deleting a per-resource bucket uses the suffixed key.
+	 *
+	 * @covers ::delete
+	 *
+	 * @return void
+	 */
+	public function test_delete_per_resource_bucket() {
+		$indicator    = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bucket_key   = \substr( \sha1( $indicator->value() ), 0, 12 );
+		$expected_key = self::OPTION_KEY_DEFAULT . '_' . $bucket_key;
+
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( $expected_key )
+			->andReturn( true );
+
+		$this->instance->delete( $indicator );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Infrastructure/Token/Token_Storage_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Token/Token_Storage_Test.php
@@ -210,4 +210,49 @@ final class Token_Storage_Test extends TestCase {
 
 		$this->instance->delete( $indicator );
 	}
+
+	/**
+	 * Tests that delete_all is scoped to the current issuer.
+	 *
+	 * @covers ::delete_all
+	 *
+	 * @return void
+	 */
+	public function test_delete_all_scoped_to_current_issuer() {
+		global $wpdb;
+
+		$wpdb          = Mockery::mock( 'wpdb' );
+		$wpdb->options = 'wp_options';
+		$wpdb->expects( 'esc_like' )->with( self::OPTION_KEY_DEFAULT )->andReturn( self::OPTION_KEY_DEFAULT );
+		$wpdb->expects( 'prepare' )->with(
+			'DELETE FROM wp_options WHERE option_name LIKE %s',
+			self::OPTION_KEY_DEFAULT . '%',
+		)->andReturn( 'PREPARED' );
+		$wpdb->expects( 'query' )->with( 'PREPARED' )->andReturn( 0 );
+
+		$this->instance->delete_all();
+	}
+
+	/**
+	 * Tests that delete_all_issuers ignores the issuer key.
+	 *
+	 * @covers ::delete_all_issuers
+	 *
+	 * @return void
+	 */
+	public function test_delete_all_issuers_purges_every_issuer() {
+		global $wpdb;
+
+		$bare_prefix   = 'wpseo_myyoast_site_tokens_';
+		$wpdb          = Mockery::mock( 'wpdb' );
+		$wpdb->options = 'wp_options';
+		$wpdb->expects( 'esc_like' )->with( $bare_prefix )->andReturn( $bare_prefix );
+		$wpdb->expects( 'prepare' )->with(
+			'DELETE FROM wp_options WHERE option_name LIKE %s',
+			$bare_prefix . '%',
+		)->andReturn( 'PREPARED' );
+		$wpdb->expects( 'query' )->with( 'PREPARED' )->andReturn( 0 );
+
+		$this->instance->delete_all_issuers();
+	}
 }

--- a/tests/Unit/MyYoast_Client/Infrastructure/Token/User_Token_Storage_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Token/User_Token_Storage_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Infrastructure\Token;
 use Mockery;
 use RuntimeException;
 use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\OIDC\Issuer_Config;
@@ -25,6 +26,16 @@ final class User_Token_Storage_Test extends TestCase {
 	 * @var string
 	 */
 	private const ISSUER_KEY = 'a1b2c3d4';
+
+	/**
+	 * The meta key for the default resource bucket.
+	 *
+	 * This shares the key with pre-RFC-8707 installs by design so existing
+	 * tokens keep working without a data migration.
+	 *
+	 * @var string
+	 */
+	private const META_KEY_DEFAULT = '_wpseo_myyoast_user_tokens_' . self::ISSUER_KEY;
 
 	/**
 	 * The user helper mock.
@@ -63,13 +74,13 @@ final class User_Token_Storage_Test extends TestCase {
 	}
 
 	/**
-	 * Tests storing a token for a user.
+	 * Tests storing a token for a user in the default bucket.
 	 *
 	 * @covers ::store
 	 *
 	 * @return void
 	 */
-	public function test_store() {
+	public function test_store_default_bucket() {
 		$token_set = new Token_Set( 'access-token', ( \time() + 900 ), 'DPoP', 'refresh-token' );
 
 		$this->encryption
@@ -79,33 +90,56 @@ final class User_Token_Storage_Test extends TestCase {
 
 		$this->user_helper
 			->expects( 'update_meta' )
-			->with( 42, '_wpseo_myyoast_user_tokens_' . self::ISSUER_KEY, 'encrypted-data' )
+			->with( 42, self::META_KEY_DEFAULT, 'encrypted-data' )
 			->once();
 
 		$this->instance->store( 42, $token_set );
 	}
 
 	/**
-	 * Tests retrieving a token for a user.
+	 * Tests storing a token for a user in a per-resource bucket.
+	 *
+	 * @covers ::store
+	 *
+	 * @return void
+	 */
+	public function test_store_per_resource_bucket() {
+		$indicator    = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bucket_key   = \substr( \sha1( $indicator->value() ), 0, 12 );
+		$expected_key = self::META_KEY_DEFAULT . '_' . $bucket_key;
+		$token_set    = new Token_Set( 'access-token', ( \time() + 900 ), 'DPoP', 'refresh-token', null, null, 0, $indicator );
+
+		$this->encryption->expects( 'encrypt' )->once()->andReturn( 'encrypted-data' );
+		$this->user_helper
+			->expects( 'update_meta' )
+			->with( 42, $expected_key, 'encrypted-data' )
+			->once();
+
+		$this->instance->store( 42, $token_set );
+	}
+
+	/**
+	 * Tests retrieving a token for a user from the default bucket.
 	 *
 	 * @covers ::get
 	 *
 	 * @return void
 	 */
-	public function test_get() {
+	public function test_get_default_bucket() {
 		$token_data = [
-			'access_token'  => 'access-123',
-			'expires_at'    => ( \time() + 900 ),
-			'token_type'    => 'DPoP',
-			'refresh_token' => 'refresh-456',
-			'id_token'      => null,
-			'scope'         => 'openid',
-			'error_count'   => 0,
+			'access_token'       => 'access-123',
+			'expires_at'         => ( \time() + 900 ),
+			'token_type'         => 'DPoP',
+			'refresh_token'      => 'refresh-456',
+			'id_token'           => null,
+			'scope'              => 'openid',
+			'error_count'        => 0,
+			'resource_indicator' => null,
 		];
 
 		$this->user_helper
 			->expects( 'get_meta' )
-			->with( 42, '_wpseo_myyoast_user_tokens_' . self::ISSUER_KEY, true )
+			->with( 42, self::META_KEY_DEFAULT, true )
 			->once()
 			->andReturn( 'encrypted-data' );
 
@@ -115,11 +149,12 @@ final class User_Token_Storage_Test extends TestCase {
 			->once()
 			->andReturn( \wp_json_encode( $token_data ) );
 
-		$result = $this->instance->get( 42 );
+		$result = $this->instance->get( 42, Resource_Indicator::default() );
 
 		$this->assertNotNull( $result );
 		$this->assertSame( 'access-123', $result->get_access_token() );
 		$this->assertSame( 'refresh-456', $result->get_refresh_token() );
+		$this->assertTrue( $result->get_resource_indicator()->is_default() );
 	}
 
 	/**
@@ -132,9 +167,10 @@ final class User_Token_Storage_Test extends TestCase {
 	public function test_get_returns_null_when_empty() {
 		$this->user_helper
 			->expects( 'get_meta' )
+			->with( 42, self::META_KEY_DEFAULT, true )
 			->andReturn( '' );
 
-		$this->assertNull( $this->instance->get( 42 ) );
+		$this->assertNull( $this->instance->get( 42, Resource_Indicator::default() ) );
 	}
 
 	/**
@@ -147,28 +183,49 @@ final class User_Token_Storage_Test extends TestCase {
 	public function test_get_returns_null_on_decryption_failure() {
 		$this->user_helper
 			->expects( 'get_meta' )
+			->with( 42, self::META_KEY_DEFAULT, true )
 			->andReturn( 'corrupted' );
 
 		$this->encryption
 			->expects( 'decrypt' )
 			->andThrow( new RuntimeException( 'fail' ) );
 
-		$this->assertNull( $this->instance->get( 42 ) );
+		$this->assertNull( $this->instance->get( 42, Resource_Indicator::default() ) );
 	}
 
 	/**
-	 * Tests deleting a user's tokens.
+	 * Tests deleting a user's default-bucket token.
 	 *
 	 * @covers ::delete
 	 *
 	 * @return void
 	 */
-	public function test_delete() {
+	public function test_delete_default_bucket() {
 		$this->user_helper
 			->expects( 'delete_meta' )
-			->with( 42, '_wpseo_myyoast_user_tokens_' . self::ISSUER_KEY )
+			->with( 42, self::META_KEY_DEFAULT )
 			->once();
 
-		$this->instance->delete( 42 );
+		$this->instance->delete( 42, Resource_Indicator::default() );
+	}
+
+	/**
+	 * Tests deleting a user's per-resource bucket uses the suffixed key.
+	 *
+	 * @covers ::delete
+	 *
+	 * @return void
+	 */
+	public function test_delete_per_resource_bucket() {
+		$indicator    = new Resource_Indicator( 'https://ai.yoa.st' );
+		$bucket_key   = \substr( \sha1( $indicator->value() ), 0, 12 );
+		$expected_key = self::META_KEY_DEFAULT . '_' . $bucket_key;
+
+		$this->user_helper
+			->expects( 'delete_meta' )
+			->with( 42, $expected_key )
+			->once();
+
+		$this->instance->delete( 42, $indicator );
 	}
 }

--- a/tests/Unit/MyYoast_Client/Infrastructure/Token/User_Token_Storage_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Token/User_Token_Storage_Test.php
@@ -228,4 +228,49 @@ final class User_Token_Storage_Test extends TestCase {
 
 		$this->instance->delete( 42, $indicator );
 	}
+
+	/**
+	 * Tests that delete_all is scoped to the current issuer.
+	 *
+	 * @covers ::delete_all
+	 *
+	 * @return void
+	 */
+	public function test_delete_all_scoped_to_current_issuer() {
+		global $wpdb;
+
+		$wpdb           = Mockery::mock( 'wpdb' );
+		$wpdb->usermeta = 'wp_usermeta';
+		$wpdb->expects( 'esc_like' )->with( self::META_KEY_DEFAULT )->andReturn( self::META_KEY_DEFAULT );
+		$wpdb->expects( 'prepare' )->with(
+			'DELETE FROM wp_usermeta WHERE meta_key LIKE %s',
+			self::META_KEY_DEFAULT . '%',
+		)->andReturn( 'PREPARED' );
+		$wpdb->expects( 'query' )->with( 'PREPARED' )->andReturn( 0 );
+
+		$this->instance->delete_all();
+	}
+
+	/**
+	 * Tests that delete_all_issuers ignores the issuer key.
+	 *
+	 * @covers ::delete_all_issuers
+	 *
+	 * @return void
+	 */
+	public function test_delete_all_issuers_purges_every_issuer() {
+		global $wpdb;
+
+		$bare_prefix    = '_wpseo_myyoast_user_tokens_';
+		$wpdb           = Mockery::mock( 'wpdb' );
+		$wpdb->usermeta = 'wp_usermeta';
+		$wpdb->expects( 'esc_like' )->with( $bare_prefix )->andReturn( $bare_prefix );
+		$wpdb->expects( 'prepare' )->with(
+			'DELETE FROM wp_usermeta WHERE meta_key LIKE %s',
+			$bare_prefix . '%',
+		)->andReturn( 'PREPARED' );
+		$wpdb->expects( 'query' )->with( 'PREPARED' )->andReturn( 0 );
+
+		$this->instance->delete_all_issuers();
+	}
 }


### PR DESCRIPTION
## Context
Needed for Yoast/reserved-tasks#1207
The MyYoast OAuth client at `src/myyoast-client/` is being prepared for a world where other Yoast services (e.g. `https://ai.yoa.st`) act as Resource Servers separate from the Authorization Server at `https://my.yoast.com`. Each Resource Server has its own scopes, so a single site or user will need to hold multiple tokens at once — one per resource server — with different audience bindings and refresh/revocation lifecycles.

Today the client speaks "default-only": it never sends a `resource` parameter and stores exactly one site token plus one user token (per WP user), keyed only by issuer. This PR adds opt-in [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707) Resource Indicator support so callers can target a non-default resource server. The default code path is unchanged — no `resource=` on the wire, same storage key as before, no data migration.

This is purely a client-side change. The MyYoast Authorization Server already supports `resource`; this PR lets us start using it.

The entire change lives behind the existing `YOAST_SEO_MYYOAST_CONNECTION` feature flag, so it is non-user-facing for end users.

## Summary

This PR can be summarized in the following changelog entry:

* Adds RFC 8707 resource-indicator support to the MyYoast OAuth client so a single site or user can hold separate tokens per resource server.

## Relevant technical choices

* **One token per resource, no multi-audience tokens.** RFC 8707 allows multi-audience tokens, but each `(user|site, resource)` getting its own token with its own scopes, refresh, and revocation lifecycle keeps the blast radius small if any one resource server is compromised, lines scopes up cleanly per RS, and makes per-resource revocation possible. DPoP doesn't substitute for audience narrowing. The CLI `--resource=<uri>` flag therefore accepts exactly one URI.
* **Client is authoritative for the canonical resource indicator.** Per RFC 8707 §2 and §4, any `resource` field echoed by the AS in the token response is ignored; `OAuth_Grant_Handler::request_token()` stamps the *requested* indicator on the returned `Token_Set`. Trusting an unverified echo into storage could later violate §2 on refresh.
* **Default bucket reuses the pre-RFC-8707 storage key** (`wpseo_myyoast_site_tokens_{issuer_key}` / `_wpseo_myyoast_user_tokens_{issuer_key}`). Explicit indicators get a `_<sha1_prefix>` suffix. Existing installs need no migration — their row IS the default bucket.
* **`Resource_Indicator` is a domain value object** with strict [RFC 3986 §4.3](https://datatracker.ietf.org/doc/html/rfc3986#section-4.3) absolute-URI validation, a `default()` null-object factory, and `is_default()` / `value()` accessors. The facade is the only layer that accepts `?string` for the indicator; everything below works in value objects where we know for sure that the value is valid.
* **`delete_all()` is per-issuer; `delete_all_issuers()` is for uninstall.** The operational sweeper (CLI `--all-resources`, `clear_all_site_tokens`) is correctly scoped to the current issuer. Uninstall cleanup uses the new cross-issuer sweeper so any stale tokens from a previously-configured issuer are also purged from `wp_options` / `wp_usermeta`.
* **WP-CLI flag reads go through `WP_CLI\Utils\get_flag_value`** for consistent default handling instead of ad-hoc `isset()` / `??` patterns.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR is feature-flagged and CLI-only. Acceptance testing is done via WP-CLI against a dev MyYoast environment with `YOAST_SEO_MYYOAST_CONNECTION` defined as `true` in `wp-config.php`.
Use the test helper plugin to switch environment to a staging/local env.

1. **Default-resource site token still works (no `resource=` on the wire):**
   * `wp yoast auth register`
   * `wp yoast auth authorize --site --scopes=service:licenses:read`
   * Expect: success message and a token row in `wp_options` under `wpseo_myyoast_site_tokens_<issuer_key>`.
2. **Second site token for a non-default resource is stored independently:**
   * `wp yoast auth authorize --site --resource=https://ai-staging.yoa.st --scopes=service:ai:consume` (or https://ai.yoa.st testing against prod. This applies to the rest of the test instructions)
   * Expect: a second `wp_options` row with a hashed suffix; the original default-resource row is unchanged.
3. **`wp yoast auth status --all-resources` enumerates both buckets:**
   * Expect: a table/json listing two site tokens, each with their resource shown (`(default)` and `https://ai-staging.yoa.st`).
4. **User authorization flow with a resource indicator:**
   * `wp yoast auth authorize --user=admin --resource=https://ai-staging.yoa.st --scopes=openid,profile,service:ai:consume` 
   * Follow the instructions (the scope descriptions for AI usage you'll see aren't indicative of real usage, but it's what we have today)
   * Visit the generated URL — confirm `resource=https%3A%2F%2Fai-staging.yoa.st` is present in the query string.
   * Authorize, copy the `code` and `state` from the callback URL, then run `wp yoast auth authorize --user=admin --code=<CODE> --state=<STATE>`. NOTE: the code and state are valid for 60 seconds. You'll get an "invalid grant" error if you're too slow. Try again if this happens)
   * Expect: exchange succeeds and you'll get a token for `resource:ai-staging.yoa.st`, `status:valid` and `scope:`_(empty)_. (The scope is missing because ai:consume is a service scope, meaning it can only be granted to client auth (machine to machine)).
5. **Per-resource revocation:**
   * `wp yoast auth revoke --user=admin --resource=https://ai-staging.yoa.st`
   * Expect: only the `ai-staging.yoa.st` bucket is removed; the default user token remains valid. (check with `wp yoast auth status --user=admin --all-resources`)
   * `wp yoast auth revoke --user=admin --site --all-resources --yes`
   * Expect: every bucket for the current user and the site is gone.
6. **Malformed resource is rejected cleanly:**
   * `wp yoast auth authorize --site --resource=not-a-uri`
   * Expect: `Site token request failed: ...` — no PHP fatal, no stack trace.
   * `wp yoast auth revoke --user=admin --resource=not-a-uri`
   * Expect: `Invalid resource indicator: ...` — no PHP fatal.
7. **Backwards compatibility with pre-RFC-8707 tokens:**
   * On an environment that already has a default site token in `wpseo_myyoast_site_tokens_<issuer_key>`, after this PR `wp yoast auth status` still finds it (key didn't change). No re-authorization required.
8. **Cleanup on plugin uninstall/reset:**
   * With tokens stored under multiple issuer keys (e.g. by editing `wp_options` to fake a stale issuer), deactivate and delete the plugin OR run `wp yoast auth reset` (both trigger the same code).
   * Expect: every `wpseo_myyoast_site_tokens_%` row and every `_wpseo_myyoast_user_tokens_%` row is gone, regardless of issuer key.

#### Relevant test scenarios

* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* WP-CLI `wp yoast auth` commands gain new flags but keep existing invocations working unchanged.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

