### PR TITLE
feat(bulk-editor): scaffold bulk edit page and React provider seam

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -698,6 +698,11 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => [ self::PREFIX . 'tailwind' ],
 			],
 			[
+				'name' => 'bulk-editor-page',
+				'src'  => 'bulk-editor-page-' . $flat_version,
+				'deps' => [ self::PREFIX . 'tailwind' ],
+			],
+			[
 				'name' => 'general-page',
 				'src'  => 'general-page-' . $flat_version,
 				'deps' => [ self::PREFIX . 'tailwind' ],

--- a/config/webpack/paths.js
+++ b/config/webpack/paths.js
@@ -17,6 +17,7 @@ const getEntries = ( sourceDirectory = "./packages/js/src" ) => ( {
 	"api-client": `${ sourceDirectory }/api-client.js`,
 	"block-editor": `${ sourceDirectory }/block-editor.js`,
 	"bulk-editor": `${ sourceDirectory }/bulk-editor.js`,
+	"bulk-editor-page": `${ sourceDirectory }/bulk-editor/initialize.js`,
 	"classic-editor": `${ sourceDirectory }/classic-editor.js`,
 	"crawl-settings": `${ sourceDirectory }/crawl-settings.js`,
 	"dashboard-widget": `${ sourceDirectory }/dashboard-widget.js`,

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -1,0 +1,3 @@
+.seo_page_wpseo_page_bulk_edit {
+	@apply yst-bg-slate-100;
+}

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -1,0 +1,20 @@
+import PropTypes from "prop-types";
+import { PlaceholderPage } from "./components";
+
+/**
+ * The bulk editor app.
+ *
+ * @param {import("./services").DataProvider} dataProvider The data provider.
+ * @param {import("@yoast/dashboard-frontend").RemoteDataProvider} remoteDataProvider The remote data provider.
+ *
+ * @returns {JSX.Element} The app.
+ */
+const App = ( { dataProvider } ) => {
+	return <PlaceholderPage dataProvider={ dataProvider } />;
+};
+
+App.propTypes = {
+	dataProvider: PropTypes.object.isRequired,
+};
+
+export default App;

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import { PlaceholderPage } from "./components";
 
 /**
@@ -11,10 +10,6 @@ import { PlaceholderPage } from "./components";
  */
 const App = ( { dataProvider } ) => {
 	return <PlaceholderPage dataProvider={ dataProvider } />;
-};
-
-App.propTypes = {
-	dataProvider: PropTypes.object.isRequired,
 };
 
 export default App;

--- a/packages/js/src/bulk-editor/components/index.js
+++ b/packages/js/src/bulk-editor/components/index.js
@@ -1,0 +1,1 @@
+export { PlaceholderPage } from "./placeholder-page";

--- a/packages/js/src/bulk-editor/components/placeholder-page.js
+++ b/packages/js/src/bulk-editor/components/placeholder-page.js
@@ -14,7 +14,7 @@ export const PlaceholderPage = ( { dataProvider } ) => {
 
 	return (
 		<Paper className="yst-m-8 yst-p-8 yst-space-y-4">
-			<Title>{ __( "Bulk edit", "wordpress-seo" ) }</Title>
+			<Title>{ __( "Bulk editor", "wordpress-seo" ) }</Title>
 			<ul className="yst-list-disc yst-list-inside">
 				{ contentTypes.map( ( contentType ) => (
 					<li key={ contentType.name }>{ contentType.label }</li>

--- a/packages/js/src/bulk-editor/components/placeholder-page.js
+++ b/packages/js/src/bulk-editor/components/placeholder-page.js
@@ -1,0 +1,29 @@
+import { __ } from "@wordpress/i18n";
+import { Paper, Title } from "@yoast/ui-library";
+import PropTypes from "prop-types";
+
+/**
+ * Temporary placeholder page until the bulk editor UI lands.
+ *
+ * @param {import("../services").DataProvider} dataProvider The data provider.
+ *
+ * @returns {JSX.Element} The placeholder page.
+ */
+export const PlaceholderPage = ( { dataProvider } ) => {
+	const contentTypes = dataProvider.getContentTypes();
+
+	return (
+		<Paper className="yst-m-8 yst-p-8 yst-space-y-4">
+			<Title>{ __( "Bulk edit", "wordpress-seo" ) }</Title>
+			<ul className="yst-list-disc yst-list-inside">
+				{ contentTypes.map( ( contentType ) => (
+					<li key={ contentType.name }>{ contentType.label }</li>
+				) ) }
+			</ul>
+		</Paper>
+	);
+};
+
+PlaceholderPage.propTypes = {
+	dataProvider: PropTypes.object.isRequired,
+};

--- a/packages/js/src/bulk-editor/components/placeholder-page.js
+++ b/packages/js/src/bulk-editor/components/placeholder-page.js
@@ -1,6 +1,5 @@
 import { __ } from "@wordpress/i18n";
 import { Paper, Title } from "@yoast/ui-library";
-import PropTypes from "prop-types";
 
 /**
  * Temporary placeholder page until the bulk editor UI lands.
@@ -22,8 +21,4 @@ export const PlaceholderPage = ( { dataProvider } ) => {
 			</ul>
 		</Paper>
 	);
-};
-
-PlaceholderPage.propTypes = {
-	dataProvider: PropTypes.object.isRequired,
 };

--- a/packages/js/src/bulk-editor/constants.js
+++ b/packages/js/src/bulk-editor/constants.js
@@ -1,0 +1,6 @@
+/**
+ * Keep constants centralized to avoid circular dependency problems.
+ */
+export const STORE_NAME = "@yoast/bulk-editor";
+
+export const ROOT_ID = "yoast-seo-bulk-editor";

--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -33,7 +33,7 @@ domReady( () => {
 		endpoints: get( window, "wpseoBulkEditorData.endpoints", {} ),
 		links: get( window, "wpseoBulkEditorData.links", {} ),
 	} );
-	const remoteDataProvider = new RemoteDataProvider( { headers: { "X-Wp-Nonce": nonce } } );
+	const remoteDataProvider = new RemoteDataProvider( { headers: { "X-WP-Nonce": nonce } } );
 
 	const router = createHashRouter(
 		createRoutesFromElements(

--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -1,0 +1,53 @@
+import { SlotFillProvider } from "@wordpress/components";
+import { select } from "@wordpress/data";
+import domReady from "@wordpress/dom-ready";
+import { createRoot } from "@wordpress/element";
+import { RemoteDataProvider } from "@yoast/dashboard-frontend";
+import { get } from "lodash";
+import { createHashRouter, createRoutesFromElements, Route, RouterProvider } from "react-router-dom";
+import { fixWordPressMenuScrolling } from "../shared-admin/helpers";
+import { LINK_PARAMS_NAME } from "../shared-admin/store";
+import App from "./app";
+import { ROOT_ID, STORE_NAME } from "./constants";
+import { DataProvider } from "./services";
+import registerStore from "./store";
+
+domReady( () => {
+	const root = document.getElementById( ROOT_ID );
+	if ( ! root ) {
+		return;
+	}
+
+	registerStore( {
+		initialState: {
+			[ LINK_PARAMS_NAME ]: get( window, "wpseoBulkEditorData.linkParams", {} ),
+		},
+	} );
+	fixWordPressMenuScrolling();
+
+	const isRtl = select( STORE_NAME ).selectPreference( "isRtl", false );
+	const nonce = get( window, "wpseoBulkEditorData.nonce", "" );
+
+	const dataProvider = new DataProvider( {
+		contentTypes: get( window, "wpseoBulkEditorData.contentTypes", [] ),
+		endpoints: get( window, "wpseoBulkEditorData.endpoints", {} ),
+		links: get( window, "wpseoBulkEditorData.links", {} ),
+	} );
+	const remoteDataProvider = new RemoteDataProvider( { headers: { "X-Wp-Nonce": nonce } } );
+
+	const router = createHashRouter(
+		createRoutesFromElements(
+			<Route path="/" element={ <App dataProvider={ dataProvider } remoteDataProvider={ remoteDataProvider } /> } />
+		)
+	);
+
+	// Mounted without the ui-library Root wrapper (RFC: Root-independent rendering).
+	// RTL is handled via the dir attribute instead of the Root context.
+	createRoot( root ).render(
+		<div dir={ isRtl ? "rtl" : "ltr" }>
+			<SlotFillProvider>
+				<RouterProvider router={ router } />
+			</SlotFillProvider>
+		</div>
+	);
+} );

--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -41,7 +41,6 @@ domReady( () => {
 		)
 	);
 
-	// Mounted without the ui-library Root wrapper (RFC: Root-independent rendering).
 	// RTL is handled via the dir attribute instead of the Root context.
 	createRoot( root ).render(
 		<div dir={ isRtl ? "rtl" : "ltr" } className="yst-root">

--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -44,7 +44,7 @@ domReady( () => {
 	// Mounted without the ui-library Root wrapper (RFC: Root-independent rendering).
 	// RTL is handled via the dir attribute instead of the Root context.
 	createRoot( root ).render(
-		<div dir={ isRtl ? "rtl" : "ltr" }>
+		<div dir={ isRtl ? "rtl" : "ltr" } className="yst-root">
 			<SlotFillProvider>
 				<RouterProvider router={ router } />
 			</SlotFillProvider>

--- a/packages/js/src/bulk-editor/services/data-provider.js
+++ b/packages/js/src/bulk-editor/services/data-provider.js
@@ -13,11 +13,11 @@ export class DataProvider {
 	#links;
 
 	/**
-	 * @param {ContentType[]} [contentTypes] The content types.
-	 * @param {Object<string,string>} [endpoints] The endpoints.
-	 * @param {Object<string,string>} [links] The links.
+	 * @param {Object} [data] The initial data.
+	 * @param {ContentType[]} [data.contentTypes] The content types.
+	 * @param {Object<string,string>} [data.endpoints] The endpoints.
+	 * @param {Object<string,string>} [data.links] The links.
 	 */
-	constructor( { contentTypes = [], endpoints = {}, links = {} } = {} ) {
 		this.#contentTypes = contentTypes;
 		this.#endpoints = endpoints;
 		this.#links = links;

--- a/packages/js/src/bulk-editor/services/data-provider.js
+++ b/packages/js/src/bulk-editor/services/data-provider.js
@@ -18,6 +18,7 @@ export class DataProvider {
 	 * @param {Object<string,string>} [data.endpoints] The endpoints.
 	 * @param {Object<string,string>} [data.links] The links.
 	 */
+	constructor( { contentTypes = [], endpoints = {}, links = {} } = {} ) {
 		this.#contentTypes = contentTypes;
 		this.#endpoints = endpoints;
 		this.#links = links;

--- a/packages/js/src/bulk-editor/services/data-provider.js
+++ b/packages/js/src/bulk-editor/services/data-provider.js
@@ -1,0 +1,62 @@
+/**
+ * @typedef {Object} ContentType A content type.
+ * @property {string} name The name of the content type.
+ * @property {string} label The label of the content type.
+ */
+
+/**
+ * Controls the data for the bulk editor.
+ */
+export class DataProvider {
+	#contentTypes;
+	#endpoints;
+	#links;
+
+	/**
+	 * @param {ContentType[]} [contentTypes] The content types.
+	 * @param {Object<string,string>} [endpoints] The endpoints.
+	 * @param {Object<string,string>} [links] The links.
+	 */
+	constructor( { contentTypes = [], endpoints = {}, links = {} } = {} ) {
+		this.#contentTypes = contentTypes;
+		this.#endpoints = endpoints;
+		this.#links = links;
+	}
+
+	/**
+	 * @returns {ContentType[]} The content types.
+	 */
+	getContentTypes() {
+		return this.#contentTypes;
+	}
+
+	/**
+	 * @param {string} endpoint The endpoint to get.
+	 * @returns {string} The endpoint or an empty string if not found.
+	 */
+	getEndpoint( endpoint ) {
+		return this.#endpoints[ endpoint ] || "";
+	}
+
+	/**
+	 * @returns {Object<string,string>} The endpoints.
+	 */
+	getEndpoints() {
+		return this.#endpoints;
+	}
+
+	/**
+	 * @param {string} link The link to get.
+	 * @returns {string} The link or an empty string if not found.
+	 */
+	getLink( link ) {
+		return this.#links[ link ] || "";
+	}
+
+	/**
+	 * @returns {Object<string,string>} The links.
+	 */
+	getLinks() {
+		return this.#links;
+	}
+}

--- a/packages/js/src/bulk-editor/services/index.js
+++ b/packages/js/src/bulk-editor/services/index.js
@@ -1,0 +1,1 @@
+export { DataProvider } from "./data-provider";

--- a/packages/js/src/bulk-editor/store/index.js
+++ b/packages/js/src/bulk-editor/store/index.js
@@ -1,0 +1,47 @@
+import { combineReducers, createReduxStore, register } from "@wordpress/data";
+import { merge } from "lodash";
+import { getInitialLinkParamsState, LINK_PARAMS_NAME, linkParamsActions, linkParamsReducer, linkParamsSelectors } from "../../shared-admin/store";
+import { STORE_NAME } from "../constants";
+import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
+
+/** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
+
+/**
+ * @param {Object} initialState Initial state.
+ * @returns {WPDataStore} The WP data store.
+ */
+const createStore = ( { initialState } ) => {
+	return createReduxStore( STORE_NAME, {
+		actions: {
+			...linkParamsActions,
+			...preferencesActions,
+		},
+		selectors: {
+			...linkParamsSelectors,
+			...preferencesSelectors,
+		},
+		initialState: merge(
+			{},
+			{
+				[ LINK_PARAMS_NAME ]: getInitialLinkParamsState(),
+				preferences: createInitialPreferencesState(),
+			},
+			initialState
+		),
+		reducer: combineReducers( {
+			[ LINK_PARAMS_NAME ]: linkParamsReducer,
+			preferences,
+		} ),
+	} );
+};
+
+/**
+ * Registers the store to WP data's default registry.
+ * @param {Object} [initialState] Initial state.
+ * @returns {void}
+ */
+const registerStore = ( { initialState = {} } = {} ) => {
+	register( createStore( { initialState } ) );
+};
+
+export default registerStore;

--- a/packages/js/src/bulk-editor/store/preferences.js
+++ b/packages/js/src/bulk-editor/store/preferences.js
@@ -1,0 +1,24 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+/**
+ * @returns {Object} The initial state.
+ */
+export const createInitialPreferencesState = () => ( {
+	...get( window, "wpseoBulkEditorData.preferences", {} ),
+} );
+
+const slice = createSlice( {
+	name: "preferences",
+	initialState: createInitialPreferencesState(),
+	reducers: {},
+} );
+
+export const preferencesSelectors = {
+	selectPreference: ( state, preference, defaultValue = {} ) => get( state, `preferences.${ preference }`, defaultValue ),
+	selectPreferences: state => get( state, "preferences", {} ),
+};
+
+export const preferencesActions = slice.actions;
+
+export default slice.reducer;

--- a/packages/js/tests/bulk-editor/initialize.test.js
+++ b/packages/js/tests/bulk-editor/initialize.test.js
@@ -1,0 +1,101 @@
+import { jest } from "@jest/globals";
+import { ROOT_ID } from "../../src/bulk-editor/constants";
+
+const mockRender = jest.fn();
+const mockCreateRoot = jest.fn( () => ( { render: mockRender } ) );
+const mockRegisterStore = jest.fn();
+const mockFixScrolling = jest.fn();
+const mockRemoteDataProvider = jest.fn();
+const mockSelectPreference = jest.fn( () => false );
+
+jest.mock( "@wordpress/dom-ready", () => ( {
+	__esModule: true,
+	"default": ( callback ) => callback(),
+} ) );
+
+jest.mock( "@wordpress/element", () => ( {
+	createRoot: ( ...args ) => mockCreateRoot( ...args ),
+} ) );
+
+jest.mock( "@wordpress/components", () => ( {
+	SlotFillProvider: ( { children } ) => children,
+} ) );
+
+jest.mock( "@wordpress/data", () => ( {
+	select: () => ( { selectPreference: mockSelectPreference } ),
+} ) );
+
+jest.mock( "react-router-dom", () => ( {
+	createHashRouter: () => ( {} ),
+	createRoutesFromElements: () => ( {} ),
+	Route: () => null,
+	RouterProvider: () => null,
+} ) );
+
+jest.mock( "@yoast/dashboard-frontend", () => ( {
+	RemoteDataProvider: function( options ) {
+		mockRemoteDataProvider( options );
+	},
+} ) );
+
+jest.mock( "../../src/bulk-editor/store", () => ( {
+	__esModule: true,
+	"default": ( ...args ) => mockRegisterStore( ...args ),
+} ) );
+
+jest.mock( "../../src/shared-admin/helpers", () => ( {
+	fixWordPressMenuScrolling: () => mockFixScrolling(),
+} ) );
+
+describe( "bulk editor initialize", () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.resetModules();
+		document.body.replaceChildren();
+		window.wpseoBulkEditorData = {
+			contentTypes: [ { name: "post", label: "Posts" } ],
+			linkParams: { foo: "bar" },
+			nonce: "test-nonce",
+		};
+	} );
+
+	test( "should not mount when the root element is absent", () => {
+		jest.isolateModules( () => {
+			require( "../../src/bulk-editor/initialize" );
+		} );
+
+		expect( mockCreateRoot ).not.toHaveBeenCalled();
+		expect( mockRegisterStore ).not.toHaveBeenCalled();
+	} );
+
+	test( "should register the store and mount the app when the root element exists", () => {
+		const root = document.createElement( "div" );
+		root.id = ROOT_ID;
+		document.body.appendChild( root );
+
+		jest.isolateModules( () => {
+			require( "../../src/bulk-editor/initialize" );
+		} );
+
+		expect( mockRegisterStore ).toHaveBeenCalledWith( {
+			initialState: { linkParams: { foo: "bar" } },
+		} );
+		expect( mockFixScrolling ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateRoot ).toHaveBeenCalledWith( root );
+		expect( mockRender ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( "should construct the remote data provider with the REST nonce header", () => {
+		const root = document.createElement( "div" );
+		root.id = ROOT_ID;
+		document.body.appendChild( root );
+
+		jest.isolateModules( () => {
+			require( "../../src/bulk-editor/initialize" );
+		} );
+
+		expect( mockRemoteDataProvider ).toHaveBeenCalledWith( {
+			headers: { "X-WP-Nonce": "test-nonce" },
+		} );
+	} );
+} );

--- a/packages/js/tests/bulk-editor/services/data-provider.test.js
+++ b/packages/js/tests/bulk-editor/services/data-provider.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "@jest/globals";
+import { DataProvider } from "../../../src/bulk-editor/services/data-provider";
+
+describe( "DataProvider", () => {
+	const contentTypes = [
+		{ name: "post", label: "Posts" },
+		{ name: "page", label: "Pages" },
+	];
+	const endpoints = { posts: "https://example.com/wp-json/yoast/v1/bulk-editor/posts" };
+	const links = { learnMore: "https://yoa.st/bulk-editor-learn-more" };
+
+	test( "should return the content types", () => {
+		const dataProvider = new DataProvider( { contentTypes, endpoints, links } );
+		expect( dataProvider.getContentTypes() ).toEqual( contentTypes );
+	} );
+
+	test( "should return an endpoint and the endpoints", () => {
+		const dataProvider = new DataProvider( { contentTypes, endpoints, links } );
+		expect( dataProvider.getEndpoint( "posts" ) ).toBe( endpoints.posts );
+		expect( dataProvider.getEndpoints() ).toEqual( endpoints );
+	} );
+
+	test( "should return a link and the links", () => {
+		const dataProvider = new DataProvider( { contentTypes, endpoints, links } );
+		expect( dataProvider.getLink( "learnMore" ) ).toBe( links.learnMore );
+		expect( dataProvider.getLinks() ).toEqual( links );
+	} );
+
+	test( "should fall back to empty values when constructed without data", () => {
+		const dataProvider = new DataProvider();
+		expect( dataProvider.getContentTypes() ).toEqual( [] );
+		expect( dataProvider.getEndpoint( "posts" ) ).toBe( "" );
+		expect( dataProvider.getLink( "learnMore" ) ).toBe( "" );
+	} );
+} );

--- a/src/bulk-editor/application/content-types/content-types-repository.php
+++ b/src/bulk-editor/application/content-types/content-types-repository.php
@@ -1,0 +1,37 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Bulk_Editor\Application\Content_Types;
+
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+
+/**
+ * The repository to get content types for the bulk editor.
+ */
+class Content_Types_Repository {
+
+	/**
+	 * The content types collector.
+	 *
+	 * @var Content_Types_Collector
+	 */
+	protected $content_types_collector;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Content_Types_Collector $content_types_collector The content types collector.
+	 */
+	public function __construct( Content_Types_Collector $content_types_collector ) {
+		$this->content_types_collector = $content_types_collector;
+	}
+
+	/**
+	 * Returns the content types array.
+	 *
+	 * @return array<array<string, string>> The content types array.
+	 */
+	public function get_content_types(): array {
+		return $this->content_types_collector->get_content_types()->to_array();
+	}
+}

--- a/src/bulk-editor/domain/content-types/content-type.php
+++ b/src/bulk-editor/domain/content-types/content-type.php
@@ -1,0 +1,53 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types;
+
+/**
+ * This class describes a content type for the bulk editor.
+ */
+class Content_Type {
+
+	/**
+	 * The name of the content type.
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * The label of the content type.
+	 *
+	 * @var string
+	 */
+	private $label;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param string $name  The name of the content type.
+	 * @param string $label The label of the content type.
+	 */
+	public function __construct( string $name, string $label ) {
+		$this->name  = $name;
+		$this->label = $label;
+	}
+
+	/**
+	 * Gets the name of the content type.
+	 *
+	 * @return string The name of the content type.
+	 */
+	public function get_name(): string {
+		return $this->name;
+	}
+
+	/**
+	 * Gets the label of the content type.
+	 *
+	 * @return string The label of the content type.
+	 */
+	public function get_label(): string {
+		return $this->label;
+	}
+}

--- a/src/bulk-editor/domain/content-types/content-types-list.php
+++ b/src/bulk-editor/domain/content-types/content-types-list.php
@@ -9,11 +9,11 @@ namespace Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types;
 class Content_Types_List {
 
 	/**
-	/**
 	 * The content types.
 	 *
 	 * @var array<string, Content_Type>
 	 */
+	private $content_types = [];
 
 	/**
 	 * Adds a content type to the list.
@@ -27,11 +27,13 @@ class Content_Types_List {
 	}
 
 	/**
-	/**
 	 * Returns the content types in the list.
 	 *
 	 * @return array<string, Content_Type> The content types in the list.
 	 */
+	public function get(): array {
+		return $this->content_types;
+	}
 
 	/**
 	 * Parses the content type list to the expected key value representation.

--- a/src/bulk-editor/domain/content-types/content-types-list.php
+++ b/src/bulk-editor/domain/content-types/content-types-list.php
@@ -9,11 +9,11 @@ namespace Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types;
 class Content_Types_List {
 
 	/**
+	/**
 	 * The content types.
 	 *
-	 * @var array<Content_Type>
+	 * @var array<string, Content_Type>
 	 */
-	private $content_types = [];
 
 	/**
 	 * Adds a content type to the list.
@@ -27,13 +27,11 @@ class Content_Types_List {
 	}
 
 	/**
+	/**
 	 * Returns the content types in the list.
 	 *
-	 * @return array<Content_Type> The content types in the list.
+	 * @return array<string, Content_Type> The content types in the list.
 	 */
-	public function get(): array {
-		return $this->content_types;
-	}
 
 	/**
 	 * Parses the content type list to the expected key value representation.

--- a/src/bulk-editor/domain/content-types/content-types-list.php
+++ b/src/bulk-editor/domain/content-types/content-types-list.php
@@ -1,0 +1,54 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types;
+
+/**
+ * This class describes a list of content types.
+ */
+class Content_Types_List {
+
+	/**
+	 * The content types.
+	 *
+	 * @var array<Content_Type>
+	 */
+	private $content_types = [];
+
+	/**
+	 * Adds a content type to the list.
+	 *
+	 * @param Content_Type $content_type The content type to add.
+	 *
+	 * @return void
+	 */
+	public function add( Content_Type $content_type ): void {
+		$this->content_types[ $content_type->get_name() ] = $content_type;
+	}
+
+	/**
+	 * Returns the content types in the list.
+	 *
+	 * @return array<Content_Type> The content types in the list.
+	 */
+	public function get(): array {
+		return $this->content_types;
+	}
+
+	/**
+	 * Parses the content type list to the expected key value representation.
+	 *
+	 * @return array<array<string, string>> The content type list presented as the expected key value representation.
+	 */
+	public function to_array(): array {
+		$array = [];
+		foreach ( $this->content_types as $content_type ) {
+			$array[] = [
+				'name'  => $content_type->get_name(),
+				'label' => $content_type->get_label(),
+			];
+		}
+
+		return $array;
+	}
+}

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -1,0 +1,56 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types;
+
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type;
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+
+/**
+ * Class that collects the post types that can be bulk edited.
+ */
+class Content_Types_Collector {
+
+	/**
+	 * The post type helper.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Post_Type_Helper $post_type_helper The post type helper.
+	 */
+	public function __construct( Post_Type_Helper $post_type_helper ) {
+		$this->post_type_helper = $post_type_helper;
+	}
+
+	/**
+	 * Returns the content types in a list.
+	 *
+	 * @return Content_Types_List The content types in a list.
+	 */
+	public function get_content_types(): Content_Types_List {
+		$content_types_list = new Content_Types_List();
+		$post_types         = $this->post_type_helper->get_accessible_post_types();
+
+		foreach ( $post_types as $post_type ) {
+			$post_type_object = \get_post_type_object( $post_type );
+			if ( empty( $post_type_object ) ) {
+				continue;
+			}
+
+			if ( ! \current_user_can( $post_type_object->cap->edit_posts ) ) {
+				continue;
+			}
+
+			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label );
+			$content_types_list->add( $content_type );
+		}
+
+		return $content_types_list;
+	}
+}

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -35,18 +35,9 @@ class Content_Types_Collector {
 	 */
 	public function get_content_types(): Content_Types_List {
 		$content_types_list = new Content_Types_List();
-		$post_types         = $this->post_type_helper->get_accessible_post_types();
+		$post_types         = $this->post_type_helper->get_indexable_post_type_objects();
 
-		foreach ( $post_types as $post_type ) {
-			$post_type_object = \get_post_type_object( $post_type );
-			if ( empty( $post_type_object ) ) {
-				continue;
-			}
-
-			if ( ! \current_user_can( $post_type_object->cap->edit_posts ) ) {
-				continue;
-			}
-
+		foreach ( $post_types as $post_type_object ) {
 			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label );
 			$content_types_list->add( $content_type );
 		}

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -38,6 +38,9 @@ class Content_Types_Collector {
 		$post_types         = $this->post_type_helper->get_indexable_post_type_objects();
 
 		foreach ( $post_types as $post_type_object ) {
+			if ( $post_type_object->show_ui === false ) {
+				continue;
+			}
 			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label );
 			$content_types_list->add( $content_type );
 		}

--- a/src/bulk-editor/infrastructure/nonces/nonce-repository.php
+++ b/src/bulk-editor/infrastructure/nonces/nonce-repository.php
@@ -1,0 +1,19 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces;
+
+/**
+ * Repository for WP nonces.
+ */
+class Nonce_Repository {
+
+	/**
+	 * Creates the nonce for a WP REST request.
+	 *
+	 * @return string
+	 */
+	public function get_rest_nonce(): string {
+		return \wp_create_nonce( 'wp_rest' );
+	}
+}

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -132,7 +132,7 @@ class Bulk_Editor_Integration implements Integration_Interface {
 		$pages[] = [
 			'wpseo_dashboard',
 			'',
-			\__( 'Bulk edit', 'wordpress-seo' ),
+			\__( 'Bulk editor', 'wordpress-seo' ),
 			'wpseo_bulk_edit',
 			self::PAGE,
 			[ $this, 'display_page' ],

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -133,7 +133,7 @@ class Bulk_Editor_Integration implements Integration_Interface {
 			'wpseo_dashboard',
 			'',
 			\__( 'Bulk editor', 'wordpress-seo' ),
-			'wpseo_bulk_edit',
+			'wpseo_manage_options',
 			self::PAGE,
 			[ $this, 'display_page' ],
 		];

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -1,0 +1,199 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\User_Interface;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Adds the bulk editor page to the Yoast admin menu.
+ */
+class Bulk_Editor_Integration implements Integration_Interface {
+
+	/**
+	 * The page name.
+	 */
+	public const PAGE = 'wpseo_page_bulk_edit';
+
+	/**
+	 * The assets name.
+	 */
+	public const ASSETS_NAME = 'bulk-editor-page';
+
+	/**
+	 * Holds the WPSEO_Admin_Asset_Manager.
+	 *
+	 * @var WPSEO_Admin_Asset_Manager
+	 */
+	private $asset_manager;
+
+	/**
+	 * Holds the Current_Page_Helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
+
+	/**
+	 * Holds the Product_Helper.
+	 *
+	 * @var Product_Helper
+	 */
+	private $product_helper;
+
+	/**
+	 * Holds the Short_Link_Helper.
+	 *
+	 * @var Short_Link_Helper
+	 */
+	private $short_link_helper;
+
+	/**
+	 * Holds the Content_Types_Repository.
+	 *
+	 * @var Content_Types_Repository
+	 */
+	private $content_types_repository;
+
+	/**
+	 * Holds the Nonce_Repository.
+	 *
+	 * @var Nonce_Repository
+	 */
+	private $nonce_repository;
+
+	/**
+	 * Constructs the instance.
+	 *
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager            The WPSEO_Admin_Asset_Manager.
+	 * @param Current_Page_Helper       $current_page_helper      The Current_Page_Helper.
+	 * @param Product_Helper            $product_helper           The Product_Helper.
+	 * @param Short_Link_Helper         $short_link_helper        The Short_Link_Helper.
+	 * @param Content_Types_Repository  $content_types_repository The Content_Types_Repository.
+	 * @param Nonce_Repository          $nonce_repository         The Nonce_Repository.
+	 */
+	public function __construct(
+		WPSEO_Admin_Asset_Manager $asset_manager,
+		Current_Page_Helper $current_page_helper,
+		Product_Helper $product_helper,
+		Short_Link_Helper $short_link_helper,
+		Content_Types_Repository $content_types_repository,
+		Nonce_Repository $nonce_repository
+	) {
+		$this->asset_manager            = $asset_manager;
+		$this->current_page_helper      = $current_page_helper;
+		$this->product_helper           = $product_helper;
+		$this->short_link_helper        = $short_link_helper;
+		$this->content_types_repository = $content_types_repository;
+		$this->nonce_repository         = $nonce_repository;
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return array<string> The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * This is the place to register hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'wpseo_submenu_pages', [ $this, 'add_page' ] );
+
+		// Are we on our page?
+		if ( $this->current_page_helper->get_current_yoast_seo_page() === self::PAGE ) {
+			\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+			\add_action( 'in_admin_header', [ $this, 'remove_notices' ], \PHP_INT_MAX );
+		}
+	}
+
+	/**
+	 * Adds the page to the (currently) last position in the array.
+	 *
+	 * @param array<array<string|callable|null>> $pages The pages.
+	 *
+	 * @return array<array<string|callable|null>> The pages.
+	 */
+	public function add_page( $pages ) {
+		$pages[] = [
+			'wpseo_dashboard',
+			'',
+			\__( 'Bulk edit', 'wordpress-seo' ),
+			'edit_posts',
+			self::PAGE,
+			[ $this, 'display_page' ],
+		];
+
+		return $pages;
+	}
+
+	/**
+	 * Displays the page.
+	 *
+	 * @return void
+	 */
+	public function display_page() {
+		echo '<div id="yoast-seo-bulk-editor"></div>';
+	}
+
+	/**
+	 * Enqueues the assets.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets() {
+		// Remove the emoji script as it is incompatible with both React and any contenteditable fields.
+		\remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+		$this->asset_manager->enqueue_script( self::ASSETS_NAME );
+		$this->asset_manager->enqueue_style( self::ASSETS_NAME );
+		$this->asset_manager->localize_script( self::ASSETS_NAME, 'wpseoBulkEditorData', $this->get_script_data() );
+	}
+
+	/**
+	 * Creates the script data.
+	 *
+	 * @return array<string, string|array<string, string|bool|array<string, string>>> The script data.
+	 */
+	public function get_script_data() {
+		return [
+			'contentTypes' => $this->content_types_repository->get_content_types(),
+			// The endpoints and links are stubs until the REST routes and app needs land in later tasks.
+			'endpoints'    => [],
+			'links'        => [],
+			'nonce'        => $this->nonce_repository->get_rest_nonce(),
+			'restRoot'     => \esc_url_raw( \rest_url() ),
+			'preferences'  => [
+				'isPremium' => $this->product_helper->is_premium(),
+				'isRtl'     => \is_rtl(),
+				'pluginUrl' => \plugins_url( '', \WPSEO_FILE ),
+			],
+			'linkParams'   => $this->short_link_helper->get_query_params(),
+		];
+	}
+
+	/**
+	 * Removes all current WP notices.
+	 *
+	 * @return void
+	 */
+	public function remove_notices() {
+		\remove_all_actions( 'admin_notices' );
+		\remove_all_actions( 'user_admin_notices' );
+		\remove_all_actions( 'network_admin_notices' );
+		\remove_all_actions( 'all_admin_notices' );
+	}
+}

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -133,7 +133,7 @@ class Bulk_Editor_Integration implements Integration_Interface {
 			'wpseo_dashboard',
 			'',
 			\__( 'Bulk edit', 'wordpress-seo' ),
-			'edit_posts',
+			'wpseo_bulk_edit',
 			self::PAGE,
 			[ $this, 'display_page' ],
 		];

--- a/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Abstract_Content_Types_Repository_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Abstract_Content_Types_Repository_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+
+use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for the Content_Types_Repository tests.
+ *
+ * @group bulk-editor
+ */
+abstract class Abstract_Content_Types_Repository_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Content_Types_Repository
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the content types collector.
+	 *
+	 * @var Mockery\MockInterface|Content_Types_Collector
+	 */
+	protected $content_types_collector;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->content_types_collector = Mockery::mock( Content_Types_Collector::class );
+
+		$this->instance = new Content_Types_Repository( $this->content_types_collector );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Constructor_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+
+/**
+ * Tests the Content_Types_Repository constructor.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository::__construct
+ */
+final class Constructor_Test extends Abstract_Content_Types_Repository_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Content_Types_Collector::class,
+			$this->getPropertyValue( $this->instance, 'content_types_collector' ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Get_Content_Types_Test.php
@@ -1,0 +1,43 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type;
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
+
+/**
+ * Tests get_content_types.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository::get_content_types
+ */
+final class Get_Content_Types_Test extends Abstract_Content_Types_Repository_Test {
+
+	/**
+	 * Tests the get_content_types method.
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types() {
+		$content_types_list = new Content_Types_List();
+		$content_types_list->add( new Content_Type( 'post', 'Posts' ) );
+
+		$this->content_types_collector
+			->expects( 'get_content_types' )
+			->once()
+			->andReturn( $content_types_list );
+
+		$this->assertSame(
+			[
+				[
+					'name'  => 'post',
+					'label' => 'Posts',
+				],
+			],
+			$this->instance->get_content_types(),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Type_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Type_Test.php
@@ -1,0 +1,54 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Domain\Content_Types;
+
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Content_Type DTO.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type
+ */
+final class Content_Type_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Content_Type
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Content_Type( 'post', 'Posts' );
+	}
+
+	/**
+	 * Tests getting the name.
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'post', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests getting the label.
+	 *
+	 * @return void
+	 */
+	public function test_get_label() {
+		$this->assertSame( 'Posts', $this->instance->get_label() );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Types_List_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Types_List_Test.php
@@ -1,0 +1,97 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Domain\Content_Types;
+
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type;
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Content_Types_List.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List
+ */
+final class Content_Types_List_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Content_Types_List
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Content_Types_List();
+	}
+
+	/**
+	 * Tests adding and getting content types.
+	 *
+	 * @return void
+	 */
+	public function test_add_and_get() {
+		$content_type = new Content_Type( 'post', 'Posts' );
+
+		$this->instance->add( $content_type );
+
+		$this->assertSame( [ 'post' => $content_type ], $this->instance->get() );
+	}
+
+	/**
+	 * Tests that adding a content type with the same name overwrites the previous one.
+	 *
+	 * @return void
+	 */
+	public function test_add_overwrites_same_name() {
+		$this->instance->add( new Content_Type( 'post', 'Posts' ) );
+
+		$overwriting_content_type = new Content_Type( 'post', 'Articles' );
+		$this->instance->add( $overwriting_content_type );
+
+		$this->assertSame( [ 'post' => $overwriting_content_type ], $this->instance->get() );
+	}
+
+	/**
+	 * Tests parsing the list to an array.
+	 *
+	 * @return void
+	 */
+	public function test_to_array() {
+		$this->instance->add( new Content_Type( 'post', 'Posts' ) );
+		$this->instance->add( new Content_Type( 'page', 'Pages' ) );
+
+		$this->assertSame(
+			[
+				[
+					'name'  => 'post',
+					'label' => 'Posts',
+				],
+				[
+					'name'  => 'page',
+					'label' => 'Pages',
+				],
+			],
+			$this->instance->to_array(),
+		);
+	}
+
+	/**
+	 * Tests parsing an empty list to an array.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_empty() {
+		$this->assertSame( [], $this->instance->to_array() );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Abstract_Content_Types_Collector_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Abstract_Content_Types_Collector_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+
+use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for the Content_Types_Collector tests.
+ *
+ * @group bulk-editor
+ */
+abstract class Abstract_Content_Types_Collector_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Content_Types_Collector
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the post type helper.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+
+		$this->instance = new Content_Types_Collector( $this->post_type_helper );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Constructor_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
+
+/**
+ * Tests the Content_Types_Collector constructor.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector::__construct
+ */
+final class Constructor_Test extends Abstract_Content_Types_Collector_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Post_Type_Helper::class,
+			$this->getPropertyValue( $this->instance, 'post_type_helper' ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -4,7 +4,6 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
 
-use Brain\Monkey\Functions;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
 
 /**
@@ -19,41 +18,18 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 	/**
 	 * Tests the get_content_types method.
 	 *
-	 * @param array<string>                $accessible_post_types The accessible post types.
-	 * @param array<object|null>           $post_type_objects     The post type objects, keyed by post type.
-	 * @param array<bool>                  $user_can_edit         Whether the user can edit, keyed by post type.
-	 * @param array<array<string, string>> $expected              The expected content types array.
+	 * @param array<object>                $indexable_post_type_objects The indexable post type objects.
+	 * @param array<array<string, string>> $expected                    The expected content types array.
 	 *
 	 * @dataProvider data_get_content_types
 	 *
 	 * @return void
 	 */
-	public function test_get_content_types(
-		array $accessible_post_types,
-		array $post_type_objects,
-		array $user_can_edit,
-		array $expected
-	) {
+	public function test_get_content_types( array $indexable_post_type_objects, array $expected ) {
 		$this->post_type_helper
-			->expects( 'get_accessible_post_types' )
+			->expects( 'get_indexable_post_type_objects' )
 			->once()
-			->andReturn( $accessible_post_types );
-
-		Functions\expect( 'get_post_type_object' )
-			->times( \count( $accessible_post_types ) )
-			->andReturnUsing(
-				static function ( $post_type ) use ( $post_type_objects ) {
-					return $post_type_objects[ $post_type ];
-				},
-			);
-
-		Functions\expect( 'current_user_can' )
-			->times( \count( $user_can_edit ) )
-			->andReturnUsing(
-				static function ( $capability ) use ( $user_can_edit ) {
-					return $user_can_edit[ $capability ];
-				},
-			);
+			->andReturn( $indexable_post_type_objects );
 
 		$content_types_list = $this->instance->get_content_types();
 
@@ -64,32 +40,22 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 	/**
 	 * Data provider for test_get_content_types.
 	 *
-	 * @return array<string, array<string, array<string|object|bool|array<string, string>>>>
+	 * @return array<string, array<string, array<object|array<string, string>>>>
 	 */
 	public static function data_get_content_types() {
-		$post_object = (object) [
-			'name'  => 'post',
-			'label' => 'Posts',
-			'cap'   => (object) [ 'edit_posts' => 'edit_posts' ],
-		];
-		$page_object = (object) [
-			'name'  => 'page',
-			'label' => 'Pages',
-			'cap'   => (object) [ 'edit_posts' => 'edit_pages' ],
-		];
-
 		return [
-			'editable post types' => [
-				'accessible_post_types' => [ 'post', 'page' ],
-				'post_type_objects'     => [
-					'post' => $post_object,
-					'page' => $page_object,
+			'indexable post types' => [
+				'indexable_post_type_objects' => [
+					(object) [
+						'name'  => 'post',
+						'label' => 'Posts',
+					],
+					(object) [
+						'name'  => 'page',
+						'label' => 'Pages',
+					],
 				],
-				'user_can_edit'         => [
-					'edit_posts' => true,
-					'edit_pages' => true,
-				],
-				'expected'              => [
+				'expected'                    => [
 					[
 						'name'  => 'post',
 						'label' => 'Posts',
@@ -100,42 +66,9 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 					],
 				],
 			],
-			'post type the user cannot edit is skipped' => [
-				'accessible_post_types' => [ 'post', 'page' ],
-				'post_type_objects'     => [
-					'post' => $post_object,
-					'page' => $page_object,
-				],
-				'user_can_edit'         => [
-					'edit_posts' => true,
-					'edit_pages' => false,
-				],
-				'expected'              => [
-					[
-						'name'  => 'post',
-						'label' => 'Posts',
-					],
-				],
-			],
-			'unknown post type is skipped' => [
-				'accessible_post_types' => [ 'post', 'unknown' ],
-				'post_type_objects'     => [
-					'post'    => $post_object,
-					'unknown' => null,
-				],
-				'user_can_edit'         => [ 'edit_posts' => true ],
-				'expected'              => [
-					[
-						'name'  => 'post',
-						'label' => 'Posts',
-					],
-				],
-			],
-			'no accessible post types' => [
-				'accessible_post_types' => [],
-				'post_type_objects'     => [],
-				'user_can_edit'         => [],
-				'expected'              => [],
+			'no indexable post types' => [
+				'indexable_post_type_objects' => [],
+				'expected'                    => [],
 			],
 		];
 	}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -1,0 +1,142 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
+
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
+
+/**
+ * Tests get_content_types.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector::get_content_types
+ */
+final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test {
+
+	/**
+	 * Tests the get_content_types method.
+	 *
+	 * @param array<string>                $accessible_post_types The accessible post types.
+	 * @param array<object|null>           $post_type_objects     The post type objects, keyed by post type.
+	 * @param array<bool>                  $user_can_edit         Whether the user can edit, keyed by post type.
+	 * @param array<array<string, string>> $expected              The expected content types array.
+	 *
+	 * @dataProvider data_get_content_types
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types(
+		array $accessible_post_types,
+		array $post_type_objects,
+		array $user_can_edit,
+		array $expected
+	) {
+		$this->post_type_helper
+			->expects( 'get_accessible_post_types' )
+			->once()
+			->andReturn( $accessible_post_types );
+
+		Functions\expect( 'get_post_type_object' )
+			->times( \count( $accessible_post_types ) )
+			->andReturnUsing(
+				static function ( $post_type ) use ( $post_type_objects ) {
+					return $post_type_objects[ $post_type ];
+				},
+			);
+
+		Functions\expect( 'current_user_can' )
+			->times( \count( $user_can_edit ) )
+			->andReturnUsing(
+				static function ( $capability ) use ( $user_can_edit ) {
+					return $user_can_edit[ $capability ];
+				},
+			);
+
+		$content_types_list = $this->instance->get_content_types();
+
+		$this->assertInstanceOf( Content_Types_List::class, $content_types_list );
+		$this->assertSame( $expected, $content_types_list->to_array() );
+	}
+
+	/**
+	 * Data provider for test_get_content_types.
+	 *
+	 * @return array<string, array<string, array<string|object|bool|array<string, string>>>>
+	 */
+	public static function data_get_content_types() {
+		$post_object = (object) [
+			'name'  => 'post',
+			'label' => 'Posts',
+			'cap'   => (object) [ 'edit_posts' => 'edit_posts' ],
+		];
+		$page_object = (object) [
+			'name'  => 'page',
+			'label' => 'Pages',
+			'cap'   => (object) [ 'edit_posts' => 'edit_pages' ],
+		];
+
+		return [
+			'editable post types' => [
+				'accessible_post_types' => [ 'post', 'page' ],
+				'post_type_objects'     => [
+					'post' => $post_object,
+					'page' => $page_object,
+				],
+				'user_can_edit'         => [
+					'edit_posts' => true,
+					'edit_pages' => true,
+				],
+				'expected'              => [
+					[
+						'name'  => 'post',
+						'label' => 'Posts',
+					],
+					[
+						'name'  => 'page',
+						'label' => 'Pages',
+					],
+				],
+			],
+			'post type the user cannot edit is skipped' => [
+				'accessible_post_types' => [ 'post', 'page' ],
+				'post_type_objects'     => [
+					'post' => $post_object,
+					'page' => $page_object,
+				],
+				'user_can_edit'         => [
+					'edit_posts' => true,
+					'edit_pages' => false,
+				],
+				'expected'              => [
+					[
+						'name'  => 'post',
+						'label' => 'Posts',
+					],
+				],
+			],
+			'unknown post type is skipped' => [
+				'accessible_post_types' => [ 'post', 'unknown' ],
+				'post_type_objects'     => [
+					'post'    => $post_object,
+					'unknown' => null,
+				],
+				'user_can_edit'         => [ 'edit_posts' => true ],
+				'expected'              => [
+					[
+						'name'  => 'post',
+						'label' => 'Posts',
+					],
+				],
+			],
+			'no accessible post types' => [
+				'accessible_post_types' => [],
+				'post_type_objects'     => [],
+				'user_can_edit'         => [],
+				'expected'              => [],
+			],
+		];
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -47,12 +47,14 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 			'indexable post types' => [
 				'indexable_post_type_objects' => [
 					(object) [
-						'name'  => 'post',
-						'label' => 'Posts',
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'show_ui' => true,
 					],
 					(object) [
-						'name'  => 'page',
-						'label' => 'Pages',
+						'name'    => 'page',
+						'label'   => 'Pages',
+						'show_ui' => true,
 					],
 				],
 				'expected'                    => [
@@ -63,6 +65,26 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 					[
 						'name'  => 'page',
 						'label' => 'Pages',
+					],
+				],
+			],
+			'post type without UI is skipped' => [
+				'indexable_post_type_objects' => [
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'hidden',
+						'label'   => 'Hidden',
+						'show_ui' => false,
+					],
+				],
+				'expected'                    => [
+					[
+						'name'  => 'post',
+						'label' => 'Posts',
 					],
 				],
 			],

--- a/tests/Unit/Bulk_Editor/Infrastructure/Nonces/Nonce_Repository_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Nonces/Nonce_Repository_Test.php
@@ -1,0 +1,35 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Nonces;
+
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Nonce_Repository.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository::get_rest_nonce
+ */
+final class Nonce_Repository_Test extends TestCase {
+
+	/**
+	 * Tests getting the REST nonce.
+	 *
+	 * @return void
+	 */
+	public function test_get_rest_nonce() {
+		Functions\expect( 'wp_create_nonce' )
+			->once()
+			->with( 'wp_rest' )
+			->andReturn( 'rest-nonce' );
+
+		$instance = new Nonce_Repository();
+
+		$this->assertSame( 'rest-nonce', $instance->get_rest_nonce() );
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Abstract_Bulk_Editor_Integration_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Abstract_Bulk_Editor_Integration_Test.php
@@ -1,0 +1,97 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Mockery;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for the Bulk_Editor_Integration tests.
+ *
+ * @group bulk-editor
+ */
+abstract class Abstract_Bulk_Editor_Integration_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Bulk_Editor_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the WPSEO_Admin_Asset_Manager mock.
+	 *
+	 * @var Mockery\MockInterface|WPSEO_Admin_Asset_Manager
+	 */
+	protected $asset_manager;
+
+	/**
+	 * Holds the Current_Page_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Current_Page_Helper
+	 */
+	protected $current_page_helper;
+
+	/**
+	 * Holds the Product_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Product_Helper
+	 */
+	protected $product_helper;
+
+	/**
+	 * Holds the Short_Link_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Short_Link_Helper
+	 */
+	protected $short_link_helper;
+
+	/**
+	 * Holds the Content_Types_Repository mock.
+	 *
+	 * @var Mockery\MockInterface|Content_Types_Repository
+	 */
+	protected $content_types_repository;
+
+	/**
+	 * Holds the Nonce_Repository mock.
+	 *
+	 * @var Mockery\MockInterface|Nonce_Repository
+	 */
+	protected $nonce_repository;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->asset_manager            = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$this->current_page_helper      = Mockery::mock( Current_Page_Helper::class );
+		$this->product_helper           = Mockery::mock( Product_Helper::class );
+		$this->short_link_helper        = Mockery::mock( Short_Link_Helper::class );
+		$this->content_types_repository = Mockery::mock( Content_Types_Repository::class );
+		$this->nonce_repository         = Mockery::mock( Nonce_Repository::class );
+
+		$this->instance = new Bulk_Editor_Integration(
+			$this->asset_manager,
+			$this->current_page_helper,
+			$this->product_helper,
+			$this->short_link_helper,
+			$this->content_types_repository,
+			$this->nonce_repository,
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
@@ -1,0 +1,41 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+/**
+ * Tests adding the bulk editor page.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::add_page
+ */
+final class Add_Page_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests adding the bulk editor page.
+	 *
+	 * @return void
+	 */
+	public function test_add_page() {
+		$this->stubTranslationFunctions();
+
+		$this->assertEquals(
+			[
+				'wpseo_tools',
+				[
+					'wpseo_dashboard',
+					'',
+					'Bulk edit',
+					'edit_posts',
+					Bulk_Editor_Integration::PAGE,
+					[ $this->instance, 'display_page' ],
+				],
+			],
+			$this->instance->add_page( [ 'wpseo_tools' ] ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
@@ -29,8 +29,8 @@ final class Add_Page_Test extends Abstract_Bulk_Editor_Integration_Test {
 				[
 					'wpseo_dashboard',
 					'',
-					'Bulk edit',
-					'wpseo_bulk_edit',
+					'Bulk editor',
+					'wpseo_manage_options',
 					Bulk_Editor_Integration::PAGE,
 					[ $this->instance, 'display_page' ],
 				],

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Add_Page_Test.php
@@ -30,7 +30,7 @@ final class Add_Page_Test extends Abstract_Bulk_Editor_Integration_Test {
 					'wpseo_dashboard',
 					'',
 					'Bulk edit',
-					'edit_posts',
+					'wpseo_bulk_edit',
 					Bulk_Editor_Integration::PAGE,
 					[ $this->instance, 'display_page' ],
 				],

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Constructor_Test.php
@@ -1,0 +1,54 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Product_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
+
+/**
+ * Tests the Bulk_Editor_Integration constructor.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::__construct
+ */
+final class Constructor_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			WPSEO_Admin_Asset_Manager::class,
+			$this->getPropertyValue( $this->instance, 'asset_manager' ),
+		);
+		$this->assertInstanceOf(
+			Current_Page_Helper::class,
+			$this->getPropertyValue( $this->instance, 'current_page_helper' ),
+		);
+		$this->assertInstanceOf(
+			Product_Helper::class,
+			$this->getPropertyValue( $this->instance, 'product_helper' ),
+		);
+		$this->assertInstanceOf(
+			Short_Link_Helper::class,
+			$this->getPropertyValue( $this->instance, 'short_link_helper' ),
+		);
+		$this->assertInstanceOf(
+			Content_Types_Repository::class,
+			$this->getPropertyValue( $this->instance, 'content_types_repository' ),
+		);
+		$this->assertInstanceOf(
+			Nonce_Repository::class,
+			$this->getPropertyValue( $this->instance, 'nonce_repository' ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Display_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Display_Page_Test.php
@@ -1,0 +1,28 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+/**
+ * Tests displaying the bulk editor page.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::display_page
+ */
+final class Display_Page_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests displaying the bulk editor page.
+	 *
+	 * @return void
+	 */
+	public function test_display_page() {
+		\ob_start();
+		$this->instance->display_page();
+		$output = \ob_get_clean();
+
+		$this->assertSame( '<div id="yoast-seo-bulk-editor"></div>', $output );
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
@@ -1,0 +1,71 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+/**
+ * Tests enqueuing the assets.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::enqueue_assets
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::get_script_data
+ */
+final class Enqueue_Assets_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests enqueuing the assets.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_assets() {
+		$this->stubEscapeFunctions();
+
+		$content_types = [
+			[
+				'name'  => 'post',
+				'label' => 'Posts',
+			],
+		];
+
+		$expected_script_data = [
+			'contentTypes' => $content_types,
+			'endpoints'    => [],
+			'links'        => [],
+			'nonce'        => 'rest-nonce',
+			'restRoot'     => 'https://example.com/wp-json/',
+			'preferences'  => [
+				'isPremium' => false,
+				'isRtl'     => false,
+				'pluginUrl' => 'https://example.com/wp-content/plugins/wordpress-seo',
+			],
+			'linkParams'   => [ 'foo' => 'bar' ],
+		];
+
+		Actions\expectRemoved( 'admin_print_scripts' )->once()->with( 'print_emoji_detection_script' );
+
+		$this->asset_manager->expects( 'enqueue_script' )->once()->with( Bulk_Editor_Integration::ASSETS_NAME );
+		$this->asset_manager->expects( 'enqueue_style' )->once()->with( Bulk_Editor_Integration::ASSETS_NAME );
+
+		$this->content_types_repository->expects( 'get_content_types' )->once()->andReturn( $content_types );
+		$this->nonce_repository->expects( 'get_rest_nonce' )->once()->andReturn( 'rest-nonce' );
+		Functions\expect( 'rest_url' )->once()->withNoArgs()->andReturn( 'https://example.com/wp-json/' );
+		$this->product_helper->expects( 'is_premium' )->once()->andReturn( false );
+		Functions\expect( 'is_rtl' )->once()->withNoArgs()->andReturn( false );
+		Functions\expect( 'plugins_url' )
+			->once()
+			->andReturn( 'https://example.com/wp-content/plugins/wordpress-seo' );
+		$this->short_link_helper->expects( 'get_query_params' )->once()->andReturn( [ 'foo' => 'bar' ] );
+
+		$this->asset_manager->expects( 'localize_script' )
+			->once()
+			->with( Bulk_Editor_Integration::ASSETS_NAME, 'wpseoBulkEditorData', $expected_script_data );
+
+		$this->instance->enqueue_assets();
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Get_Conditionals_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Get_Conditionals_Test.php
@@ -1,0 +1,27 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+
+/**
+ * Tests the retrieval of the conditionals.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::get_conditionals
+ */
+final class Get_Conditionals_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests the retrieval of the conditionals.
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Admin_Conditional::class ], Bulk_Editor_Integration::get_conditionals() );
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Register_Hooks_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Register_Hooks_Test.php
@@ -1,0 +1,57 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+/**
+ * Tests the registration of the hooks.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::register_hooks
+ */
+final class Register_Hooks_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests the registration of the hooks when not on the bulk editor page.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_not_on_bulk_editor_page() {
+		Filters\expectAdded( 'wpseo_submenu_pages' )->once()->with( [ $this->instance, 'add_page' ] );
+
+		$this->current_page_helper->expects( 'get_current_yoast_seo_page' )
+			->once()
+			->withNoArgs()
+			->andReturn( 'foo' );
+
+		Actions\expectAdded( 'admin_enqueue_scripts' )->never();
+		Actions\expectAdded( 'in_admin_header' )->never();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests the registration of the hooks when on the bulk editor page.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_on_bulk_editor_page() {
+		Filters\expectAdded( 'wpseo_submenu_pages' )->once()->with( [ $this->instance, 'add_page' ] );
+
+		$this->current_page_helper->expects( 'get_current_yoast_seo_page' )
+			->once()
+			->withNoArgs()
+			->andReturn( Bulk_Editor_Integration::PAGE );
+
+		Actions\expectAdded( 'admin_enqueue_scripts' )->once()->with( [ $this->instance, 'enqueue_assets' ] );
+		Actions\expectAdded( 'in_admin_header' )->once()->with( [ $this->instance, 'remove_notices' ], \PHP_INT_MAX );
+
+		$this->instance->register_hooks();
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Remove_Notices_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Remove_Notices_Test.php
@@ -1,0 +1,30 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests removing notices in the admin header.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration::remove_notices
+ */
+final class Remove_Notices_Test extends Abstract_Bulk_Editor_Integration_Test {
+
+	/**
+	 * Tests removing notices in the admin header.
+	 *
+	 * @return void
+	 */
+	public function test_remove_notices() {
+		Functions\expect( 'remove_all_actions' )
+			->with( 'admin_notices', 'user_admin_notices', 'network_admin_notices', 'all_admin_notices' )
+			->times( 4 );
+
+		$this->instance->remove_notices();
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Remove_Notices_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Remove_Notices_Test.php
@@ -21,9 +21,10 @@ final class Remove_Notices_Test extends Abstract_Bulk_Editor_Integration_Test {
 	 * @return void
 	 */
 	public function test_remove_notices() {
-		Functions\expect( 'remove_all_actions' )
-			->with( 'admin_notices', 'user_admin_notices', 'network_admin_notices', 'all_admin_notices' )
-			->times( 4 );
+		Functions\expect( 'remove_all_actions' )->once()->with( 'admin_notices' );
+		Functions\expect( 'remove_all_actions' )->once()->with( 'user_admin_notices' );
+		Functions\expect( 'remove_all_actions' )->once()->with( 'network_admin_notices' );
+		Functions\expect( 'remove_all_actions' )->once()->with( 'all_admin_notices' );
 
 		$this->instance->remove_notices();
 	}


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This PR stands up the foundation: a new onion feature folder `src/bulk-editor/` with a page integration that registers a standalone `wpseo_page_bulk_edit` page, enqueues the new `bulk-editor-page` script + style, and localizes `wpseoBulkEditorData` (content types, endpoint/link stubs, REST nonce + root, isPremium, isRtl, linkParams).
* On the JS side it scaffolds `packages/js/src/bulk-editor/` with the DataProvider + RemoteDataProvider seam, a `@wordpress/data` view-state store, and a SlotFillProvider + hash router, mounted **without** the ui-library `Root` wrapper (Root-independent rendering, RFC Yoast/engineering#16).

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces the scaffold for the new Bulk edit admin page.

## Relevant technical choices:

* Script data is localized to a dedicated `wpseoBulkEditorData` object (instead of the shared `wpseoScriptData`) to keep the app's data namespaced from the start.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out this branch, run `composer install`, `yarn install`, and `yarn build` (or `grunt build:dev`).
* In the admin menu, go to **Yoast SEO** and verify a new **Bulk edit** submenu item appears (at the bottom of the Yoast SEO menu).
* Click **Bulk edit** and verify a placeholder page loads with the title "Bulk edit" and a bullet list of your site's content types (at least "Posts" and "Pages").
* In the console, type `wpseoBulkEditorData` and verify it contains `contentTypes`, `endpoints`, `links`, `nonce`, `restRoot`, `preferences`, and `linkParams`.
* Go to **Yoast SEO → Tools → Bulk editor** and verify the existing (old) bulk editor still works exactly as before: the tabs, the post list, and saving a new title still function.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
The console should show no errors when loading the new Bulk edit page; the React app is mounted without the ui-library `Root` wrapper, so styling glitches or context errors would surface there.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable — this PR targets the `feature/bulk-editor` epic branch; QA happens at the epic level once the full bulk editor UI is in place.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO admin menu (a new submenu item is added via the `wpseo_submenu_pages` filter).
* The admin asset manager (a new style registration was added to `styles_to_be_loaded()`).
* The legacy Tools → Bulk editor page should be regression-tested to confirm it is unaffected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1278
