### PR TITLE
fix(ui-library): replace defaultProps with ES6 defaults for React 19

### DIFF
--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -6,6 +6,9 @@ import Autocomplete from "../../elements/autocomplete";
 import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id Identifier.
  * @param {Object} validation The validation state.
@@ -21,7 +24,7 @@ const AutocompleteField = forwardRef( ( {
 	label,
 	disabled = false,
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {

--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -18,10 +19,10 @@ import { useDescribedBy } from "../../hooks";
 const AutocompleteField = forwardRef( ( {
 	id,
 	label,
-	disabled,
-	description,
-	validation,
-	className,
+	disabled = false,
+	description = null,
+	validation = {},
+	className = "",
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -65,12 +66,6 @@ AutocompleteField.propTypes = {
 		message: PropTypes.node,
 	} ),
 	className: PropTypes.string,
-};
-AutocompleteField.defaultProps = {
-	disabled: false,
-	description: null,
-	validation: {},
-	className: "",
 };
 
 AutocompleteField.Option = Autocomplete.Option;

--- a/packages/ui-library/src/components/card/index.js
+++ b/packages/ui-library/src/components/card/index.js
@@ -63,7 +63,7 @@ Footer.propTypes = {
  * @param {string} className The className.
  * @returns {JSX.Element} The card component.
  */
-const Card = forwardRef( ( { as: Component, children, className, ...props }, ref ) => (
+const Card = forwardRef( ( { as: Component = "div", children, className = "", ...props }, ref ) => (
 	<Component { ...props } className={ classNames( "yst-card", className ) } ref={ ref }>
 		{ children }
 	</Component>
@@ -74,10 +74,6 @@ Card.propTypes = {
 	as: PropTypes.elementType,
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
-};
-Card.defaultProps = {
-	as: "div",
-	className: "",
 };
 
 Card.Header = Header;

--- a/packages/ui-library/src/components/checkbox-group/index.js
+++ b/packages/ui-library/src/components/checkbox-group/index.js
@@ -5,6 +5,10 @@ import React, { useCallback } from "react";
 import Checkbox from "../../elements/checkbox";
 import Label from "../../elements/label";
 
+// Stable references so the empty-array defaults keep a constant identity across renders.
+const DEFAULT_VALUES = [];
+const DEFAULT_OPTIONS = [];
+
 /**
  * @param {JSX.node} [children=null] Children are rendered below the checkbox group. Either use this or the `options` prop.
  * @param {string} [id] Identifier.
@@ -23,11 +27,11 @@ const CheckboxGroup = ( {
 	children = null,
 	id = "",
 	name = "",
-	values = [],
+	values = DEFAULT_VALUES,
 	label = "",
 	description = "",
 	disabled = false,
-	options = [],
+	options = DEFAULT_OPTIONS,
 	onChange = noop,
 	className = "",
 	...props

--- a/packages/ui-library/src/components/file-import/index.js
+++ b/packages/ui-library/src/components/file-import/index.js
@@ -86,22 +86,22 @@ const createStatusConditionalRender = ( status ) => {
  * @returns {JSX.Element} The FileImport component.
  */
 const FileImport = forwardRef( ( {
-	children = "",
+	children = null,
 	id,
 	name,
 	selectLabel,
 	dropLabel,
 	screenReaderLabel,
 	abortScreenReaderLabel,
-	selectDescription,
-	status,
+	selectDescription = "",
+	status = FILE_IMPORT_STATUS.idle,
 	onChange,
 	onAbort,
 	feedbackTitle,
-	feedbackDescription,
-	progressMin,
-	progressMax,
-	progress,
+	feedbackDescription = "",
+	progressMin = null,
+	progressMax = null,
+	progress = null,
 }, ref ) => {
 	const isSelected = useMemo( () => status === FILE_IMPORT_STATUS.selected, [ status ] );
 	const isLoading = useMemo( () => status === FILE_IMPORT_STATUS.loading, [ status ] );
@@ -211,15 +211,6 @@ FileImport.propTypes = {
 	status: PropTypes.oneOf( values( FILE_IMPORT_STATUS ) ),
 	onChange: PropTypes.func.isRequired,
 	onAbort: PropTypes.func.isRequired,
-};
-FileImport.defaultProps = {
-	children: null,
-	selectDescription: "",
-	feedbackDescription: "",
-	progressMin: null,
-	progressMax: null,
-	progress: null,
-	status: FILE_IMPORT_STATUS.idle,
 };
 
 FileImport.Selected = createStatusConditionalRender( FILE_IMPORT_STATUS.selected );

--- a/packages/ui-library/src/components/modal/container.js
+++ b/packages/ui-library/src/components/modal/container.js
@@ -7,7 +7,7 @@ import React, { forwardRef } from "react";
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Header = forwardRef( ( { children, className }, ref ) => (
+const Header = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-header", className ) }>
 		{ children }
 	</div>
@@ -17,16 +17,13 @@ Header.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Header.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Content = forwardRef( ( { children, className }, ref ) => (
+const Content = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-content", className ) }>
 		{ children }
 	</div>
@@ -36,16 +33,13 @@ Content.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Content.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Footer = forwardRef( ( { children, className }, ref ) => (
+const Footer = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-footer", className ) }>
 		{ children }
 	</div>
@@ -55,16 +49,13 @@ Footer.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Footer.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-export const Container = forwardRef( ( { children, className }, ref ) => (
+export const Container = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container", className ) }>
 		{ children }
 	</div>
@@ -73,9 +64,6 @@ Container.displayName = "Modal.Container";
 Container.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
-};
-Container.defaultProps = {
-	className: "",
 };
 
 Container.Header = Header;

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -16,7 +16,7 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The title.
  */
-const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className = "", as = "h1", ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			as={ as }
@@ -39,12 +39,6 @@ Title.propTypes = {
 	children: PropTypes.node.isRequired,
 	as: PropTypes.elementType,
 };
-Title.defaultProps = {
-	// eslint-disable-next-line no-undefined
-	size: undefined,
-	className: "",
-	as: "h1",
-};
 
 /**
  * @param {string} [className] Additional classname for the button.
@@ -53,7 +47,7 @@ Title.defaultProps = {
  * @param {JSX.node} [children] Possible to override the default screen reader text and X icon.
  * @returns {JSX.Element} The close button.
  */
-const CloseButton = forwardRef( ( { className, onClick, screenReaderText, children, ...props }, ref ) => {
+const CloseButton = forwardRef( ( { className = "", onClick, screenReaderText = "Close", children, ...props }, ref ) => {
 	const { onClose } = useModalContext();
 	const svgAriaProps = useSvgAria();
 
@@ -81,14 +75,6 @@ CloseButton.propTypes = {
 	onClick: PropTypes.func,
 	screenReaderText: PropTypes.string,
 	children: PropTypes.node,
-};
-CloseButton.defaultProps = {
-	className: "",
-	// eslint-disable-next-line no-undefined
-	onClick: undefined,
-	screenReaderText: "Close",
-	// eslint-disable-next-line no-undefined
-	children: undefined,
 };
 
 /**
@@ -118,11 +104,6 @@ Panel.propTypes = {
 	className: PropTypes.string,
 	hasCloseButton: PropTypes.bool,
 	closeButtonScreenReaderText: PropTypes.string,
-};
-Panel.defaultProps = {
-	className: "",
-	hasCloseButton: true,
-	closeButtonScreenReaderText: "Close",
 };
 
 export const classNameMap = {
@@ -202,11 +183,6 @@ Modal.propTypes = {
 	className: PropTypes.string,
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 	initialFocus: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
-};
-Modal.defaultProps = {
-	className: "",
-	position: "center",
-	initialFocus: null,
 };
 
 Modal.Panel = Panel;

--- a/packages/ui-library/src/components/radio-group/index.js
+++ b/packages/ui-library/src/components/radio-group/index.js
@@ -13,6 +13,9 @@ const classNameMap = {
 	},
 };
 
+// Stable reference so the empty-array default keeps a constant identity across renders.
+const DEFAULT_OPTIONS = [];
+
 /**
  * @param {JSX.node} [children=null] Children are rendered below the radio group. Either use this or the `options` prop.
  * @param {string} [id=""] Identifier.
@@ -35,7 +38,7 @@ const RadioGroup = ( {
 	value = "",
 	label = "",
 	description = "",
-	options = [],
+	options = DEFAULT_OPTIONS,
 	onChange = noop,
 	variant = "default",
 	disabled = false,

--- a/packages/ui-library/src/components/root/index.js
+++ b/packages/ui-library/src/components/root/index.js
@@ -7,12 +7,15 @@ const defaultRootContext = {
 
 export const RootContext = createContext( defaultRootContext );
 
+// Stable reference so the empty-object default keeps a constant identity across renders.
+const DEFAULT_CONTEXT = {};
+
 /**
  * @param {JSX.node} children The React children.
  * @param {{ isRtl: boolean }} context The root context value.
  * @returns {JSX.Element} The Root component.
  */
-const Root = ( { children, context = {}, ...props } ) => {
+const Root = ( { children, context = DEFAULT_CONTEXT, ...props } ) => {
 	return (
 		<RootContext.Provider value={ { ...defaultRootContext, ...context } }>
 			<div className="yst-root" { ...props }>

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -18,10 +19,10 @@ import { useDescribedBy } from "../../hooks";
 const SelectField = forwardRef( ( {
 	id,
 	label,
-	description,
-	disabled,
-	validation,
-	className,
+	description = null,
+	disabled = false,
+	validation = {},
+	className = "",
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -63,12 +64,6 @@ SelectField.propTypes = {
 		message: PropTypes.node,
 	} ),
 	className: PropTypes.string,
-};
-SelectField.defaultProps = {
-	description: null,
-	disabled: false,
-	validation: {},
-	className: "",
 };
 
 SelectField.Option = Select.Option;

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -6,6 +6,9 @@ import Select from "../../elements/select";
 import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id Identifier.
  * @param {JSX.Element} error Error node.
@@ -21,7 +24,7 @@ const SelectField = forwardRef( ( {
 	label,
 	description = null,
 	disabled = false,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {

--- a/packages/ui-library/src/components/stepper/index.js
+++ b/packages/ui-library/src/components/stepper/index.js
@@ -155,14 +155,6 @@ Stepper.propTypes = {
 	} ) ),
 	ProgressBar: PropTypes.elementType,
 };
-Stepper.defaultProps = {
-	className: "",
-	steps: [],
-	// eslint-disable-next-line no-undefined
-	children: undefined,
-	currentStep: 0,
-	ProgressBar: StepperProgressBar,
-};
 
 Stepper.Context = StepperContext;
 Stepper.ProgressBar = StepperProgressBar;

--- a/packages/ui-library/src/components/stepper/index.js
+++ b/packages/ui-library/src/components/stepper/index.js
@@ -53,6 +53,10 @@ const getCurrentStepPercentage = ( percentage, step ) => {
 	return 0;
 };
 
+// Stable reference so the `steps` dependency of the layout effect below keeps a
+// constant identity across renders (defaultProps used to provide a single instance).
+const DEFAULT_STEPS = [];
+
 /**
  *
  * @param {JSX.Node} [children] Content of the stepper.
@@ -62,7 +66,7 @@ const getCurrentStepPercentage = ( percentage, step ) => {
  *
  * @returns {JSX.Element} The Stepper element.
  */
-export const Stepper = forwardRef( ( { children, currentStep = 0, className = "", steps = [], ProgressBar = StepperProgressBar }, ref ) => {
+export const Stepper = forwardRef( ( { children, currentStep = 0, className = "", steps = DEFAULT_STEPS, ProgressBar = StepperProgressBar }, ref ) => {
 	const [ progressBarPosition, setProgressBarPosition ] = useState( { left: 0, right: 0, stepsLengthPercentage: [] } );
 	const [ stepRefs, setStepRefs ] = useState( [] );
 

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -20,11 +21,11 @@ import { useDescribedBy } from "../../hooks";
 const TagField = forwardRef( ( {
 	id,
 	label,
-	labelSuffix,
-	disabled,
-	className,
-	description,
-	validation,
+	labelSuffix = null,
+	disabled = false,
+	className = "",
+	description = null,
+	validation = {},
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -67,13 +68,6 @@ TagField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TagField.defaultProps = {
-	labelSuffix: null,
-	disabled: false,
-	className: "",
-	description: null,
-	validation: {},
 };
 
 export default TagField;

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -7,6 +7,9 @@ import TagInput from "../../elements/tag-input";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {string} label The label.
@@ -25,7 +28,7 @@ const TagField = forwardRef( ( {
 	disabled = false,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -23,12 +24,12 @@ const TextField = forwardRef( ( {
 	id,
 	onChange,
 	label,
-	labelSuffix,
-	disabled,
-	readOnly,
-	className,
-	description,
-	validation,
+	labelSuffix = null,
+	disabled = false,
+	readOnly = false,
+	className = "",
+	description = null,
+	validation = {},
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -84,14 +85,6 @@ TextField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TextField.defaultProps = {
-	labelSuffix: null,
-	disabled: false,
-	readOnly: false,
-	className: "",
-	description: null,
-	validation: {},
 };
 
 export default TextField;

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -7,6 +7,9 @@ import TextInput from "../../elements/text-input";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {function} onChange The input change handler.
@@ -29,7 +32,7 @@ const TextField = forwardRef( ( {
 	readOnly = false,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -21,10 +22,10 @@ const TextareaField = forwardRef( ( {
 	id,
 	label,
 	className = "",
-	description = "",
+	description = null,
 	validation = {},
-	disabled,
-	readOnly,
+	disabled = false,
+	readOnly = false,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -73,13 +74,6 @@ TextareaField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TextareaField.defaultProps = {
-	className: "",
-	description: null,
-	disabled: false,
-	readOnly: false,
-	validation: {},
 };
 
 export default TextareaField;

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -7,6 +7,9 @@ import Textarea from "../../elements/textarea";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {string} label The label.
@@ -23,7 +26,7 @@ const TextareaField = forwardRef( ( {
 	label,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	disabled = false,
 	readOnly = false,
 	...props

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Switch } from "@headlessui/react";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -19,15 +20,15 @@ import Toggle from "../../elements/toggle";
  */
 const ToggleField = forwardRef( ( {
 	id,
-	children,
+	children = null,
 	label,
-	labelSuffix,
-	description,
+	labelSuffix = null,
+	description = null,
 	checked,
-	disabled,
+	disabled = false,
 	onChange,
-	className,
-	"aria-label": ariaLabel,
+	className = "",
+	"aria-label": ariaLabel = null,
 	...props
 }, ref ) => (
 	<Switch.Group
@@ -69,14 +70,6 @@ ToggleField.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	"aria-label": PropTypes.string,
-};
-ToggleField.defaultProps = {
-	children: null,
-	labelSuffix: null,
-	description: null,
-	disabled: false,
-	className: "",
-	"aria-label": null,
 };
 
 export default ToggleField;

--- a/packages/ui-library/src/elements/alert/index.js
+++ b/packages/ui-library/src/elements/alert/index.js
@@ -60,11 +60,5 @@ const propTypes = {
 
 Alert.displayName = "Alert";
 Alert.propTypes = propTypes;
-Alert.defaultProps = {
-	as: "span",
-	variant: "info",
-	className: "",
-	role: "status",
-};
 
 export default Alert;

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Combobox, Transition } from "@headlessui/react";
 import XIcon from "@heroicons/react/outline/XIcon";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
@@ -102,22 +103,22 @@ ClearSelection.propTypes = {
  */
 const Autocomplete = forwardRef( ( {
 	id,
-	value,
-	children,
-	selectedLabel,
-	label,
-	labelProps,
-	labelSuffix,
+	value = null,
+	children = null,
+	selectedLabel = "",
+	label = "",
+	labelProps = {},
+	labelSuffix = null,
 	onChange,
 	onQueryChange,
-	onClear,
-	validation,
-	placeholder,
-	className,
-	buttonProps,
-	clearButtonScreenReaderText,
-	nullable,
-	disabled,
+	onClear = null,
+	validation = {},
+	placeholder = "",
+	className = "",
+	buttonProps = {},
+	clearButtonScreenReaderText = "Clear",
+	nullable = false,
+	disabled = false,
 	...props
 }, ref ) => {
 	const getDisplayValue = useCallback( constant( selectedLabel ), [ selectedLabel ] );
@@ -220,22 +221,6 @@ const propTypes = {
 
 Autocomplete.displayName = "Autocomplete";
 Autocomplete.propTypes = propTypes;
-Autocomplete.defaultProps = {
-	children: null,
-	value: null,
-	selectedLabel: "",
-	label: "",
-	labelProps: {},
-	labelSuffix: null,
-	validation: {},
-	placeholder: "",
-	className: "",
-	buttonProps: {},
-	clearButtonScreenReaderText: "Clear",
-	nullable: false,
-	onClear: null,
-	disabled: false,
-};
 
 Autocomplete.Option = Option;
 Autocomplete.Option.displayName = "Autocomplete.Option";

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -15,6 +15,11 @@ import { ValidationInput } from "../validation";
 const AutocompleteButton = forwardRef( ( props, ref ) => <Combobox.Button as="div" ref={ ref } { ...props } /> );
 AutocompleteButton.displayName = "AutocompleteButton";
 
+// Stable references matching the old defaultProps single instance, so they keep a constant identity across renders.
+const DEFAULT_LABEL_PROPS = {};
+const DEFAULT_VALIDATION = {};
+const DEFAULT_BUTTON_PROPS = {};
+
 /**
  * @param {React.ReactNode} [children=null] The children.
  * @param {string} value The value.
@@ -107,15 +112,15 @@ const Autocomplete = forwardRef( ( {
 	children = null,
 	selectedLabel = "",
 	label = "",
-	labelProps = {},
+	labelProps = DEFAULT_LABEL_PROPS,
 	labelSuffix = null,
 	onChange,
 	onQueryChange,
 	onClear = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	placeholder = "",
 	className = "",
-	buttonProps = {},
+	buttonProps = DEFAULT_BUTTON_PROPS,
 	clearButtonScreenReaderText = "Clear",
 	nullable = false,
 	disabled = false,

--- a/packages/ui-library/src/elements/badge/index.js
+++ b/packages/ui-library/src/elements/badge/index.js
@@ -28,10 +28,10 @@ const classNameMap = {
  */
 const Badge = forwardRef( ( {
 	children,
-	as: Component,
-	variant,
-	size,
-	className,
+	as: Component = "span",
+	variant = "info",
+	size = "default",
+	className = "",
 	...props
 }, ref ) => (
 	<Component
@@ -58,11 +58,5 @@ const propTypes = {
 
 Badge.displayName = "Badge";
 Badge.propTypes = propTypes;
-Badge.defaultProps = {
-	as: "span",
-	variant: "info",
-	size: "default",
-	className: "",
-};
 
 export default Badge;

--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import { keys } from "lodash";
 import PropTypes from "prop-types";
@@ -37,13 +38,13 @@ export const classNameMap = {
  */
 const Button = forwardRef( ( {
 	children,
-	as: Component,
+	as: Component = "button",
 	type,
-	variant,
-	size,
-	isLoading,
-	disabled,
-	className,
+	variant = "primary",
+	size = "default",
+	isLoading = false,
+	disabled = false,
+	className = "",
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -80,15 +81,4 @@ Button.propTypes = {
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
 };
-Button.defaultProps = {
-	as: "button",
-	// eslint-disable-next-line no-undefined
-	type: undefined,
-	variant: "primary",
-	size: "default",
-	isLoading: false,
-	disabled: false,
-	className: "",
-};
-
 export default Button;

--- a/packages/ui-library/src/elements/checkbox/index.js
+++ b/packages/ui-library/src/elements/checkbox/index.js
@@ -51,10 +51,5 @@ Checkbox.propTypes = {
 	className: PropTypes.string,
 	disabled: PropTypes.bool,
 };
-Checkbox.defaultProps = {
-	className: "",
-	disabled: false,
-	label: "",
-};
 
 export default Checkbox;

--- a/packages/ui-library/src/elements/code/index.js
+++ b/packages/ui-library/src/elements/code/index.js
@@ -32,9 +32,5 @@ Code.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	className: PropTypes.string,
 };
-Code.defaultProps = {
-	variant: "default",
-	className: "",
-};
 
 export default Code;

--- a/packages/ui-library/src/elements/file-input/index.js
+++ b/packages/ui-library/src/elements/file-input/index.js
@@ -30,12 +30,12 @@ const FileInput = forwardRef( ( {
 	selectLabel,
 	dropLabel,
 	screenReaderLabel,
-	selectDescription,
-	disabled,
-	iconAs: IconComponent,
+	selectDescription = "",
+	disabled = false,
+	iconAs: IconComponent = DocumentAddIcon,
 	onChange,
-	onDrop,
-	className,
+	onDrop = noop,
+	className = "",
 	...props
 }, ref ) => {
 	const [ isDragOver, setIsDragOver ] = useState( false );
@@ -113,13 +113,6 @@ FileInput.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onDrop: PropTypes.func,
 	className: PropTypes.string,
-};
-FileInput.defaultProps = {
-	selectDescription: "",
-	disabled: false,
-	iconAs: DocumentAddIcon,
-	className: "",
-	onDrop: noop,
 };
 
 export default FileInput;

--- a/packages/ui-library/src/elements/label/index.js
+++ b/packages/ui-library/src/elements/label/index.js
@@ -10,10 +10,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} Label component.
  */
 const Label = forwardRef( ( {
-	as: Component,
-	className,
-	label,
-	children,
+	as: Component = "label",
+	className = "",
+	label = "",
+	children = "",
 	...props
 }, ref ) => (
 	<Component
@@ -31,12 +31,6 @@ Label.propTypes = {
 	children: PropTypes.string,
 	as: PropTypes.elementType,
 	className: PropTypes.string,
-};
-Label.defaultProps = {
-	label: "",
-	children: "",
-	as: "label",
-	className: "",
 };
 
 export default Label;

--- a/packages/ui-library/src/elements/link/index.js
+++ b/packages/ui-library/src/elements/link/index.js
@@ -19,9 +19,9 @@ const classNameMap = {
  * @returns {JSX.Element} The link.
  */
 const Link = forwardRef( ( {
-	as: Component,
-	variant,
-	className,
+	as: Component = "a",
+	variant = "default",
+	className = "",
 	children,
 	...props
 }, ref ) => (
@@ -44,11 +44,6 @@ Link.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	as: PropTypes.elementType,
 	className: PropTypes.string,
-};
-Link.defaultProps = {
-	as: "a",
-	variant: "default",
-	className: "",
 };
 
 export default Link;

--- a/packages/ui-library/src/elements/paper/index.js
+++ b/packages/ui-library/src/elements/paper/index.js
@@ -25,10 +25,6 @@ Paper.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
-Paper.defaultProps = {
-	as: "div",
-	className: "",
-};
 
 Paper.Header = Header;
 Paper.Header.displayName = "Paper.Header";

--- a/packages/ui-library/src/elements/progress-bar/index.js
+++ b/packages/ui-library/src/elements/progress-bar/index.js
@@ -35,8 +35,5 @@ ProgressBar.propTypes = {
 	progressClassName: PropTypes.string,
 	className: PropTypes.string,
 };
-ProgressBar.defaultProps = {
-	className: "",
-};
 
 export default ProgressBar;

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -29,11 +30,11 @@ const Radio = forwardRef( ( {
 	name,
 	value,
 	label,
-	screenReaderLabel,
-	variant,
-	disabled,
-	className,
-	isLabelDangerousHtml,
+	screenReaderLabel = "",
+	variant = "default",
+	disabled = false,
+	className = "",
+	isLabelDangerousHtml = false,
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -110,13 +111,6 @@ Radio.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
-};
-Radio.defaultProps = {
-	screenReaderLabel: "",
-	variant: "default",
-	disabled: false,
-	className: "",
-	isLabelDangerousHtml: false,
 };
 
 export default Radio;

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -43,6 +43,12 @@ const Option = ( { value, label } ) => {
 
 Option.propTypes = optionPropType;
 
+// Stable references matching the old defaultProps single instance, so they keep a constant identity across renders.
+const DEFAULT_OPTIONS = [];
+const DEFAULT_LABEL_PROPS = {};
+const DEFAULT_VALIDATION = {};
+const DEFAULT_BUTTON_PROPS = {};
+
 /**
  * @param {string} id Identifier.
  * @param {string} value Selected value.
@@ -63,17 +69,17 @@ Option.propTypes = optionPropType;
 const Select = forwardRef( ( {
 	id,
 	value,
-	options = [],
+	options = DEFAULT_OPTIONS,
 	children = null,
 	selectedLabel = "",
 	label = "",
-	labelProps = {},
+	labelProps = DEFAULT_LABEL_PROPS,
 	labelSuffix = null,
 	onChange,
 	disabled = false,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
-	buttonProps = {},
+	buttonProps = DEFAULT_BUTTON_PROPS,
 	...props
 }, ref ) => {
 	const selectedOption = useMemo( () => (

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Listbox, Transition } from "@headlessui/react";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
@@ -62,17 +63,17 @@ Option.propTypes = optionPropType;
 const Select = forwardRef( ( {
 	id,
 	value,
-	options,
-	children,
-	selectedLabel,
-	label,
-	labelProps,
-	labelSuffix,
+	options = [],
+	children = null,
+	selectedLabel = "",
+	label = "",
+	labelProps = {},
+	labelSuffix = null,
 	onChange,
-	disabled,
-	validation,
-	className,
-	buttonProps,
+	disabled = false,
+	validation = {},
+	className = "",
+	buttonProps = {},
 	...props
 }, ref ) => {
 	const selectedOption = useMemo( () => (
@@ -146,18 +147,6 @@ Select.propTypes = {
 	} ),
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
-};
-Select.defaultProps = {
-	options: [],
-	children: null,
-	selectedLabel: "",
-	label: "",
-	labelProps: {},
-	labelSuffix: null,
-	disabled: false,
-	validation: {},
-	className: "",
-	buttonProps: {},
 };
 
 Select.Option = Option;

--- a/packages/ui-library/src/elements/spinner/index.js
+++ b/packages/ui-library/src/elements/spinner/index.js
@@ -25,9 +25,9 @@ export const classNameMap = {
  * @returns {JSX.Element} The spinner.
  */
 const Spinner = forwardRef( ( {
-	variant,
-	size,
-	className,
+	variant = "default",
+	size = "4",
+	className = "",
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
 
@@ -59,11 +59,6 @@ Spinner.propTypes = {
 	variant: PropTypes.oneOf( keys( classNameMap.variant ) ),
 	size: PropTypes.oneOf( keys( classNameMap.size ) ),
 	className: PropTypes.string,
-};
-Spinner.defaultProps = {
-	variant: "default",
-	size: "4",
-	className: "",
 };
 
 export default Spinner;

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -121,10 +121,6 @@ Table.propTypes = {
 	className: PropTypes.string,
 	variant: PropTypes.oneOf( Object.keys( tableVariants ) ),
 };
-Table.defaultProps = {
-	className: "",
-	variant: "default",
-};
 
 Table.Head = Head;
 Table.Head.displayName = "Table.Head";

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import XIcon from "@heroicons/react/solid/XIcon";
 import classNames from "classnames";
 import { isString, map, noop } from "lodash";
@@ -72,14 +73,14 @@ Tag.propTypes = {
  */
 const TagInput = forwardRef( ( {
 	tags = [],
-	children,
-	className,
-	disabled,
-	onAddTag,
-	onRemoveTag,
-	onSetTags,
-	onBlur,
-	screenReaderRemoveTag,
+	children = null,
+	className = "",
+	disabled = false,
+	onAddTag = noop,
+	onRemoveTag = noop,
+	onSetTags = noop,
+	onBlur = noop,
+	screenReaderRemoveTag = "Remove tag",
 	...props
 }, ref ) => {
 	const [ text, setText ] = useState( "" );
@@ -157,17 +158,6 @@ TagInput.propTypes = {
 	onSetTags: PropTypes.func,
 	onBlur: PropTypes.func,
 	screenReaderRemoveTag: PropTypes.string,
-};
-TagInput.defaultProps = {
-	tags: [],
-	children: null,
-	className: "",
-	disabled: false,
-	onAddTag: noop,
-	onRemoveTag: noop,
-	onSetTags: noop,
-	onBlur: noop,
-	screenReaderRemoveTag: "Remove tag",
 };
 
 TagInput.Tag = Tag;

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -6,6 +6,9 @@ import PropTypes from "prop-types";
 import React, { forwardRef, useCallback, useState } from "react";
 import { Badge } from "../../index";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_TAGS = [];
+
 /**
  * @param {string} tag The tag / label.
  * @param {number} index The tag index.
@@ -72,7 +75,7 @@ Tag.propTypes = {
  * @returns {JSX.Element} The element.
  */
 const TagInput = forwardRef( ( {
-	tags = [],
+	tags = DEFAULT_TAGS,
 	children = null,
 	className = "",
 	disabled = false,

--- a/packages/ui-library/src/elements/text-input/index.js
+++ b/packages/ui-library/src/elements/text-input/index.js
@@ -11,10 +11,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} TextInput component.
  */
 const TextInput = forwardRef( ( {
-	type,
-	className,
-	disabled,
-	readOnly,
+	type = "text",
+	className = "",
+	disabled = false,
+	readOnly = false,
 	...props
 }, ref ) => (
 	<input
@@ -38,12 +38,6 @@ TextInput.propTypes = {
 	className: PropTypes.string,
 	disabled: PropTypes.bool,
 	readOnly: PropTypes.bool,
-};
-TextInput.defaultProps = {
-	type: "text",
-	className: "",
-	disabled: false,
-	readOnly: false,
 };
 
 export default TextInput;

--- a/packages/ui-library/src/elements/textarea/index.js
+++ b/packages/ui-library/src/elements/textarea/index.js
@@ -10,10 +10,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} Textarea component.
  */
 const Textarea = forwardRef( ( {
-	disabled,
-	cols,
-	rows,
-	className,
+	disabled = false,
+	cols = 20,
+	rows = 2,
+	className = "",
 	...props
 }, ref ) => (
 	<textarea
@@ -36,12 +36,6 @@ Textarea.propTypes = {
 	disabled: PropTypes.bool,
 	cols: PropTypes.number,
 	rows: PropTypes.number,
-};
-Textarea.defaultProps = {
-	className: "",
-	disabled: false,
-	cols: 20,
-	rows: 2,
 };
 
 export default Textarea;

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undefined */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -19,9 +18,9 @@ export const classNameMap = {
  */
 const Title = forwardRef( ( {
 	children,
-	as: Component,
+	as: Component = "h1",
 	size,
-	className,
+	className = "",
 	...props
 }, ref ) => {
 	return (
@@ -46,10 +45,4 @@ Title.propTypes = {
 	size: PropTypes.oneOf( Object.keys( classNameMap.size ) ),
 	className: PropTypes.string,
 };
-Title.defaultProps = {
-	as: "h1",
-	size: undefined,
-	className: "",
-};
-
 export default Title;

--- a/packages/ui-library/src/elements/toggle/index.js
+++ b/packages/ui-library/src/elements/toggle/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undefined */
+/* eslint-disable complexity */
 import { Switch, Transition } from "@headlessui/react";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import XIcon from "@heroicons/react/solid/XIcon";
@@ -23,13 +23,13 @@ import { useSvgAria } from "../../hooks";
  */
 const Toggle = forwardRef( ( {
 	id,
-	as: Component,
-	checked,
+	as: Component = "button",
+	checked = false,
 	screenReaderLabel,
 	onChange,
-	disabled,
-	className,
-	type,
+	disabled = false,
+	className = "",
+	type = "",
 	checkedIcon,
 	unCheckedIcon,
 	...props
@@ -97,15 +97,6 @@ Toggle.propTypes = {
 	className: PropTypes.string,
 	checkedIcon: PropTypes.node,
 	unCheckedIcon: PropTypes.node,
-};
-Toggle.defaultProps = {
-	as: "button",
-	checked: false,
-	disabled: false,
-	type: "",
-	className: "",
-	checkedIcon: undefined,
-	unCheckedIcon: undefined,
 };
 
 export default Toggle;

--- a/packages/ui-library/src/elements/tooltip/index.js
+++ b/packages/ui-library/src/elements/tooltip/index.js
@@ -26,16 +26,17 @@ const variantClassNameMap = {
  * @param {string} [variant] Variant of the tooltip.
  * @returns {JSX.Element} Tooltip component.
  */
-const Tooltip = forwardRef( ( { children, as: Component, className, position, ...props }, ref ) => {
+const Tooltip = forwardRef( ( { children = null, as: Component = "div", className = "", position = "top", variant = "dark", ...props }, ref ) => {
 	return (
 		<Component
 			ref={ ref }
 			className={ classNames( "yst-tooltip",
 				positionClassNameMap[ position ],
-				variantClassNameMap[ props.variant ],
+				variantClassNameMap[ variant ],
 				className,
 			) }
 			role="tooltip"
+			variant={ variant }
 			{ ...props }
 		>
 			{ children }
@@ -51,12 +52,4 @@ Tooltip.propTypes = {
 	position: PropTypes.oneOf( Object.keys( positionClassNameMap ) ),
 	variant: PropTypes.oneOf( Object.keys( variantClassNameMap ) ),
 };
-Tooltip.defaultProps = {
-	as: "div",
-	children: null,
-	className: "",
-	position: "top",
-	variant: "dark",
-};
-
 export default Tooltip;

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -47,9 +47,5 @@ ValidationInput.propTypes = {
 	} ),
 	className: PropTypes.string,
 };
-ValidationInput.defaultProps = {
-	validation: {},
-	className: "",
-};
 
 export default ValidationInput;

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
 import ValidationIcon from "./validation-icon";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 const CLASSNAME_MAP = {
 	variant: {
 		success: "yst-validation-input--success",
@@ -20,7 +23,7 @@ const CLASSNAME_MAP = {
  */
 const ValidationInput = forwardRef( ( {
 	as: Component,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {


### PR DESCRIPTION
## Context

React 19 ignores `defaultProps` on function/`forwardRef` components, so props that relied on them arrive `undefined` and throw when dereferenced (e.g. `Title`'s `as`, `Button`'s `variant`), which crashed the whole Yoast metabox on the Gutenberg 23.3 RC (React 19.2.4). This moves every `@yoast/ui-library` component that used `defaultProps` to ES6 default parameters. No net behaviour change on React 18.3; it is React 19 prep for WordPress 7.1.

**Verified on a React 19.2.4 site (Gutenberg 23.3-RC1):** with this change the Yoast metabox, sidebar and Settings render with a clean console; without it the metabox fails to render. The follow-up render smoke test (separate PR) also passes 58/58 `@yoast/ui-library` components on both React 18.3 and 19.2.4. Sibling of #23316.

## Summary

This PR can be summarized in the following changelog entry:

* [ui-library] Replaces deprecated `defaultProps` with ES6 default parameters across `@yoast/ui-library` components so they keep rendering on React 19, which ignores `defaultProps` for function components.

## Relevant technical choices:

The PR has three commits:

1. **defaultProps → ES6 defaults** across 33 components. The 12 the conversion pushes over the ESLint `complexity` warning get a file-level `eslint-disable complexity` (matching the existing ~118-file convention in this repo; the threshold itself is unchanged). `Tooltip`'s `variant` was previously forwarded via `...props`; it is re-forwarded explicitly so the change stays behaviour-neutral.
2. **Stabilise empty object/array defaults.** `defaultProps` provided one stable instance; inline `{}` / `[]` defaults allocate a fresh value each render, breaking dependency-array identity. Left as-is this regressed three components (Stepper's `steps` looped a layout effect, Select's `options` fed a `useMemo`, TagInput's `tags` fed a `useCallback`). Hoisted every such default to a module-level constant.
3. **(separate commit, pre-existing)** Stabilise the same pattern in `CheckboxGroup`, `RadioGroup`, and `Root`, which already used inline `[]` / `{}` defaults in trunk (never `defaultProps`-backed); `CheckboxGroup`'s `values` feeds a `useCallback` dependency. Found while auditing the conversion, hence the separate commit.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* On the Gutenberg 23.3 RC (React 19.2.4), open a post with the browser console open: the Yoast metabox/sidebar render with no errors (without this change the metabox fails to render).
* On current WordPress (React 18.3), confirm no visual regression in `@yoast/ui-library` UI (Settings, metabox, buttons, fields, modals).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The key check is the browser console in the block editor on a React 19 build: the Yoast metabox and sidebar must render.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA tests on the Gutenberg 23.3-RC1 (React 19) build, following the acceptance test steps above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Anything rendering `@yoast/ui-library` components: the Yoast SEO Settings UI, the metabox/sidebar, and add-ons that consume the package.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities. Verified on a React 19.2.4 (Gutenberg 23.3-RC1) site (metabox, sidebar and Settings render cleanly) and via the follow-up render smoke test (58/58 components on the React 18.3 / 19.2.4 matrix).
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for. Tested with Free, Premium, Local, News and Video active.
* [ ] I have added unit tests to verify the code works as intended. The render smoke test ships in the follow-up tests PR.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to the WBSO document.

Refs Yoast/reserved-tasks#231, Yoast/reserved-tasks#246

Fixes Yoast/reserved-tasks#1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
