### PR TITLE
feat(tracking): include the web-server family in server data

### DIFF
--- a/admin/tracking/class-tracking-server-data.php
+++ b/admin/tracking/class-tracking-server-data.php
@@ -36,10 +36,11 @@ class WPSEO_Tracking_Server_Data implements WPSEO_Collection {
 			$server_data['Hostname'] = gethostbyaddr( $ipaddress );
 		}
 
-		$server_data['os']            = function_exists( 'php_uname' ) ? php_uname() : PHP_OS;
-		$server_data['PhpVersion']    = PHP_VERSION;
-		$server_data['CurlVersion']   = $this->get_curl_info();
-		$server_data['PhpExtensions'] = $this->get_php_extensions();
+		$server_data['os']             = function_exists( 'php_uname' ) ? php_uname() : PHP_OS;
+		$server_data['PhpVersion']     = PHP_VERSION;
+		$server_data['CurlVersion']    = $this->get_curl_info();
+		$server_data['PhpExtensions']  = $this->get_php_extensions();
+		$server_data['ServerSoftware'] = isset( $_SERVER['SERVER_SOFTWARE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SERVER_SOFTWARE'] ) ) : '';
 
 		return $server_data;
 	}


### PR DESCRIPTION
## Context

We collect telemetry to understand how Yoast SEO is deployed, but the server-data collection currently captures OS, PHP version, curl info and PHP extensions — not the web-server family. This PR fills the gap with `$_SERVER['SERVER_SOFTWARE']` so we can size what proportion of installs runs on each server family (Apache, Nginx, IIS, LiteSpeed, …) and decide where to invest server-tier features.

Tracked under: Yoast/wordpress-seo-premium#4968. Pairs with [`Yoast/wordpress-seo-premium#4969`](https://github.com/Yoast/wordpress-seo-premium/pull/4969).

## Summary

This PR can be summarized in the following changelog entry:

* Adds the web-server family to the server data collected for opt-in tracking.

## Relevant technical choices:

* Single-line addition to `WPSEO_Tracking_Server_Data::get_server_data()`. Output key: `server.ServerSoftware`.
* Sanitised with `sanitize_text_field( wp_unslash( … ) )` — `$_SERVER['SERVER_SOFTWARE']` is host-controlled, not user input, but the convention is to pass through `wp_unslash` + `sanitize_text_field` consistently.
* Falls back to an empty string when the SAPI does not populate `SERVER_SOFTWARE` (rare; some CLI contexts).
* No PII concerns: server software string is host-side. Not added to the anonymisation list.
* **No unit tests added.** `WPSEO_Tracking_Server_Data` has no existing test coverage in `tests/`. Standing up a new test file for a single one-line `$_SERVER`-read addition would be disproportionate; the existing tracking collectors are exercised end-to-end at integration time rather than unit-tested.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

**Setup**

1. Enable tracking: **Yoast SEO → Settings → General → Site preferences → Usage tracking → on**.

2. Turn on WordPress debug logging so we can capture the outgoing payload. Edit `wp-config.php` and ensure these two lines are set above the *"That's all, stop editing!"* comment:
   ```php
   define( 'WP_DEBUG', true );
   define( 'WP_DEBUG_LOG', true );
   ```

3. Create the file `wp-content/mu-plugins/log-yoast-tracking.php` (create the `mu-plugins` folder if it doesn't exist) with this content — it intercepts the tracking HTTP request and writes the payload to `wp-content/debug.log` without letting it leave the server:
   ```php
   <?php
   add_filter(
       'pre_http_request',
       function ( $preempt, $args, $url ) {
           if ( strpos( $url, 'tracking.yoast.com' ) !== false ) {
               error_log( "Yoast tracking payload:\n" . $args['body'] );
               // Pretend the request succeeded so Yoast does not retry.
               return [ 'response' => [ 'code' => 200 ], 'body' => '' ];
           }
           return $preempt;
       },
       10,
       3,
   );
   ```

**Run the test**

4. Force the next tracking send (otherwise it only fires every two weeks): delete the throttle option. Either:
   - From the CLI: `wp option delete wpseo_tracking_last_request`
   - Or run this SQL: `DELETE FROM wp_options WHERE option_name = 'wpseo_tracking_last_request';`

5. Load any wp-admin page (e.g. **Yoast SEO → General**). The tracking send fires on `admin_init`.

6. Open `wp-content/debug.log` (e.g. `tail wp-content/debug.log` in a terminal). Look for a `Yoast tracking payload:` line followed by a long JSON blob.

**Expected**

7. The JSON contains a top-level `"server"` object that includes `"ServerSoftware"` with the test environment's web-server string. Examples:
   - Apache: `"ServerSoftware":"Apache/2.4.62 (Debian)"`
   - Nginx: `"ServerSoftware":"nginx/1.24.0"`
   - LiteSpeed: `"ServerSoftware":"LiteSpeed"`

   The exact string depends on the local server; what matters is that the field exists and is not empty.

8. (Optional, if a second environment is available) Repeat on a different server family and verify the field reflects that server's string.

**Clean up**

9. Delete `wp-content/mu-plugins/log-yoast-tracking.php`.
10. Revert the `WP_DEBUG` / `WP_DEBUG_LOG` flags in `wp-config.php` if they weren't on before.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* `WPSEO_Tracking_Server_Data::get()` — the returned array gains one key. The only consumer is `WPSEO_Tracking::send()`. No in-site behaviour changes.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Refs Yoast/wordpress-seo-premium#4968

