### PR TITLE
1235 switch Heroicons imports to individual direct paths in settings

### DIFF
--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-max-depth */
 import { Transition } from "@headlessui/react";
-import { ColorSwatchIcon, DesktopComputerIcon, NewspaperIcon } from "@heroicons/react/outline";
+import ColorSwatchIcon from "@heroicons/react/outline/ColorSwatchIcon";
+import DesktopComputerIcon from "@heroicons/react/outline/DesktopComputerIcon";
+import NewspaperIcon from "@heroicons/react/outline/NewspaperIcon";
 import { useSelect } from "@wordpress/data";
 import { useCallback, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";

--- a/packages/js/src/settings/components/advanced-menu.js
+++ b/packages/js/src/settings/components/advanced-menu.js
@@ -1,4 +1,4 @@
-import { AdjustmentsIcon } from "@heroicons/react/outline";
+import AdjustmentsIcon from "@heroicons/react/outline/AdjustmentsIcon";
 import { useEffect } from "@wordpress/element";
 import { SidebarNavigation, useNavigationContext } from "@yoast/ui-library";
 import { useLocation } from "react-router-dom";

--- a/packages/js/src/settings/components/children-limiter-button.js
+++ b/packages/js/src/settings/components/children-limiter-button.js
@@ -1,4 +1,5 @@
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/solid";
+import ChevronDownIcon from "@heroicons/react/solid/ChevronDownIcon";
+import ChevronUpIcon from "@heroicons/react/solid/ChevronUpIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { useSvgAria } from "@yoast/ui-library";

--- a/packages/js/src/settings/components/feature-item.js
+++ b/packages/js/src/settings/components/feature-item.js
@@ -5,7 +5,8 @@ import { useFormikContext } from "formik";
 import { useDisabledMessage, useSelectSettings, useToggleHandlerWithModals } from "../hooks";
 import { get, has } from "lodash";
 import { Button, Link, Title, ToggleField, useSvgAria } from "@yoast/ui-library";
-import { LockOpenIcon, ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { FormikValueChangeField } from "../../shared-admin/components/form";
 

--- a/packages/js/src/settings/components/features-section.js
+++ b/packages/js/src/settings/components/features-section.js
@@ -1,5 +1,6 @@
 import { Title, useSvgAria } from "@yoast/ui-library";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/solid";
+import ChevronDownIcon from "@heroicons/react/solid/ChevronDownIcon";
+import ChevronUpIcon from "@heroicons/react/solid/ChevronUpIcon";
 import { FeatureItem } from "./feature-item";
 import { useCallback } from "@wordpress/element";
 import { useSelectSettings, useDispatchSettings } from "../hooks";

--- a/packages/js/src/settings/components/formik-media-select-field.js
+++ b/packages/js/src/settings/components/formik-media-select-field.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { PhotographIcon } from "@heroicons/react/outline";
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button, Label, Link, useDescribedBy } from "@yoast/ui-library";

--- a/packages/js/src/settings/components/formik-page-select-field.js
+++ b/packages/js/src/settings/components/formik-page-select-field.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { DocumentAddIcon } from "@heroicons/react/outline";
+import DocumentAddIcon from "@heroicons/react/outline/DocumentAddIcon";
 import { useCallback, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { AutocompleteField, Spinner } from "@yoast/ui-library";

--- a/packages/js/src/settings/components/formik-user-select-field.js
+++ b/packages/js/src/settings/components/formik-user-select-field.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { UserAddIcon } from "@heroicons/react/outline";
+import UserAddIcon from "@heroicons/react/outline/UserAddIcon";
 import apiFetch from "@wordpress/api-fetch";
 import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";

--- a/packages/js/src/settings/components/llms-txt-unsaved-changes-modal.js
+++ b/packages/js/src/settings/components/llms-txt-unsaved-changes-modal.js
@@ -1,4 +1,4 @@
-import { ExclamationIcon } from "@heroicons/react/outline";
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
 import { Button, Modal, useSvgAria } from "@yoast/ui-library";
 import { noop } from "lodash";
 import PropTypes from "prop-types";

--- a/packages/js/src/settings/components/schema-api-integrations-section.js
+++ b/packages/js/src/settings/components/schema-api-integrations-section.js
@@ -1,5 +1,6 @@
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";
 import PropTypes from "prop-types";

--- a/packages/js/src/settings/components/schema-disable-confirmation-modal.js
+++ b/packages/js/src/settings/components/schema-disable-confirmation-modal.js
@@ -1,4 +1,4 @@
-import { ExclamationIcon } from "@heroicons/react/outline";
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
 import { __ } from "@wordpress/i18n";
 import { Button, Modal, useSvgAria } from "@yoast/ui-library";
 import { noop } from "lodash";

--- a/packages/js/src/settings/components/schema-programmatically-disabled-modal.js
+++ b/packages/js/src/settings/components/schema-programmatically-disabled-modal.js
@@ -1,4 +1,4 @@
-import { ExclamationIcon } from "@heroicons/react/outline";
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Code, Modal, useSvgAria } from "@yoast/ui-library";

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
 import { Combobox } from "@headlessui/react";
-import { SearchIcon, XIcon } from "@heroicons/react/outline";
+import SearchIcon from "@heroicons/react/outline/SearchIcon";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { Code, Modal, Title, useNavigationContext, useSvgAria, useToggleState } from "@yoast/ui-library";

--- a/packages/js/src/settings/components/site-feature-description.js
+++ b/packages/js/src/settings/components/site-feature-description.js
@@ -1,6 +1,7 @@
 import { __ } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";
-import { ChevronUpIcon, ChevronDownIcon } from "@heroicons/react/outline";
+import ChevronUpIcon from "@heroicons/react/outline/ChevronUpIcon";
+import ChevronDownIcon from "@heroicons/react/outline/ChevronDownIcon";
 
 /**
  * Site feature description component.

--- a/packages/js/src/settings/components/xml-sitemap-button.js
+++ b/packages/js/src/settings/components/xml-sitemap-button.js
@@ -1,6 +1,6 @@
 import { Button } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
-import { ExternalLinkIcon } from "@heroicons/react/outline";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
 
 /**
  * The xml sitemap button component for the feature row in the Site Features settings.

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -1,5 +1,6 @@
-import { ExternalLinkIcon, TrashIcon } from "@heroicons/react/outline";
-import { PlusIcon } from "@heroicons/react/solid";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/solid/PlusIcon";
 import { useCallback, useEffect, useMemo, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button, Radio, RadioGroup, ToggleField, useToggleState } from "@yoast/ui-library";

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity */
 import { Transition } from "@headlessui/react";
-import { TrashIcon } from "@heroicons/react/outline";
-import { PlusIcon } from "@heroicons/react/solid";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/solid/PlusIcon";
 import { Fragment, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -1,4 +1,5 @@
-import { CheckCircleIcon, ArrowNarrowRightIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { getPremiumBenefits, getWooSeoBenefits } from "../../helpers/get-premium-benefits";

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
-import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
-import { CheckCircleIcon } from "@heroicons/react/solid";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { Badge, Button, Paper, Title } from "@yoast/ui-library";
 import classNames from "classnames";

--- a/packages/js/src/shared-admin/components/unsaved-changes-modal.js
+++ b/packages/js/src/shared-admin/components/unsaved-changes-modal.js
@@ -1,4 +1,4 @@
-import { ExclamationIcon } from "@heroicons/react/outline";
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
 import { __ } from "@wordpress/i18n";
 import { Button, Modal, useSvgAria } from "@yoast/ui-library";
 import { noop } from "lodash";


### PR DESCRIPTION
## Context

Switches Heroicons imports in \`packages/js/src/settings/\` from barrel paths (e.g. \`@heroicons/react/outline\`) to individual ESM paths (e.g. \`@heroicons/react/outline/MagnifyingGlassIcon\`) to reduce the plugin bundle size by allowing the bundler to tree-shake unused icons.

## Summary
This PR can be summarized in the following changelog entry:

* Switches Heroicons imports to individual direct paths in the settings to reduce bundle size.

## Relevant technical choices:

* Only the settings files are changed in this PR. The same change for other parts of the plugin is tracked in separate PRs.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Open the browser console (F12) before starting — verify no JS errors related to icon imports appear at any point.

**Settings page** (Yoast SEO → Settings)

- [x] Verify the sidebar navigation icons render: color swatch (Categories & tags), desktop computer (General), and newspaper (Content types) icons appear next to each menu item.
- [x] Verify the advanced settings icon (adjustments/sliders icon) appears next to the Advanced menu item.
- [x] Type in the search bar and verify the magnifying glass icon appears inside the field; clear the search and verify the X icon appears on the clear button.
- [x] Expand a feature section and verify the chevron-down icon rotates to chevron-up; collapse it and verify it rotates back.
- [x] Click "Show more" / "Show less" on a feature list and verify the chevron icon toggles direction.
- [x] On a premium feature item, verify the open padlock icon appears on the upsell button and the arrow icon appears on the "learn more" link.
- [x] Open a media select field (e.g. site image) and verify the photograph placeholder icon appears before an image is chosen.
- [x] Open a page select field and verify the document-add icon appears on the "add new page" link.
- [x] Open a user select field and verify the user-add icon appears on the "add new user" link.
- [x] Click the XML sitemap button and verify the external link icon appears.
- [x] On the Schema API integrations section, verify: check icon (active), X icon (inactive), and open padlock icon (premium unlock) all appear correctly.
- [x] Trigger the schema disable confirmation modal and verify the exclamation/warning icon appears.
- [x] Trigger the schema programmatically disabled modal and verify the exclamation/warning icon appears.
- [x] Trigger the LLMs.txt unsaved changes modal and verify the exclamation/warning icon appears.
   - In a site that has no llms.txt file, go to Yoast settings->llms.txt
   - Enable the main toggle to enable the feature but dont save
   - Click the View the llms.txt file button and you will get the modal
- [x] On any settings page with unsaved changes, trigger the unsaved changes modal and verify the red exclamation icon appears.

**Premium upsell sidebar / list** (Yoast SEO → Settings — free version)

- [x] In the settings sidebar, find a premium upsell card and verify the checkmark-circle icons appear next to each benefit item and the right-arrow icon appears on the CTA button.
- [x] In a premium upsell list, verify the checkmark-circle icons appear next to each benefit item and the right-arrow icon appears on the "learn more" link.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — verify no JS errors related to icon imports.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a non-user-facing refactor of internal import paths. No user-visible behaviour changes.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO Settings page and all its components that use Heroicons icons.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1235
