### PR TITLE
fix: align icons in RTL for upsells

### DIFF
--- a/css/src/adminbar.css
+++ b/css/src/adminbar.css
@@ -197,6 +197,9 @@
 #wpadminbar #wp-admin-bar-wpseo_brand_insights_premium {
 	@apply yst-flex;
 }
+.yoast-brand-insights-content .yst-external-link-icon {
+	@apply rtl:yst-rotate-[270deg];
+}
 
 #wpadminbar #wp-admin-bar-wpseo_brand_insights .ab-item,
 #wpadminbar #wp-admin-bar-wpseo_brand_insights_premium .ab-item {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "cd ../.. && wp-scripts build --config config/webpack/webpack.config.js",
     "test": "jest",
-    "lint": "eslint . --max-warnings=41"
+    "lint": "eslint . --max-warnings=40"
   },
   "dependencies": {
     "@draft-js-plugins/mention": "^5.0.0",

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -1,9 +1,8 @@
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
 import { useMemo } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { getPremiumBenefits, getWooSeoBenefits } from "../../helpers/get-premium-benefits";
-import { safeCreateInterpolateElement } from "../../helpers/i18n";
 import { Button, Title } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { ReactComponent as YoastSeoLogo } from "../../../images/yoast-premium-logo-new.svg";
@@ -44,35 +43,11 @@ const UpsellButton = ( { isBlackFriday, link, linkProps } ) => {
  */
 const UpsellTitle = ( { isWooCommerceActive } ) => <Title
 	as="h2"
-	className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold",
+	className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold yst-whitespace-nowrap",
 		isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500" )
 	}
 >
-	{ isWooCommerceActive
-		? safeCreateInterpolateElement(
-			sprintf(
-			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$s%2$s %3$s", "wordpress-seo" ),
-				"<nowrap>",
-				"</nowrap>",
-				"Yoast WooCommerce SEO"
-			),
-			{
-				nowrap: <span className="yst-whitespace-nowrap" />,
-			}
-		)
-		: safeCreateInterpolateElement(
-			sprintf(
-				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$s%2$s %3$s", "wordpress-seo" ),
-				"<nowrap>",
-				"</nowrap>",
-				"Yoast SEO Premium"
-			),
-			{
-				nowrap: <span className="yst-whitespace-nowrap" />,
-			}
-		) }
+	{ isWooCommerceActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium" }
 </Title>;
 
 /**
@@ -154,4 +129,5 @@ PremiumUpsellCard.propTypes = {
 	link: PropTypes.string.isRequired,
 	linkProps: PropTypes.object.isRequired,
 	isPromotionActive: PropTypes.func.isRequired,
+	isWooCommerceActive: PropTypes.bool.isRequired,
 };

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -30,7 +30,7 @@ const UpsellButton = ( { isBlackFriday, link, linkProps } ) => {
 		{ ...linkProps }
 	>
 		<span>{ isBlackFriday ? __( "Buy now for 30% off", "wordpress-seo" ) : __( "Buy now", "wordpress-seo" ) }</span>
-		<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0 rtl:yst-rotate-180" />
+		<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0 yst-icon-rtl" />
 	</Button>;
 };
 

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -35,11 +35,11 @@ const UpsellButton = ( { isBlackFriday, link, linkProps } ) => {
 };
 
 /**
- * The Logo component for the Premium Upsell Card.
+ * The title component for the Premium Upsell Card.
  *
  * @param {*} props The props.
  * @param {boolean} props.isWooCommerceActive Whether WooCommerce is active.
- * @returns {JSX.Element} The Logo component.
+ * @returns {JSX.Element} The upsell title component.
  */
 const UpsellTitle = ( { isWooCommerceActive } ) => <Title
 	as="h2"

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
 import { useMemo } from "@wordpress/element";
@@ -103,7 +104,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 			<ul className="yst-list-outside yst-text-slate-600 yst-mt-4 yst-flex yst-flex-col yst-gap-2">
 				{ getBenefits( true ).map( ( benefit, index ) => (
 					<li key={ `upsell-benefit-${ index }` } className="yst-flex yst-items-start">
-						<CheckCircleIcon className="yst-mr-2 yst-text-green-500 yst-w-[19.5px] yst-h-[19.5px] yst-flex-shrink-0" />
+						<CheckCircleIcon className="yst-me-2 yst-text-green-500 yst-w-[19.5px] yst-h-[19.5px] yst-flex-shrink-0" />
 						{ benefit }
 					</li>
 				) ) }
@@ -118,7 +119,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 				{ ...linkProps }
 			>
 				<span>{ upsellButtonText }</span>
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0" />
+				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0 rtl:yst-rotate-180" />
 			</Button>
 			<p className="yst-text-center yst-text-xs yst-font-normal yst-leading-5 yst-text-slate-500 yst-italic yst-mt-3 yst-mb-2">
 				{ microCopy }

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -43,7 +43,7 @@ const UpsellButton = ( { isBlackFriday, link, linkProps } ) => {
  */
 const UpsellTitle = ( { isWooCommerceActive } ) => <Title
 	as="h2"
-	className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold yst-whitespace-nowrap",
+	className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold",
 		isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500" )
 	}
 >

--- a/packages/js/src/shared-admin/components/premium-upsell-card.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-card.js
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
 import { useMemo } from "@wordpress/element";
@@ -11,6 +10,70 @@ import { ReactComponent as YoastSeoLogo } from "../../../images/yoast-premium-lo
 import { ReactComponent as WooSeoLogo } from "../../../images/woo-seo-logo-new.svg";
 // Note that the same logo in images has a width and height, which we do not want here.
 import classNames  from "classnames";
+
+/**
+ * UpsellButton component.
+ *
+ * @param {Object} props The props.
+ * @param {boolean} props.isBlackFriday Whether the Black Friday promotion is active.
+ * @param {string} props.link The link for the button.
+ * @param {Object} props.linkProps Additional props for the button link.
+ * @returns {JSX.Element} The Upsell button.
+ */
+const UpsellButton = ( { isBlackFriday, link, linkProps } ) => {
+	return <Button
+		as="a"
+		variant="upsell"
+		href={ link }
+		target="_blank"
+		rel="noopener"
+		className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
+		{ ...linkProps }
+	>
+		<span>{ isBlackFriday ? __( "Buy now for 30% off", "wordpress-seo" ) : __( "Buy now", "wordpress-seo" ) }</span>
+		<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0 rtl:yst-rotate-180" />
+	</Button>;
+};
+
+/**
+ * The Logo component for the Premium Upsell Card.
+ *
+ * @param {*} props The props.
+ * @param {boolean} props.isWooCommerceActive Whether WooCommerce is active.
+ * @returns {JSX.Element} The Logo component.
+ */
+const UpsellTitle = ( { isWooCommerceActive } ) => <Title
+	as="h2"
+	className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold",
+		isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500" )
+	}
+>
+	{ isWooCommerceActive
+		? safeCreateInterpolateElement(
+			sprintf(
+			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+				__( "%1$s%2$s %3$s", "wordpress-seo" ),
+				"<nowrap>",
+				"</nowrap>",
+				"Yoast WooCommerce SEO"
+			),
+			{
+				nowrap: <span className="yst-whitespace-nowrap" />,
+			}
+		)
+		: safeCreateInterpolateElement(
+			sprintf(
+				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
+				__( "%1$s%2$s %3$s", "wordpress-seo" ),
+				"<nowrap>",
+				"</nowrap>",
+				"Yoast SEO Premium"
+			),
+			{
+				nowrap: <span className="yst-whitespace-nowrap" />,
+			}
+		) }
+</Title>;
 
 /**
  * @param {string} link The link.
@@ -35,43 +98,15 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 		}
 		return __( "Optimize your site faster, smarter, and with more confidence.", "wordpress-seo" );
 	}, [ isWooCommerceActive ] );
-	let upsellButtonText = __( "Buy now", "wordpress-seo" );
+
 	const microCopy = useMemo( () => {
 		if ( isWooCommerceActive ) {
 			return	__( "Less friction. Smarter optimization.", "wordpress-seo" );
 		}
 		return __( "Less friction. Faster publishing.", "wordpress-seo" );
 	}, [ isWooCommerceActive ] );
-	const upsellTitle = isWooCommerceActive
-		? safeCreateInterpolateElement(
-			sprintf(
-			/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$s%2$s %3$s", "wordpress-seo" ),
-				"<nowrap>",
-				"</nowrap>",
-				"Yoast WooCommerce SEO"
-			),
-			{
-				nowrap: <span className="yst-whitespace-nowrap" />,
-			}
-		)
-		: safeCreateInterpolateElement(
-			sprintf(
-				/* translators: %1$s and %2$s expand to a span wrap to avoid linebreaks. %3$s expands to "Yoast SEO Premium". */
-				__( "%1$s%2$s %3$s", "wordpress-seo" ),
-				"<nowrap>",
-				"</nowrap>",
-				"Yoast SEO Premium"
-			),
-			{
-				nowrap: <span className="yst-whitespace-nowrap" />,
-			}
-		);
 	const isBlackFriday = isPromotionActive( "black-friday-promotion" );
 
