### PR TITLE
1239 switch Heroicons imports to individual direct paths in related-keyphrase-suggestions and search-metadata-previews

### DIFF
--- a/packages/js/src/components/DefaultSeoDataAlert.js
+++ b/packages/js/src/components/DefaultSeoDataAlert.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { ExclamationCircleIcon } from "@heroicons/react/solid";
+import ExclamationCircleIcon from "@heroicons/react/solid/ExclamationCircleIcon";
 import { select } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import { Fragment, useCallback, useMemo } from "@wordpress/element";

--- a/packages/js/src/components/WincherSEOPerformanceModal.js
+++ b/packages/js/src/components/WincherSEOPerformanceModal.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 /* External dependencies */
-import { ChartBarIcon } from "@heroicons/react/solid";
+import ChartBarIcon from "@heroicons/react/solid/ChartBarIcon";
 import { Fragment, useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { useSvgAria } from "@yoast/ui-library/src";

--- a/packages/js/src/components/WooCommerceUpsell.js
+++ b/packages/js/src/components/WooCommerceUpsell.js
@@ -1,6 +1,6 @@
 import { __, sprintf } from "@wordpress/i18n";
 import PropTypes from "prop-types";
-import { LockOpenIcon } from "@heroicons/react/outline";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { Button, Root } from "@yoast/ui-library";
 
 /**

--- a/packages/js/src/components/contentAnalysis/PremiumSeoAnalysisUpsellAd.js
+++ b/packages/js/src/components/contentAnalysis/PremiumSeoAnalysisUpsellAd.js
@@ -2,7 +2,7 @@ import { __, sprintf } from "@wordpress/i18n";
 import { useSelect } from "@wordpress/data";
 import { Title, useSvgAria, Button } from "@yoast/ui-library";
 import { ReactComponent as CrownIcon } from "../../../images/icon-crown.svg";
-import { LockOpenIcon } from "@heroicons/react/outline";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { WooSeoAnalysisUpsellAd } from "./WooSeoAnalysisUpsellAd";
 

--- a/packages/js/src/components/contentAnalysis/Results.js
+++ b/packages/js/src/components/contentAnalysis/Results.js
@@ -1,7 +1,7 @@
 import { ContentAnalysis } from "@yoast/analysis-report";
 import { IconButtonToggle } from "@yoast/components";
 import { Badge } from "@yoast/ui-library";
-import { LockClosedIcon } from "@heroicons/react/solid";
+import LockClosedIcon from "@heroicons/react/solid/LockClosedIcon";
 import { __ } from "@wordpress/i18n";
 import { Component, Fragment } from "@wordpress/element";
 import { doAction } from "@wordpress/hooks";

--- a/packages/js/src/components/contentAnalysis/WooSeoAnalysisUpsellAd.js
+++ b/packages/js/src/components/contentAnalysis/WooSeoAnalysisUpsellAd.js
@@ -1,7 +1,10 @@
 import { __, sprintf } from "@wordpress/i18n";
 import { Title, useSvgAria, Button } from "@yoast/ui-library";
-import { LockOpenIcon, PhotographIcon, TagIcon, IdentificationIcon } from "@heroicons/react/outline";
-import { ShoppingCartIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
+import TagIcon from "@heroicons/react/outline/TagIcon";
+import IdentificationIcon from "@heroicons/react/outline/IdentificationIcon";
+import ShoppingCartIcon from "@heroicons/react/solid/ShoppingCartIcon";
 import { useSelect } from "@wordpress/data";
 import { getLocationKey } from "./PremiumSeoAnalysisUpsellAd";
 

--- a/packages/js/src/components/contentBlocks/AddBlockButton.js
+++ b/packages/js/src/components/contentBlocks/AddBlockButton.js
@@ -1,4 +1,4 @@
-import { PlusIcon } from "@heroicons/react/outline";
+import PlusIcon from "@heroicons/react/outline/PlusIcon";
 import { createBlock } from "@wordpress/blocks";
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback, useState } from "@wordpress/element";

--- a/packages/js/src/components/contentBlocks/BenefitItems.js
+++ b/packages/js/src/components/contentBlocks/BenefitItems.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
-import { UserGroupIcon, CollectionIcon } from "@heroicons/react/outline";
+import UserGroupIcon from "@heroicons/react/outline/UserGroupIcon";
+import CollectionIcon from "@heroicons/react/outline/CollectionIcon";
 
 import { PREMIUM_CONTENT_BLOCKS, getPremiumBlocksForPages } from "./ContentBlocks";
 

--- a/packages/js/src/components/contentBlocks/ContentBlock.js
+++ b/packages/js/src/components/contentBlocks/ContentBlock.js
@@ -1,5 +1,5 @@
-import { LockClosedIcon } from "@heroicons/react/solid";
-import { CheckIcon } from "@heroicons/react/outline";
+import LockClosedIcon from "@heroicons/react/solid/LockClosedIcon";
+import CheckIcon from "@heroicons/react/outline/CheckIcon";
 import { useSelect } from "@wordpress/data";
 import { useEffect, useState } from "@wordpress/element";
 import { SvgIcon } from "@yoast/components";

--- a/packages/js/src/components/contentBlocks/ContentBlocks.js
+++ b/packages/js/src/components/contentBlocks/ContentBlocks.js
@@ -1,4 +1,7 @@
-import { ClockIcon, LinkIcon, SparklesIcon, ViewListIcon } from "@heroicons/react/outline";
+import ClockIcon from "@heroicons/react/outline/ClockIcon";
+import LinkIcon from "@heroicons/react/outline/LinkIcon";
+import SparklesIcon from "@heroicons/react/outline/SparklesIcon";
+import ViewListIcon from "@heroicons/react/outline/ViewListIcon";
 import { useCallback, useContext } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { LocationContext } from "@yoast/externals/contexts";

--- a/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
+++ b/packages/js/src/components/modals/InternalLinkingSuggestionsUpsell.js
@@ -1,5 +1,5 @@
 /* global wpseoAdminL10n */
-import { LockClosedIcon } from "@heroicons/react/solid";
+import LockClosedIcon from "@heroicons/react/solid/LockClosedIcon";
 import { __, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
 import { useRootContext } from "@yoast/externals/contexts";

--- a/packages/js/src/components/modals/KeywordUpsell.js
+++ b/packages/js/src/components/modals/KeywordUpsell.js
@@ -1,5 +1,5 @@
 /* global wpseoAdminL10n */
-import { LockClosedIcon } from "@heroicons/react/solid";
+import LockClosedIcon from "@heroicons/react/solid/LockClosedIcon";
 import { useContext } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";

--- a/packages/js/src/components/modals/UpsellModal.js
+++ b/packages/js/src/components/modals/UpsellModal.js
@@ -2,8 +2,9 @@
 import { Button, Modal, Title } from "@yoast/ui-library";
 import { ReactComponent as YoastLogo } from "../../../images/Yoast_icon_kader.svg";
 import { useSelect } from "@wordpress/data";
-import { LockOpenIcon } from "@heroicons/react/outline";
-import { CheckCircleIcon, ShoppingCartIcon } from "@heroicons/react/solid";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ShoppingCartIcon from "@heroicons/react/solid/ShoppingCartIcon";
 import { useMemo, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import classNames from "classnames";

--- a/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
+++ b/packages/js/src/components/modals/editorModals/SearchAppearanceModal.js
@@ -1,5 +1,5 @@
 /* External dependencies */
-import { SearchIcon } from "@heroicons/react/solid";
+import SearchIcon from "@heroicons/react/solid/SearchIcon";
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { useSvgAria } from "@yoast/ui-library/src";

--- a/packages/js/src/components/modals/editorModals/SocialAppearanceModal.js
+++ b/packages/js/src/components/modals/editorModals/SocialAppearanceModal.js
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 /* External dependencies */
-import { ShareIcon } from "@heroicons/react/solid";
+import ShareIcon from "@heroicons/react/solid/ShareIcon";
 import { __ } from "@wordpress/i18n";
 import { Fragment } from "@wordpress/element";
 import PropTypes from "prop-types";

--- a/packages/js/src/insights/components/insights-modal.js
+++ b/packages/js/src/insights/components/insights-modal.js
@@ -1,4 +1,4 @@
-import { LightBulbIcon } from "@heroicons/react/solid";
+import LightBulbIcon from "@heroicons/react/solid/LightBulbIcon";
 import { useSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { isFeatureEnabled } from "@yoast/feature-flag";

--- a/packages/js/tests/components/contentBlocks/AddBlockButton.test.js
+++ b/packages/js/tests/components/contentBlocks/AddBlockButton.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { useDispatch, useSelect } from "@wordpress/data";
 import { createBlock } from "@wordpress/blocks";
 import { ContentBlocksUpsell } from "../../../src/components/modals/ContentBlocksUpsell";
@@ -16,9 +16,10 @@ jest.mock( "@wordpress/blocks", () => ( {
 } ) );
 
 // Mock Heroicons
-jest.mock( "@heroicons/react/outline", () => ( {
-	PlusIcon: ( { className } ) => <svg className={ className } data-testid="plus-icon" />,
-} ) );
+jest.mock( "@heroicons/react/outline/PlusIcon", () => {
+	const PlusIcon = ( { className } ) => <svg className={ className } data-testid="plus-icon" />;
+	return PlusIcon;
+} );
 
 jest.mock( "../../../src/components/modals/ContentBlocksUpsell", () => ( {
 	ContentBlocksUpsell: jest.fn( () => <div data-testid="upsell-modal" /> ),
@@ -155,7 +156,7 @@ describe( "AddBlockButton", () => {
 			expect( button ).toHaveClass( "yoast-add-block-button--clicked" );
 
 			// Fast-forward the timeout
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -199,13 +200,13 @@ describe( "AddBlockButton", () => {
 			expect( mockInsertBlock ).not.toHaveBeenCalled();
 		} );
 
-		it( "does not show clicked state when upsell badge is shown", () => {
+		it( "does not show clicked state when upsell badge is shown", async() => {
 			render( <AddBlockButton { ...defaultProps } showUpsellBadge={ true } /> );
 
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			expect( button ).not.toHaveClass( "yoast-add-block-button__icon--clicked" );
 		} );
@@ -230,7 +231,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -257,7 +258,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -284,7 +285,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( mockInsertBlock ).toHaveBeenCalledWith( { name: "test/block" }, 1 );
@@ -304,7 +305,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( mockInsertBlock ).toHaveBeenCalledWith( { name: "test/block" }, 2 );
@@ -330,7 +331,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( mockInsertBlock ).toHaveBeenCalledWith( { name: "test/block" }, 1 );
@@ -356,7 +357,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( mockInsertBlock ).toHaveBeenCalledWith( { name: "test/block" }, 1 );
@@ -395,7 +396,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -421,7 +422,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -444,7 +445,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );
@@ -471,7 +472,7 @@ describe( "AddBlockButton", () => {
 			const button = screen.getByRole( "button" );
 			fireEvent.click( button );
 
-			jest.advanceTimersByTime( 300 );
+			await act( async() => jest.advanceTimersByTime( 300 ) );
 
 			await waitFor( () => {
 				expect( createBlock ).toHaveBeenCalledWith( "test/block" );

--- a/packages/js/tests/components/contentBlocks/ContentBlock.test.js
+++ b/packages/js/tests/components/contentBlocks/ContentBlock.test.js
@@ -34,17 +34,15 @@ jest.mock( "../../../src/components/contentBlocks/AddBlockButton", () => ( {
 	),
 } ) );
 
-jest.mock( "@heroicons/react/solid", () => ( {
-	LockClosedIcon: ( props ) => (
-		<div data-testid="lock-icon" { ...props } />
-	),
-} ) );
+jest.mock( "@heroicons/react/solid/LockClosedIcon", () => {
+	const LockClosedIcon = ( props ) => <div data-testid="lock-icon" { ...props } />;
+	return LockClosedIcon;
+} );
 
-jest.mock( "@heroicons/react/outline", () => ( {
-	CheckIcon: ( props ) => (
-		<div data-testid="check-icon" { ...props } />
-	),
-} ) );
+jest.mock( "@heroicons/react/outline/CheckIcon", () => {
+	const CheckIcon = ( props ) => <div data-testid="check-icon" { ...props } />;
+	return CheckIcon;
+} );
 
 describe( "ContentBlock", () => {
 	const defaultProps = {
@@ -53,6 +51,7 @@ describe( "ContentBlock", () => {
 		isPremiumBlock: false,
 		hasNewBadgeLabel: false,
 		renderNewBadgeLabel: jest.fn( () => <span data-testid="new-badge">New</span> ),
+		location: "sidebar",
 	};
 
 	beforeEach( () => {

--- a/packages/related-keyphrase-suggestions/eslint.config.mjs
+++ b/packages/related-keyphrase-suggestions/eslint.config.mjs
@@ -16,6 +16,17 @@ export default [
 			},
 		},
 		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					name: "@heroicons/react/outline",
+					message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
+				},
+				{
+					name: "@heroicons/react/solid",
+					message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+				},
+			],
 			// Account for webpack externals and potentially unbuilt packages in the monorepo setup.
 			"import/no-unresolved": [
 				"error",

--- a/packages/related-keyphrase-suggestions/src/components/Modal/index.js
+++ b/packages/related-keyphrase-suggestions/src/components/Modal/index.js
@@ -2,7 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
 import { Link, Modal as BaseModal } from "@yoast/ui-library";
-import { ExternalLinkIcon, ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import { YoastIcon } from "./YoastIcon";
 
 /**

--- a/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/PremiumUpsell/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button } from "@yoast/ui-library";
-import { LockOpenIcon } from "@heroicons/react/outline";
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
 
 /**
  * The premium upsell component.

--- a/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
+++ b/packages/related-keyphrase-suggestions/src/elements/TableButton/index.js
@@ -1,7 +1,10 @@
 import React, { forwardRef } from "react";
 import classNames from "classnames";
 import PropTypes from "prop-types";
-import { TrashIcon, PlusIcon, CheckIcon, XIcon } from "@heroicons/react/outline";
+import TrashIcon from "@heroicons/react/outline/TrashIcon";
+import PlusIcon from "@heroicons/react/outline/PlusIcon";
+import CheckIcon from "@heroicons/react/outline/CheckIcon";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { Button } from "@yoast/ui-library";
 import { __ } from "@wordpress/i18n";
 

--- a/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
+++ b/packages/related-keyphrase-suggestions/src/elements/UserMessage/components/RequestLimitReached.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { __, sprintf } from "@wordpress/i18n";
 import { Alert, Button } from "@yoast/ui-library";
-import { ArrowNarrowRightIcon } from "@heroicons/react/outline";
+import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 
 /**
  * Display the message for a request that has reached the limit.

--- a/packages/search-metadata-previews/eslint.config.mjs
+++ b/packages/search-metadata-previews/eslint.config.mjs
@@ -14,6 +14,17 @@ export default [
 			},
 		},
 		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					name: "@heroicons/react/outline",
+					message: "Import individual icons instead, e.g. import PlusIcon from '@heroicons/react/outline/PlusIcon'.",
+				},
+				{
+					name: "@heroicons/react/solid",
+					message: "Import individual icons instead, e.g. import CheckIcon from '@heroicons/react/solid/CheckIcon'.",
+				},
+			],
 			// Account for webpack externals and potentially unbuilt packages in the monorepo setup.
 			"import/no-unresolved": [
 				"error",

--- a/packages/search-metadata-previews/src/snippet-editor/ModeSwitcher.js
+++ b/packages/search-metadata-previews/src/snippet-editor/ModeSwitcher.js
@@ -1,8 +1,8 @@
 // External dependencies.
 import React, { useCallback } from "react";
 import { __ } from "@wordpress/i18n";
-import { DeviceMobileIcon } from "@heroicons/react/outline";
-import { DesktopComputerIcon } from "@heroicons/react/solid";
+import DeviceMobileIcon from "@heroicons/react/outline/DeviceMobileIcon";
+import DesktopComputerIcon from "@heroicons/react/solid/DesktopComputerIcon";
 
 // Yoast dependencies.
 import { Label, Toggle, Root, useSvgAria } from "@yoast/ui-library";


### PR DESCRIPTION
## Context

Switches Heroicons imports in editor sidebar/metabox components (\`packages/js/src/components\`, \`packages/js/src/insights\`), \`packages/related-keyphrase-suggestions\`, and \`packages/search-metadata-previews\` from barrel paths (e.g. \`@heroicons/react/outline\`) to individual ESM paths to reduce the plugin bundle size by allowing the bundler to tree-shake unused icons.

## Summary
This PR can be summarized in the following changelog entry:

* Switches Heroicons imports to individual direct paths in the editor sidebar/metabox components to reduce bundle size.
* [@yoast/search-metadata-previews 0.1.0 other] Switches Heroicons imports to individual direct paths to reduce bundle size in consuming applications.
* [@yoast/related-keyphrase-suggestions 0.1.0 other] Switches Heroicons imports to individual direct paths to reduce bundle size in consuming applications.

## Relevant technical choices:

* Individual ESM paths (e.g. \`@heroicons/react/solid/ExclamationCircleIcon\`) are used instead of barrel imports (e.g. \`@heroicons/react/solid\`) because bundlers cannot tree-shake named exports from barrel files — every icon in the set ends up in the bundle even when only one is used.
* This PR covers the editor sidebar/metabox components (\`packages/js/src/components\`, \`packages/js/src/insights\`), \`packages/related-keyphrase-suggestions\`, and \`packages/search-metadata-previews\`. Changes for the remaining parts of the codebase are tracked in separate PRs in this series.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Open the browser console (F12) before starting — verify no JS errors related to icon imports appear at any point.

**Editor sidebar / metabox** (open any post or page)

- [x] Edit a post in the block editor and check Search Appearance tab has the magnifying glass icon.
- [x] Check the Social Appearance tab has the share icon.
- [x] In the SEO analysis results tab, verify the closed lock icon appears in the premium badge on upsell items.
- [x] In content analysis upsell ads (Premium SEO Analysis, Woo SEO Analysis), verify the open padlock icon appears on the upsell button; for the Woo ad, also verify the photograph, tag, ID, and shopping cart feature icons appear.
- [x] In the Content Blocks panel (on block editor), verify: plus icon (add block button), closed lock icon (premium badge), checkmark (added block indicator), clock (estimated reading time), link (related links), sparkles (AI summarize), and list (table of contents) icons all render.
- [x] Check Internal Linking Suggestions upsell and verify the closed lock icon appears in the premium badge.
- [x] Check "Add related Keyphrase" upsell has the closed lock icon in a badge.
- [x] Open a general upsell modal and verify: open padlock (upsell button), checkmark-circle (benefits list), and shopping cart (WooCommerce variant) icons appear.
- [x] Verify the lightbulb icon appears in the Insights tab in the block editor sidebar.
- [x] With an incomplete site configuration (e.g. organisation name not set), open the post editor and check the Yoast SEO metabox or sidebar. Verify the amber exclamation-circle icon appears in the alert.
- [x] With the Wincher integration active, open a post and publish or update it. In the pre-publish panel, open the Wincher SEO Performance modal. Verify the chart-bar icon appears in the modal.

**Related keyphrases** (editor sidebar / metabox — requires SEMrush integration)

- [x] In the post editor, open the Yoast SEO metabox or sidebar and navigate to the _Related keyphrases_ tab. Verify the external-link icon appears on the SEMrush modal link and the right-arrow icon appears on the "Get related keyphrases" button.
- [x] In the related keyphrases table, add a keyphrase and verify the plus icon appears on the add button, the checkmark icon appears on confirmation, and the trash icon appears on the delete button.
- [x] In the related keyphrases table, trigger the request limit reached message and verify the right-arrow icon appears on the upgrade button.
- [x] On the premium upsell banner (free version), verify the open padlock icon appears on the upsell button.

**Snippet editor** (editor sidebar / metabox)

- [x] In the post editor, open the Yoast SEO snippet editor. Verify the desktop-computer icon appears on the desktop preview toggle and the mobile-phone icon appears on the mobile preview toggle.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — verify no JS errors related to icon imports.
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a non-user-facing refactor of internal import paths. No user-visible behaviour changes.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The related keyphrases panel in the post editor and the snippet editor mode switcher.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1239
