### PR TITLE
feat(llms-txt): add wpseo_llmstxt_content filter

### DIFF
--- a/src/llms-txt/application/markdown-builders/markdown-builder.php
+++ b/src/llms-txt/application/markdown-builders/markdown-builder.php
@@ -109,6 +109,24 @@ class Markdown_Builder {
 			$section->escape_markdown( $this->markdown_escaper );
 		}
 
-		return $this->llms_txt_renderer->render();
+		$content = $this->llms_txt_renderer->render();
+
+		/**
+		 * Filter: 'wpseo_llmstxt_content' - Allows appending extra markdown content to the LLMs.txt file.
+		 *
+		 * Mirrors the behaviour of the `wpseo_sitemap_{$type}_content` filter used in the XML sitemaps:
+		 * the returned string is appended to the rendered llms.txt content as-is. Callers are responsible
+		 * for valid, escaped markdown. A common use case is adding extra `## Heading` link list sections
+		 * in bulk from code instead of through the admin UI, for example:
+		 *
+		 *     add_filter( 'wpseo_llmstxt_content', static function ( $content ) {
+		 *         return $content . "\n## My pages\n- [Page 1](https://example.com/1)\n";
+		 *     } );
+		 *
+		 * @param string $content The rendered LLMs.txt content so far.
+		 */
+		$content = (string) \apply_filters( 'wpseo_llmstxt_content', $content );
+
+		return $content;
 	}
 }

--- a/tests/Unit/Llms_Txt/Application/Markdown_Builders/Markdown_Builder/Render_Test.php
+++ b/tests/Unit/Llms_Txt/Application/Markdown_Builders/Markdown_Builder/Render_Test.php
@@ -4,6 +4,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Llms_Txt\Application\Markdown_Builders\Markdown_Builder;
 
+use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Llms_Txt\Domain\Markdown\Sections\Description;
 use Yoast\WP\SEO\Llms_Txt\Domain\Markdown\Sections\Intro;
@@ -11,7 +12,7 @@ use Yoast\WP\SEO\Llms_Txt\Domain\Markdown\Sections\Link_List;
 use Yoast\WP\SEO\Llms_Txt\Domain\Markdown\Sections\Title;
 
 /**
- * Tests the Markdown_Builder constructor.
+ * Tests the Markdown_Builder render method.
  *
  * @group llms.txt
  *
@@ -20,12 +21,11 @@ use Yoast\WP\SEO\Llms_Txt\Domain\Markdown\Sections\Title;
 final class Render_Test extends Abstract_Markdown_Builder_Test {
 
 	/**
-	 * Tests the render method.
+	 * Sets up the section mocks and renderer expectations shared by all render tests.
 	 *
 	 * @return void
 	 */
-	public function test_render() {
-		// Mocks for sections.
+	private function set_up_render_pipeline(): void {
 		$built_intro              = Mockery::mock( Intro::class );
 		$built_title              = Mockery::mock( Title::class );
 		$built_description        = Mockery::mock( Description::class );
@@ -77,9 +77,44 @@ final class Render_Test extends Abstract_Markdown_Builder_Test {
 		$built_link_list1->shouldReceive( 'escape_markdown' )->once()->with( $this->markdown_escaper );
 		$built_link_list2->shouldReceive( 'escape_markdown' )->once()->with( $this->markdown_escaper );
 		$optional_built_link_list->shouldReceive( 'escape_markdown' )->once()->with( $this->markdown_escaper );
+	}
+
+	/**
+	 * Tests the render method when no callback is attached to the wpseo_llmstxt_content filter.
+	 *
+	 * @return void
+	 */
+	public function test_render_without_filter_callback() {
+		$this->set_up_render_pipeline();
 
 		$this->llms_txt_renderer->shouldReceive( 'render' )->once()->andReturn( 'final markdown output' );
 
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_llmstxt_content', 'final markdown output' )
+			->andReturn( 'final markdown output' );
+
 		$this->assertSame( 'final markdown output', $this->instance->render() );
+	}
+
+	/**
+	 * Tests that a callback attached to wpseo_llmstxt_content can append extra content.
+	 *
+	 * @return void
+	 */
+	public function test_render_with_filter_callback_appending_content() {
+		$this->set_up_render_pipeline();
+
+		$rendered = "## Optional\n- [Sitemap index](https://example.com/sitemap_index.xml)\n";
+		$extra    = "\n## My pages\n- [Page 1](https://example.com/1)\n";
+
+		$this->llms_txt_renderer->shouldReceive( 'render' )->once()->andReturn( $rendered );
+
+		Monkey\Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_llmstxt_content', $rendered )
+			->andReturn( $rendered . $extra );
+
+		$this->assertSame( $rendered . $extra, $this->instance->render() );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The community asked for a hook to bulk-add custom link list sections to the `llms.txt` file from code, because managing 1000+ entries through the admin UI is impractical (see issue #22522 and [the linked wp.org thread](https://wordpress.org/support/topic/llms-txt-filters-hooks/)).
* This PR adds a small filter that mirrors the long-standing `wpseo_sitemap_{$type}_content` pattern used by the XML sitemap, so the same mental model applies in both features.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a `wpseo_llmstxt_content` filter to append extra markdown content to the generated `llms.txt` file.

## Relevant technical choices:

* Mirrors the existing `wpseo_sitemap_{$type}_content` pattern: a simple `string -> string` filter applied at the end of `Markdown_Builder::render()`, so the contract and mental model are identical to the XML sitemap.
* Follows the existing `wpseo_llmstxt_*` naming convention already used by `wpseo_llmstxt_encoding_prefix`, `wpseo_llmstxt_link_description`, and `wpseo_llmstxt_filesystem_path` (no underscore between `llms` and `txt`).
* The filter is applied after the `Markdown_Escaper` pass, so callers are responsible for valid, pre-escaped markdown — same contract as the sitemap content filter.
* Output naturally lands after the `## Optional` section, which is the requested position in the issue.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Activate Yoast SEO and enable the `llms.txt` feature (Yoast SEO → Settings → APIs → llms.txt → toggle on, save).
2. Visit `https://<your-site>/llms.txt` once and confirm the file is generated and renders normally, ending with an `## Optional` section that links to the sitemap index.
3. Add the following snippet to a mu-plugin or your active theme's `functions.php`:

   ```php
   add_filter( 'wpseo_llmstxt_content', static function ( $content ) {
       return $content . "\n## My pages\n- [Page 1](https://example.com/1)\n- [Page 2](https://example.com/2)\n";
   } );