### PR TITLE
test(ui-library): add React render smoke test on React 18.3 and 19.2

### DIFF
--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -72,6 +72,7 @@ jobs:
           - 'search-metadata-previews'
           - 'social-metadata-forms'
           - 'social-metadata-previews'
+          - 'ui-library'
 
     name: "TestJS - ${{ matrix.package }} (full)"
 
@@ -229,3 +230,51 @@ jobs:
         with:
           flag-name: package-${{ matrix.package }}
           parallel: true
+
+
+  #########################################################################################
+  # React 19 compatibility leg: run a package's tests against the React version that
+  # WordPress 7.1 / the Gutenberg 23.3 RC ships (19.2.4), in addition to the default
+  # React 18.3 run in `yarn-test-full`. Scoped to ui-library for now; add packages to the
+  # matrix as they become React-19-ready (e.g. once `components` drops react-test-renderer).
+  #########################################################################################
+  yarn-test-react19:
+    runs-on: ubuntu-latest
+
+    strategy:
+      # Each package/version is independent; don't stop the others when one fails.
+      fail-fast: false
+      matrix:
+        package:
+          - 'ui-library'
+        react:
+          - '19.2.4'
+
+    name: "TestJS - ${{ matrix.package }} (React ${{ matrix.react }})"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up node and enable caching of dependencies
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: './.nvmrc'
+          cache: 'yarn'
+
+      # Force the target React across every workspace via a yarn resolution, then install.
+      # A plain `yarn add -W` would not override packages that pin react@^18 in their own
+      # dependencies; `resolutions` overrides every range. @testing-library/react v16
+      # supports both React 18 and 19, so it is left untouched.
+      - name: Force React ${{ matrix.react }}
+        env:
+          REACT_VERSION: ${{ matrix.react }}
+        run: |
+          node -e "const fs = require('fs'); const p = JSON.parse(fs.readFileSync('package.json', 'utf8')); const v = process.env.REACT_VERSION; p.resolutions = { ...(p.resolutions || {}), react: v, 'react-dom': v }; fs.writeFileSync('package.json', JSON.stringify(p, null, 2));"
+          yarn install --force
+
+      - name: Run Javascript tests
+        run: yarn test --ci
+        working-directory: packages/${{ matrix.package }}

