### PR TITLE
fix(components): guard styled button rgba() against React 19 defaultProps removal

### DIFF
--- a/packages/components/src/IconButtonToggle.js
+++ b/packages/components/src/IconButtonToggle.js
@@ -6,15 +6,32 @@ import { colors } from "@yoast/style-guide";
 import SvgIcon from "./SvgIcon";
 import IconButtonBase from "./IconButtonBase";
 
+const changingIconButtonDefaults = {
+	unpressedBoxShadowColor: colors.$color_button_border,
+	pressedBoxShadowColor: colors.$color_purple,
+	pressedBackground: colors.$color_pink_dark,
+	unpressedBackground: colors.$color_button,
+	pressedIconColor: colors.$color_white,
+	unpressedIconColor: colors.$color_button_text,
+	hoverBorderColor: colors.$color_white,
+	marksButtonStatus: "enabled",
+	disabledIconColor: colors.$color_grey,
+};
 
 /**
  * Returns the ChangingIconButton component.
  *
- * @param {Object} props Component props.
+ * @param {Object} componentProps Component props.
  *
  * @returns {ReactElement} ChangingIconButton component.
  */
-const ChangingIconButton = function( props ) {
+const ChangingIconButton = function( componentProps ) {
+	/*
+	 * React 19's automatic JSX runtime no longer applies defaultProps to function components, which
+	 * would drop these colours to undefined and render the button unstyled. Merging the defaults here
+	 * keeps them on both runtimes; defaultProps is kept as well for classic consumers.
+	 */
+	const props = { ...changingIconButtonDefaults, ...componentProps };
 	const buttonsAreDisabled = props.marksButtonStatus === "disabled";
 
 	let iconColor;
@@ -69,16 +86,7 @@ ChangingIconButton.propTypes = {
 	className: PropTypes.string,
 };
 
-ChangingIconButton.defaultProps = {
-	unpressedBoxShadowColor: colors.$color_button_border,
-	pressedBoxShadowColor: colors.$color_purple,
-	pressedBackground: colors.$color_pink_dark,
-	unpressedBackground: colors.$color_button,
-	pressedIconColor: colors.$color_white,
-	unpressedIconColor: colors.$color_button_text,
-	hoverBorderColor: colors.$color_white,
-	marksButtonStatus: "enabled",
-	disabledIconColor: colors.$color_grey,
-};
+// Kept for classic-runtime consumers; the in-component merge applies these on React 19.
+ChangingIconButton.defaultProps = changingIconButtonDefaults;
 
 export default ChangingIconButton;

--- a/packages/components/src/buttons/Button.js
+++ b/packages/components/src/buttons/Button.js
@@ -1,6 +1,5 @@
 // External dependencies.
 import styled from "styled-components";
-import flow from "lodash/flow";
 import PropTypes from "prop-types";
 
 // Yoast dependencies.
@@ -16,14 +15,42 @@ const settings = {
 const ieMinHeight = settings.minHeight - ( settings.verticalPadding * 2 ) - ( settings.borderWidth * 2 );
 
 /**
+ * Builds a styled-components `attrs` callback that fills in the given defaults for any prop that is
+ * not provided. React 19's automatic JSX runtime no longer applies `defaultProps` to function /
+ * `forwardRef` components (styled components included), so applying the defaults here keeps them
+ * working on both runtimes; `defaultProps` is kept as well for classic consumers.
+ *
+ * @param {Object} defaults The default prop values.
+ *
+ * @returns {function(Object): Object} An `attrs` callback returning only the missing defaults.
+ */
+function withDefaults( defaults ) {
+	return ( props ) => {
+		const filled = {};
+		Object.keys( defaults ).forEach( ( key ) => {
+			if ( typeof props[ key ] === "undefined" ) {
+				filled[ key ] = defaults[ key ];
+			}
+		} );
+		return filled;
+	};
+}
+
+/**
  * Returns a component with applied base button styles.
  *
- * @param {ReactElement} component The original component.
+ * The defaults are applied here, on the outermost styled layer, via `.attrs`. Because this is the
+ * outermost layer the defaulted props propagate to every inner style layer (hover/focus/active),
+ * so each button keeps its own defaults on the React 19 automatic runtime, which ignores
+ * `defaultProps`.
+ *
+ * @param {ReactElement} component   The original component.
+ * @param {Object}       [defaults]  Default prop values to apply via `.attrs`.
  *
  * @returns {ReactElement} Component with applied base button styles.
  */
-export function addBaseStyle( component ) {
-	return styled( component )`
+export function addBaseStyle( component, defaults = {} ) {
+	return styled( component ).attrs( withDefaults( defaults ) )`
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -124,16 +151,30 @@ export function addActiveStyle( component ) {
  *
  * @returns {ReactElement} Component with applied styles.
  */
-export const addButtonStyles = flow( [
+export const addButtonStyles = ( component, defaults ) =>
 	/*
-	 * Styled-components applies the generated CSS classes in a reversed order,
-	 * but we want them in the order: base - hover - focus - active.
+	 * Styled-components applies the generated CSS classes in a reversed order, but we want them in
+	 * the order: base - hover - focus - active. The defaults are applied on the outermost (base)
+	 * layer so they reach every inner layer's interpolations on the React 19 automatic runtime.
 	 */
-	addActiveStyle,
-	addFocusStyle,
-	addHoverStyle,
-	addBaseStyle,
-] );
+	addBaseStyle( addHoverStyle( addFocusStyle( addActiveStyle( component ) ) ), defaults );
+
+const baseButtonDefaults = {
+	type: "button",
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+	hoverColor: colors.$color_button_text_hover,
+	hoverBackgroundColor: colors.$color_button_hover,
+	activeColor: colors.$color_button_text_hover,
+	activeBackgroundColor: colors.$color_button,
+	activeBorderColor: colors.$color_button_border_active,
+	focusColor: colors.$color_button_text_hover,
+	focusBackgroundColor: colors.$color_white,
+	focusBorderColor: colors.$color_blue,
+	focusBoxShadowColor: colors.$color_blue_dark,
+};
 
 /**
  * Returns a basic styled button.
@@ -148,7 +189,8 @@ export const BaseButton = addButtonStyles(
 		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-	`
+	`,
+	baseButtonDefaults
 );
 
 BaseButton.propTypes = {
@@ -168,22 +210,8 @@ BaseButton.propTypes = {
 	focusBoxShadowColor: PropTypes.string,
 };
 
-BaseButton.defaultProps = {
-	type: "button",
-	backgroundColor: colors.$color_button,
-	textColor: colors.$color_button_text,
-	borderColor: colors.$color_button_border,
-	boxShadowColor: colors.$color_button_border,
-	hoverColor: colors.$color_button_text_hover,
-	hoverBackgroundColor: colors.$color_button_hover,
-	activeColor: colors.$color_button_text_hover,
-	activeBackgroundColor: colors.$color_button,
-	activeBorderColor: colors.$color_button_border_active,
-	focusColor: colors.$color_button_text_hover,
-	focusBackgroundColor: colors.$color_white,
-	focusBorderColor: colors.$color_blue,
-	focusBoxShadowColor: colors.$color_blue_dark,
-};
+// Kept for classic-runtime consumers; addButtonStyles applies these via .attrs for React 19.
+BaseButton.defaultProps = baseButtonDefaults;
 
 /**
  * Returns a styled Button with set font size.

--- a/packages/components/src/buttons/LinkButton.js
+++ b/packages/components/src/buttons/LinkButton.js
@@ -8,6 +8,23 @@ import { colors, rgba } from "@yoast/style-guide";
 // Internal dependencies.
 import { addButtonStyles } from "./Button";
 
+const linkButtonDefaults = {
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+	hoverColor: colors.$color_button_text_hover,
+	hoverBackgroundColor: colors.$color_button_hover,
+	hoverBorderColor: colors.$color_button_border_hover,
+	activeColor: colors.$color_button_text_hover,
+	activeBackgroundColor: colors.$color_button,
+	activeBorderColor: colors.$color_button_border_hover,
+	focusColor: colors.$color_button_text_hover,
+	focusBackgroundColor: colors.$color_white,
+	focusBorderColor: colors.$color_blue,
+	focusBoxShadowColor: colors.$color_blue_dark,
+};
+
 /**
  * Returns a basic link styled like a button.
  *
@@ -22,7 +39,8 @@ export const LinkButton = addButtonStyles(
 		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-	`
+	`,
+	linkButtonDefaults
 );
 
 LinkButton.propTypes = {
@@ -42,19 +60,5 @@ LinkButton.propTypes = {
 	focusBoxShadowColor: PropTypes.string,
 };
 
-LinkButton.defaultProps = {
-	backgroundColor: colors.$color_button,
-	textColor: colors.$color_button_text,
-	borderColor: colors.$color_button_border,
-	boxShadowColor: colors.$color_button_border,
-	hoverColor: colors.$color_button_text_hover,
-	hoverBackgroundColor: colors.$color_button_hover,
-	hoverBorderColor: colors.$color_button_border_hover,
-	activeColor: colors.$color_button_text_hover,
-	activeBackgroundColor: colors.$color_button,
-	activeBorderColor: colors.$color_button_border_hover,
-	focusColor: colors.$color_button_text_hover,
-	focusBackgroundColor: colors.$color_white,
-	focusBorderColor: colors.$color_blue,
-	focusBoxShadowColor: colors.$color_blue_dark,
-};
+// Kept for classic-runtime consumers; the `.attrs` above is what applies these on React 19.
+LinkButton.defaultProps = linkButtonDefaults;

--- a/packages/components/tests/buttonReact19Test.js
+++ b/packages/components/tests/buttonReact19Test.js
@@ -1,0 +1,84 @@
+// External dependencies.
+import React from "react";
+import renderer from "react-test-renderer";
+
+// Internal dependencies.
+import { BaseButton, LinkButton } from "../src/index";
+import IconButtonToggle from "../src/IconButtonToggle";
+
+const noop = () => {};
+
+/**
+ * Renders an element with the component's `defaultProps` temporarily removed, mirroring
+ * React 19's automatic JSX runtime, which no longer applies `defaultProps` to
+ * function/forwardRef components. The buttons keep their defaults working through a
+ * styled-components `.attrs` callback instead, so each guard asserts the button still
+ * renders when `defaultProps` are not applied (without it the `rgba( props.<color> )`
+ * interpolations receive `undefined` and throw).
+ *
+ * @param {React.ComponentType} Component     The component whose `defaultProps` to drop.
+ * @param {Function}            renderElement Callback that returns the element to render.
+ *
+ * @returns {void}
+ */
+const expectRendersWithoutDefaultProps = ( Component, renderElement ) => {
+	const previousDefaults = Component.defaultProps;
+	// `null` makes React's reconciler skip defaultProps (its falsy check), mirroring the automatic
+	// runtime. styled components make `defaultProps` non-configurable, so it cannot be deleted.
+	Component.defaultProps = null;
+	try {
+		// Build the element here, after defaultProps is neutralised: the classic runtime applies
+		// defaultProps at element-creation time, not at render time, so an element created earlier
+		// would keep its defaults and mask the regression.
+		expect( () => renderer.create( renderElement() ) ).not.toThrow();
+	} finally {
+		Component.defaultProps = previousDefaults;
+	}
+};
+
+test( "BaseButton renders when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	expectRendersWithoutDefaultProps( BaseButton, () => <BaseButton>ButtonValue</BaseButton> );
+} );
+
+test( "LinkButton renders when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	expectRendersWithoutDefaultProps( LinkButton, () => <LinkButton>LinkButtonValue</LinkButton> );
+} );
+
+test( "IconButtonToggle keeps its default styling when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	const props = {
+		name: "group1",
+		id: "RadioButton",
+		ariaLabel: "important toggle",
+		icon: "eye",
+		pressed: false,
+		onClick: noop,
+	};
+	const withDefaults = renderer.create( <IconButtonToggle { ...props } /> ).toJSON();
+
+	const previousDefaults = IconButtonToggle.defaultProps;
+	// `null` makes React's reconciler skip defaultProps, mirroring the automatic runtime.
+	IconButtonToggle.defaultProps = null;
+	try {
+		const withoutDefaults = renderer.create( <IconButtonToggle { ...props } /> ).toJSON();
+		// IconButtonToggle merges its own defaults internally, so dropping defaultProps (which React
+		// 19's automatic runtime does) must still produce the same styled output. Comparing the full
+		// render, not just checking that it renders, guards those merged default colours against
+		// silent regressions.
+		expect( withoutDefaults ).toEqual( withDefaults );
+	} finally {
+		IconButtonToggle.defaultProps = previousDefaults;
+	}
+} );
+
+test( "BaseButton keeps type=button when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	const previousDefaults = BaseButton.defaultProps;
+	BaseButton.defaultProps = null;
+	try {
+		const tree = renderer.create( <BaseButton>ButtonValue</BaseButton> ).toJSON();
+		// A typeless <button> defaults to submit and would submit surrounding forms, so the
+		// runtime-safe default must keep type="button" even without defaultProps.
+		expect( tree.props.type ).toBe( "button" );
+	} finally {
+		BaseButton.defaultProps = previousDefaults;
+	}
+} );


