### PR TITLE
refactor: render Redirects and AI consent screens with createRoot

### DIFF
--- a/packages/js/src/ai-consent/initialize.js
+++ b/packages/js/src/ai-consent/initialize.js
@@ -1,6 +1,6 @@
 import { useSelect } from "@wordpress/data";
 import domReady from "@wordpress/dom-ready";
-import { Fragment, render, useCallback, useRef } from "@wordpress/element";
+import { createRoot, Fragment, useCallback, useRef } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Modal, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
@@ -80,6 +80,6 @@ domReady( () => {
 
 	const root = document.getElementById( "ai-generator-consent" );
 	if ( root ) {
-		render( <App />, root );
+		createRoot( root ).render( <App /> );
 	}
 } );

--- a/packages/js/src/redirects/initialize.js
+++ b/packages/js/src/redirects/initialize.js
@@ -1,5 +1,5 @@
 import domReady from "@wordpress/dom-ready";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import registerStore from "./store";
 import { select } from "@wordpress/data";
@@ -28,10 +28,9 @@ domReady( () => {
 
 	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );
 
-	render(
+	createRoot( root ).render(
 		<Root context={ { isRtl } }>
 			<AppProvider />
-		</Root>,
-		root
+		</Root>
 	);
 } );


### PR DESCRIPTION
## Context

React 19 (shipping in the Gutenberg plugin 23.3, targeted for WordPress 7.1) removes the `render`/`hydrate` exports from `@wordpress/element`. Most of `packages/js` was migrated to `createRoot` during the React 19 prep (Yoast/reserved-tasks#238), but two shipped entry points still imported `render`: the AI-consent button (`ai-consent/initialize.js`) and the Redirects screen (`redirects/initialize.js`). On React 19 those `render()` calls throw `(0 , n.render) is not a function`, leaving the target UI blank. This PR closes the gap by switching both to `createRoot().render()`.

**Verified on a React 19.2.4 site (Gutenberg 23.3-RC1):** without this PR the AI-consent button (user profile page) and the Free Redirects screen both fail to render with that TypeError; with it, both render with a clean console.

**Where each mount surfaces — they reproduce under opposite Premium states:**
- `ai-consent/initialize.js` renders the consent button on the **user profile page**, and only when **Premium is active** (the integration's conditionals require it).
- `redirects/initialize.js` drives the Redirects screen **only when Premium is inactive** (the Free Redirects page). With Premium active, Premium ships its own, already React-19-safe redirects bundle, so Free's mount is not exercised there.

## Summary

This PR can be summarized in the following changelog entry:

* Migrates the Redirects screen and AI consent button from the removed `@wordpress/element` `render()` to `createRoot()`, for React 19 compatibility.

## Relevant technical choices:

* Used the `createRoot( root ).render( … )` pattern already used by the sibling initializers (`packages/js/src/general/initialize.js`, `settings/initialize.js`). The `helpers/reactRoot.js` helper was intentionally not used: it wraps children in editor-only `TopLevelProviders`/`SlotFillProvider`, which these admin screens do not need.
* No unit tests added and coverage holds flat: these are `domReady` → `createRoot` DOM-mount entry points with no unit-test surface, and the change is a behaviour-neutral API swap on React 18. ESLint passes on both files. Behaviour was instead verified by hand on a React 19.2.4 build (see test instructions).

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

Requires a React 19 build (the Gutenberg 23.3+ plugin active, or WordPress 7.1) with the browser console open. Sanity check: in the console, `wp.element.render` is `undefined` and `wp.element.createRoot` is a function.

**A. AI-consent button — test with Yoast SEO Premium ACTIVE:**
1. Activate Yoast SEO + Yoast SEO Premium.
2. Go to **Users → Profile** and scroll to the Yoast **"AI features"** row.
3. Expected: the Grant/Revoke-consent button renders and the console is clean. Without this PR, the console throws `(0 , n.render) is not a function` from `js/dist/ai-consent.js` and the button never appears.

**B. Redirects screen — test with Yoast SEO Premium INACTIVE:**
1. Deactivate Yoast SEO Premium (keep Free active).
2. Go to **Yoast SEO → Redirects**.
3. Expected: the Redirects screen renders and the console is clean. Without this PR, the console throws `(0 , n.render) is not a function` from `js/dist/redirects.js` and the page is blank.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The key check is the browser console on the two screens above, on a React 19 build. Note the Premium on/off requirement differs per screen (A needs Premium on, B needs Premium off).

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA tests on the Gutenberg 23.3-RC1 (React 19) build, following the acceptance test steps above (A needs Premium active, B needs Premium inactive).

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The AI-consent button on the user profile page (Premium active).
* The Free Redirects screen (Premium inactive). With Premium active the Redirects screen uses Premium's own bundle and is unaffected by this change.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities. Verified on a React 19.2.4 (Gutenberg 23.3-RC1) site: both mounts crash without the fix and render cleanly with it.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for. Tested with Free + Premium (and with Premium toggled off for the Redirects path).
* [ ] I have added unit tests to verify the code works as intended. These are DOM-mount entry points with no unit-test surface; verified by hand on React 19.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to the WBSO document.

Refs Yoast/reserved-tasks#235, Yoast/reserved-tasks#238

Fixes Yoast/reserved-tasks#1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)
