### PR TITLE
1237 switch Heroicons imports to individual direct paths in integrations page

### DIFF
--- a/packages/js/src/integrations-page/acf-integration.js
+++ b/packages/js/src/integrations-page/acf-integration.js
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";

--- a/packages/js/src/integrations-page/algolia-integration.js
+++ b/packages/js/src/integrations-page/algolia-integration.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { ArrowSmRightIcon, XIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Slot } from "@wordpress/components";
 import { useCallback, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";

--- a/packages/js/src/integrations-page/mastodon-integration.js
+++ b/packages/js/src/integrations-page/mastodon-integration.js
@@ -1,4 +1,5 @@
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";

--- a/packages/js/src/integrations-page/plugin-integration.js
+++ b/packages/js/src/integrations-page/plugin-integration.js
@@ -1,4 +1,5 @@
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Fragment } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { PropTypes } from "prop-types";

--- a/packages/js/src/integrations-page/simple-integration.js
+++ b/packages/js/src/integrations-page/simple-integration.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { ArrowSmRightIcon, CheckIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { Badge, Button, Link } from "@yoast/ui-library";

--- a/packages/js/src/integrations-page/site-kit-integration.js
+++ b/packages/js/src/integrations-page/site-kit-integration.js
@@ -1,5 +1,5 @@
 /* eslint-disable complexity */
-import { CheckIcon } from "@heroicons/react/solid";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import apiFetch from "@wordpress/api-fetch";
 import { useSelect } from "@wordpress/data";
 import { useCallback, useState } from "@wordpress/element";

--- a/packages/js/src/integrations-page/toggleable-integration.js
+++ b/packages/js/src/integrations-page/toggleable-integration.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { ArrowSmRightIcon, XIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Slot } from "@wordpress/components";
 import { useCallback, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";

--- a/packages/js/src/integrations-page/woocommerce-integration.js
+++ b/packages/js/src/integrations-page/woocommerce-integration.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity */
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { CheckIcon, XIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import CheckIcon from "@heroicons/react/solid/CheckIcon";
+import XIcon from "@heroicons/react/solid/XIcon";
 import { Fragment } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";

--- a/packages/js/src/shared-admin/components/site-kit-consent-modal.js
+++ b/packages/js/src/shared-admin/components/site-kit-consent-modal.js
@@ -1,4 +1,4 @@
-import { ArrowSmRightIcon } from "@heroicons/react/solid";
+import ArrowSmRightIcon from "@heroicons/react/solid/ArrowSmRightIcon";
 import { __ } from "@wordpress/i18n";
 import { Button, Modal, useSvgAria } from "@yoast/ui-library";
 import PropTypes from "prop-types";


### PR DESCRIPTION
## Context

Switches Heroicons imports in \`packages/js/src/integrations-page/\` from barrel paths (e.g. \`@heroicons/react/outline\`) to individual ESM paths (e.g. \`@heroicons/react/outline/CheckIcon\`) to reduce the plugin bundle size by allowing the bundler to tree-shake unused icons.

## Summary
This PR can be summarized in the following changelog entry:

* Switches Heroicons imports to individual direct paths in the integrations page to reduce bundle size.

## Relevant technical choices:

* Only the integrations page files are changed in this PR. Changes for other parts of the plugin are tracked in separate PRs.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Open the browser console (F12) before starting — verify no JS errors related to icon imports appear at any point.

**Integrations page** (Yoast SEO → Integrations)

- [x] For each active integration (ACF, Mastodon, Plugin integrations, Site Kit), verify the check icon (active) and X icon (inactive/error) render correctly as status indicators.
- [x] For premium integrations (Algolia, WooCommerce, toggleable integrations), verify the open padlock icon appears on the upsell button and the right-arrow icon appears on the "learn more" link.
- [x] For the WooCommerce integration card, verify all three icon states appear: open padlock (premium unlock), checkmark (active feature), and X (inactive feature).

**Site Kit consent modal** (Yoast SEO → Integrations → Site Kit)

- [x] On the Site Kit integration card, trigger the consent modal. Verify the right-arrow icon appears on the confirm/proceed button.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — verify no JS errors related to icon imports.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a non-user-facing refactor of internal import paths. No user-visible behaviour changes.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO Integrations page and all its integration cards.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1237