### PR DESCRIPTION
## Context

React 19 (Gutenberg 23.3 / WordPress 7.1) stops applying `defaultProps` to function and `forwardRef` components when the element is created through the **automatic JSX runtime** (`jsx()`); the classic `createElement` runtime still applies them. Several `@yoast/components` styled buttons (`Button`/`BaseButton`, `LinkButton`, and the `IconButtonToggle` eye/highlight toggle) interpolate `rgba( props.<color> )`, and those colours are supplied only by `defaultProps`. When an automatic-runtime consumer (Free's `packages/js`) renders one of these buttons, the default colours drop to `undefined`, `rgba(undefined)` throws in polished's `parseToRgb`, and the surrounding subtree crashes.

Verified live on a React 19.2.4 site (Gutenberg 23.3-RC1) with all three React-19 readiness PRs applied: the block-editor **content-analysis "Highlight this result in the text" eye toggles** (`IconButtonToggle`, rendered via `packages/js`' `Results.js`) render fully styled, with the `box-shadow` `rgba()` resolved to a real colour and no `parseToRgb` throw, and the console is clean. `BaseButton` / `LinkButton` surfaces (Workouts, Free admin screens) likewise render cleanly.

Part of the React 19 readiness work tracked in Yoast/reserved-tasks#235.

## Summary

This PR can be summarized in the following changelog entry:

* [@yoast/components] Fixes a bug where buttons could crash the surrounding UI on React 19 because their default colours were no longer applied.

## Relevant technical choices:

* `BaseButton` and `LinkButton` apply their own defaults through a styled-components `.attrs` callback, routed through the outermost `addBaseStyle` layer so the defaults reach every inner hover/focus/active interpolation on both JSX runtimes. This keeps each button's own defaults correct on React 19 (e.g. `LinkButton` keeps its own `activeBorderColor` and `BaseButton` keeps `type="button"`), which a single shared fallback could not.
* `IconButtonToggle` merges its colour defaults in-component (a plain `{ ...defaults, ...props }` spread) so they survive the automatic runtime and its rendered styling stays intact, rather than relying on `defaultProps`.
* `defaultProps` is kept on each component for classic-runtime consumers; the `.attrs`/in-component merge is what makes them safe on the automatic runtime.
* `IconButtonBase` is intentionally left untouched: it has no defaults of its own and its colours are always passed by its only consumer, `IconButtonToggle`, which now supplies defined values.
* Behaviour is unchanged on React 18 and under the classic runtime: the existing component snapshot tests are untouched.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

Requires a React-19 environment (the Gutenberg 23.3+ plugin active, or WordPress 7.1) with Yoast SEO active. Test with the browser console open.

1. Open a post in the block editor, add a paragraph of text and set a focus keyphrase so the SEO and readability analyses run. Each assessment result shows a small **eye "Highlight this result in the text"** toggle. The toggles should render styled (light-grey background, a subtle bottom box-shadow, a 1px border) and the console should show no `hex notation` / `Cannot read properties of undefined` errors. Before this fix they threw in `parseToRgb` and crashed the analysis subtree.
2. Open **Yoast SEO → Workouts** and other Free admin screens. `BaseButton` / `LinkButton` should render and the console should stay clean.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The bug is a render/console crash, only observable on a React 19 build (Gutenberg 23.3+), so test with the console open in the block editor.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA tests on the Gutenberg 23.3-RC1 (React 19) build, following the acceptance test steps above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Any surface that renders `@yoast/components` `Button` / `LinkButton` / `IconButtonToggle` through the automatic JSX runtime (Free `packages/js`: the content-analysis result toggles and the Workouts screens). No effect on React 18 or classic-runtime consumers (the other add-ons).

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [x] I have written documentation for this change. Code comments explain the `.attrs` default mechanism on `BaseButton`/`LinkButton` and the in-component default merge on `IconButtonToggle`.

## Quality assurance

* [x] I have tested this code to the best of my abilities. Verified live on a React 19.2.4 (Gutenberg 23.3-RC1) site: the editor content-analysis eye toggles render fully styled and the console is clean.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for. Tested with Free and Premium active.
* [x] I have added unit tests to verify the code works as intended. `tests/buttonReact19Test.js` renders `BaseButton` / `LinkButton` / `IconButtonToggle` with `defaultProps` neutralised (mirroring the automatic runtime) and asserts they still render, that `BaseButton` keeps `type="button"`, and that `IconButtonToggle` produces identical styled output.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.

Refs Yoast/reserved-tasks#235, Yoast/reserved-tasks#231
Fixes Yoast/reserved-tasks#1253

🤖 Generated with [Claude Code](https://claude.com/claude-code)
