### PR TITLE
fix: spacing between webinar notice and general page notices

### DIFF
--- a/css/src/general-page.css
+++ b/css/src/general-page.css
@@ -26,16 +26,6 @@ body.toplevel_page_wpseo_dashboard {
 		margin-right: 12px;
 	}
 
-	.yoast-general-page-notice .notice-dismiss {
-		position: relative;
-		@apply yst-text-slate-400
-		hover:yst-text-slate-500
-	}
-
-	.yoast-general-page-notice .notice-dismiss:before {
-		display: none;
-	}
-
 	.yoast-general-page-notice .notice-yoast img {
 		display: none;
 	}
@@ -49,18 +39,14 @@ body.toplevel_page_wpseo_dashboard {
 		margin-top: 0;
 	}
 
-	.yoast-webinar-dashboard .notice-dismiss:before {
-		/* yst-text-slate-400 */
-		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2394A3B8' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>") no-repeat center;
-		background-size: contain;
-		content: '';
+	.yoast-webinar-dashboard .notice-dismiss:before{
+		@apply yst-top-3 yst-right-3 yst-absolute;
 	}
 
-	.yoast-webinar-dashboard .notice-dismiss:hover:before {
-		/* yst-text-slate-500 */
-		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2364748b' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>") no-repeat center;
-		background-size: contain;
-		content: '';
+	.yoast-webinar-dashboard .notice-dismiss:before, .yoast-general-page-notice .notice-dismiss:before {
+		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2394A3B8' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>") no-repeat center;
+		color:transparent;
+		background-size: 20px;
 	}
 
 	.yoast-webinar-dashboard p {

--- a/css/src/general-page.css
+++ b/css/src/general-page.css
@@ -3,10 +3,6 @@ body.toplevel_page_wpseo_dashboard {
 		display: none;
 	}
 
-	.yoast-general-page-notices:last-child {
-		margin-bottom: 2rem;
-	}
-
 	.yoast-general-page-notice, .yoast-webinar-dashboard {
 		background: white;
 		padding: 0.75rem;
@@ -55,13 +51,15 @@ body.toplevel_page_wpseo_dashboard {
 
 	.yoast-webinar-dashboard .notice-dismiss:before {
 		/* yst-text-slate-400 */
-		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2394A3B8' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>");
+		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2394A3B8' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>") no-repeat center;
+		background-size: contain;
 		content: '';
 	}
 
 	.yoast-webinar-dashboard .notice-dismiss:hover:before {
 		/* yst-text-slate-500 */
-		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2364748b' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>");
+		background: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='2' stroke='%2364748b' class='yst-h-5 yst-w-5' role='img'><path stroke-linecap='round' stroke-linejoin='round' d='M6 18L18 6M6 6l12 12'></path></svg>") no-repeat center;
+		background-size: contain;
 		content: '';
 	}
 

--- a/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
+++ b/packages/js/src/components/trustpilot-review-notification/trustpilot-review-notification.js
@@ -27,6 +27,7 @@ export const TrustpilotReviewNotification = ( props ) => {
 			hasIcon={ false }
 			isAlertDismissed={ ! shouldShow }
 			onDismissed={ dismiss }
+			className="yst-m-0"
 			{ ...props }
 		>
 			{ __( "Happy with the plugin?", "wordpress-seo" ) }

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -14,7 +14,6 @@ import classNames from "classnames";
  *
  * @returns {Component} The composed Notification component.
  */
-
 export const PersistentDismissableNotification = ( {
 	children,
 	id,
@@ -59,6 +58,7 @@ PersistentDismissableNotification.propTypes = {
 	image: PropTypes.elementType,
 	isAlertDismissed: PropTypes.bool.isRequired,
 	onDismissed: PropTypes.func.isRequired,
+	className: PropTypes.string,
 };
 
 export default withPersistentDismiss( PersistentDismissableNotification );

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -1,6 +1,8 @@
+/* eslint-disable complexity */
 import { __ } from "@wordpress/i18n";
 import PropTypes from "prop-types";
 import withPersistentDismiss from "./withPersistentDismiss";
+import classNames from "classnames";
 
 /**
  * @param {string} id The id.
@@ -21,9 +23,10 @@ export const PersistentDismissableNotification = ( {
 	image: Image = null,
 	isAlertDismissed,
 	onDismissed,
+	className = "",
 } ) => {
 	return isAlertDismissed ? null : (
-		<div id={ id } className="notice-yoast yoast is-dismissible yoast-webinar-dashboard yoast-general-page-notices yst-m-0">
+		<div id={ id } className={ classNames( "notice-yoast yoast is-dismissible yoast-webinar-dashboard", className ) }>
 			<div className="notice-yoast__container">
 				<div>
 					<div className="notice-yoast__header">

--- a/packages/js/src/containers/PersistentDismissableNotification.js
+++ b/packages/js/src/containers/PersistentDismissableNotification.js
@@ -26,7 +26,7 @@ export const PersistentDismissableNotification = ( {
 	className = "",
 } ) => {
 	return isAlertDismissed ? null : (
-		<div id={ id } className={ classNames( "notice-yoast yoast is-dismissible yoast-webinar-dashboard", className ) }>
+		<div id={ id } className={ classNames( "notice-yoast yoast is-dismissible", className ) }>
 			<div className="notice-yoast__container">
 				<div>
 					<div className="notice-yoast__header">

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -135,16 +135,21 @@ const App = () => {
 									enterFrom="yst-opacity-0"
 									enterTo="yst-opacity-100"
 								>
-									{ pathname !== ROUTES.firstTimeConfiguration && <div className="yst-flex yst-flex-col yst-gap-3 yst-justify-between">
-										<WebinarPromoNotification store={ STORE_NAME } url={ webinarIntroSettingsUrl } image={ null } />
-										{ notices.length > 0 && <div className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-space-y-3 yoast-general-page-notices" : "yst-hidden" }> {
+									{ pathname !== ROUTES.firstTimeConfiguration && <div>
+										<WebinarPromoNotification
+											store={ STORE_NAME }
+											url={ webinarIntroSettingsUrl }
+											image={ null }
+											className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-3" : "yst-mb-8" }
+										/>
+										{ notices.length > 0 && <div> {
 											notices.map( ( notice, index ) =>
 												<Notice
 													key={ index }
 													id={ notice.id || "yoast-general-page-notice-" + index }
 													title={ notice.header }
 													isDismissable={ notice.isDismissable }
-													className={ notice.isDismissed ? "yst-hidden" : "" }
+													className={ notice.isDismissed ? "yst-hidden" : "yst-mb-3 last:yst-mb-8" }
 												>
 													{ notice.content }
 												</Notice>

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import { Transition } from "@headlessui/react";
 import AdjustmentsIcon from "@heroicons/react/outline/AdjustmentsIcon";
 import BellIcon from "@heroicons/react/outline/BellIcon";
@@ -11,14 +10,12 @@ import { addQueryArgs } from "@wordpress/url";
 import { Notifications, SidebarNavigation, useSvgAria } from "@yoast/ui-library";
 import PropTypes from "prop-types";
 import { Link, Outlet, useLocation } from "react-router-dom";
-import { Notice, OptInContainer } from "./components";
+import { Notices, OptInContainer } from "./components";
 import { STORE_NAME } from "./constants";
-import WebinarPromoNotification from "../components/WebinarPromoNotification";
 import { deleteMigratingNotices } from "../helpers/migrateNotices";
 import { useNotificationCountSync, useSelectGeneralPage } from "./hooks";
 import { MenuItemLink, YoastLogo } from "../shared-admin/components";
 import { ROUTES } from "./routes";
-import classNames from "classnames";
 
 /**
  * @param {string} [idSuffix] Extra id suffix. Can prevent double IDs on the page.
@@ -137,32 +134,10 @@ const App = () => {
 									enterFrom="yst-opacity-0"
 									enterTo="yst-opacity-100"
 								>
-									{ pathname !== ROUTES.firstTimeConfiguration && <div>
-										<WebinarPromoNotification
-											store={ STORE_NAME }
-											url={ webinarIntroSettingsUrl }
-											image={ null }
-											className={
-												classNames(
-													notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-3" : "yst-mb-8",
-													"yoast-webinar-dashboard"
-												) }
-										/>
-										{ notices.length > 0 && <div className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-8" : "" }> {
-											notices.map( ( notice, index ) =>
-												<Notice
-													key={ index }
-													id={ notice.id || "yoast-general-page-notice-" + index }
-													title={ notice.header }
-													isDismissable={ notice.isDismissable }
-													className={ notice.isDismissed ? "yst-hidden" : "yst-mb-3" }
-												>
-													{ notice.content }
-												</Notice>
-											)
-										}
-										</div> }
-									</div> }
+									{ pathname !== ROUTES.firstTimeConfiguration && <Notices
+										notices={ notices }
+										webinarIntroSettingsUrl={ webinarIntroSettingsUrl }
+									/> }
 									<Outlet />
 								</Transition>
 							</main>

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -17,6 +17,7 @@ import { deleteMigratingNotices } from "../helpers/migrateNotices";
 import { useNotificationCountSync, useSelectGeneralPage } from "./hooks";
 import { MenuItemLink, YoastLogo } from "../shared-admin/components";
 import { ROUTES } from "./routes";
+import classNames from "classnames";
 
 /**
  * @param {string} [idSuffix] Extra id suffix. Can prevent double IDs on the page.
@@ -140,7 +141,11 @@ const App = () => {
 											store={ STORE_NAME }
 											url={ webinarIntroSettingsUrl }
 											image={ null }
-											className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-3" : "yst-mb-8" }
+											className={
+												classNames(
+													notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-3" : "yst-mb-8",
+													"yoast-webinar-dashboard"
+												) }
 										/>
 										{ notices.length > 0 && <div> {
 											notices.map( ( notice, index ) =>

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -135,7 +135,7 @@ const App = () => {
 									enterFrom="yst-opacity-0"
 									enterTo="yst-opacity-100"
 								>
-									{ pathname !== ROUTES.firstTimeConfiguration && <div>
+									{ pathname !== ROUTES.firstTimeConfiguration && <div className="yst-flex yst-flex-col yst-gap-3 yst-justify-between">
 										<WebinarPromoNotification store={ STORE_NAME } url={ webinarIntroSettingsUrl } image={ null } />
 										{ notices.length > 0 && <div className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-space-y-3 yoast-general-page-notices" : "yst-hidden" }> {
 											notices.map( ( notice, index ) =>

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Transition } from "@headlessui/react";
 import AdjustmentsIcon from "@heroicons/react/outline/AdjustmentsIcon";
 import BellIcon from "@heroicons/react/outline/BellIcon";
@@ -147,14 +148,14 @@ const App = () => {
 													"yoast-webinar-dashboard"
 												) }
 										/>
-										{ notices.length > 0 && <div> {
+										{ notices.length > 0 && <div className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-8" : "" }> {
 											notices.map( ( notice, index ) =>
 												<Notice
 													key={ index }
 													id={ notice.id || "yoast-general-page-notice-" + index }
 													title={ notice.header }
 													isDismissable={ notice.isDismissable }
-													className={ notice.isDismissed ? "yst-hidden" : "yst-mb-3 last:yst-mb-8" }
+													className={ notice.isDismissed ? "yst-hidden" : "yst-mb-3" }
 												>
 													{ notice.content }
 												</Notice>

--- a/packages/js/src/general/components/index.js
+++ b/packages/js/src/general/components/index.js
@@ -11,3 +11,4 @@ export { OptInContainer } from "./opt-in-container";
 export { TaskListUpsellRow } from "./task-list-upsell-row";
 export { Task } from "./task";
 export { TaskListModal } from "./task-list-modal";
+export { Notices } from "./notices";

--- a/packages/js/src/general/components/notice.js
+++ b/packages/js/src/general/components/notice.js
@@ -31,13 +31,11 @@ export function Notice( { title, id, isDismissable, children, className = "" } )
 			<div className="yst-flex yst-flex-row yst-items-center yst-min-h-[24px]">
 				<span className="yoast-icon" />
 				{ title && <div className="yst-text-sm yst-font-medium" dangerouslySetInnerHTML={ { __html: title } } /> }
-				{ isDismissable && <button
-					type="button" className="notice-dismiss" onClick={ handleDismiss }
-				>
-					<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
-				</button>
-
-				}
+				{ isDismissable && (
+					<button type="button" className="notice-dismiss" onClick={ handleDismiss }>
+						<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+					</button>
+				) }
 			</div>
 			{ children && (
 				<div className="yst-flex-1 yst-text-sm yst-max-w-[600px] yst-ps-[29px]" dangerouslySetInnerHTML={ { __html: children } } />

--- a/packages/js/src/general/components/notice.js
+++ b/packages/js/src/general/components/notice.js
@@ -1,8 +1,6 @@
-import XIcon from "@heroicons/react/outline/XIcon";
 import { useDispatch } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
-import { useSvgAria } from "@yoast/ui-library";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import { STORE_NAME } from "../constants";
@@ -19,7 +17,6 @@ import { STORE_NAME } from "../constants";
  * @returns {JSX.Element} The Notice.
  */
 export function Notice( { title, id, isDismissable, children, className = "" } ) {
-	const ariaSvgProps = useSvgAria();
 	const { dismissNotice } = useDispatch( STORE_NAME );
 
 	const handleDismiss = useCallback( () => {
@@ -30,21 +27,16 @@ export function Notice( { title, id, isDismissable, children, className = "" } )
 	}, [ dismissNotice, id ] );
 
 	return (
-		<div id={ id } className={ classNames( "yst-p-3 yst-rounded-md yoast-general-page-notice", className ) }>
+		<div id={ id } className={ classNames( "yst-p-3 yst-rounded-md yoast-general-page-notice yst-relative", className ) }>
 			<div className="yst-flex yst-flex-row yst-items-center yst-min-h-[24px]">
 				<span className="yoast-icon" />
 				{ title && <div className="yst-text-sm yst-font-medium" dangerouslySetInnerHTML={ { __html: title } } /> }
-				{ isDismissable &&
-					<div className="yst-relative yst-ms-auto">
-						<button
-							type="button"
-							className="notice-dismiss"
-							onClick={ handleDismiss }
-						>
-							<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
-							<XIcon className="yst-h-5 yst-w-5" { ...ariaSvgProps } />
-						</button>
-					</div>
+				{ isDismissable && <button
+					type="button" className="notice-dismiss" onClick={ handleDismiss }
+				>
+					<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+				</button>
+
 				}
 			</div>
 			{ children && (

--- a/packages/js/src/general/components/notices.js
+++ b/packages/js/src/general/components/notices.js
@@ -1,0 +1,38 @@
+import WebinarPromoNotification from "../../components/WebinarPromoNotification";
+import { Notice } from ".";
+import classNames from "classnames";
+import { STORE_NAME } from "../constants";
+
+/**
+ * The notices component that renders the notices on the general page.
+ * @param {object} props
+ * @param {object[]} props.notices The notices to render.
+ * @param {string} props.webinarIntroSettingsUrl The URL to the webinar intro settings page.
+ * @returns {JSX.Element} The notices component.
+ */
+export const Notices = ( { notices, webinarIntroSettingsUrl } ) => ( <div>
+	<WebinarPromoNotification
+		store={ STORE_NAME }
+		url={ webinarIntroSettingsUrl }
+		image={ null }
+		className={
+			classNames(
+				notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-3" : "yst-mb-8",
+				"yoast-webinar-dashboard"
+			) }
+	/>
+	{ notices.length > 0 && <div className={ notices.filter( notice => ! notice.isDismissed ).length > 0 ? "yst-mb-8" : "" }> {
+		notices.map( ( notice, index ) =>
+			<Notice
+				key={ index }
+				id={ notice.id || "yoast-general-page-notice-" + index }
+				title={ notice.header }
+				isDismissable={ notice.isDismissable }
+				className={ notice.isDismissed ? "yst-hidden" : "yst-mb-3" }
+			>
+				{ notice.content }
+			</Notice>
+		)
+	}
+	</div> }
+</div> );

--- a/packages/js/src/general/components/notices.js
+++ b/packages/js/src/general/components/notices.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import classNames from "classnames";
 import { STORE_NAME } from "../constants";
 import WebinarPromoNotification from "../../components/WebinarPromoNotification";
@@ -36,3 +37,14 @@ export const Notices = ( { notices, webinarIntroSettingsUrl } ) => ( <div>
 	}
 	</div> }
 </div> );
+
+Notices.propTypes = {
+	notices: PropTypes.arrayOf( PropTypes.shape( {
+		id: PropTypes.string,
+		header: PropTypes.string.isRequired,
+		content: PropTypes.string.isRequired,
+		isDismissable: PropTypes.bool.isRequired,
+		isDismissed: PropTypes.bool.isRequired,
+	} ) ).isRequired,
+	webinarIntroSettingsUrl: PropTypes.string.isRequired,
+};

--- a/packages/js/src/general/components/notices.js
+++ b/packages/js/src/general/components/notices.js
@@ -1,7 +1,7 @@
-import WebinarPromoNotification from "../../components/WebinarPromoNotification";
-import { Notice } from ".";
 import classNames from "classnames";
 import { STORE_NAME } from "../constants";
+import WebinarPromoNotification from "../../components/WebinarPromoNotification";
+import { Notice } from ".";
 
 /**
  * The notices component that renders the notices on the general page.

--- a/packages/js/src/hooks/use-first-eligible-notification.js
+++ b/packages/js/src/hooks/use-first-eligible-notification.js
@@ -39,7 +39,7 @@ export const useFirstEligibleNotification = ( { webinarIntroUrl } ) => {
 		},
 		{
 			getIsEligible: shouldShowWebinarPromotionNotificationInSidebar,
-			component: ( props ) => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } { ...props } />,
+			component: ( props ) => <WebinarPromoNotification hasIcon={ false } image={ null } url={ webinarIntroUrl } className="yst-m-0" { ...props } />,
 		},
 		{
 			getIsEligible: () => true,

--- a/packages/js/tests/general/components/route-error-fallback.test.js
+++ b/packages/js/tests/general/components/route-error-fallback.test.js
@@ -9,6 +9,8 @@ const LINK = "https://yoa.st/general-error-support";
 jest.mock( "@wordpress/data", () => ( {
 	useSelect: jest.fn( () => LINK ),
 	registerStore: jest.fn(),
+	withSelect: jest.fn( () => component => component ),
+	withDispatch: jest.fn( () => component => component ),
 } ) );
 
 /**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Following the deouple of the webinar notice margin in the editor, we need to address that in the general page.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the dismiss button in the Webinar promo notice in general page was transparent.

## Relevant technical choices:

* Fixes unreleased bug in general page where the space between Webinar promo notice and other notices is missing.
* Decouple the `PersistentDismissableNotification` from the general page by adding claaNmae prop, since it is used also in editor.
* I couldn't use last child class because the notices are still rendered, but hidden.
* Fixes unreleased bug where the trustpilot review notice spacing in the editor was double.
* Addes `notices.js` to reduce complexity of `app.js`.
* Adding `notices.js` to the general components index introduced an indirect module-load-time dependency on `withSelect` and `withDispatch` (via `WebinarPromoNotification` → `withPersistentDismiss`). The existing `route-error-fallback` test only mocked `useSelect` and `registerStore`, so loading the index threw `TypeError: withSelect is not a function` before any test ran. Fixed by adding identity-HOC mocks for both in the `@wordpress/data` mock.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On a new site install Yoast premium and keep it not active.
* Go to general page and check you have 3 notices, The webinar promo, the activation of premium and the first time configuration, and there is equal space between them.
* You can restore those notices using the yoast test helper and reseting options. To reset webinar notice, check user meta `_yoast_alerts_dismissed` and set the webinar notice to 0.
* Check the webinar notice has a dismiss X button.
* Check the dismiss button is identical in all 3 notices.
* Hover the dismiss button and check the X color slightly changes.
* Check the dismiss button is the same in RTL.

Before this PR:
<img width="1704" height="429" alt="Screenshot 2026-05-28 at 15 30 43" src="https://github.com/user-attachments/assets/3e4aa41f-1241-4460-83d8-8f3edc949b31" />

With this PR:
<img width="1723" height="371" alt="Screenshot 2026-05-29 at 10 08 05" src="https://github.com/user-attachments/assets/989a14fe-fb50-4bbc-a295-65d02d056c16" />

* Dismiss the second notice and check the space between the upsell card and the notice is the same.
* Dismiss the last notification and check the space between the upsell card and the notice is the same.

<img width="1481" height="164" alt="Screenshot 2026-05-29 at 10 04 19" src="https://github.com/user-attachments/assets/a2b7744b-cbe9-4815-9fed-d1cc263fc57b" />

* Edit a post in block editor and go to Yoast sidebar. Check the Webinar notification in the same as before:
<img width="387" height="414" alt="Screenshot 2026-05-29 at 10 07 06" src="https://github.com/user-attachments/assets/401cf22b-f9b2-450f-a22d-521cad0f0f14" />

* Check the above in Elementor too

* Improve the SEO score to get green light and check you see the trustpilot review notice with the spaces around it like int he screenshot:
<img width="297" height="307" alt="Screenshot 2026-05-29 at 12 12 58" src="https://github.com/user-attachments/assets/6ee5e26f-7eda-4d07-8bd3-c680c763c900" />

* Check the above in Elementor too

* Go back to general page and dismiss the webinar notice
* Check it is dismissed.


#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1248