--- a/packages/ui-library/jest.config.js
+++ b/packages/ui-library/jest.config.js
@@ -2,6 +2,17 @@ const path = require( "path" );
 
 module.exports = {
 	preset: "@yoast/jest-preset",
+	// The preset's testMatch globs `tests/**`, so exclude helper files and the disabled
+	// storyshots suite (which imports uninstalled packages) from being picked up as tests.
+	testPathIgnorePatterns: [
+		"<rootDir>/node_modules/",
+		"<rootDir>/vendor/",
+		"<rootDir>/tests/storyshots.js",
+		"<rootDir>/tests/setup.js",
+		"<rootDir>/tests/mocks/",
+	],
+	// Polyfill browser APIs that jsdom lacks but Headless UI relies on.
+	setupFilesAfterEnv: [ path.resolve( __dirname, "tests/setup.js" ) ],
 	moduleNameMapper: {
 		"\\.(scss|css)$": require.resolve(
 			"@wordpress/jest-preset-default/scripts/style-mock.js",

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -28,6 +28,7 @@
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build",
     "publish:storybook": "./scripts/publish-storybook.sh",
+    "test": "jest tests/react-render-smoke.test.js",
     "test:storyshots": "yarn build:storybook --test --quiet && jest tests/storyshots.js",
     "t_st": "yarn test:storyshots",
     "lint": "eslint . --max-warnings=3"
@@ -54,6 +55,7 @@
     "@storybook/theming": "^7.6.17",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/forms": "^0.5.9",
+    "@testing-library/react": "^16.2.0",
     "@wordpress/jest-preset-default": "^8.0.1",
     "@yoast/browserslist-config": "^1.2.5",
     "@yoast/eslint-config": "^8.1.0",

--- a/packages/ui-library/tests/react-render-smoke.test.js
+++ b/packages/ui-library/tests/react-render-smoke.test.js
@@ -1,0 +1,347 @@
+/**
+ * Render smoke test for every exported visual component.
+ *
+ * Each component is rendered with ONLY its required props (children plus any
+ * prop-types `isRequired` prop) inside `<Root>`, and we assert it mounts
+ * without throwing. Optional / previously-defaulted props are deliberately
+ * omitted: omitting them is exactly what surfaces the React-19 class of bug
+ * where a missing `defaultProps` default becomes `undefined` and is then
+ * dereferenced (e.g. Title's `as`, Button's `variant`).
+ *
+ * The list is data-driven so it is trivial to extend: add a
+ * `{ name, Component, props }` entry to `cases`.
+ */
+import { noop } from "lodash";
+import React from "react";
+import { render } from "@testing-library/react";
+import {
+	Alert,
+	Autocomplete,
+	AutocompleteField,
+	Badge,
+	Button,
+	Card,
+	Checkbox,
+	CheckboxGroup,
+	ChildrenLimiter,
+	Code,
+	DropdownMenu,
+	ErrorBoundary,
+	FeatureUpsell,
+	FileImport,
+	GradientSparklesIcon,
+	ImageSelect,
+	Label,
+	Link,
+	Modal,
+	ModalNotification,
+	Notifications,
+	Pagination,
+	Paper,
+	Popover,
+	ProgressBar,
+	Radio,
+	RadioGroup,
+	Root,
+	ScoreIcon,
+	Select,
+	SelectField,
+	SidebarNavigation,
+	SkeletonLoader,
+	Spinner,
+	Stepper,
+	Table,
+	TagField,
+	TagInput,
+	Textarea,
+	TextareaField,
+	TextField,
+	TextInput,
+	Title,
+	Toast,
+	Toggle,
+	ToggleField,
+	Tooltip,
+	TooltipContainer,
+	TooltipTrigger,
+	TooltipWithContext,
+	ValidationIcon,
+	ValidationInput,
+	ValidationMessage,
+} from "../src";
+
+/**
+ * The cases to render. Each supplies ONLY required props.
+ *
+ * @type {{name: string, Component: React.ComponentType, props: Object}[]}
+ */
+const cases = [
+	// Elements.
+	{ name: "Alert", Component: Alert, props: { children: "Alert" } },
+	{
+		name: "Autocomplete",
+		Component: Autocomplete,
+		props: { id: "ac", onChange: noop, onQueryChange: noop },
+	},
+	// Note: `Autocomplete.Option` / `Select.Option` are intentionally omitted. They are
+	// Headless UI `Combobox.Option` / `Listbox.Option` wrappers that throw when rendered
+	// without their parent `Combobox` / `Listbox`, so they cannot be smoke-tested standalone.
+	// Their default-param conversions are exercised through the parent components above.
+	{ name: "Badge", Component: Badge, props: { children: "Badge" } },
+	{ name: "Button", Component: Button, props: { children: "Button" } },
+	{
+		name: "Checkbox",
+		Component: Checkbox,
+		props: { id: "cb", name: "cb", value: "cb" },
+	},
+	{ name: "Code", Component: Code, props: { children: "code" } },
+	{ name: "Label", Component: Label, props: {} },
+	{ name: "Link", Component: Link, props: { children: "Link" } },
+	{
+		name: "Paper",
+		Component: Paper,
+		props: { children: "Paper" },
+	},
+	{
+		name: "ProgressBar",
+		Component: ProgressBar,
+		props: { min: 0, max: 100, progress: 50 },
+	},
+	{
+		name: "Radio",
+		Component: Radio,
+		props: { id: "r", name: "r", value: "r", label: "Radio" },
+	},
+	{
+		name: "Select",
+		Component: Select,
+		props: { id: "sel", value: "a", onChange: noop },
+	},
+	{ name: "SkeletonLoader", Component: SkeletonLoader, props: {} },
+	{ name: "Spinner", Component: Spinner, props: {} },
+	{
+		name: "ScoreIcon",
+		Component: ScoreIcon,
+		props: { score: "good" },
+	},
+	{ name: "GradientSparklesIcon", Component: GradientSparklesIcon, props: {} },
+	{
+		name: "Table",
+		Component: Table,
+		props: { children: <Table.Body><Table.Row><Table.Cell>Cell</Table.Cell></Table.Row></Table.Body> },
+	},
+	{ name: "TagInput", Component: TagInput, props: {} },
+	{
+		name: "TagInput.Tag",
+		Component: TagInput.Tag,
+		props: { tag: "tag", index: 0, onRemoveTag: noop, screenReaderRemoveTag: "Remove" },
+	},
+	{ name: "TextInput", Component: TextInput, props: {} },
+	{ name: "Textarea", Component: Textarea, props: {} },
+	{
+		name: "Title",
+		Component: Title,
+		props: { children: "Title" },
+	},
+	{
+		name: "Toggle",
+		Component: Toggle,
+		props: { id: "tg", screenReaderLabel: "Toggle", onChange: noop },
+	},
+	{ name: "Tooltip", Component: Tooltip, props: {} },
+	{
+		name: "ValidationIcon",
+		Component: ValidationIcon,
+		props: {},
+	},
+	{
+		// `as` is required (isRequired). Provide a host element.
+		name: "ValidationInput",
+		Component: ValidationInput,
+		props: { as: "input" },
+	},
+	{
+		name: "ValidationMessage",
+		Component: ValidationMessage,
+		props: { children: "Message" },
+	},
+	{
+		name: "ErrorBoundary",
+		Component: ErrorBoundary,
+		// react-error-boundary requires one of the fallback props plus children.
+		props: { fallback: <span>Error</span>, children: <span>Content</span> },
+	},
+
+	// Compound element: ModalNotification needs to be open with a Panel child to render meaningfully.
+	{
+		name: "ModalNotification",
+		Component: ModalNotification,
+		props: {
+			isOpen: true,
+			onClose: noop,
+			children: <ModalNotification.Panel>Panel</ModalNotification.Panel>,
+		},
+	},
+
+	// Compound element: Toast renders inside a Notifications-less context fine; it only needs id + visibility.
+	{
+		name: "Toast",
+		Component: Toast,
+		props: { id: "toast", isVisible: false, setIsVisible: noop, children: <Toast.Title title="Toast" /> },
+	},
+
+	// Components.
+	{
+		name: "AutocompleteField",
+		Component: AutocompleteField,
+		props: { id: "acf", label: "Label", onChange: noop, onQueryChange: noop },
+	},
+	{ name: "Card", Component: Card, props: { children: "Card" } },
+	{ name: "CheckboxGroup", Component: CheckboxGroup, props: {} },
+	{
+		name: "ChildrenLimiter",
+		Component: ChildrenLimiter,
+		props: {
+			limit: 1,
+			children: [ <span key="1">1</span>, <span key="2">2</span> ],
+			renderButton: () => <button type="button">More</button>,
+		},
+	},
+	{
+		name: "FeatureUpsell",
+		Component: FeatureUpsell,
+		props: { children: "Feature" },
+	},
+	{
+		name: "FileImport",
+		Component: FileImport,
+		props: {
+			id: "fi",
+			name: "fi",
+			selectLabel: "Select",
+			dropLabel: "Drop",
+			screenReaderLabel: "File",
+			abortScreenReaderLabel: "Abort",
+			feedbackTitle: "Title",
+			onChange: noop,
+			onAbort: noop,
+		},
+	},
+	{
+		name: "Modal",
+		Component: Modal,
+		props: {
+			isOpen: true,
+			onClose: noop,
+			children: <Modal.Panel>Panel</Modal.Panel>,
+		},
+	},
+	{ name: "Notifications", Component: Notifications, props: {} },
+	{
+		name: "Pagination",
+		Component: Pagination,
+		props: {
+			current: 1,
+			total: 3,
+			onNavigate: noop,
+			screenReaderTextPrevious: "Previous",
+			screenReaderTextNext: "Next",
+		},
+	},
+	{
+		name: "Popover",
+		Component: Popover,
+		props: { children: "Popover" },
+	},
+	{ name: "RadioGroup", Component: RadioGroup, props: {} },
+	{
+		name: "SelectField",
+		Component: SelectField,
+		props: { id: "sf", label: "Label", value: "a", onChange: noop },
+	},
+	{
+		name: "SidebarNavigation",
+		Component: SidebarNavigation,
+		props: { children: <span>Nav</span> },
+	},
+	{
+		name: "Stepper",
+		Component: Stepper,
+		props: { steps: [ { id: "s1", children: <span>Step 1</span> } ] },
+	},
+	{
+		name: "TagField",
+		Component: TagField,
+		props: { id: "tf", label: "Label" },
+	},
+	{
+		name: "TextField",
+		Component: TextField,
+		props: { id: "txt", label: "Label", onChange: noop },
+	},
+	{
+		name: "TextareaField",
+		Component: TextareaField,
+		props: { id: "taf", label: "Label" },
+	},
+	{
+		name: "ToggleField",
+		Component: ToggleField,
+		props: { id: "tgf", label: "Label", checked: false, onChange: noop },
+	},
+	{
+		name: "ImageSelect",
+		Component: ImageSelect,
+		props: {
+			id: "img",
+			label: "Label",
+			imageUrl: "",
+			selectButtonLabel: "Select",
+			replaceButtonLabel: "Replace",
+			onSelectImage: noop,
+			isDisabled: false,
+			children: <span>Preview</span>,
+		},
+	},
+
+	// Tooltip container family.
+	{
+		name: "TooltipContainer",
+		Component: TooltipContainer,
+		props: { children: "Tooltip container" },
+	},
+	{
+		name: "TooltipTrigger",
+		Component: TooltipTrigger,
+		props: { children: "Trigger" },
+	},
+	{
+		name: "TooltipWithContext",
+		Component: TooltipWithContext,
+		props: { children: "Tooltip" },
+	},
+
+	// DropdownMenu needs a Button + List inside the headlessui Menu.
+	{
+		name: "DropdownMenu",
+		Component: DropdownMenu,
+		props: {
+			children: <>
+				<DropdownMenu.IconTrigger screenReaderTriggerLabel="Open" />
+				<DropdownMenu.List>
+					<DropdownMenu.ButtonItem>Item</DropdownMenu.ButtonItem>
+				</DropdownMenu.List>
+			</>,
+		},
+	},
+];
+
+describe( "ui-library render smoke test (React " + React.version + ")", () => {
+	test.each( cases )( "$name mounts with only required props", ( { Component, props } ) => {
+		expect( () => render(
+			<Root>
+				<Component { ...props } />
+			</Root>,
+		) ).not.toThrow();
+	} );
+} );

--- a/packages/ui-library/tests/react-render-smoke.test.js
+++ b/packages/ui-library/tests/react-render-smoke.test.js
@@ -4,9 +4,24 @@
  * Each component is rendered with ONLY its required props (children plus any
  * prop-types `isRequired` prop) inside `<Root>`, and we assert it mounts
  * without throwing. Optional / previously-defaulted props are deliberately
- * omitted: omitting them is exactly what surfaces the React-19 class of bug
- * where a missing `defaultProps` default becomes `undefined` and is then
- * dereferenced (e.g. Title's `as`, Button's `variant`).
+ * omitted: omitting them is exactly what surfaces the class of bug where a
+ * missing `defaultProps` default becomes `undefined` and is then dereferenced
+ * (e.g. Title's `as`, Button's `variant`).
+ *
+ * On top of the per-component required-props cases, the list carries two extra
+ * kinds of case that exercise DEFAULT states the curated props would otherwise
+ * mask:
+ *
+ * 1. Children-path variants. Several components branch between a data prop
+ *    (`steps` / `options`) and a `children` prop. The data-prop default (an
+ *    empty array) is the risky path: when that default lacks a stable identity
+ *    it can drive an effect into an infinite render loop. These variants render
+ *    the component through `children` with the data prop OMITTED so the default
+ *    array is what backs the render. `.not.toThrow()` catches both crashes and
+ *    React's "Maximum update depth exceeded" loop error, so the Stepper variant
+ *    below is a regression guard for the `DEFAULT_STEPS` stable-identity fix.
+ * 2. Required-props-only variants for components whose curated case above passes
+ *    optional scaffolding props, so their omitted defaults are exercised too.
  *
  * The list is data-driven so it is trivial to extend: add a
  * `{ name, Component, props }` entry to `cases`.
@@ -332,6 +347,51 @@ const cases = [
 					<DropdownMenu.ButtonItem>Item</DropdownMenu.ButtonItem>
 				</DropdownMenu.List>
 			</>,
+		},
+	},
+
+	// Children-path variants: render the data-prop components through `children` with the
+	// data prop (`steps` / `options`) OMITTED, so the empty-array default backs the render.
+
+	// Must-have regression guard: with `children` and the default (empty) `steps`, an
+	// unstable default array re-fired the layout effect every render, looping forever
+	// ("Maximum update depth exceeded"). The stable `DEFAULT_STEPS` fix is what this catches.
+	{
+		name: "Stepper (children, default steps)",
+		Component: Stepper,
+		props: { children: <Stepper.Step id="s1" index={ 0 }>Step</Stepper.Step> },
+	},
+	{
+		name: "CheckboxGroup (children, default options)",
+		Component: CheckboxGroup,
+		props: { children: <CheckboxGroup.Checkbox id="cgc" name="cgc" value="a" label="A" /> },
+	},
+	{
+		name: "RadioGroup (children, default options)",
+		Component: RadioGroup,
+		props: { children: <RadioGroup.Radio id="rgr" name="rgr" value="a" label="A" /> },
+	},
+	{
+		// Select is the parent Listbox, so its Option children render fine here (unlike a
+		// standalone Option). This drives the `children || options.map(...)` branch with the
+		// default (empty) options array.
+		name: "Select (children, default options)",
+		Component: Select,
+		props: { id: "selc", value: "a", onChange: noop, children: <Select.Option value="a" label="A" /> },
+	},
+
+	// Required-props-only variant: the ImageSelect case above passes optional `isDisabled`
+	// and `children`; render with only the props it actually needs so those defaults apply.
+	{
+		name: "ImageSelect (required only)",
+		Component: ImageSelect,
+		props: {
+			id: "img2",
+			label: "Label",
+			imageUrl: "",
+			selectButtonLabel: "Select",
+			replaceButtonLabel: "Replace",
+			onSelectImage: noop,
 		},
 	},
 ];

--- a/packages/ui-library/tests/setup.js
+++ b/packages/ui-library/tests/setup.js
@@ -1,0 +1,32 @@
+/**
+ * Test setup: polyfill browser APIs that jsdom lacks but Headless UI relies on.
+ *
+ * Headless UI's open `Dialog` (used by Modal and ModalNotification) and some of
+ * its other primitives reference `IntersectionObserver` and `ResizeObserver`,
+ * which jsdom does not implement. These are inert no-op stubs: they let the
+ * components mount in the render smoke test without affecting behaviour.
+ */
+
+/* eslint-disable jsdoc/require-jsdoc -- Inert no-op stubs for jsdom. */
+class MockObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+	takeRecords() {
+		return [];
+	}
+}
+/* eslint-enable jsdoc/require-jsdoc */
+
+if ( typeof global.IntersectionObserver === "undefined" ) {
+	global.IntersectionObserver = MockObserver;
+}
+
+if ( typeof global.ResizeObserver === "undefined" ) {
+	global.ResizeObserver = MockObserver;
+}
+
+// jsdom does not implement scrollIntoView, which Headless UI calls on focus.
+if ( typeof Element !== "undefined" && ! Element.prototype.scrollIntoView ) {
+	Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
## Context

React 19's automatic JSX runtime no longer applies `defaultProps` to function/`forwardRef` components, which crashed `@yoast/ui-library` rendering (the Yoast metabox/sidebar/Settings). That was fixed by converting the components to ES6 default params in Yoast/wordpress-seo#23317.

To stop that class of regression coming back silently, this PR adds a render smoke test that mounts every `@yoast/ui-library` component and asserts it renders without throwing, run in CI on both React 18.3 and React 19.2. A failure on either runtime means a component lost a default (or otherwise fails to mount).

Part of the React 19 readiness work tracked in Yoast/reserved-tasks#235.

## Summary

This PR can be summarized in the following changelog entry:

* [@yoast/ui-library] Adds a React render smoke test that mounts every component, run in CI on React 18.3 and 19.2.

## Relevant technical choices:

* The smoke test (`packages/ui-library/tests/react-render-smoke.test.js`) renders each exported component with the minimal required props and asserts it mounts without throwing; the default-state render paths exercise the components whose defaults previously came from `defaultProps`.
* CI (`.github/workflows/jstest.yml`) runs the suite against React 18.3 and React 19.2, so the same test guards both the current and upcoming runtimes.
* No production code changes: only the test, its setup, the ui-library jest config, and the CI workflow.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. From `packages/ui-library`, run `npx jest tests/react-render-smoke.test.js`. Every component should render with no thrown errors.
2. CI runs the suite automatically on both the React 18.3 and React 19.2 matrix legs; both should be green.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

None of the above apply: this is a Jest/jsdom test run in CI, not a browser or editor test. The meaningful check is the smoke suite passing on both the React 18.3 and React 19.2 CI legs.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable: this is an internal test/CI change with no user-visible behaviour to verify at RC time.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Test and CI only: `packages/ui-library/tests/`, the ui-library jest config, and `.github/workflows/jstest.yml`. No runtime / shipped-code impact.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Refs Yoast/reserved-tasks#235, Yoast/reserved-tasks#1251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
