### PR TITLE
ci(build-zip): harden workflow (SHA pins, fork guard, no creds)

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -9,18 +9,22 @@ jobs:
   build:
     name: "Build plugin zip"
     runs-on: ubuntu-latest
+    # Don't run on forks.
     if: >
-      github.event_name == 'workflow_dispatch' ||
+      github.repository_owner == 'Yoast' &&
       (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/build-zip')
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/build-zip')
+        )
       )
 
     steps:
       - name: Check actions access
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -34,7 +38,7 @@ jobs:
 
       - name: Add reaction to command
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -47,7 +51,7 @@ jobs:
       - name: Get PR head ref
         if: github.event_name == 'issue_comment'
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { data: pr } = await github.rest.pulls.get({
@@ -58,18 +62,19 @@ jobs:
             core.setOutput('ref', pr.head.ref);
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.pr.outputs.ref || '' }}
+          persist-credentials: false
 
       - name: Install PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: 7.4
           coverage: none
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: './.nvmrc'
 
@@ -87,7 +92,7 @@ jobs:
         run: mv artifact wordpress-seo
 
       - name: Upload zip
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wordpress-seo-${{ steps.timestamp.outputs.value }}
           path: wordpress-seo/
@@ -95,7 +100,7 @@ jobs:
 
       - name: Post artifact link
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.createComment({


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Backport the three security-hardening choices applied to the Premium `build-zip` workflow ([Yoast/wordpress-seo-premium#4965](https://github.com/Yoast/wordpress-seo-premium/pull/4965)) so Free's equivalent workflow matches the same threat model. Two of the three patterns are already used elsewhere in Free's workflows.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ...".
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hardens the build-zip GitHub Actions workflow.

## Relevant technical choices:

* SHA-pinned third-party actions (with `# vX.Y.Z` comments so Dependabot updates SHA and tag in lockstep). This is the one new convention for Free workflows — every other Free workflow uses tag refs. `build-zip.yml` is a sensible place to start because it runs PR-provided code.
* Fork-owner guard (`github.repository_owner == 'Yoast'`) — matches the pattern already used in `deploy.yml`, `merge-conflict-check.yml`, and `generate-changelog.yml`.
* `persist-credentials: false` on `actions/checkout` so `GITHUB_TOKEN` isn't left in `.git/config` while `yarn install` / `grunt artifact` later run PR-provided code — matches ~13 other Free workflows.
* No pre-push checks (`composer …`, `yarn …`, `grunt build:images`) apply to this CI-only YAML change — no PHP / JS / image files touched.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. After merging, comment `/build-zip` on any open PR targeting `trunk`. Confirm the comment receives a 🚀 reaction within a few seconds, the workflow runs to completion, a follow-up comment is posted with a link to the workflow run, and the `wordpress-seo-<timestamp>` artifact downloads successfully.
2. From the *Actions* tab, open *Build Plugin Zip* and trigger it via *Run workflow* on `trunk`; confirm an artifact appears with 1-day retention.
3. Comment something starting with `/build-zip` from an account without `triage`+ access (or temporarily lower your role to simulate); confirm the workflow fails at the *Check actions access* step without building anything.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable — CI-only change, does not ship in the plugin artifact.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* `.github/workflows/build-zip.yml` only. No runtime plugin code is touched.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Refs [Yoast/reserved-tasks#1227](https://github.com/Yoast/reserved-tasks/issues/1227)
