### PR TITLE
fix: ensure compatibility with Gutenberg 23.3 (React 19)

### DIFF
--- a/packages/components/src/IconButtonToggle.js
+++ b/packages/components/src/IconButtonToggle.js
@@ -6,15 +6,32 @@ import { colors } from "@yoast/style-guide";
 import SvgIcon from "./SvgIcon";
 import IconButtonBase from "./IconButtonBase";
 
+const changingIconButtonDefaults = {
+	unpressedBoxShadowColor: colors.$color_button_border,
+	pressedBoxShadowColor: colors.$color_purple,
+	pressedBackground: colors.$color_pink_dark,
+	unpressedBackground: colors.$color_button,
+	pressedIconColor: colors.$color_white,
+	unpressedIconColor: colors.$color_button_text,
+	hoverBorderColor: colors.$color_white,
+	marksButtonStatus: "enabled",
+	disabledIconColor: colors.$color_grey,
+};
 
 /**
  * Returns the ChangingIconButton component.
  *
- * @param {Object} props Component props.
+ * @param {Object} componentProps Component props.
  *
  * @returns {ReactElement} ChangingIconButton component.
  */
-const ChangingIconButton = function( props ) {
+const ChangingIconButton = function( componentProps ) {
+	/*
+	 * React 19's automatic JSX runtime no longer applies defaultProps to function components, which
+	 * would drop these colours to undefined and render the button unstyled. Merging the defaults here
+	 * keeps them on both runtimes; defaultProps is kept as well for classic consumers.
+	 */
+	const props = { ...changingIconButtonDefaults, ...componentProps };
 	const buttonsAreDisabled = props.marksButtonStatus === "disabled";
 
 	let iconColor;
@@ -69,16 +86,7 @@ ChangingIconButton.propTypes = {
 	className: PropTypes.string,
 };
 
-ChangingIconButton.defaultProps = {
-	unpressedBoxShadowColor: colors.$color_button_border,
-	pressedBoxShadowColor: colors.$color_purple,
-	pressedBackground: colors.$color_pink_dark,
-	unpressedBackground: colors.$color_button,
-	pressedIconColor: colors.$color_white,
-	unpressedIconColor: colors.$color_button_text,
-	hoverBorderColor: colors.$color_white,
-	marksButtonStatus: "enabled",
-	disabledIconColor: colors.$color_grey,
-};
+// Kept for classic-runtime consumers; the in-component merge applies these on React 19.
+ChangingIconButton.defaultProps = changingIconButtonDefaults;
 
 export default ChangingIconButton;

--- a/packages/components/src/buttons/Button.js
+++ b/packages/components/src/buttons/Button.js
@@ -1,6 +1,5 @@
 // External dependencies.
 import styled from "styled-components";
-import flow from "lodash/flow";
 import PropTypes from "prop-types";
 
 // Yoast dependencies.
@@ -16,14 +15,42 @@ const settings = {
 const ieMinHeight = settings.minHeight - ( settings.verticalPadding * 2 ) - ( settings.borderWidth * 2 );
 
 /**
+ * Builds a styled-components `attrs` callback that fills in the given defaults for any prop that is
+ * not provided. React 19's automatic JSX runtime no longer applies `defaultProps` to function /
+ * `forwardRef` components (styled components included), so applying the defaults here keeps them
+ * working on both runtimes; `defaultProps` is kept as well for classic consumers.
+ *
+ * @param {Object} defaults The default prop values.
+ *
+ * @returns {function(Object): Object} An `attrs` callback returning only the missing defaults.
+ */
+function withDefaults( defaults ) {
+	return ( props ) => {
+		const filled = {};
+		Object.keys( defaults ).forEach( ( key ) => {
+			if ( typeof props[ key ] === "undefined" ) {
+				filled[ key ] = defaults[ key ];
+			}
+		} );
+		return filled;
+	};
+}
+
+/**
  * Returns a component with applied base button styles.
  *
- * @param {ReactElement} component The original component.
+ * The defaults are applied here, on the outermost styled layer, via `.attrs`. Because this is the
+ * outermost layer the defaulted props propagate to every inner style layer (hover/focus/active),
+ * so each button keeps its own defaults on the React 19 automatic runtime, which ignores
+ * `defaultProps`.
+ *
+ * @param {ReactElement} component   The original component.
+ * @param {Object}       [defaults]  Default prop values to apply via `.attrs`.
  *
  * @returns {ReactElement} Component with applied base button styles.
  */
-export function addBaseStyle( component ) {
-	return styled( component )`
+export function addBaseStyle( component, defaults = {} ) {
+	return styled( component ).attrs( withDefaults( defaults ) )`
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
@@ -124,16 +151,30 @@ export function addActiveStyle( component ) {
  *
  * @returns {ReactElement} Component with applied styles.
  */
-export const addButtonStyles = flow( [
+export const addButtonStyles = ( component, defaults ) =>
 	/*
-	 * Styled-components applies the generated CSS classes in a reversed order,
-	 * but we want them in the order: base - hover - focus - active.
+	 * Styled-components applies the generated CSS classes in a reversed order, but we want them in
+	 * the order: base - hover - focus - active. The defaults are applied on the outermost (base)
+	 * layer so they reach every inner layer's interpolations on the React 19 automatic runtime.
 	 */
-	addActiveStyle,
-	addFocusStyle,
-	addHoverStyle,
-	addBaseStyle,
-] );
+	addBaseStyle( addHoverStyle( addFocusStyle( addActiveStyle( component ) ) ), defaults );
+
+const baseButtonDefaults = {
+	type: "button",
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+	hoverColor: colors.$color_button_text_hover,
+	hoverBackgroundColor: colors.$color_button_hover,
+	activeColor: colors.$color_button_text_hover,
+	activeBackgroundColor: colors.$color_button,
+	activeBorderColor: colors.$color_button_border_active,
+	focusColor: colors.$color_button_text_hover,
+	focusBackgroundColor: colors.$color_white,
+	focusBorderColor: colors.$color_blue,
+	focusBoxShadowColor: colors.$color_blue_dark,
+};
 
 /**
  * Returns a basic styled button.
@@ -148,7 +189,8 @@ export const BaseButton = addButtonStyles(
 		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-	`
+	`,
+	baseButtonDefaults
 );
 
 BaseButton.propTypes = {
@@ -168,22 +210,8 @@ BaseButton.propTypes = {
 	focusBoxShadowColor: PropTypes.string,
 };
 
-BaseButton.defaultProps = {
-	type: "button",
-	backgroundColor: colors.$color_button,
-	textColor: colors.$color_button_text,
-	borderColor: colors.$color_button_border,
-	boxShadowColor: colors.$color_button_border,
-	hoverColor: colors.$color_button_text_hover,
-	hoverBackgroundColor: colors.$color_button_hover,
-	activeColor: colors.$color_button_text_hover,
-	activeBackgroundColor: colors.$color_button,
-	activeBorderColor: colors.$color_button_border_active,
-	focusColor: colors.$color_button_text_hover,
-	focusBackgroundColor: colors.$color_white,
-	focusBorderColor: colors.$color_blue,
-	focusBoxShadowColor: colors.$color_blue_dark,
-};
+// Kept for classic-runtime consumers; addButtonStyles applies these via .attrs for React 19.
+BaseButton.defaultProps = baseButtonDefaults;
 
 /**
  * Returns a styled Button with set font size.

--- a/packages/components/src/buttons/LinkButton.js
+++ b/packages/components/src/buttons/LinkButton.js
@@ -8,6 +8,23 @@ import { colors, rgba } from "@yoast/style-guide";
 // Internal dependencies.
 import { addButtonStyles } from "./Button";
 
+const linkButtonDefaults = {
+	backgroundColor: colors.$color_button,
+	textColor: colors.$color_button_text,
+	borderColor: colors.$color_button_border,
+	boxShadowColor: colors.$color_button_border,
+	hoverColor: colors.$color_button_text_hover,
+	hoverBackgroundColor: colors.$color_button_hover,
+	hoverBorderColor: colors.$color_button_border_hover,
+	activeColor: colors.$color_button_text_hover,
+	activeBackgroundColor: colors.$color_button,
+	activeBorderColor: colors.$color_button_border_hover,
+	focusColor: colors.$color_button_text_hover,
+	focusBackgroundColor: colors.$color_white,
+	focusBorderColor: colors.$color_blue,
+	focusBoxShadowColor: colors.$color_blue_dark,
+};
+
 /**
  * Returns a basic link styled like a button.
  *
@@ -22,7 +39,8 @@ export const LinkButton = addButtonStyles(
 		border-color: ${ props => props.borderColor };
 		background: ${ props => props.backgroundColor };
 		box-shadow: 0 1px 0 ${ props => rgba( props.boxShadowColor, 1 ) };
-	`
+	`,
+	linkButtonDefaults
 );
 
 LinkButton.propTypes = {
@@ -42,19 +60,5 @@ LinkButton.propTypes = {
 	focusBoxShadowColor: PropTypes.string,
 };
 
-LinkButton.defaultProps = {
-	backgroundColor: colors.$color_button,
-	textColor: colors.$color_button_text,
-	borderColor: colors.$color_button_border,
-	boxShadowColor: colors.$color_button_border,
-	hoverColor: colors.$color_button_text_hover,
-	hoverBackgroundColor: colors.$color_button_hover,
-	hoverBorderColor: colors.$color_button_border_hover,
-	activeColor: colors.$color_button_text_hover,
-	activeBackgroundColor: colors.$color_button,
-	activeBorderColor: colors.$color_button_border_hover,
-	focusColor: colors.$color_button_text_hover,
-	focusBackgroundColor: colors.$color_white,
-	focusBorderColor: colors.$color_blue,
-	focusBoxShadowColor: colors.$color_blue_dark,
-};
+// Kept for classic-runtime consumers; the `.attrs` above is what applies these on React 19.
+LinkButton.defaultProps = linkButtonDefaults;

--- a/packages/components/tests/buttonReact19Test.js
+++ b/packages/components/tests/buttonReact19Test.js
@@ -1,0 +1,84 @@
+// External dependencies.
+import React from "react";
+import renderer from "react-test-renderer";
+
+// Internal dependencies.
+import { BaseButton, LinkButton } from "../src/index";
+import IconButtonToggle from "../src/IconButtonToggle";
+
+const noop = () => {};
+
+/**
+ * Renders an element with the component's `defaultProps` temporarily removed, mirroring
+ * React 19's automatic JSX runtime, which no longer applies `defaultProps` to
+ * function/forwardRef components. The buttons keep their defaults working through a
+ * styled-components `.attrs` callback instead, so each guard asserts the button still
+ * renders when `defaultProps` are not applied (without it the `rgba( props.<color> )`
+ * interpolations receive `undefined` and throw).
+ *
+ * @param {React.ComponentType} Component     The component whose `defaultProps` to drop.
+ * @param {Function}            renderElement Callback that returns the element to render.
+ *
+ * @returns {void}
+ */
+const expectRendersWithoutDefaultProps = ( Component, renderElement ) => {
+	const previousDefaults = Component.defaultProps;
+	// `null` makes React's reconciler skip defaultProps (its falsy check), mirroring the automatic
+	// runtime. styled components make `defaultProps` non-configurable, so it cannot be deleted.
+	Component.defaultProps = null;
+	try {
+		// Build the element here, after defaultProps is neutralised: the classic runtime applies
+		// defaultProps at element-creation time, not at render time, so an element created earlier
+		// would keep its defaults and mask the regression.
+		expect( () => renderer.create( renderElement() ) ).not.toThrow();
+	} finally {
+		Component.defaultProps = previousDefaults;
+	}
+};
+
+test( "BaseButton renders when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	expectRendersWithoutDefaultProps( BaseButton, () => <BaseButton>ButtonValue</BaseButton> );
+} );
+
+test( "LinkButton renders when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	expectRendersWithoutDefaultProps( LinkButton, () => <LinkButton>LinkButtonValue</LinkButton> );
+} );
+
+test( "IconButtonToggle keeps its default styling when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	const props = {
+		name: "group1",
+		id: "RadioButton",
+		ariaLabel: "important toggle",
+		icon: "eye",
+		pressed: false,
+		onClick: noop,
+	};
+	const withDefaults = renderer.create( <IconButtonToggle { ...props } /> ).toJSON();
+
+	const previousDefaults = IconButtonToggle.defaultProps;
+	// `null` makes React's reconciler skip defaultProps, mirroring the automatic runtime.
+	IconButtonToggle.defaultProps = null;
+	try {
+		const withoutDefaults = renderer.create( <IconButtonToggle { ...props } /> ).toJSON();
+		// IconButtonToggle merges its own defaults internally, so dropping defaultProps (which React
+		// 19's automatic runtime does) must still produce the same styled output. Comparing the full
+		// render, not just checking that it renders, guards those merged default colours against
+		// silent regressions.
+		expect( withoutDefaults ).toEqual( withDefaults );
+	} finally {
+		IconButtonToggle.defaultProps = previousDefaults;
+	}
+} );
+
+test( "BaseButton keeps type=button when its defaultProps are not applied (React 19 automatic runtime)", () => {
+	const previousDefaults = BaseButton.defaultProps;
+	BaseButton.defaultProps = null;
+	try {
+		const tree = renderer.create( <BaseButton>ButtonValue</BaseButton> ).toJSON();
+		// A typeless <button> defaults to submit and would submit surrounding forms, so the
+		// runtime-safe default must keep type="button" even without defaultProps.
+		expect( tree.props.type ).toBe( "button" );
+	} finally {
+		BaseButton.defaultProps = previousDefaults;
+	}
+} );

--- a/packages/js/src/ai-consent/initialize.js
+++ b/packages/js/src/ai-consent/initialize.js
@@ -1,6 +1,6 @@
 import { useSelect } from "@wordpress/data";
 import domReady from "@wordpress/dom-ready";
-import { Fragment, render, useCallback, useRef } from "@wordpress/element";
+import { createRoot, Fragment, useCallback, useRef } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Modal, useToggleState } from "@yoast/ui-library";
 import classNames from "classnames";
