### PR TITLE
1236 switch Heroicons imports to individual direct paths in general page, first-time configuration and dashboard

### DIFF
--- a/packages/dashboard-frontend/eslint.config.mjs
+++ b/packages/dashboard-frontend/eslint.config.mjs
@@ -18,6 +18,17 @@ export default [
 			},
 		},
 		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					name: "@heroicons/react/outline",
+					message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
+				},
+				{
+					name: "@heroicons/react/solid",
+					message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+				},
+			],
 			// Account for webpack externals and potentially un-built packages in the monorepo setup.
 			"import/no-unresolved": [
 				"error",

--- a/packages/dashboard-frontend/src/components/info-tooltip.js
+++ b/packages/dashboard-frontend/src/components/info-tooltip.js
@@ -1,5 +1,5 @@
 import { TooltipContainer, TooltipTrigger, TooltipWithContext } from "@yoast/ui-library";
-import { InformationCircleIcon } from "@heroicons/react/outline";
+import InformationCircleIcon from "@heroicons/react/outline/InformationCircleIcon";
 
 /**
  * The info tooltip component.

--- a/packages/dashboard-frontend/src/components/widget-table.js
+++ b/packages/dashboard-frontend/src/components/widget-table.js
@@ -1,7 +1,7 @@
 import { Table, TooltipContainer, TooltipTrigger, TooltipWithContext } from "@yoast/ui-library";
 import classNames from "classnames";
 import { SCORE_META } from "../scores/score-meta";
-import { XIcon } from "@heroicons/react/solid";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { __ } from "@wordpress/i18n";
 
 /**

--- a/packages/dashboard-frontend/src/icons/task-status-icon.js
+++ b/packages/dashboard-frontend/src/icons/task-status-icon.js
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from "@heroicons/react/outline";
+import CheckCircleIcon from "@heroicons/react/outline/CheckCircleIcon";
 import { EllipseWithInnerDot } from ".";
 import { __ } from "@wordpress/i18n";
 

--- a/packages/dashboard-frontend/src/task-list/components/call-to-action-button.js
+++ b/packages/dashboard-frontend/src/task-list/components/call-to-action-button.js
@@ -1,6 +1,8 @@
 /* eslint-disable complexity */
 import { Button } from "@yoast/ui-library";
-import { TrashIcon, PlusIcon, ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/outline/PlusIcon";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 

--- a/packages/dashboard-frontend/src/task-list/components/child-tasks.js
+++ b/packages/dashboard-frontend/src/task-list/components/child-tasks.js
@@ -1,5 +1,6 @@
 import { TasksProgressBar } from "./tasks-progressbar";
-import { ArrowNarrowRightIcon, ArrowNarrowLeftIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
+import ArrowNarrowLeftIcon from "@heroicons/react/outline/ArrowNarrowLeftIcon";
 import { useCallback, useState, useMemo, useEffect } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, useSvgAria } from "@yoast/ui-library";

--- a/packages/dashboard-frontend/src/task-list/components/duration.js
+++ b/packages/dashboard-frontend/src/task-list/components/duration.js
@@ -1,4 +1,4 @@
-import { ClockIcon } from "@heroicons/react/outline";
+import ClockIcon from "@heroicons/react/outline/ClockIcon";
 import { useSvgAria, SkeletonLoader } from "@yoast/ui-library";
 import classNames from "classnames";
 import { useTaskListContext } from "../task-list-context";

--- a/packages/dashboard-frontend/src/task-list/components/get-tasks-error-row.js
+++ b/packages/dashboard-frontend/src/task-list/components/get-tasks-error-row.js
@@ -1,7 +1,8 @@
 import { Button, Table, Title } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { useCallback, useEffect } from "@wordpress/element";
-import { ExclamationIcon, RefreshIcon } from "@heroicons/react/outline";
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
+import RefreshIcon from "@heroicons/react/outline/RefreshIcon";
 
 /**
  * The GetTasksErrorRow component to display an error row when fetching tasks fails.

--- a/packages/dashboard-frontend/src/task-list/components/priority.js
+++ b/packages/dashboard-frontend/src/task-list/components/priority.js
@@ -1,4 +1,6 @@
-import { ChevronDoubleUpIcon, ChevronDoubleDownIcon, MenuAlt4Icon } from "@heroicons/react/outline";
+import ChevronDoubleUpIcon from "@heroicons/react/outline/ChevronDoubleUpIcon";
+import ChevronDoubleDownIcon from "@heroicons/react/outline/ChevronDoubleDownIcon";
+import MenuAlt4Icon from "@heroicons/react/outline/MenuAlt4Icon";
 import { __ } from "@wordpress/i18n";
 import { useSvgAria, SkeletonLoader } from "@yoast/ui-library";
 import classNames from "classnames";

--- a/packages/dashboard-frontend/src/task-list/components/single-task-button.js
+++ b/packages/dashboard-frontend/src/task-list/components/single-task-button.js
@@ -2,7 +2,7 @@ import { Duration } from "./duration";
 import { Priority } from "./priority";
 import { TasksProgressBadge } from "./tasks-progress-badge";
 import { TaskStatusIcon } from "../../icons";
-import { ChevronRightIcon } from "@heroicons/react/outline";
+import ChevronRightIcon from "@heroicons/react/outline/ChevronRightIcon";
 import classNames from "classnames";
 import { useCallback } from "@wordpress/element";
 

--- a/packages/dashboard-frontend/src/task-list/components/task-row.js
+++ b/packages/dashboard-frontend/src/task-list/components/task-row.js
@@ -1,4 +1,4 @@
-import { ChevronRightIcon } from "@heroicons/react/outline";
+import ChevronRightIcon from "@heroicons/react/outline/ChevronRightIcon";
 import { Table, useSvgAria, SkeletonLoader, useToggleState } from "@yoast/ui-library";
 import { Priority } from "./priority";
 import { Duration } from "./duration";

--- a/packages/dashboard-frontend/src/task-list/components/tasks-progress-badge.js
+++ b/packages/dashboard-frontend/src/task-list/components/tasks-progress-badge.js
@@ -1,6 +1,6 @@
 import { Badge, SkeletonLoader, useSvgAria } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { CheckCircleIcon } from "@heroicons/react/outline";
+import CheckCircleIcon from "@heroicons/react/outline/CheckCircleIcon";
 import classNames from "classnames";
 
 /**

--- a/packages/dashboard-frontend/src/widgets/top-pages-widget.js
+++ b/packages/dashboard-frontend/src/widgets/top-pages-widget.js
@@ -1,4 +1,4 @@
-import { PencilIcon } from "@heroicons/react/outline";
+import PencilIcon from "@heroicons/react/outline/PencilIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, SkeletonLoader, TooltipContainer, TooltipTrigger, TooltipWithContext } from "@yoast/ui-library";
 import { useCallback, useMemo } from "react";

--- a/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
+++ b/packages/js/src/dashboard/widgets/site-kit-setup-widget.js
@@ -1,5 +1,7 @@
-import { ArrowNarrowRightIcon, TrashIcon, XIcon } from "@heroicons/react/outline";
-import { CheckCircleIcon } from "@heroicons/react/solid";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import XIcon from "@heroicons/react/outline/XIcon";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import { useCallback, useEffect } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Widget } from "@yoast/dashboard-frontend";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/alert.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/alert.js
@@ -2,7 +2,10 @@
 // Duplicated from admin-ui! ( admin-ui/packages/toolkit/components/alert.js )
 // Addition: "success" case, fade in alert.
 
-import { CheckCircleIcon, ExclamationIcon, InformationCircleIcon, XCircleIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ExclamationIcon from "@heroicons/react/solid/ExclamationIcon";
+import InformationCircleIcon from "@heroicons/react/solid/InformationCircleIcon";
+import XCircleIcon from "@heroicons/react/solid/XCircleIcon";
 import { useCallback, useState } from "@wordpress/element";
 import classNames from "classnames";
 import PropTypes from "prop-types";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/combo-box.js
@@ -1,5 +1,6 @@
 import { Combobox } from "@headlessui/react";
-import { CheckIcon, SelectorIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import { Fragment, useCallback, useEffect, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/image-select.js
@@ -1,4 +1,4 @@
-import { PhotographIcon } from "@heroicons/react/outline";
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button, Link } from "@yoast/ui-library";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/single-select.js
@@ -1,5 +1,7 @@
 import { Listbox, Transition } from "@headlessui/react";
-import { CheckIcon, ExclamationCircleIcon, SelectorIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
+import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
 import { Fragment, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import classNames from "classnames";

--- a/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/base/text-input.js
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
-import { CheckCircleIcon, ExclamationCircleIcon } from "@heroicons/react/solid";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
 import { useMemo } from "@wordpress/element";
 import classNames from "classnames";
 import { PropTypes } from "prop-types";

--- a/packages/js/src/first-time-configuration/tailwind-components/step-circle.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/step-circle.js
@@ -1,4 +1,4 @@
-import { CheckIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import { useEffect, useState } from "@wordpress/element";
 import PropTypes from "prop-types";
 import { stepperTimingClasses } from "../stepper-helper";

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/finish/finish-step.js
@@ -1,8 +1,8 @@
-import { ExternalLinkIcon } from "@heroicons/react/solid";
+import ExternalLinkIcon from "@heroicons/react/solid/ExternalLinkIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { get } from "lodash";
 import { Button } from "@yoast/ui-library";
-import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 
 /**
  * Goes to the Dashboard tab by clicking the tab button.

--- a/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
+++ b/packages/js/src/first-time-configuration/tailwind-components/steps/social-profiles/social-field-array.js
@@ -1,5 +1,5 @@
-import { TrashIcon } from "@heroicons/react/outline";
-import { PlusIcon } from "@heroicons/react/solid";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/solid/PlusIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -1,5 +1,8 @@
 import { Transition } from "@headlessui/react";
-import { AdjustmentsIcon, BellIcon, ChartPieIcon, ClipboardCheckIcon } from "@heroicons/react/outline";
+import AdjustmentsIcon from "@heroicons/react/outline/AdjustmentsIcon";
+import BellIcon from "@heroicons/react/outline/BellIcon";
+import ChartPieIcon from "@heroicons/react/outline/ChartPieIcon";
+import ClipboardCheckIcon from "@heroicons/react/outline/ClipboardCheckIcon";
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback, useEffect } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";

--- a/packages/js/src/general/components/alert-items/ping-other-admins-alert-item.js
+++ b/packages/js/src/general/components/alert-items/ping-other-admins-alert-item.js
@@ -2,7 +2,7 @@
 import classNames from "classnames";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
-import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import { select, useDispatch } from "@wordpress/data";
 import { useState, useCallback, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";

--- a/packages/js/src/general/components/alerts-list.js
+++ b/packages/js/src/general/components/alerts-list.js
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
-import { EyeIcon, EyeOffIcon } from "@heroicons/react/outline";
+import EyeIcon from "@heroicons/react/outline/EyeIcon";
+import EyeOffIcon from "@heroicons/react/outline/EyeOffIcon";
 import { useDispatch } from "@wordpress/data";
 import { useCallback, useContext } from "@wordpress/element";
 import { Button } from "@yoast/ui-library";

--- a/packages/js/src/general/components/alerts-title.js
+++ b/packages/js/src/general/components/alerts-title.js
@@ -1,4 +1,4 @@
-import { ExclamationCircleIcon } from "@heroicons/react/outline";
+import ExclamationCircleIcon from "@heroicons/react/outline/ExclamationCircleIcon";
 import { useContext } from "@wordpress/element";
 import { Title } from "@yoast/ui-library";
 import classNames from "classnames";

--- a/packages/js/src/general/components/collapsible.js
+++ b/packages/js/src/general/components/collapsible.js
@@ -1,5 +1,5 @@
 import { Disclosure } from "@headlessui/react";
-import { ChevronDownIcon } from "@heroicons/react/outline";
+import ChevronDownIcon from "@heroicons/react/outline/ChevronDownIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 

--- a/packages/js/src/general/components/notice.js
+++ b/packages/js/src/general/components/notice.js
@@ -1,4 +1,4 @@
-import { XIcon } from "@heroicons/react/outline";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { useDispatch } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";

--- a/packages/js/src/general/components/notifications.js
+++ b/packages/js/src/general/components/notifications.js
@@ -1,6 +1,6 @@
 import { __, _n } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
-import { BellIcon } from "@heroicons/react/outline";
+import BellIcon from "@heroicons/react/outline/BellIcon";
 import { Alert, Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
 import { AlertsTitle } from "./alerts-title";

--- a/packages/js/src/general/components/problems.js
+++ b/packages/js/src/general/components/problems.js
@@ -1,6 +1,6 @@
 import { __, _n } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
-import { ExclamationCircleIcon } from "@heroicons/react/outline";
+import ExclamationCircleIcon from "@heroicons/react/outline/ExclamationCircleIcon";
 import { Paper } from "@yoast/ui-library";
 import { AlertsList } from "./alerts-list";
 import { AlertsTitle } from "./alerts-title";

--- a/packages/js/src/general/components/task-list-opt-in-notification.js
+++ b/packages/js/src/general/components/task-list-opt-in-notification.js
@@ -1,7 +1,7 @@
 import { ModalNotification, Button, useSvgAria, useModalNotificationContext } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 import { ReactComponent as YoastIcon } from "../../../images/Yoast_icon_kader.svg";
-import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import classNames from "classnames";
 import { useCallback, useEffect } from "@wordpress/element";
 import { STORE_NAME } from "../constants";

--- a/packages/js/src/general/components/task-list-upsell-row.js
+++ b/packages/js/src/general/components/task-list-upsell-row.js
@@ -1,6 +1,7 @@
 import { Button, Table, Title } from "@yoast/ui-library";
 import { __, sprintf } from "@wordpress/i18n";
-import { LockClosedIcon, LockOpenIcon } from "@heroicons/react/outline";
+import LockClosedIcon from "@heroicons/react/outline/LockClosedIcon";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { select } from "@wordpress/data";
 import { STORE_NAME } from "../constants";
 

--- a/packages/js/tests/general/components/alerts-title.test.js
+++ b/packages/js/tests/general/components/alerts-title.test.js
@@ -1,7 +1,7 @@
 import { render } from "../../test-utils";
 import { AlertsTitle } from "../../../src/general/components/alerts-title";
 import { AlertsContext } from "../../../src/general/contexts/alerts-context";
-import { BellIcon } from "@heroicons/react/outline";
+import BellIcon from "@heroicons/react/outline/BellIcon";
 
 const notificationsTheme = {
 	Icon: BellIcon,


### PR DESCRIPTION
## Context

Switches Heroicons imports in \`packages/js/src/general/\`, \`packages/js/src/first-time-configuration/\`, \`packages/dashboard-frontend/src/\`, and \`packages/js/src/dashboard/\` from barrel paths (e.g. \`@heroicons/react/outline\`) to individual ESM paths (e.g. \`@heroicons/react/outline/BellIcon\`) to reduce the plugin bundle size by allowing the bundler to tree-shake unused icons.

## Summary
This PR can be summarized in the following changelog entry:

* Switches Heroicons imports to individual direct paths in the general page, first-time configuration wizard, and dashboard to reduce bundle size.

## Relevant technical choices:

* Only the general page, first-time configuration, and dashboard files are changed in this PR. Changes for other parts of the plugin are tracked in separate PRs.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Open the browser console (F12) before starting — verify no JS errors related to icon imports appear at any point.

**General page** (Yoast SEO → General)

- [x] Verify the sidebar navigation icons render: adjustments icon (Dashboard), bell icon (Alert center), pie chart icon (First-time configuration overview), clipboard-check icon (Task list).
- [ ] Expand a collapsible section and verify the chevron-down icon rotates to indicate open state; collapse and verify it rotates back.
- [x] In the Alerts section, verify the exclamation-circle icon appears in the section title (Problems / Alerts title).
- [x] Toggle alert visibility and verify the eye / eye-off icon switches correctly.
- [x] In the Notifications section, verify the bell icon appears.
- [x] Dismiss a notice and verify the X icon appears on the dismiss button.
- [x] In the Task list upsell row, verify the closed lock (premium) and open padlock (unlock) icons appear.
- [x] In the "Ping other admins" alert item, verify the right-arrow icon appears on the send button.
- [x] In the task list opt-in notification, verify the right-arrow icon appears on the "Show me" button.

**First-time configuration wizard** (Yoast SEO → General → First-time configuration)

- [x] Navigate through the wizard and verify the checkmark icon appears inside each completed step circle.
- [x] In any alert within the wizard (success, warning, info, error), verify the correct icon renders: check-circle (success), exclamation (warning), information-circle (info), X-circle (error).
- [x] In a combo-box or single-select field, verify the selector/chevron icon appears on the dropdown and a checkmark appears next to the selected option; verify an exclamation-circle icon appears when the field has an error.
- [x] In a text input field, verify the check-circle (valid) and exclamation-circle (invalid) feedback icons appear correctly.
- [x] In an image select field, verify the photograph placeholder icon appears when no image is selected.
- [x] On the Finish step, verify the external-link icon appears on the relevant links and the right-arrow icon appears on navigation buttons.
- [x] In the Social profiles step, verify the plus icon appears on "add profile" and the trash icon appears on "delete profile" buttons.

**Dashboard** (Yoast SEO Dashboard / site health widget)

- [x] Verify the information-circle icon appears on info tooltips.
- [x] In the task list, verify: right-arrow chevron (task row / single-task-button hover), checkmark-circle (completed task status and progress badge), clock (task duration), trash/plus/right-arrow (call-to-action buttons), and left/right arrows (child-task pagination) all render.
- [x] In the task priority column, verify: red double-chevron-up (high priority), amber menu-alt4 (medium priority), and gray double-chevron-down (low priority) icons appear.
- [x] Trigger a task-fetch error and verify the exclamation icon (in a red circle) and the refresh icon (reload button) appear.
- [ ] In the top-pages widget, verify the pencil/edit icon appears on the edit-page button.
- [x] In the Site Kit setup widget, verify: right-arrow (learn more), trash (permanent dismiss), X (dismiss), and checkmark-circle (benefits) icons all render.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — verify no JS errors related to icon imports.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a non-user-facing refactor of internal import paths. No user-visible behaviour changes.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO General page, the first-time configuration wizard, and the dashboard widget.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1236