### PR TITLE
1230 switch heroicons individual imports in UI library

### DIFF
--- a/packages/ui-library/eslint.config.mjs
+++ b/packages/ui-library/eslint.config.mjs
@@ -17,12 +17,16 @@ export default [
 			"no-restricted-imports": [
 				"error",
 				{
-					name: "@heroicons/react/outline",
-					message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
-				},
-				{
-					name: "@heroicons/react/solid",
-					message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+					paths: [
+						{
+							name: "@heroicons/react/outline",
+							message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
+						},
+						{
+							name: "@heroicons/react/solid",
+							message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+						},
+					],
 				},
 			],
 			"template-curly-spacing": [

--- a/packages/ui-library/eslint.config.mjs
+++ b/packages/ui-library/eslint.config.mjs
@@ -14,6 +14,17 @@ export default [
 			},
 		},
 		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					name: "@heroicons/react/outline",
+					message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
+				},
+				{
+					name: "@heroicons/react/solid",
+					message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+				},
+			],
 			"template-curly-spacing": [
 				"error",
 				"always",

--- a/packages/ui-library/src/components/dropdown-menu/index.js
+++ b/packages/ui-library/src/components/dropdown-menu/index.js
@@ -1,4 +1,4 @@
-import { DotsVerticalIcon } from "@heroicons/react/outline";
+import DotsVerticalIcon from "@heroicons/react/outline/DotsVerticalIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { Fragment } from "react";

--- a/packages/ui-library/src/components/dropdown-menu/stories.js
+++ b/packages/ui-library/src/components/dropdown-menu/stories.js
@@ -1,6 +1,7 @@
 import { DropdownMenu } from ".";
 import React from "react";
-import { XIcon, TrashIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
 import { component } from "./docs";
 
 export const Factory = {

--- a/packages/ui-library/src/components/feature-upsell/index.js
+++ b/packages/ui-library/src/components/feature-upsell/index.js
@@ -1,4 +1,4 @@
-import { LockOpenIcon } from "@heroicons/react/outline";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React from "react";

--- a/packages/ui-library/src/components/file-import/index.js
+++ b/packages/ui-library/src/components/file-import/index.js
@@ -1,5 +1,6 @@
 import { Transition } from "@headlessui/react";
-import { DocumentTextIcon, XIcon } from "@heroicons/react/outline";
+import DocumentTextIcon from "@heroicons/react/outline/DocumentTextIcon";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { capitalize, includes, isEmpty, isNull, values } from "lodash";
 import PropTypes from "prop-types";
 import React, { createContext, forwardRef, useCallback, useContext, useMemo } from "react";

--- a/packages/ui-library/src/components/image-select/index.js
+++ b/packages/ui-library/src/components/image-select/index.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from "react";
 import { useImageSelectContext } from "./hooks";
 import { ImageSelectContext } from "./context";
 import classNames from "classnames";
-import { PhotographIcon } from "@heroicons/react/outline";
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import { Button, Link, useSvgAria } from "../../index";
 
 /**

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from "@headlessui/react";
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef, Fragment } from "react";

--- a/packages/ui-library/src/components/pagination/index.js
+++ b/packages/ui-library/src/components/pagination/index.js
@@ -1,4 +1,5 @@
-import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/solid";
+import ChevronLeftIcon from "@heroicons/react/solid/ChevronLeftIcon";
+import ChevronRightIcon from "@heroicons/react/solid/ChevronRightIcon";
 import classNames from "classnames";
 import { parseInt } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/components/popover/index.js
+++ b/packages/ui-library/src/components/popover/index.js
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import React, { createContext, forwardRef, useCallback, useContext, Fragment } from "react";
 import { Transition } from "@headlessui/react";
 import { noop } from "lodash";

--- a/packages/ui-library/src/components/sidebar-navigation/collapsible.js
+++ b/packages/ui-library/src/components/sidebar-navigation/collapsible.js
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from "@heroicons/react/outline";
+import ChevronDownIcon from "@heroicons/react/outline/ChevronDownIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { useCallback, useEffect } from "react";

--- a/packages/ui-library/src/components/sidebar-navigation/mobile.js
+++ b/packages/ui-library/src/components/sidebar-navigation/mobile.js
@@ -1,5 +1,6 @@
 import { Dialog } from "@headlessui/react";
-import { MenuAlt2Icon, XIcon } from "@heroicons/react/outline";
+import MenuAlt2Icon from "@heroicons/react/outline/MenuAlt2Icon";
+import XIcon from "@heroicons/react/outline/XIcon";
 import PropTypes from "prop-types";
 import React, { useCallback } from "react";
 import { useNavigationContext } from "./index";

--- a/packages/ui-library/src/components/sidebar-navigation/stories.js
+++ b/packages/ui-library/src/components/sidebar-navigation/stories.js
@@ -1,4 +1,7 @@
-import { AdjustmentsIcon, ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
+import AdjustmentsIcon from "@heroicons/react/outline/AdjustmentsIcon";
+import ColorSwatchIcon from "@heroicons/react/outline/ColorSwatchIcon";
+import DesktopComputerIcon from "@heroicons/react/outline/DesktopComputerIcon";
+import NewspaperIcon from "@heroicons/react/outline/NewspaperIcon";
 import { useArgs } from "@storybook/preview-api";
 import React, { useCallback, useEffect } from "react";
 import SidebarNavigation from ".";

--- a/packages/ui-library/src/components/stepper/step.js
+++ b/packages/ui-library/src/components/stepper/step.js
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { useContext } from "react";

--- a/packages/ui-library/src/components/stepper/stories.js
+++ b/packages/ui-library/src/components/stepper/stories.js
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import { useArgs } from "@storybook/preview-api";
 import classNames from "classnames";
 import React, { useCallback, useContext } from "react";

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -1,6 +1,7 @@
 import { Combobox, Transition } from "@headlessui/react";
-import { XIcon } from "@heroicons/react/outline";
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
+import XIcon from "@heroicons/react/outline/XIcon";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import classNames from "classnames";
 import { constant } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/file-input/index.js
+++ b/packages/ui-library/src/elements/file-input/index.js
@@ -1,4 +1,4 @@
-import { DocumentAddIcon } from "@heroicons/react/outline";
+import DocumentAddIcon from "@heroicons/react/outline/DocumentAddIcon";
 import classNames from "classnames";
 import { isEmpty, noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/file-input/stories.js
+++ b/packages/ui-library/src/elements/file-input/stories.js
@@ -1,4 +1,4 @@
-import { DesktopComputerIcon } from "@heroicons/react/outline";
+import DesktopComputerIcon from "@heroicons/react/outline/DesktopComputerIcon";
 import { noop } from "lodash";
 import React from "react";
 import FileInput from ".";

--- a/packages/ui-library/src/elements/modal-notification/index.js
+++ b/packages/ui-library/src/elements/modal-notification/index.js
@@ -1,5 +1,5 @@
 import { Dialog, Portal, Transition } from "@headlessui/react";
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import classNames from "classnames";
 import { isArray, noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -1,5 +1,6 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef, Fragment, useCallback, useMemo } from "react";

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -1,4 +1,4 @@
-import { XIcon } from "@heroicons/react/solid";
+import XIcon from "@heroicons/react/solid/XIcon";
 import classNames from "classnames";
 import { isString, map, noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/toast/index.js
+++ b/packages/ui-library/src/elements/toast/index.js
@@ -1,5 +1,5 @@
 import { Transition } from "@headlessui/react";
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import classNames from "classnames";
 import { isArray, noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/toggle/index.js
+++ b/packages/ui-library/src/elements/toggle/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undefined */
 import { Switch, Transition } from "@headlessui/react";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import classNames from "classnames";
 import { noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/ui-library/src/elements/validation/constants.js
+++ b/packages/ui-library/src/elements/validation/constants.js
@@ -1,4 +1,7 @@
-import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ExclamationIcon from "@heroicons/react/solid/ExclamationIcon";
+import InformationCircleIcon from "@heroicons/react/solid/InformationCircleIcon";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
 
 export const VALIDATION_VARIANTS = {
 	success: "success",


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Switches Heroicons imports in `@yoast/ui-library` from barrel paths (e.g. `@heroicons/react/outline`) to individual ESM paths (e.g. `@heroicons/react/outline/XIcon`) to reduce the plugin bundle size.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ...\.
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ...\.
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoasy/ui-library 0.1.0 other] Switches Heroicons imports to individual direct paths to reduce bundle size in consuming applications.

## Relevant technical choices:

* Added eslint rue to enforce future imports.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Run Storybook for the `ui-library` package: `cd packages/ui-library && yarn storybook`.
2. For each component/element listed below, open the corresponding story and verify that the icon(s) render correctly (no broken/missing icon, no console errors).

One example of where this is implemented: `packages/ui-library/src/components/modal/index.js` — the `XIcon` import was changed from `@heroicons/react/outline` (barrel) to `@heroicons/react/outline/XIcon` (individual ESM path).

**Elements**

- **Autocomplete** → open the _Autocomplete_ story → verify the selector/chevron icon appears on the dropdown, the X icon appears on the clear button for the nullable story, and a checkmark appears next to the selected option. For the vaidation story, verify that the correct icon appears for each validation state: checkmark circle (success), exclamation (warning), information circle (info), exclamation circle (error).
- **FileInput** → open the _FileInput_ story → verify the document-add icon appears in the file input area. And in the custom icon is a desktop computer icon.
- **ModalNotification** → open the _ModalNotification_ story → verify the X icon appears on the dismiss button.
- **Radio** → open the _Radio_ story → select a radio option and verify the filled check-circle icon appears.
- **Select** → open the _Select_ story → verify the selector/chevron icon appears on the dropdown and a checkmark appears next to the selected option.
- **TagInput** → open the _TagInput_ story → add a tag and verify the X icon appears on the tag removal button.
- **Toast** → open the _Toast_ story → verify the X icon appears on the dismiss button.
- **Toggle** → open the _Toggle_ story → toggle on and verify the checkmark icon appears; toggle off and verify the X icon appears.

**Components**

- **DropdownMenu** → open the _DropdownMenu_ story → verify the vertical dots icon (⋮) appears on the trigger button.
- **FeatureUpsell** → open the _FeatureUpsell_ story → verify the open padlock icon appears on the upsell button.
- **FileImport** → open the _FileImport_ story → trigger a file import and verify the document icon appears in the feedback header and the X icon appears on the abort button.
- **ImageSelect** → open the _ImageSelect_ story → verify the photograph/image placeholder icon appears when no image is selected.
- **Modal** → open the _Modal_ story → open a modal and verify the X icon appears on the close button.
- **Pagination** → open the _Pagination_ story → verify the left chevron (‹) and right chevron (›) icons appear on the previous/next buttons.
- **Popover** → open the _Popover_ story → open a popover and verify the X icon appears on the close button.
- **SidebarNavigation (Collapsible)** → open the _SidebarNavigation_ story → verify the chevron-down icon appears on the collapsible menu item toggle.
- **SidebarNavigation (Mobile)** → open the _SidebarNavigation_ mobile story → verify the hamburger (menu) icon appears on the open button and the X icon appears on the close button.
- **Stepper** → open the _Stepper_ story → mark a step as complete and verify the checkmark icon appears in the step circle.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

**Elements**

- **Autocomplete** → Go to Yoast SEO -> Settings -> Site basics -> Site policies: verify the selector/chevron icon appears on the dropdown, the X icon appears on the clear button when option is selected.
- **ModalNotification** → Yoast SEO -> General, check the task list opt in notification (or trigger it by removing the usermera `_yoast_wpseo_task_list_opt_in_notification_seen` → verify the X icon appears on the dismiss button.
- **Radio** → Go to Yoast SEO -> Settings -> Site basics → select a Title separator
 radio option and verify the filled check-circle icon appears.
- **Select** → with Premium enabled, Go to Yoast SEO -> redirects → Check the select with the label "Redirect Type", verify the selector/chevron icon appears on the dropdown and a checkmark appears next to the selected option.
- **TagInput** → Go to Yoast SEO -> Settings -> Crawl optimization -> Additional URL parameters to allow -> enable Remove unregistered URL parameters → add a tag and verify the X icon appears on the tag removal button.
- **Toast** → Edit a post in the block editor and click on "Get content suggestions" (without Premiun) -> Trigger the spark limit notification by using over 5 sparkd → verify the X icon appears on the dismiss button.
- **Toggle** → In the Yoast SEO -> Settings -> Site features: Verify the checkmark icon appears when toggled on and the X icon when toggled off.
- **Validation** → Go to Yoast SEO -> Settings -> Site basics  → Check you see the alert starting with "An organization name and logo need to be set for structured data to work properly...", verify that the Info icon appears in the alert.

**Components**

- **DropdownMenu** → Go to Yoast SEO -> General -> Check the Site kit widget  → verify the vertical dots icon (⋮) appears on the trigger button.
- **FeatureUpsell** → On the free version, open the Yoast SEO metabox → _Social_ tab. Verify the padlock icon appears on the upsell button.
- **ImageSelect** → Edit a post and open the Yoast SEO metabox → _Social_ tab. Verify the image icon/placeholder appears in the social image select field.
- **Modal** → In the post editor metabox, open the SEMrush _Related keyphrases_ modal. Verify the X icon appears on the close button.
- **Pagination** → Go to _Yoast SEO → Redirects_. Verify the left/right chevron icons appear on the previous/next pagination buttons.
- **SidebarNavigation** → Go to the Yoast SEO settings page. Verify the chevron icon appears on collapsible sidebar items.
- **Stepper** → Open the Yoast SEO -> General. Have Google site kit activated and check the stepper has the Check icon on the first steps.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

All UI Library components and elements that use Heroicons: DropdownMenu, FeatureUpsell, FileImport, ImageSelect, Modal, Pagination, Popover, SidebarNavigation, Stepper, Autocomplete, FileInput, ModalNotification, Radio, Select, TagInput, Toast, Toggle, and Validation.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1230