@@ -80,6 +80,6 @@ domReady( () => {
 
 	const root = document.getElementById( "ai-generator-consent" );
 	if ( root ) {
-		render( <App />, root );
+		createRoot( root ).render( <App /> );
 	}
 } );

--- a/packages/js/src/redirects/initialize.js
+++ b/packages/js/src/redirects/initialize.js
@@ -1,5 +1,5 @@
 import domReady from "@wordpress/dom-ready";
-import { render } from "@wordpress/element";
+import { createRoot } from "@wordpress/element";
 import { Root } from "@yoast/ui-library";
 import registerStore from "./store";
 import { select } from "@wordpress/data";
@@ -28,10 +28,9 @@ domReady( () => {
 
 	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );
 
-	render(
+	createRoot( root ).render(
 		<Root context={ { isRtl } }>
 			<AppProvider />
-		</Root>,
-		root
+		</Root>
 	);
 } );

--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -6,6 +6,9 @@ import Autocomplete from "../../elements/autocomplete";
 import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id Identifier.
  * @param {Object} validation The validation state.
@@ -21,7 +24,7 @@ const AutocompleteField = forwardRef( ( {
 	label,
 	disabled = false,
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {

--- a/packages/ui-library/src/components/autocomplete-field/index.js
+++ b/packages/ui-library/src/components/autocomplete-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -18,10 +19,10 @@ import { useDescribedBy } from "../../hooks";
 const AutocompleteField = forwardRef( ( {
 	id,
 	label,
-	disabled,
-	description,
-	validation,
-	className,
+	disabled = false,
+	description = null,
+	validation = {},
+	className = "",
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -65,12 +66,6 @@ AutocompleteField.propTypes = {
 		message: PropTypes.node,
 	} ),
 	className: PropTypes.string,
-};
-AutocompleteField.defaultProps = {
-	disabled: false,
-	description: null,
-	validation: {},
-	className: "",
 };
 
 AutocompleteField.Option = Autocomplete.Option;

--- a/packages/ui-library/src/components/card/index.js
+++ b/packages/ui-library/src/components/card/index.js
@@ -63,7 +63,7 @@ Footer.propTypes = {
  * @param {string} className The className.
  * @returns {JSX.Element} The card component.
  */
-const Card = forwardRef( ( { as: Component, children, className, ...props }, ref ) => (
+const Card = forwardRef( ( { as: Component = "div", children, className = "", ...props }, ref ) => (
 	<Component { ...props } className={ classNames( "yst-card", className ) } ref={ ref }>
 		{ children }
 	</Component>
@@ -74,10 +74,6 @@ Card.propTypes = {
 	as: PropTypes.elementType,
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
-};
-Card.defaultProps = {
-	as: "div",
-	className: "",
 };
 
 Card.Header = Header;

--- a/packages/ui-library/src/components/checkbox-group/index.js
+++ b/packages/ui-library/src/components/checkbox-group/index.js
@@ -5,6 +5,10 @@ import React, { useCallback } from "react";
 import Checkbox from "../../elements/checkbox";
 import Label from "../../elements/label";
 
+// Stable references so the empty-array defaults keep a constant identity across renders.
+const DEFAULT_VALUES = [];
+const DEFAULT_OPTIONS = [];
+
 /**
  * @param {JSX.node} [children=null] Children are rendered below the checkbox group. Either use this or the `options` prop.
  * @param {string} [id] Identifier.
@@ -23,11 +27,11 @@ const CheckboxGroup = ( {
 	children = null,
 	id = "",
 	name = "",
-	values = [],
+	values = DEFAULT_VALUES,
 	label = "",
 	description = "",
 	disabled = false,
-	options = [],
+	options = DEFAULT_OPTIONS,
 	onChange = noop,
 	className = "",
 	...props

--- a/packages/ui-library/src/components/file-import/index.js
+++ b/packages/ui-library/src/components/file-import/index.js
@@ -86,22 +86,22 @@ const createStatusConditionalRender = ( status ) => {
  * @returns {JSX.Element} The FileImport component.
  */
 const FileImport = forwardRef( ( {
-	children = "",
+	children = null,
 	id,
 	name,
 	selectLabel,
 	dropLabel,
 	screenReaderLabel,
 	abortScreenReaderLabel,
-	selectDescription,
-	status,
+	selectDescription = "",
+	status = FILE_IMPORT_STATUS.idle,
 	onChange,
 	onAbort,
 	feedbackTitle,
-	feedbackDescription,
-	progressMin,
-	progressMax,
-	progress,
+	feedbackDescription = "",
+	progressMin = null,
+	progressMax = null,
+	progress = null,
 }, ref ) => {
 	const isSelected = useMemo( () => status === FILE_IMPORT_STATUS.selected, [ status ] );
 	const isLoading = useMemo( () => status === FILE_IMPORT_STATUS.loading, [ status ] );
@@ -211,15 +211,6 @@ FileImport.propTypes = {
 	status: PropTypes.oneOf( values( FILE_IMPORT_STATUS ) ),
 	onChange: PropTypes.func.isRequired,
 	onAbort: PropTypes.func.isRequired,
-};
-FileImport.defaultProps = {
-	children: null,
-	selectDescription: "",
-	feedbackDescription: "",
-	progressMin: null,
-	progressMax: null,
-	progress: null,
-	status: FILE_IMPORT_STATUS.idle,
 };
 
 FileImport.Selected = createStatusConditionalRender( FILE_IMPORT_STATUS.selected );

--- a/packages/ui-library/src/components/modal/container.js
+++ b/packages/ui-library/src/components/modal/container.js
@@ -7,7 +7,7 @@ import React, { forwardRef } from "react";
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Header = forwardRef( ( { children, className }, ref ) => (
+const Header = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-header", className ) }>
 		{ children }
 	</div>
@@ -17,16 +17,13 @@ Header.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Header.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Content = forwardRef( ( { children, className }, ref ) => (
+const Content = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-content", className ) }>
 		{ children }
 	</div>
@@ -36,16 +33,13 @@ Content.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Content.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-const Footer = forwardRef( ( { children, className }, ref ) => (
+const Footer = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container-footer", className ) }>
 		{ children }
 	</div>
@@ -55,16 +49,13 @@ Footer.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
 };
-Footer.defaultProps = {
-	className: "",
-};
 
 /**
  * @param {JSX.node} children The content.
  * @param {string} [className] Extra class.
  * @returns {JSX.Element} The element.
  */
-export const Container = forwardRef( ( { children, className }, ref ) => (
+export const Container = forwardRef( ( { children, className = "" }, ref ) => (
 	<div ref={ ref } className={ classNames( "yst-modal__container", className ) }>
 		{ children }
 	</div>
@@ -73,9 +64,6 @@ Container.displayName = "Modal.Container";
 Container.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
-};
-Container.defaultProps = {
-	className: "",
 };
 
 Container.Header = Header;

--- a/packages/ui-library/src/components/modal/index.js
+++ b/packages/ui-library/src/components/modal/index.js
@@ -16,7 +16,7 @@ import { ModalContext, useModalContext } from "./hooks";
  * @param {Object} [props] Additional props.
  * @returns {JSX.Element} The title.
  */
-const Title = forwardRef( ( { children, size, className, as, ...props }, ref ) => {
+const Title = forwardRef( ( { children, size, className = "", as = "h1", ...props }, ref ) => {
 	return (
 		<Dialog.Title
 			as={ as }
@@ -39,12 +39,6 @@ Title.propTypes = {
 	children: PropTypes.node.isRequired,
 	as: PropTypes.elementType,
 };
-Title.defaultProps = {
-	// eslint-disable-next-line no-undefined
-	size: undefined,
-	className: "",
-	as: "h1",
-};
 
 /**
  * @param {string} [className] Additional classname for the button.
@@ -53,7 +47,7 @@ Title.defaultProps = {
  * @param {JSX.node} [children] Possible to override the default screen reader text and X icon.
  * @returns {JSX.Element} The close button.
  */
-const CloseButton = forwardRef( ( { className, onClick, screenReaderText, children, ...props }, ref ) => {
+const CloseButton = forwardRef( ( { className = "", onClick, screenReaderText = "Close", children, ...props }, ref ) => {
 	const { onClose } = useModalContext();
 	const svgAriaProps = useSvgAria();
 
@@ -81,14 +75,6 @@ CloseButton.propTypes = {
 	onClick: PropTypes.func,
 	screenReaderText: PropTypes.string,
 	children: PropTypes.node,
-};
-CloseButton.defaultProps = {
-	className: "",
-	// eslint-disable-next-line no-undefined
-	onClick: undefined,
-	screenReaderText: "Close",
-	// eslint-disable-next-line no-undefined
-	children: undefined,
 };
 
 /**
@@ -118,11 +104,6 @@ Panel.propTypes = {
 	className: PropTypes.string,
 	hasCloseButton: PropTypes.bool,
 	closeButtonScreenReaderText: PropTypes.string,
-};
-Panel.defaultProps = {
-	className: "",
-	hasCloseButton: true,
-	closeButtonScreenReaderText: "Close",
 };
 
 export const classNameMap = {
@@ -202,11 +183,6 @@ Modal.propTypes = {
 	className: PropTypes.string,
 	position: PropTypes.oneOf( Object.keys( classNameMap.position ) ),
 	initialFocus: PropTypes.oneOfType( [ PropTypes.func, PropTypes.object ] ),
-};
-Modal.defaultProps = {
-	className: "",
-	position: "center",
-	initialFocus: null,
 };
 
 Modal.Panel = Panel;

--- a/packages/ui-library/src/components/radio-group/index.js
+++ b/packages/ui-library/src/components/radio-group/index.js
@@ -13,6 +13,9 @@ const classNameMap = {
 	},
 };
 
+// Stable reference so the empty-array default keeps a constant identity across renders.
+const DEFAULT_OPTIONS = [];
+
 /**
  * @param {JSX.node} [children=null] Children are rendered below the radio group. Either use this or the `options` prop.
  * @param {string} [id=""] Identifier.
@@ -35,7 +38,7 @@ const RadioGroup = ( {
 	value = "",
 	label = "",
 	description = "",
-	options = [],
+	options = DEFAULT_OPTIONS,
 	onChange = noop,
 	variant = "default",
 	disabled = false,

--- a/packages/ui-library/src/components/root/index.js
+++ b/packages/ui-library/src/components/root/index.js
@@ -7,12 +7,15 @@ const defaultRootContext = {
 
 export const RootContext = createContext( defaultRootContext );
 
+// Stable reference so the empty-object default keeps a constant identity across renders.
+const DEFAULT_CONTEXT = {};
+
 /**
  * @param {JSX.node} children The React children.
  * @param {{ isRtl: boolean }} context The root context value.
  * @returns {JSX.Element} The Root component.
  */
-const Root = ( { children, context = {}, ...props } ) => {
+const Root = ( { children, context = DEFAULT_CONTEXT, ...props } ) => {
 	return (
 		<RootContext.Provider value={ { ...defaultRootContext, ...context } }>
 			<div className="yst-root" { ...props }>

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -18,10 +19,10 @@ import { useDescribedBy } from "../../hooks";
 const SelectField = forwardRef( ( {
 	id,
 	label,
-	description,
-	disabled,
-	validation,
-	className,
+	description = null,
+	disabled = false,
+	validation = {},
+	className = "",
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -63,12 +64,6 @@ SelectField.propTypes = {
 		message: PropTypes.node,
 	} ),
 	className: PropTypes.string,
-};
-SelectField.defaultProps = {
-	description: null,
-	disabled: false,
-	validation: {},
-	className: "",
 };
 
 SelectField.Option = Select.Option;

--- a/packages/ui-library/src/components/select-field/index.js
+++ b/packages/ui-library/src/components/select-field/index.js
@@ -6,6 +6,9 @@ import Select from "../../elements/select";
 import { ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id Identifier.
  * @param {JSX.Element} error Error node.
@@ -21,7 +24,7 @@ const SelectField = forwardRef( ( {
 	label,
 	description = null,
 	disabled = false,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {

--- a/packages/ui-library/src/components/stepper/index.js
+++ b/packages/ui-library/src/components/stepper/index.js
@@ -155,14 +155,6 @@ Stepper.propTypes = {
 	} ) ),
 	ProgressBar: PropTypes.elementType,
 };
-Stepper.defaultProps = {
-	className: "",
-	steps: [],
-	// eslint-disable-next-line no-undefined
-	children: undefined,
-	currentStep: 0,
-	ProgressBar: StepperProgressBar,
-};
 
 Stepper.Context = StepperContext;
 Stepper.ProgressBar = StepperProgressBar;

--- a/packages/ui-library/src/components/stepper/index.js
+++ b/packages/ui-library/src/components/stepper/index.js
@@ -53,6 +53,10 @@ const getCurrentStepPercentage = ( percentage, step ) => {
 	return 0;
 };
 
+// Stable reference so the `steps` dependency of the layout effect below keeps a
+// constant identity across renders (defaultProps used to provide a single instance).
+const DEFAULT_STEPS = [];
+
 /**
  *
  * @param {JSX.Node} [children] Content of the stepper.
@@ -62,7 +66,7 @@ const getCurrentStepPercentage = ( percentage, step ) => {
  *
  * @returns {JSX.Element} The Stepper element.
  */
-export const Stepper = forwardRef( ( { children, currentStep = 0, className = "", steps = [], ProgressBar = StepperProgressBar }, ref ) => {
+export const Stepper = forwardRef( ( { children, currentStep = 0, className = "", steps = DEFAULT_STEPS, ProgressBar = StepperProgressBar }, ref ) => {
 	const [ progressBarPosition, setProgressBarPosition ] = useState( { left: 0, right: 0, stepsLengthPercentage: [] } );
 	const [ stepRefs, setStepRefs ] = useState( [] );
 

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -20,11 +21,11 @@ import { useDescribedBy } from "../../hooks";
 const TagField = forwardRef( ( {
 	id,
 	label,
-	labelSuffix,
-	disabled,
-	className,
-	description,
-	validation,
+	labelSuffix = null,
+	disabled = false,
+	className = "",
+	description = null,
+	validation = {},
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -67,13 +68,6 @@ TagField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TagField.defaultProps = {
-	labelSuffix: null,
-	disabled: false,
-	className: "",
-	description: null,
-	validation: {},
 };
 
 export default TagField;

--- a/packages/ui-library/src/components/tag-field/index.js
+++ b/packages/ui-library/src/components/tag-field/index.js
@@ -7,6 +7,9 @@ import TagInput from "../../elements/tag-input";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {string} label The label.
@@ -25,7 +28,7 @@ const TagField = forwardRef( ( {
 	disabled = false,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -23,12 +24,12 @@ const TextField = forwardRef( ( {
 	id,
 	onChange,
 	label,
-	labelSuffix,
-	disabled,
-	readOnly,
-	className,
-	description,
-	validation,
+	labelSuffix = null,
+	disabled = false,
+	readOnly = false,
+	className = "",
+	description = null,
+	validation = {},
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -84,14 +85,6 @@ TextField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TextField.defaultProps = {
-	labelSuffix: null,
-	disabled: false,
-	readOnly: false,
-	className: "",
-	description: null,
-	validation: {},
 };
 
 export default TextField;

--- a/packages/ui-library/src/components/text-field/index.js
+++ b/packages/ui-library/src/components/text-field/index.js
@@ -7,6 +7,9 @@ import TextInput from "../../elements/text-input";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {function} onChange The input change handler.
@@ -29,7 +32,7 @@ const TextField = forwardRef( ( {
 	readOnly = false,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -21,10 +22,10 @@ const TextareaField = forwardRef( ( {
 	id,
 	label,
 	className = "",
-	description = "",
+	description = null,
 	validation = {},
-	disabled,
-	readOnly,
+	disabled = false,
+	readOnly = false,
 	...props
 }, ref ) => {
 	const { ids, describedBy } = useDescribedBy( id, { validation: validation?.message, description } );
@@ -73,13 +74,6 @@ TextareaField.propTypes = {
 		variant: PropTypes.string,
 		message: PropTypes.node,
 	} ),
-};
-TextareaField.defaultProps = {
-	className: "",
-	description: null,
-	disabled: false,
-	readOnly: false,
-	validation: {},
 };
 
 export default TextareaField;

--- a/packages/ui-library/src/components/textarea-field/index.js
+++ b/packages/ui-library/src/components/textarea-field/index.js
@@ -7,6 +7,9 @@ import Textarea from "../../elements/textarea";
 import { ValidationInput, ValidationMessage } from "../../elements/validation";
 import { useDescribedBy } from "../../hooks";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 /**
  * @param {string} id The ID of the input.
  * @param {string} label The label.
@@ -23,7 +26,7 @@ const TextareaField = forwardRef( ( {
 	label,
 	className = "",
 	description = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	disabled = false,
 	readOnly = false,
 	...props

--- a/packages/ui-library/src/components/toggle-field/index.js
+++ b/packages/ui-library/src/components/toggle-field/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Switch } from "@headlessui/react";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -19,15 +20,15 @@ import Toggle from "../../elements/toggle";
  */
 const ToggleField = forwardRef( ( {
 	id,
-	children,
+	children = null,
 	label,
-	labelSuffix,
-	description,
+	labelSuffix = null,
+	description = null,
 	checked,
-	disabled,
+	disabled = false,
 	onChange,
-	className,
-	"aria-label": ariaLabel,
+	className = "",
+	"aria-label": ariaLabel = null,
 	...props
 }, ref ) => (
 	<Switch.Group
@@ -69,14 +70,6 @@ ToggleField.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	"aria-label": PropTypes.string,
-};
-ToggleField.defaultProps = {
-	children: null,
-	labelSuffix: null,
-	description: null,
-	disabled: false,
-	className: "",
-	"aria-label": null,
 };
 
 export default ToggleField;

--- a/packages/ui-library/src/elements/alert/index.js
+++ b/packages/ui-library/src/elements/alert/index.js
@@ -60,11 +60,5 @@ const propTypes = {
 
 Alert.displayName = "Alert";
 Alert.propTypes = propTypes;
-Alert.defaultProps = {
-	as: "span",
-	variant: "info",
-	className: "",
-	role: "status",
-};
 
 export default Alert;

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Combobox, Transition } from "@headlessui/react";
 import XIcon from "@heroicons/react/outline/XIcon";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
@@ -102,22 +103,22 @@ ClearSelection.propTypes = {
  */
 const Autocomplete = forwardRef( ( {
 	id,
-	value,
-	children,
-	selectedLabel,
-	label,
-	labelProps,
-	labelSuffix,
+	value = null,
+	children = null,
+	selectedLabel = "",
+	label = "",
+	labelProps = {},
+	labelSuffix = null,
 	onChange,
 	onQueryChange,
-	onClear,
-	validation,
-	placeholder,
-	className,
-	buttonProps,
-	clearButtonScreenReaderText,
-	nullable,
-	disabled,
+	onClear = null,
+	validation = {},
+	placeholder = "",
+	className = "",
+	buttonProps = {},
+	clearButtonScreenReaderText = "Clear",
+	nullable = false,
+	disabled = false,
 	...props
 }, ref ) => {
 	const getDisplayValue = useCallback( constant( selectedLabel ), [ selectedLabel ] );
@@ -220,22 +221,6 @@ const propTypes = {
 
 Autocomplete.displayName = "Autocomplete";
 Autocomplete.propTypes = propTypes;
-Autocomplete.defaultProps = {
-	children: null,
-	value: null,
-	selectedLabel: "",
-	label: "",
-	labelProps: {},
-	labelSuffix: null,
-	validation: {},
-	placeholder: "",
-	className: "",
-	buttonProps: {},
-	clearButtonScreenReaderText: "Clear",
-	nullable: false,
-	onClear: null,
-	disabled: false,
-};
 
 Autocomplete.Option = Option;
 Autocomplete.Option.displayName = "Autocomplete.Option";

--- a/packages/ui-library/src/elements/autocomplete/index.js
+++ b/packages/ui-library/src/elements/autocomplete/index.js
@@ -15,6 +15,11 @@ import { ValidationInput } from "../validation";
 const AutocompleteButton = forwardRef( ( props, ref ) => <Combobox.Button as="div" ref={ ref } { ...props } /> );
 AutocompleteButton.displayName = "AutocompleteButton";
 
+// Stable references matching the old defaultProps single instance, so they keep a constant identity across renders.
+const DEFAULT_LABEL_PROPS = {};
+const DEFAULT_VALIDATION = {};
+const DEFAULT_BUTTON_PROPS = {};
+
 /**
  * @param {React.ReactNode} [children=null] The children.
  * @param {string} value The value.
@@ -107,15 +112,15 @@ const Autocomplete = forwardRef( ( {
 	children = null,
 	selectedLabel = "",
 	label = "",
-	labelProps = {},
+	labelProps = DEFAULT_LABEL_PROPS,
 	labelSuffix = null,
 	onChange,
 	onQueryChange,
 	onClear = null,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	placeholder = "",
 	className = "",
-	buttonProps = {},
+	buttonProps = DEFAULT_BUTTON_PROPS,
 	clearButtonScreenReaderText = "Clear",
 	nullable = false,
 	disabled = false,

--- a/packages/ui-library/src/elements/badge/index.js
+++ b/packages/ui-library/src/elements/badge/index.js
@@ -28,10 +28,10 @@ const classNameMap = {
  */
 const Badge = forwardRef( ( {
 	children,
-	as: Component,
-	variant,
-	size,
-	className,
+	as: Component = "span",
+	variant = "info",
+	size = "default",
+	className = "",
 	...props
 }, ref ) => (
 	<Component
@@ -58,11 +58,5 @@ const propTypes = {
 
 Badge.displayName = "Badge";
 Badge.propTypes = propTypes;
-Badge.defaultProps = {
-	as: "span",
-	variant: "info",
-	size: "default",
-	className: "",
-};
 
 export default Badge;

--- a/packages/ui-library/src/elements/button/index.js
+++ b/packages/ui-library/src/elements/button/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import classNames from "classnames";
 import { keys } from "lodash";
 import PropTypes from "prop-types";
@@ -37,13 +38,13 @@ export const classNameMap = {
  */
 const Button = forwardRef( ( {
 	children,
-	as: Component,
+	as: Component = "button",
 	type,
-	variant,
-	size,
-	isLoading,
-	disabled,
-	className,
+	variant = "primary",
+	size = "default",
+	isLoading = false,
+	disabled = false,
+	className = "",
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -80,15 +81,4 @@ Button.propTypes = {
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
 };
-Button.defaultProps = {
-	as: "button",
-	// eslint-disable-next-line no-undefined
-	type: undefined,
-	variant: "primary",
-	size: "default",
-	isLoading: false,
-	disabled: false,
-	className: "",
-};
-
 export default Button;

--- a/packages/ui-library/src/elements/checkbox/index.js
+++ b/packages/ui-library/src/elements/checkbox/index.js
@@ -51,10 +51,5 @@ Checkbox.propTypes = {
 	className: PropTypes.string,
 	disabled: PropTypes.bool,
 };
-Checkbox.defaultProps = {
-	className: "",
-	disabled: false,
-	label: "",
-};
 
 export default Checkbox;

--- a/packages/ui-library/src/elements/code/index.js
+++ b/packages/ui-library/src/elements/code/index.js
@@ -32,9 +32,5 @@ Code.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	className: PropTypes.string,
 };
-Code.defaultProps = {
-	variant: "default",
-	className: "",
-};
 
 export default Code;

--- a/packages/ui-library/src/elements/file-input/index.js
+++ b/packages/ui-library/src/elements/file-input/index.js
@@ -30,12 +30,12 @@ const FileInput = forwardRef( ( {
 	selectLabel,
 	dropLabel,
 	screenReaderLabel,
-	selectDescription,
-	disabled,
-	iconAs: IconComponent,
+	selectDescription = "",
+	disabled = false,
+	iconAs: IconComponent = DocumentAddIcon,
 	onChange,
-	onDrop,
-	className,
+	onDrop = noop,
+	className = "",
 	...props
 }, ref ) => {
 	const [ isDragOver, setIsDragOver ] = useState( false );
@@ -113,13 +113,6 @@ FileInput.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	onDrop: PropTypes.func,
 	className: PropTypes.string,
-};
-FileInput.defaultProps = {
-	selectDescription: "",
-	disabled: false,
-	iconAs: DocumentAddIcon,
-	className: "",
-	onDrop: noop,
 };
 
 export default FileInput;

--- a/packages/ui-library/src/elements/label/index.js
+++ b/packages/ui-library/src/elements/label/index.js
@@ -10,10 +10,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} Label component.
  */
 const Label = forwardRef( ( {
-	as: Component,
-	className,
-	label,
-	children,
+	as: Component = "label",
+	className = "",
+	label = "",
+	children = "",
 	...props
 }, ref ) => (
 	<Component
@@ -31,12 +31,6 @@ Label.propTypes = {
 	children: PropTypes.string,
 	as: PropTypes.elementType,
 	className: PropTypes.string,
-};
-Label.defaultProps = {
-	label: "",
-	children: "",
-	as: "label",
-	className: "",
 };
 
 export default Label;

--- a/packages/ui-library/src/elements/link/index.js
+++ b/packages/ui-library/src/elements/link/index.js
@@ -19,9 +19,9 @@ const classNameMap = {
  * @returns {JSX.Element} The link.
  */
 const Link = forwardRef( ( {
-	as: Component,
-	variant,
-	className,
+	as: Component = "a",
+	variant = "default",
+	className = "",
 	children,
 	...props
 }, ref ) => (
@@ -44,11 +44,6 @@ Link.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	as: PropTypes.elementType,
 	className: PropTypes.string,
-};
-Link.defaultProps = {
-	as: "a",
-	variant: "default",
-	className: "",
 };
 
 export default Link;

--- a/packages/ui-library/src/elements/paper/index.js
+++ b/packages/ui-library/src/elements/paper/index.js
@@ -25,10 +25,6 @@ Paper.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node.isRequired,
 };
-Paper.defaultProps = {
-	as: "div",
-	className: "",
-};
 
 Paper.Header = Header;
 Paper.Header.displayName = "Paper.Header";

--- a/packages/ui-library/src/elements/progress-bar/index.js
+++ b/packages/ui-library/src/elements/progress-bar/index.js
@@ -35,8 +35,5 @@ ProgressBar.propTypes = {
 	progressClassName: PropTypes.string,
 	className: PropTypes.string,
 };
-ProgressBar.defaultProps = {
-	className: "",
-};
 
 export default ProgressBar;

--- a/packages/ui-library/src/elements/radio/index.js
+++ b/packages/ui-library/src/elements/radio/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
@@ -29,11 +30,11 @@ const Radio = forwardRef( ( {
 	name,
 	value,
 	label,
-	screenReaderLabel,
-	variant,
-	disabled,
-	className,
-	isLabelDangerousHtml,
+	screenReaderLabel = "",
+	variant = "default",
+	disabled = false,
+	className = "",
+	isLabelDangerousHtml = false,
 	...props
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
@@ -110,13 +111,6 @@ Radio.propTypes = {
 	variant: PropTypes.oneOf( Object.keys( classNameMap.variant ) ),
 	disabled: PropTypes.bool,
 	className: PropTypes.string,
-};
-Radio.defaultProps = {
-	screenReaderLabel: "",
-	variant: "default",
-	disabled: false,
-	className: "",
-	isLabelDangerousHtml: false,
 };
 
 export default Radio;

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -43,6 +43,12 @@ const Option = ( { value, label } ) => {
 
 Option.propTypes = optionPropType;
 
+// Stable references matching the old defaultProps single instance, so they keep a constant identity across renders.
+const DEFAULT_OPTIONS = [];
+const DEFAULT_LABEL_PROPS = {};
+const DEFAULT_VALIDATION = {};
+const DEFAULT_BUTTON_PROPS = {};
+
 /**
  * @param {string} id Identifier.
  * @param {string} value Selected value.
@@ -63,17 +69,17 @@ Option.propTypes = optionPropType;
 const Select = forwardRef( ( {
 	id,
 	value,
-	options = [],
+	options = DEFAULT_OPTIONS,
 	children = null,
 	selectedLabel = "",
 	label = "",
-	labelProps = {},
+	labelProps = DEFAULT_LABEL_PROPS,
 	labelSuffix = null,
 	onChange,
 	disabled = false,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
-	buttonProps = {},
+	buttonProps = DEFAULT_BUTTON_PROPS,
 	...props
 }, ref ) => {
 	const selectedOption = useMemo( () => (

--- a/packages/ui-library/src/elements/select/index.js
+++ b/packages/ui-library/src/elements/select/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import { Listbox, Transition } from "@headlessui/react";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import SelectorIcon from "@heroicons/react/solid/SelectorIcon";
@@ -62,17 +63,17 @@ Option.propTypes = optionPropType;
 const Select = forwardRef( ( {
 	id,
 	value,
-	options,
-	children,
-	selectedLabel,
-	label,
-	labelProps,
-	labelSuffix,
+	options = [],
+	children = null,
+	selectedLabel = "",
+	label = "",
+	labelProps = {},
+	labelSuffix = null,
 	onChange,
-	disabled,
-	validation,
-	className,
-	buttonProps,
+	disabled = false,
+	validation = {},
+	className = "",
+	buttonProps = {},
 	...props
 }, ref ) => {
 	const selectedOption = useMemo( () => (
@@ -146,18 +147,6 @@ Select.propTypes = {
 	} ),
 	className: PropTypes.string,
 	buttonProps: PropTypes.object,
-};
-Select.defaultProps = {
-	options: [],
-	children: null,
-	selectedLabel: "",
-	label: "",
-	labelProps: {},
-	labelSuffix: null,
-	disabled: false,
-	validation: {},
-	className: "",
-	buttonProps: {},
 };
 
 Select.Option = Option;

--- a/packages/ui-library/src/elements/spinner/index.js
+++ b/packages/ui-library/src/elements/spinner/index.js
@@ -25,9 +25,9 @@ export const classNameMap = {
  * @returns {JSX.Element} The spinner.
  */
 const Spinner = forwardRef( ( {
-	variant,
-	size,
-	className,
+	variant = "default",
+	size = "4",
+	className = "",
 }, ref ) => {
 	const svgAriaProps = useSvgAria();
 
@@ -59,11 +59,6 @@ Spinner.propTypes = {
 	variant: PropTypes.oneOf( keys( classNameMap.variant ) ),
 	size: PropTypes.oneOf( keys( classNameMap.size ) ),
 	className: PropTypes.string,
-};
-Spinner.defaultProps = {
-	variant: "default",
-	size: "4",
-	className: "",
 };
 
 export default Spinner;

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -121,10 +121,6 @@ Table.propTypes = {
 	className: PropTypes.string,
 	variant: PropTypes.oneOf( Object.keys( tableVariants ) ),
 };
-Table.defaultProps = {
-	className: "",
-	variant: "default",
-};
 
 Table.Head = Head;
 Table.Head.displayName = "Table.Head";

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import XIcon from "@heroicons/react/solid/XIcon";
 import classNames from "classnames";
 import { isString, map, noop } from "lodash";
@@ -72,14 +73,14 @@ Tag.propTypes = {
  */
 const TagInput = forwardRef( ( {
 	tags = [],
-	children,
-	className,
-	disabled,
-	onAddTag,
-	onRemoveTag,
-	onSetTags,
-	onBlur,
-	screenReaderRemoveTag,
+	children = null,
+	className = "",
+	disabled = false,
+	onAddTag = noop,
+	onRemoveTag = noop,
+	onSetTags = noop,
+	onBlur = noop,
+	screenReaderRemoveTag = "Remove tag",
 	...props
 }, ref ) => {
 	const [ text, setText ] = useState( "" );
@@ -157,17 +158,6 @@ TagInput.propTypes = {
 	onSetTags: PropTypes.func,
 	onBlur: PropTypes.func,
 	screenReaderRemoveTag: PropTypes.string,
-};
-TagInput.defaultProps = {
-	tags: [],
-	children: null,
-	className: "",
-	disabled: false,
-	onAddTag: noop,
-	onRemoveTag: noop,
-	onSetTags: noop,
-	onBlur: noop,
-	screenReaderRemoveTag: "Remove tag",
 };
 
 TagInput.Tag = Tag;

--- a/packages/ui-library/src/elements/tag-input/index.js
+++ b/packages/ui-library/src/elements/tag-input/index.js
@@ -6,6 +6,9 @@ import PropTypes from "prop-types";
 import React, { forwardRef, useCallback, useState } from "react";
 import { Badge } from "../../index";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_TAGS = [];
+
 /**
  * @param {string} tag The tag / label.
  * @param {number} index The tag index.
@@ -72,7 +75,7 @@ Tag.propTypes = {
  * @returns {JSX.Element} The element.
  */
 const TagInput = forwardRef( ( {
-	tags = [],
+	tags = DEFAULT_TAGS,
 	children = null,
 	className = "",
 	disabled = false,

--- a/packages/ui-library/src/elements/text-input/index.js
+++ b/packages/ui-library/src/elements/text-input/index.js
@@ -11,10 +11,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} TextInput component.
  */
 const TextInput = forwardRef( ( {
-	type,
-	className,
-	disabled,
-	readOnly,
+	type = "text",
+	className = "",
+	disabled = false,
+	readOnly = false,
 	...props
 }, ref ) => (
 	<input
@@ -38,12 +38,6 @@ TextInput.propTypes = {
 	className: PropTypes.string,
 	disabled: PropTypes.bool,
 	readOnly: PropTypes.bool,
-};
-TextInput.defaultProps = {
-	type: "text",
-	className: "",
-	disabled: false,
-	readOnly: false,
 };
 
 export default TextInput;

--- a/packages/ui-library/src/elements/textarea/index.js
+++ b/packages/ui-library/src/elements/textarea/index.js
@@ -10,10 +10,10 @@ import React, { forwardRef } from "react";
  * @returns {JSX.Element} Textarea component.
  */
 const Textarea = forwardRef( ( {
-	disabled,
-	cols,
-	rows,
-	className,
+	disabled = false,
+	cols = 20,
+	rows = 2,
+	className = "",
 	...props
 }, ref ) => (
 	<textarea
@@ -36,12 +36,6 @@ Textarea.propTypes = {
 	disabled: PropTypes.bool,
 	cols: PropTypes.number,
 	rows: PropTypes.number,
-};
-Textarea.defaultProps = {
-	className: "",
-	disabled: false,
-	cols: 20,
-	rows: 2,
 };
 
 export default Textarea;

--- a/packages/ui-library/src/elements/title/index.js
+++ b/packages/ui-library/src/elements/title/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undefined */
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
@@ -19,9 +18,9 @@ export const classNameMap = {
  */
 const Title = forwardRef( ( {
 	children,
-	as: Component,
+	as: Component = "h1",
 	size,
-	className,
+	className = "",
 	...props
 }, ref ) => {
 	return (
@@ -46,10 +45,4 @@ Title.propTypes = {
 	size: PropTypes.oneOf( Object.keys( classNameMap.size ) ),
 	className: PropTypes.string,
 };
-Title.defaultProps = {
-	as: "h1",
-	size: undefined,
-	className: "",
-};
-
 export default Title;

--- a/packages/ui-library/src/elements/toggle/index.js
+++ b/packages/ui-library/src/elements/toggle/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-undefined */
+/* eslint-disable complexity */
 import { Switch, Transition } from "@headlessui/react";
 import CheckIcon from "@heroicons/react/solid/CheckIcon";
 import XIcon from "@heroicons/react/solid/XIcon";
@@ -23,13 +23,13 @@ import { useSvgAria } from "../../hooks";
  */
 const Toggle = forwardRef( ( {
 	id,
-	as: Component,
-	checked,
+	as: Component = "button",
+	checked = false,
 	screenReaderLabel,
 	onChange,
-	disabled,
-	className,
-	type,
+	disabled = false,
+	className = "",
+	type = "",
 	checkedIcon,
 	unCheckedIcon,
 	...props
@@ -97,15 +97,6 @@ Toggle.propTypes = {
 	className: PropTypes.string,
 	checkedIcon: PropTypes.node,
 	unCheckedIcon: PropTypes.node,
-};
-Toggle.defaultProps = {
-	as: "button",
-	checked: false,
-	disabled: false,
-	type: "",
-	className: "",
-	checkedIcon: undefined,
-	unCheckedIcon: undefined,
 };
 
 export default Toggle;

--- a/packages/ui-library/src/elements/tooltip/index.js
+++ b/packages/ui-library/src/elements/tooltip/index.js
@@ -26,16 +26,17 @@ const variantClassNameMap = {
  * @param {string} [variant] Variant of the tooltip.
  * @returns {JSX.Element} Tooltip component.
  */
-const Tooltip = forwardRef( ( { children, as: Component, className, position, ...props }, ref ) => {
+const Tooltip = forwardRef( ( { children = null, as: Component = "div", className = "", position = "top", variant = "dark", ...props }, ref ) => {
 	return (
 		<Component
 			ref={ ref }
 			className={ classNames( "yst-tooltip",
 				positionClassNameMap[ position ],
-				variantClassNameMap[ props.variant ],
+				variantClassNameMap[ variant ],
 				className,
 			) }
 			role="tooltip"
+			variant={ variant }
 			{ ...props }
 		>
 			{ children }
@@ -51,12 +52,4 @@ Tooltip.propTypes = {
 	position: PropTypes.oneOf( Object.keys( positionClassNameMap ) ),
 	variant: PropTypes.oneOf( Object.keys( variantClassNameMap ) ),
 };
-Tooltip.defaultProps = {
-	as: "div",
-	children: null,
-	className: "",
-	position: "top",
-	variant: "dark",
-};
-
 export default Tooltip;

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -47,9 +47,5 @@ ValidationInput.propTypes = {
 	} ),
 	className: PropTypes.string,
 };
-ValidationInput.defaultProps = {
-	validation: {},
-	className: "",
-};
 
 export default ValidationInput;

--- a/packages/ui-library/src/elements/validation/validation-input.js
+++ b/packages/ui-library/src/elements/validation/validation-input.js
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
 import ValidationIcon from "./validation-icon";
 
+// Stable reference matching the old defaultProps single instance, so it keeps a constant identity across renders.
+const DEFAULT_VALIDATION = {};
+
 const CLASSNAME_MAP = {
 	variant: {
 		success: "yst-validation-input--success",
@@ -20,7 +23,7 @@ const CLASSNAME_MAP = {
  */
 const ValidationInput = forwardRef( ( {
 	as: Component,
-	validation = {},
+	validation = DEFAULT_VALIDATION,
 	className = "",
 	...props
 }, ref ) => {


### PR DESCRIPTION
## Context

Gutenberg 23.3 (RC1) bundles **React 19.2.4** and is targeted for WordPress 7.1. React 19's automatic JSX runtime removes `render`/`hydrate` from `@wordpress/element` and stops applying `defaultProps` to function/`forwardRef` components, which broke several Free surfaces on the new runtime.

This PR merges the `feature/fix-gutenberg-23.3` integration branch into `release/27.8`. It bundles the three fixes that restore React 19 compatibility, each already reviewed and merged into the feature branch:

* **#23316** — migrate the Redirects screen and the AI-consent button from the removed `render()` to `createRoot().render()`.
* **#23317** — convert `@yoast/ui-library` components from `defaultProps` to ES6 default params (metabox/sidebar/Settings).
* **#23319** — keep `@yoast/components` button defaults working without `defaultProps` (content-analysis eye toggles, `BaseButton`/`LinkButton`).

All three were verified live on a React 19.2.4 site (Gutenberg 23.3-RC1): every affected surface renders with a clean console, and there is no regression on React 18.3.

Part of the React 19 readiness work tracked in Yoast/reserved-tasks#235.

## Summary

This PR can be summarized in the following changelog entry:

* Ensures compatibility with the React 19 version bundled in Gutenberg 23.3 (WordPress 7.1), fixing several screens and components that could otherwise fail to render.

## Relevant technical choices:

* The three changes are confined to Free `packages/js` entry points and the shared `@yoast/ui-library` and `@yoast/components` packages; add-ons consume the shared packages through the `yoast`/`wp` externals, so the fixes propagate.
* Each fix keeps working on both React 18.3 (WP 7.0) and React 19.2 (Gutenberg 23.3 / WP 7.1) so dual-version support holds during the overlap. `defaultProps` is kept alongside the runtime-safe mechanisms for classic-runtime consumers.
* No behaviour change on React 18 / the classic runtime.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

The acceptance-test instructions from each of the three merged PRs are reproduced in full below. All are React-19-only render/console crashes, so test on a React 19 build (the Gutenberg 23.3+ plugin active, or WordPress 7.1) with the browser console open.

#### From #23316 — Redirects screen & AI-consent button (createRoot)

Requires a React 19 build (the Gutenberg 23.3+ plugin active, or WordPress 7.1) with the browser console open. Sanity check: in the console, `wp.element.render` is `undefined` and `wp.element.createRoot` is a function.

**A. AI-consent button — test with Yoast SEO Premium ACTIVE:**
1. Activate Yoast SEO + Yoast SEO Premium.
2. Go to **Users → Profile** and scroll to the Yoast **"AI features"** row.
3. Expected: the Grant/Revoke-consent button renders and the console is clean. Without this PR, the console throws `(0 , n.render) is not a function` from `js/dist/ai-consent.js` and the button never appears.

**B. Redirects screen — test with Yoast SEO Premium INACTIVE:**
1. Deactivate Yoast SEO Premium (keep Free active).
2. Go to **Yoast SEO → Redirects**.
3. Expected: the Redirects screen renders and the console is clean. Without this PR, the console throws `(0 , n.render) is not a function` from `js/dist/redirects.js` and the page is blank.

#### From #23317 — @yoast/ui-library defaultProps → ES6 defaults

* On the Gutenberg 23.3 RC (React 19.2.4), open a post with the browser console open: the Yoast metabox/sidebar render with no errors (without this change the metabox fails to render).
* On current WordPress (React 18.3), confirm no visual regression in `@yoast/ui-library` UI (Settings, metabox, buttons, fields, modals).

#### From #23319 — @yoast/components button defaults

Requires a React-19 environment (the Gutenberg 23.3+ plugin active, or WordPress 7.1) with Yoast SEO active. Test with the browser console open.
1. Open a post in the block editor, add a paragraph of text and set a focus keyphrase so the SEO and readability analyses run. Each assessment result shows a small **eye "Highlight this result in the text"** toggle. The toggles should render styled (light-grey background, a subtle bottom box-shadow, a 1px border) and the console should show no `hex notation` / `Cannot read properties of undefined` errors. Before this fix they threw in `parseToRgb` and crashed the analysis subtree.
2. Open **Yoast SEO → Workouts** and other Free admin screens. `BaseButton` / `LinkButton` should render and the console should stay clean.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The breakage is React-19-only and surfaces as a render/console crash, so test with the browser console open in the block editor on a Gutenberg 23.3+ build.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA tests on the Gutenberg 23.3-RC1 (React 19) build, following the acceptance-test steps from all three PRs above. Note #23316 step A needs Premium **active** and step B needs Premium **inactive**; also re-check on a React 18.3 (WP 7.0) site for dual-version support.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* **`@yoast/ui-library` (#23317)** underpins the whole modern Yoast admin UI, so every screen built with it needs a regression pass: **Settings** (all tabs, fields, toggles, selects, radio groups, modals), the **Dashboard**, the **First-time configuration** wizard, **Academy**, **Support**, **Integrations**, and the editor **metabox/sidebar**.
* **`@yoast/components` (#23319)** buttons render in the editor **content-analysis results** (the eye/highlight toggles), the **Workouts**, and other Free admin screens using `BaseButton`/`LinkButton`.
* **createRoot (#23316)** is narrow: only the **Redirects** screen and the **AI-consent** button on **Users → Profile**.
* The shared `@yoast/ui-library` / `@yoast/components` packages are bundled into **Premium, Local, News, Video and WooCommerce** through the `yoast`/`wp` externals, so those add-ons' React UIs (e.g. Premium link suggestions, SEMrush/Wincher, social previews; add-on sidebars and settings) should also be smoke-tested.
* The main regression risk is visual/render breakage from the shared-component changes, so test the surfaces above on **both React 19 (Gutenberg 23.3 / WP 7.1)** and **React 18.3 (WP 7.0)**.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.

Refs Yoast/reserved-tasks#235

🤖 Generated with [Claude Code](https://claude.com/claude-code)