-	if ( isBlackFriday ) {
-		upsellButtonText = __( "Buy now for 30% off", "wordpress-seo" );
-	}
 	return (
 		<div
 			className={ classNames( "yst-p-6 yst-rounded-lg yst-text-slate-600 yst-bg-white yst-shadow yst-border",
@@ -91,14 +126,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 					<span className="banner_text">{ __( "BLACK FRIDAY | 30% OFF", "wordpress-seo" ) }</span>
 				</div>
 			</div> }
-			<Title
-				as="h2"
-				className={ classNames( "yst-mt-6 yst-text-xl yst-font-semibold",
-					isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500" )
-				}
-			>
-				{ upsellTitle }
-			</Title>
+			<UpsellTitle isWooCommerceActive={ isWooCommerceActive } />
 			<p className="yst-mt-3 yst-font-medium yst-text-slate-800">{ infoSubHeader }</p>
 			<p className="yst-mt-1 yst-font-normal">{ info }</p>
 			<ul className="yst-list-outside yst-text-slate-600 yst-mt-4 yst-flex yst-flex-col yst-gap-2">
@@ -109,18 +137,7 @@ export const PremiumUpsellCard = ( { link, linkProps, isPromotionActive, isWooCo
 					</li>
 				) ) }
 			</ul>
-			<Button
-				as="a"
-				variant="upsell"
-				href={ link }
-				target="_blank"
-				rel="noopener"
-				className="yst-flex yst-justify-center yst-gap-2 yst-mt-4 focus:yst-ring-offset-primary-500"
-				{ ...linkProps }
-			>
-				<span>{ upsellButtonText }</span>
-				<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst--ms-1 yst-shrink-0 rtl:yst-rotate-180" />
-			</Button>
+			<UpsellButton link={ link } linkProps={ linkProps } isBlackFriday={ isBlackFriday } />
 			<p className="yst-text-center yst-text-xs yst-font-normal yst-leading-5 yst-text-slate-500 yst-italic yst-mt-3 yst-mb-2">
 				{ microCopy }
 			</p>

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -110,7 +110,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 								size="small"
 								variant="plain"
 								className={ classNames(
-									"yst-mr-2 yst-bg-opacity-15",
+									"yst-me-2 yst-bg-opacity-15",
 									isWooCommerceActive ? "yst-bg-woo-light yst-text-[#006499]" : "yst-bg-primary-500 yst-text-primary-500"
 								) }
 								key={ `now-including-${ index }` }

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -17,7 +17,7 @@ import { ReactComponent as TrolleyIcon } from "../../../images/icon-trolley.svg"
  */
 const UpsellTitle = ( { isWooCommerceActive } ) => <div className="yst-flex yst-items-center">
 	<Title as="h2" size="4" className={ `yst-text-xl yst-font-semibold ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
-		{ (
+		{ sprintf(
 			/* translators: %s expands to product name: "Yoast WooCommerce SEO" or "Yoast SEO Premium" */
 			__( "Upgrade to %s", "wordpress-seo" ),
 			isWooCommerceActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -17,17 +17,11 @@ import { ReactComponent as TrolleyIcon } from "../../../images/icon-trolley.svg"
  */
 const UpsellTitle = ( { isWooCommerceActive } ) => <div className="yst-flex yst-items-center">
 	<Title as="h2" size="4" className={ `yst-text-xl yst-font-semibold ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
-		{ isWooCommerceActive
-			? sprintf(
-				/* translators: %s expands to "Yoast WooCommerce SEO */
-				__( "Upgrade to %s", "wordpress-seo" ),
-				"Yoast WooCommerce SEO"
-			)
-			: sprintf(
-				/* translators: %s expands to "Yoast SEO" Premium */
-				__( "Upgrade to %s", "wordpress-seo" ),
-				"Yoast SEO Premium"
-			) }
+		{ (
+			/* translators: %s expands to product name: "Yoast WooCommerce SEO" or "Yoast SEO Premium" */
+			__( "Upgrade to %s", "wordpress-seo" ),
+			isWooCommerceActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
+		) }
 	</Title>
 	{ isWooCommerceActive
 		? <TrolleyIcon className="yst-ms-2 yst-w-4 yst-h-3" />
@@ -46,17 +40,11 @@ const UpsellTitle = ( { isWooCommerceActive } ) => <div className="yst-flex yst-
  * @returns {JSX.Element} The Upsell button.
  */
 const UpsellButton = ( { isWooCommerceActive, premiumLink, premiumUpsellConfig = {}, isBlackFriday } ) => {
-	let upsellTitle = isWooCommerceActive
-		? sprintf(
-			/* translators: %s expands to "Yoast WooCommerce SEO" */
-			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast WooCommerce SEO"
-		)
-		: sprintf(
-			/* translators: %s expands to "Yoast SEO" Premium */
-			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast SEO Premium"
-		);
+	let upsellTitle = sprintf(
+		/* translators: %s expands to product name: "Yoast WooCommerce SEO" or "Yoast SEO Premium" */
+		__( "Explore %s now!", "wordpress-seo" ),
+		isWooCommerceActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
+	);
 
 	if ( isBlackFriday ) {
 		upsellTitle = __( "Get 30% off now!", "wordpress-seo" );

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import ArrowNarrowRightIcon from "@heroicons/react/outline/ArrowNarrowRightIcon";
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import { __, sprintf } from "@wordpress/i18n";
@@ -9,6 +8,79 @@ import { getPremiumBenefits, getWooSeoBenefits } from "../../helpers/get-premium
 import { ReactComponent as CrownIcon } from "../../../images/icon-crown.svg";
 import { ReactComponent as TrolleyIcon } from "../../../images/icon-trolley.svg";
 
+/**
+ * The title of the premium upsell card.
+ *
+ * @param {*} props The props.
+ * @param {boolean} props.isWooCommerceActive Whether WooCommerce is active.
+ * @returns {JSX.Element} The upsell title.
+ */
+const UpsellTitle = ( { isWooCommerceActive } ) => <div className="yst-flex yst-items-center">
+	<Title as="h2" size="4" className={ `yst-text-xl yst-font-semibold ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
+		{ isWooCommerceActive
+			? sprintf(
+				/* translators: %s expands to "Yoast WooCommerce SEO */
+				__( "Upgrade to %s", "wordpress-seo" ),
+				"Yoast WooCommerce SEO"
+			)
+			: sprintf(
+				/* translators: %s expands to "Yoast SEO" Premium */
+				__( "Upgrade to %s", "wordpress-seo" ),
+				"Yoast SEO Premium"
+			) }
+	</Title>
+	{ isWooCommerceActive
+		? <TrolleyIcon className="yst-ms-2 yst-w-4 yst-h-3" />
+		: <CrownIcon className="yst-ms-2 yst-w-4 yst-h-3" />
+	}
+</div>;
+
+/**
+ * The Upsell button component.
+ *
+ * @param {*} props The props.
+ * @param {boolean} props.isWooCommerceActive Whether WooCommerce is active.
+ * @param {string} props.premiumLink The premium link.
+ * @param {Object} [props.premiumUpsellConfig] The premium upsell configuration data.
+ * @param {boolean} props.isBlackFriday Whether the Black Friday promotion is active.
+ * @returns {JSX.Element} The Upsell button.
+ */
+const UpsellButton = ( { isWooCommerceActive, premiumLink, premiumUpsellConfig = {}, isBlackFriday } ) => {
+	let upsellTitle = isWooCommerceActive
+		? sprintf(
+			/* translators: %s expands to "Yoast WooCommerce SEO" */
+			__( "Explore %s now!", "wordpress-seo" ),
+			"Yoast WooCommerce SEO"
+		)
+		: sprintf(
+			/* translators: %s expands to "Yoast SEO" Premium */
+			__( "Explore %s now!", "wordpress-seo" ),
+			"Yoast SEO Premium"
+		);
+
+	if ( isBlackFriday ) {
+		upsellTitle = __( "Get 30% off now!", "wordpress-seo" );
+	}
+	return <Button
+		as="a"
+		variant="upsell"
+		size="extra-large"
+		href={ premiumLink }
+		className="yst-gap-2 yst-mt-6 sm:yst-max-w-sm"
+		target="_blank"
+		rel="noopener"
+		{ ...premiumUpsellConfig }
+	>
+		{ upsellTitle }
+		<span className="yst-sr-only">
+			{
+				/* translators: Hidden accessibility text. */
+				__( "(Opens in a new browser tab)", "wordpress-seo" )
+			}
+		</span>
+		<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
+	</Button>;
+};
 /**
  * @param {string} premiumLink The premium link.
  * @param {Object} premiumUpsellConfig The premium upsell configuration data.
@@ -34,21 +106,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 		? classNames( "yst-bg-woo-light", "yst-text-[#006499]" )
 		: classNames( "yst-bg-primary-500", "yst-text-primary-500" );
 
-	let upsellTitle = isWooCommerceActive
-		? sprintf(
-			/* translators: %s expands to "Yoast WooCommerce SEO" */
-			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast WooCommerce SEO"
-		)
-		: sprintf(
-			/* translators: %s expands to "Yoast SEO" Premium */
-			__( "Explore %s now!", "wordpress-seo" ),
-			"Yoast SEO Premium"
-		);
 
-	if ( isBlackFriday ) {
-		upsellTitle = __( "Get 30% off now!", "wordpress-seo" );
-	}
 	return (
 		<Paper as="div" className="yst-max-w-4xl">
 			{ isBlackFriday && <div
@@ -58,27 +116,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 				<div>{ __( "BLACK FRIDAY", "wordpress-seo" ) }</div>
 			</div> }
 			<div className="yst-p-6 yst-flex yst-flex-col">
-				<div className="yst-flex yst-items-center">
-					<>
-						<Title as="h2" size="4" className={ `yst-text-xl yst-font-semibold ${ isWooCommerceActive ? "yst-text-woo-light" : "yst-text-primary-500 " }` }>
-							{ isWooCommerceActive
-								? sprintf(
-									/* translators: %s expands to "Yoast WooCommerce SEO */
-									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast WooCommerce SEO"
-								)
-								: sprintf(
-									/* translators: %s expands to "Yoast SEO" Premium */
-									__( "Upgrade to %s", "wordpress-seo" ),
-									"Yoast SEO Premium"
-								) }
-						</Title>
-						{ isWooCommerceActive
-							? <TrolleyIcon className="yst-ml-2 yst-w-4 yst-h-3" />
-							: <CrownIcon className="yst-ml-2 yst-w-4 yst-h-3" />
-						}
-					</>
-				</div>
+				<UpsellTitle isWooCommerceActive={ isWooCommerceActive } />
 				<div
 					className="yst-font-medium yst-text-slate-800 yst-text-xs yst-leading-7 yst-mt-2"
 				>
@@ -100,28 +138,15 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 				</div>
 				<ul className="yst-grid yst-grid-cols-1 sm:yst-grid-cols-2 yst-gap-x-6 yst-gap-y-2 yst-list-none yst-list-outside yst-text-slate-600 yst-mt-4">
 					{ getBenefits().map( ( benefit, index ) => (
-						<li key={ `upsell-benefit-${ index }` } className="yst-flex yst-items-start"><CheckCircleIcon className="yst-mr-2 yst-text-green-500 yst-w-[19.5px] yst-h-[19.5px] yst-flex-shrink-0" />{ benefit }</li>
+						<li key={ `upsell-benefit-${ index }` } className="yst-flex yst-items-start"><CheckCircleIcon className="yst-me-2 yst-text-green-500 yst-w-[19.5px] yst-h-[19.5px] yst-flex-shrink-0" />{ benefit }</li>
 					) ) }
 				</ul>
-				<Button
-					as="a"
-					variant="upsell"
-					size="extra-large"
-					href={ premiumLink }
-					className="yst-gap-2 yst-mt-6 sm:yst-max-w-sm"
-					target="_blank"
-					rel="noopener"
-					{ ...premiumUpsellConfig }
-				>
-					{ upsellTitle }
-					<span className="yst-sr-only">
-						{
-							/* translators: Hidden accessibility text. */
-							__( "(Opens in a new browser tab)", "wordpress-seo" )
-						}
-					</span>
-					<ArrowNarrowRightIcon className="yst-w-4 yst-h-4 yst-icon-rtl" />
-				</Button>
+				<UpsellButton
+					isBlackFriday={ isBlackFriday }
+					isWooCommerceActive={ isWooCommerceActive }
+					premiumLink={ premiumLink }
+					premiumUpsellConfig={ premiumUpsellConfig }
+				/>
 			</div>
 		</Paper>
 	);

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -78,9 +78,7 @@ const UpsellButton = ( { isWooCommerceActive, premiumLink, premiumUpsellConfig =
  */
 export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPromotionActive, isWooCommerceActive } ) => {
 	const isBlackFriday = isPromotionActive( "black-friday-promotion" );
-	const getBenefits = isWooCommerceActive
-		? getWooSeoBenefits
-		: getPremiumBenefits;
+	const getBenefits = isWooCommerceActive ? getWooSeoBenefits : getPremiumBenefits;
 
 	const nowIncluding = [
 		...( isWooCommerceActive ? [ "Yoast SEO Premium" ] : [] ),
@@ -89,11 +87,6 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 		"Video SEO",
 		__( "Google Docs add-on (1 seat)", "wordpress-seo" ),
 	];
-
-	const badgeClasses = isWooCommerceActive
-		? classNames( "yst-bg-woo-light", "yst-text-[#006499]" )
-		: classNames( "yst-bg-primary-500", "yst-text-primary-500" );
-
 
 	return (
 		<Paper as="div" className="yst-max-w-4xl">
@@ -116,7 +109,10 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 							<Badge
 								size="small"
 								variant="plain"
-								className={ classNames( "yst-mr-2 yst-bg-opacity-15", badgeClasses ) }
+								className={ classNames(
+									"yst-mr-2 yst-bg-opacity-15",
+									isWooCommerceActive ? "yst-bg-woo-light yst-text-[#006499]" : "yst-bg-primary-500 yst-text-primary-500"
+								) }
 								key={ `now-including-${ index }` }
 							>
 								{ addon }

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -9,7 +9,7 @@ import { ReactComponent as CrownIcon } from "../../../images/icon-crown.svg";
 import { ReactComponent as TrolleyIcon } from "../../../images/icon-trolley.svg";
 
 /**
- * The title of the premium upsell card.
+ * The title of the premium upsell list.
  *
  * @param {*} props The props.
  * @param {boolean} props.isWooCommerceActive Whether WooCommerce is active.

--- a/packages/js/src/shared-admin/components/premium-upsell-list.js
+++ b/packages/js/src/shared-admin/components/premium-upsell-list.js
@@ -101,7 +101,7 @@ export const PremiumUpsellList = ( { premiumLink, premiumUpsellConfig = {}, isPr
 				<div
 					className="yst-font-medium yst-text-slate-800 yst-text-xs yst-leading-7 yst-mt-2"
 				>
-					<span className="yst-mr-2">
+					<span className="yst-me-2">
 						{ __( "Now includes:", "wordpress-seo" ) }
 					</span>
 					<div className="yst-inline-block">


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Aligns direction and spacing of icons in upsell card, list and buttons.

## Relevant technical choices:

* In the upsell card and list I split the code to several components to reduce complexity and with that I reduced the lint warnings to 40 and removed list ignore comment.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Deactivate Yoast SEO Premium we you have it.
* Change site or user language to an RTL language like Hebrew or Arabic.
* Enable the black friday campain by editing line 16 in `src/promotions/domain/black-friday-promotion.php`:
* ```new Time_Interval( \gmmktime( 10, 00, 00, 11, 27, 2025 ), \gmmktime( 10, 00, 00, 12, 1, 2026 ) ),```
* Got to Yoast SEO -> Settings 
* [ ] Check the upsell sidebar has the black friday strip.
* [ ] Check the title is `Yoast SEO Premium`
* [ ] Enable Woocommerce and check the title is `Yoast WooCommerce SEO` and it is not overflowing the card.
* [ ] Check the green check marks has space between the text and icon.
* [ ] Check the arrow in the button is aligned.
* [ ] In the upsell list card at the bottom of the Settings page check the title is `Upgrade to Yoast SEO Premium` and has a crown icon next to it with some spacing between the icon and the title.
* [ ] Enable woocommerce and check the title has changed. to WooCommerce SEO and so is the icon but the spacing is the same.
* [ ] Check there is no margin in the `Now includes` text before the badges.
<img width="971" height="319" alt="Screenshot 2026-06-01 at 13 37 24" src="https://github.com/user-attachments/assets/c9ab69e1-c335-4bc1-b7dd-fabd07222ed0" />

* [ ] Check the green check marks has space between the text and icon.
* [ ] Check the arrow in the button is aligned.
* [ ] In the admin menu, check the `AI Brand Insights` button has an Icon facing outward.
* [ ] Change language back to LTR and repeat the tests.
<img width="286" height="650" alt="Screenshot 2026-05-28 at 12 15 51" src="https://github.com/user-attachments/assets/ee82bee4-0cee-4cc6-b755-1650ccd9d780" />

<img width="226" height="303" alt="Screenshot 2026-05-28 at 11 40 59" src="https://github.com/user-attachments/assets/95887460-c0ae-4cf0-90f8-d57a04f9c204" />
<img width="1011" height="343" alt="Screenshot 2026-05-28 at 13 22 47" src="https://github.com/user-attachments/assets/939758f3-2ec0-44f0-bbe1-b5cf746c7d81" />


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1246
