### PR TITLE
fix(components): replace function-component defaultProps with ES6 defaults for React 19

### DIFF
--- a/packages/components/src/ArticleList.js
+++ b/packages/components/src/ArticleList.js
@@ -103,23 +103,23 @@ ArticleListItem.propTypes = {
  *
  * @returns {ReactElement} The ArticleList component.
  */
-const ArticleList = ( props ) => {
+const ArticleList = ( { className = "articlelist-feed", feed, title, footerLinkText, feedLink } ) => {
 	return (
 		<ArticleListContainer
-			className={ props.className }
+			className={ className }
 		>
 			<ArticleListHeader
-				className={ `${ props.className }__header` }
+				className={ `${ className }__header` }
 			>
-				{ props.title ? props.title : props.feed.title }
+				{ title ? title : feed.title }
 			</ArticleListHeader>
 			<FeedList
-				className={ `${ props.className }__posts` }
+				className={ `${ className }__posts` }
 				role="list"
 			>
-				{ props.feed.items.map( item => (
+				{ feed.items.map( item => (
 					<ArticleListItem
-						className={ `${ props.className }__post` }
+						className={ `${ className }__post` }
 						key={ item.link }
 						title={ item.title }
 						link={ item.link }
@@ -127,15 +127,15 @@ const ArticleList = ( props ) => {
 					/>
 				) ) }
 			</FeedList>
-			{ props.footerLinkText &&
+			{ footerLinkText &&
 			<ArticleListFooter
-				className={ `${ props.className }__footer` }
+				className={ `${ className }__footer` }
 			>
 				<ArticleListLink
-					className={ `${ props.className }__footer-link` }
-					href={ props.feedLink ? props.feedLink : props.feed.link }
+					className={ `${ className }__footer-link` }
+					href={ feedLink ? feedLink : feed.link }
 				>
-					{ props.footerLinkText }
+					{ footerLinkText }
 				</ArticleListLink>
 			</ArticleListFooter>
 			}
@@ -149,10 +149,6 @@ ArticleList.propTypes = {
 	title: PropTypes.string,
 	footerLinkText: PropTypes.string,
 	feedLink: PropTypes.string,
-};
-
-ArticleList.defaultProps = {
-	className: "articlelist-feed",
 };
 
 export default ArticleList;

--- a/packages/components/src/CardBanner.js
+++ b/packages/components/src/CardBanner.js
@@ -37,10 +37,14 @@ const BannerTriangle = styled.span`
  * @returns {ReactElement} The banner element.
  * @constructor
  */
-export default function Banner( props ) {
+export default function Banner( {
+	backgroundColor = colors.$color_pink_dark,
+	textColor = colors.$color_white,
+	children = null,
+} ) {
 	return <Fragment>
-		<BannerContents backgroundColor={ props.backgroundColor } textColor={ props.textColor }>
-			{ props.children }
+		<BannerContents backgroundColor={ backgroundColor } textColor={ textColor }>
+			{ children }
 		</BannerContents>
 		<BannerTriangle />
 	</Fragment>;
@@ -50,10 +54,4 @@ Banner.propTypes = {
 	backgroundColor: PropTypes.string,
 	textColor: PropTypes.string,
 	children: PropTypes.any,
-};
-
-Banner.defaultProps = {
-	backgroundColor: colors.$color_pink_dark,
-	textColor: colors.$color_white,
-	children: null,
 };

--- a/packages/components/src/Collapsible.js
+++ b/packages/components/src/Collapsible.js
@@ -115,23 +115,23 @@ const StyledHeading = wrapInHeading( StyledIconsButton, { level: 2, fontSize: "1
  */
 export function CollapsibleStateless( props ) {
 	const {
-		children,
-		className,
-		hasPadding,
-		hasSeparator,
-		Heading,
-		id,
+		children = null,
+		className = null,
+		hasPadding = false,
+		hasSeparator = false,
+		Heading = StyledHeading,
+		id = null,
 		isOpen,
 		onToggle,
-		prefixIcon,
-		prefixIconCollapsed,
-		suffixIcon,
-		suffixIconCollapsed,
-		subTitle,
+		prefixIcon = null,
+		prefixIconCollapsed = null,
+		suffixIcon = null,
+		suffixIconCollapsed = null,
+		subTitle = null,
 		title,
-		titleScreenReaderText,
-		renderNewBadgeLabel,
-		hasNewBadgeLabel,
+		titleScreenReaderText = null,
+		renderNewBadgeLabel = () => {},
+		hasNewBadgeLabel = false,
 	} = props;
 
 	let wrappedChildren = children;
@@ -203,23 +203,6 @@ CollapsibleStateless.propTypes = {
 	id: PropTypes.string,
 	renderNewBadgeLabel: PropTypes.func,
 	hasNewBadgeLabel: PropTypes.bool,
-};
-
-CollapsibleStateless.defaultProps = {
-	Heading: StyledHeading,
-	id: null,
-	children: null,
-	className: null,
-	subTitle: null,
-	titleScreenReaderText: null,
-	hasSeparator: false,
-	hasPadding: false,
-	prefixIcon: null,
-	prefixIconCollapsed: null,
-	suffixIcon: null,
-	suffixIconCollapsed: null,
-	renderNewBadgeLabel: () => {},
-	hasNewBadgeLabel: false,
 };
 
 /**

--- a/packages/components/src/Heading.js
+++ b/packages/components/src/Heading.js
@@ -7,12 +7,12 @@ import PropTypes from "prop-types";
  * @param {Object} props The props to use.
  * @returns {ReactElement} The rendered component.
  */
-const Heading = ( props ) => {
-	const HeadingLevel = `h${ props.level }`;
+const Heading = ( { level = 1, className, children } ) => {
+	const HeadingLevel = `h${ level }`;
 
 	return (
-		<HeadingLevel className={ props.className }>
-			{ props.children }
+		<HeadingLevel className={ className }>
+			{ children }
 		</HeadingLevel>
 	);
 };
@@ -21,10 +21,6 @@ Heading.propTypes = {
 	level: PropTypes.number,
 	className: PropTypes.string,
 	children: PropTypes.any,
-};
-
-Heading.defaultProps = {
-	level: 1,
 };
 
 export default Heading;

--- a/packages/components/src/Icon.js
+++ b/packages/components/src/Icon.js
@@ -11,9 +11,10 @@ import _omit from "lodash/omit";
  * @returns {ReactElement} Icon component.
  */
 const Icon = ( props ) => {
+	const { width = "16px", height = "16px" } = props;
 	const IconComponent = styled( props.icon )`
-		width: ${ props.width };
-		height: ${ props.height };
+		width: ${ width };
+		height: ${ height };
 		${ props.color ? `fill: ${ props.color };` : "" }
 		flex: 0 0 auto;
 	`;
@@ -29,11 +30,6 @@ Icon.propTypes = {
 	width: PropTypes.string,
 	height: PropTypes.string,
 	color: PropTypes.string,
-};
-
-Icon.defaultProps = {
-	width: "16px",
-	height: "16px",
 };
 
 export default Icon;

--- a/packages/components/src/IconButtonToggle.js
+++ b/packages/components/src/IconButtonToggle.js
@@ -26,11 +26,6 @@ const changingIconButtonDefaults = {
  * @returns {ReactElement} ChangingIconButton component.
  */
 const ChangingIconButton = function( componentProps ) {
-	/*
-	 * React 19's automatic JSX runtime no longer applies defaultProps to function components, which
-	 * would drop these colours to undefined and render the button unstyled. Merging the defaults here
-	 * keeps them on both runtimes; defaultProps is kept as well for classic consumers.
-	 */
 	const props = { ...changingIconButtonDefaults, ...componentProps };
 	const buttonsAreDisabled = props.marksButtonStatus === "disabled";
 
@@ -85,8 +80,5 @@ ChangingIconButton.propTypes = {
 	disabledIconColor: PropTypes.string,
 	className: PropTypes.string,
 };
-
-// Kept for classic-runtime consumers; the in-component merge applies these on React 19.
-ChangingIconButton.defaultProps = changingIconButtonDefaults;
 
 export default ChangingIconButton;

--- a/packages/components/src/IconCTAEditButton.js
+++ b/packages/components/src/IconCTAEditButton.js
@@ -33,22 +33,32 @@ const IconButtonBase = styled.button`
  *
  * @returns {ReactElement} IconCTAEditButton component.
  */
-const IconCTAEditButton = function( props ) {
+const IconCTAEditButton = function( {
+	id,
+	ariaLabel,
+	onClick,
+	boxShadowColor = colors.$color_button_border,
+	background = colors.$color_button,
+	iconColor = colors.$color_button_text,
+	icon,
+	hoverBorderColor = colors.$color_white,
+	className,
+} ) {
 	return (
 		<IconButtonBase
 			type="button"
-			onClick={ props.onClick }
-			boxShadowColor={ props.boxShadowColor }
-			background={ props.background }
-			id={ props.id }
-			aria-label={ props.ariaLabel }
-			iconColor={ props.iconColor }
-			hoverBorderColor={ props.hoverBorderColor }
-			className={ props.className }
+			onClick={ onClick }
+			boxShadowColor={ boxShadowColor }
+			background={ background }
+			id={ id }
+			aria-label={ ariaLabel }
+			iconColor={ iconColor }
+			hoverBorderColor={ hoverBorderColor }
+			className={ className }
 		>
 			<SvgIcon
-				icon={ props.icon }
-				color={ props.iconColor }
+				icon={ icon }
+				color={ iconColor }
 				size="18px"
 			/>
 		</IconButtonBase>
@@ -65,13 +75,6 @@ IconCTAEditButton.propTypes = {
 	icon: PropTypes.string.isRequired,
 	hoverBorderColor: PropTypes.string,
 	className: PropTypes.string,
-};
-
-IconCTAEditButton.defaultProps = {
-	boxShadowColor: colors.$color_button_border,
-	background: colors.$color_button,
-	iconColor: colors.$color_button_text,
-	hoverBorderColor: colors.$color_white,
 };
 
 export default IconCTAEditButton;

--- a/packages/components/src/Label.js
+++ b/packages/components/src/Label.js
@@ -21,14 +21,14 @@ export const SimulatedLabel = styled.div`
  * @returns {JSX} A representation of the label HTML element based on the passed props.
  * @constructor
  */
-const Label = ( props ) => {
+const Label = ( { "for": htmlFor, className = "", optionalAttributes = {}, children } ) => {
 	return (
 		<label
-			htmlFor={ props.for }
-			className={ props.className }
-			{ ...props.optionalAttributes }
+			htmlFor={ htmlFor }
+			className={ className }
+			{ ...optionalAttributes }
 		>
-			{ props.children }
+			{ children }
 		</label>
 	);
 };
@@ -47,16 +47,6 @@ Label.propTypes = {
 	} ),
 	children: PropTypes.any.isRequired,
 	className: PropTypes.string,
-};
-
-/**
- * Defines the default values for the properties.
- *
- * @type {{for: string, text: string}}
- */
-Label.defaultProps = {
-	className: "",
-	optionalAttributes: {},
 };
 
 export default Label;

--- a/packages/components/src/Loader.js
+++ b/packages/components/src/Loader.js
@@ -9,7 +9,7 @@ import styled, { keyframes } from "styled-components";
  *
  * @returns {React.Element} The Loader component.
  */
-const Loader = ( { className } ) => {
+const Loader = ( { className = "" } ) => {
 	if ( className !== "" ) {
 		className += " ";
 	}
@@ -75,10 +75,6 @@ const Loader = ( { className } ) => {
 
 Loader.propTypes = {
 	className: PropTypes.string,
-};
-
-Loader.defaultProps = {
-	className: "",
 };
 
 const heartbeat = keyframes`

--- a/packages/components/src/Notification.js
+++ b/packages/components/src/Notification.js
@@ -80,23 +80,32 @@ const StyledIcon = styled( SvgIcon )`
  *
  * @returns {ReactElement} styled notification.
  */
-function Notification( props ) {
-	const Heading = `${ props.headingLevel }`;
+function Notification( {
+	imageSrc,
+	imageWidth,
+	imageHeight,
+	title,
+	html,
+	isDismissable = false,
+	onClick,
+	headingLevel = "h3",
+} ) {
+	const Heading = `${ headingLevel }`;
 
 	return <Paper>
-		<NotificationContainer isDismissable={ props.isDismissable }>
-			{ props.imageSrc && <NotificationImage
-				src={ props.imageSrc }
-				imageWidth={ props.imageWidth }
-				imageHeight={ props.imageHeight }
+		<NotificationContainer isDismissable={ isDismissable }>
+			{ imageSrc && <NotificationImage
+				src={ imageSrc }
+				imageWidth={ imageWidth }
+				imageHeight={ imageHeight }
 				alt=""
 			/> }
 			<NotificationContent>
-				<Heading>{ props.title }</Heading>
-				<p className="prova" dangerouslySetInnerHTML={ { __html: props.html } } />
+				<Heading>{ title }</Heading>
+				<p className="prova" dangerouslySetInnerHTML={ { __html: html } } />
 			</NotificationContent>
-			{ props.isDismissable && <DismissButton
-				onClick={ props.onClick }
+			{ isDismissable && <DismissButton
+				onClick={ onClick }
 				type="button"
 				aria-label={ __( "Dismiss this notice", "wordpress-seo" ) }
 			>
@@ -115,11 +124,6 @@ Notification.propTypes = {
 	isDismissable: PropTypes.bool,
 	onClick: PropTypes.func,
 	headingLevel: PropTypes.string,
-};
-
-Notification.defaultProps = {
-	isDismissable: false,
-	headingLevel: "h3",
 };
 
 export default Notification;

--- a/packages/components/src/Paper.js
+++ b/packages/components/src/Paper.js
@@ -11,7 +11,7 @@ import { colors } from "@yoast/style-guide";
  *
  * @returns {ReactElement} The paper-styled div.
  */
-const Paper = styled.div`
+const Paper = styled.div.attrs( ( { backgroundColor = colors.$color_white, minHeight = "0" } ) => ( { backgroundColor, minHeight } ) )`
 	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 	background-color: ${ props => props.backgroundColor };
 	min-height: ${ props => props.minHeight };
@@ -20,11 +20,6 @@ const Paper = styled.div`
 Paper.propTypes = {
 	backgroundColor: PropTypes.string,
 	minHeight: PropTypes.string,
-};
-
-Paper.defaultProps = {
-	backgroundColor: colors.$color_white,
-	minHeight: "0",
 };
 
 export default Paper;

--- a/packages/components/src/ProgressBar.js
+++ b/packages/components/src/ProgressBar.js
@@ -12,7 +12,14 @@ import { colors } from "@yoast/style-guide";
  *
  * @returns {ReactElement} The ProgressBar component.
  */
-const ProgressBar = styled.progress`
+const ProgressBar = styled.progress.attrs( ( {
+	max = 1,
+	value = 0,
+	progressColor = colors.$color_good,
+	backgroundColor = colors.$color_background_light,
+	borderColor = colors.$color_input_border,
+	"aria-hidden": ariaHidden = "true",
+} ) => ( { max, value, progressColor, backgroundColor, borderColor, "aria-hidden": ariaHidden } ) )`
 	box-sizing: border-box;
 	width: 100%;
 	height: 8px;
@@ -40,16 +47,6 @@ const ProgressBar = styled.progress`
 		border: 0;
 	}
 `;
-
-
-ProgressBar.defaultProps = {
-	max: 1,
-	value: 0,
-	progressColor: colors.$color_good,
-	backgroundColor: colors.$color_background_light,
-	borderColor: colors.$color_input_border,
-	"aria-hidden": "true",
-};
 
 ProgressBar.propTypes = {
 	max: PropTypes.number,

--- a/packages/components/src/ScoreAssessments.js
+++ b/packages/components/src/ScoreAssessments.js
@@ -97,15 +97,15 @@ const ScoreAssessmentList = styled.ul`
  *
  * @returns {ReactElement} The rendered component.
  */
-const ScoreAssessments = ( props ) => {
+const ScoreAssessments = ( { className = "score-assessments", items } ) => {
 	return (
 		<ScoreAssessmentList
-			className={ props.className }
+			className={ className }
 			role="list"
 		>
-			{ props.items.map( ( item, index ) =>
+			{ items.map( ( item, index ) =>
 				<ScoreAssessment
-					className={ `${ props.className }__item` }
+					className={ `${ className }__item` }
 					key={ index }
 					scoreColor={ item.color }
 					html={ item.html }
@@ -125,10 +125,6 @@ ScoreAssessments.propTypes = {
 			value: PropTypes.number,
 		} )
 	),
-};
-
-ScoreAssessments.defaultProps = {
-	className: "score-assessments",
 };
 
 export default ScoreAssessments;

--- a/packages/components/src/Section.js
+++ b/packages/components/src/Section.js
@@ -9,15 +9,15 @@ import Heading from "./Heading";
  * @param {Object} props The props to use.
  * @returns {ReactElement} The rendered component.
  */
-const Section = ( props ) => {
+const Section = ( { className, headingText, headingLevel = 1, headingClassName, children } ) => {
 	return (
-		<section className={ props.className }>
-			{ props.headingText &&
-				<Heading level={ props.headingLevel } className={ props.headingClassName }>
-					{ props.headingText }
+		<section className={ className }>
+			{ headingText &&
+				<Heading level={ headingLevel } className={ headingClassName }>
+					{ headingText }
 				</Heading>
 			}
-			{ props.children }
+			{ children }
 		</section>
 	);
 };
@@ -28,10 +28,6 @@ Section.propTypes = {
 	headingLevel: PropTypes.number,
 	headingClassName: PropTypes.string,
 	children: PropTypes.any,
-};
-
-Section.defaultProps = {
-	headingLevel: 1,
 };
 
 export default Section;

--- a/packages/components/src/StackedProgressBar.js
+++ b/packages/components/src/StackedProgressBar.js
@@ -28,11 +28,11 @@ StackedProgressBarProgress.propTypes = {
  *
  * @returns {ReactElement} The StackedProgressBarContainer component.
  */
-const StackedProgressBar = ( props ) => {
+const StackedProgressBar = ( { className = "stacked-progress-bar", items, barHeight = "24px" } ) => {
 	let totalValue = 0;
-	for ( let i = 0; i < props.items.length; i++ ) {
-		props.items[ i ].value = Math.max( props.items[ i ].value, 0 );
-		totalValue += props.items[ i ].value;
+	for ( let i = 0; i < items.length; i++ ) {
+		items[ i ].value = Math.max( items[ i ].value, 0 );
+		totalValue += items[ i ].value;
 	}
 
 	if ( totalValue <= 0 ) {
@@ -41,12 +41,12 @@ const StackedProgressBar = ( props ) => {
 
 	return (
 		<StackedProgressBarContainer
-			className={ props.className }
-			barHeight={ props.barHeight }
+			className={ className }
+			barHeight={ barHeight }
 		>
-			{ props.items.map( ( item, index ) =>
+			{ items.map( ( item, index ) =>
 				<StackedProgressBarProgress
-					className={ `${ props.className }__part` }
+					className={ `${ className }__part` }
 					key={ index }
 					progressColor={ item.color }
 					progressWidth={ item.value / totalValue * 100 }
@@ -65,11 +65,6 @@ StackedProgressBar.propTypes = {
 		} )
 	),
 	barHeight: PropTypes.string,
-};
-
-StackedProgressBar.defaultProps = {
-	className: "stacked-progress-bar",
-	barHeight: "24px",
 };
 
 export default StackedProgressBar;

--- a/packages/components/src/StyledSection.js
+++ b/packages/components/src/StyledSection.js
@@ -68,29 +68,40 @@ export const StyledSectionBase = styled( Section )`
  *
  * @returns {ReactElement} The rendered component.
  */
-const StyledSection = ( props ) => {
+const StyledSection = ( {
+	className = "yoast-section",
+	headingLevel = 2,
+	headingClassName,
+	headingColor,
+	headingIcon,
+	headingIconColor,
+	headingIconSize,
+	headingText,
+	hasPaperStyle = true,
+	children,
+} ) => {
 	return (
 		<StyledSectionBase
-			className={ props.className }
-			headingColor={ props.headingColor }
-			hasPaperStyle={ props.hasPaperStyle }
+			className={ className }
+			headingColor={ headingColor }
+			hasPaperStyle={ hasPaperStyle }
 		>
-			{ props.headingText &&
+			{ headingText &&
 				<StyledHeading
-					level={ props.headingLevel }
-					className={ props.headingClassName }
+					level={ headingLevel }
+					className={ headingClassName }
 				>
-					{ props.headingIcon &&
+					{ headingIcon &&
 						<StyledIcon
-							icon={ props.headingIcon }
-							color={ props.headingIconColor }
-							size={ props.headingIconSize }
+							icon={ headingIcon }
+							color={ headingIconColor }
+							size={ headingIconSize }
 						/>
 					}
-					{ props.headingText }
+					{ headingText }
 				</StyledHeading>
 			}
-			{ props.children }
+			{ children }
 		</StyledSectionBase>
 	);
 };
@@ -106,12 +117,6 @@ StyledSection.propTypes = {
 	headingText: PropTypes.string,
 	hasPaperStyle: PropTypes.bool,
 	children: PropTypes.any,
-};
-
-StyledSection.defaultProps = {
-	className: "yoast-section",
-	headingLevel: 2,
-	hasPaperStyle: true,
 };
 
 export default StyledSection;

--- a/packages/components/src/SynonymsInput.js
+++ b/packages/components/src/SynonymsInput.js
@@ -33,7 +33,6 @@ const SynonymsInput = ( props ) => {
 		type = "text",
 		...inputProps
 	} = props;
-	inputProps.type = type;
 
 	return (
 		<InputContainer>
@@ -45,6 +44,7 @@ const SynonymsInput = ( props ) => {
 			</SynonymsFieldLabelContainer>
 			<InputField
 				{ ...inputProps }
+				type={ type }
 				autoComplete="off"
 			/>
 		</InputContainer>

--- a/packages/components/src/SynonymsInput.js
+++ b/packages/components/src/SynonymsInput.js
@@ -28,10 +28,12 @@ const StyledYoastInputLabel = styled( InputLabel )`
  */
 const SynonymsInput = ( props ) => {
 	const {
-		label,
-		helpLink,
+		label = "",
+		helpLink = null,
+		type = "text",
 		...inputProps
 	} = props;
+	inputProps.type = type;
 
 	return (
 		<InputContainer>
@@ -54,12 +56,6 @@ SynonymsInput.propTypes = {
 	id: PropTypes.string.isRequired,
 	label: PropTypes.string,
 	helpLink: PropTypes.node,
-};
-
-SynonymsInput.defaultProps = {
-	type: "text",
-	label: "",
-	helpLink: null,
 };
 
 export default SynonymsInput;

--- a/packages/components/src/WordList.js
+++ b/packages/components/src/WordList.js
@@ -19,7 +19,7 @@ import PropTypes from "prop-types";
 const WordList = ( props ) => {
 	console.warn( "The WordList component has been deprecated and will be removed in a future release." );
 
-	const { title, classNamePrefix, words, header, footer } = props;
+	const { title, classNamePrefix = "", words, header = "", footer = "" } = props;
 
 	const list = (
 		<ol className={ classNamePrefix + "__list" }>
@@ -52,12 +52,6 @@ WordList.propTypes = {
 	header: PropTypes.string,
 	footer: PropTypes.string,
 	classNamePrefix: PropTypes.string,
-};
-
-WordList.defaultProps = {
-	classNamePrefix: "",
-	header: "",
-	footer: "",
 };
 
 export default WordList;

--- a/packages/components/src/YouTubeVideo.js
+++ b/packages/components/src/YouTubeVideo.js
@@ -28,10 +28,20 @@ const YoutubeVideoContainer = styled.div`
  *
  * @returns {ReactElement} The YouTubeVideo component.
  */
-export default function YouTubeVideo( props ) {
+export default function YouTubeVideo( {
+	width = 560,
+	height = 315,
+	frameBorder = 0,
+	allowFullScreen = true,
+	...props
+} ) {
 	return (
 		<YoutubeVideoContainer>
 			<IFrame
+				width={ width }
+				height={ height }
+				frameBorder={ frameBorder }
+				allowFullScreen={ allowFullScreen }
 				{ ...props }
 			/>
 		</YoutubeVideoContainer>
@@ -45,11 +55,4 @@ YouTubeVideo.propTypes = {
 	title: PropTypes.string.isRequired,
 	frameBorder: PropTypes.number,
 	allowFullScreen: PropTypes.bool,
-};
-
-YouTubeVideo.defaultProps = {
-	width: 560,
-	height: 315,
-	frameBorder: 0,
-	allowFullScreen: true,
 };

--- a/packages/components/src/button/Button.js
+++ b/packages/components/src/button/Button.js
@@ -72,12 +72,12 @@ const getVariantIcons = variant => variantToIcon[ variant ] || null;
 export const Button = ( props ) => {
 	// Split Button.js specific props from all other props.
 	const {
-		children,
-		className,
-		variant,
-		small,
-		type,
-		buttonRef,
+		children = null,
+		className = "",
+		variant = "primary",
+		small = false,
+		type = "button",
+		buttonRef = null,
 		...restProps
 	} = props;
 
@@ -112,16 +112,6 @@ Button.propTypes = {
 	),
 };
 
-Button.defaultProps = {
-	className: "",
-	type: "button",
-	variant: "primary",
-	small: false,
-	children: null,
-	onClick: null,
-	buttonRef: null,
-};
-
 /**
  * A link, styled to look like a button.
  *
@@ -136,11 +126,11 @@ Button.defaultProps = {
  */
 export const ButtonStyledLink = ( props ) => {
 	const {
-		children,
-		className,
-		variant,
-		small,
-		buttonRef,
+		children = null,
+		className = "",
+		variant = "primary",
+		small = false,
+		buttonRef = null,
 		...restProps
 	} = props;
 
@@ -171,12 +161,4 @@ ButtonStyledLink.propTypes = {
 			PropTypes.arrayOf( PropTypes.node ),
 		]
 	),
-};
-
-ButtonStyledLink.defaultProps = {
-	className: "",
-	variant: "primary",
-	small: false,
-	children: null,
-	buttonRef: null,
 };

--- a/packages/components/src/buttons/Button.js
+++ b/packages/components/src/buttons/Button.js
@@ -18,7 +18,7 @@ const ieMinHeight = settings.minHeight - ( settings.verticalPadding * 2 ) - ( se
  * Builds a styled-components `attrs` callback that fills in the given defaults for any prop that is
  * not provided. React 19's automatic JSX runtime no longer applies `defaultProps` to function /
  * `forwardRef` components (styled components included), so applying the defaults here keeps them
- * working on both runtimes; `defaultProps` is kept as well for classic consumers.
+ * working on both runtimes.
  *
  * @param {Object} defaults The default prop values.
  *
@@ -209,9 +209,6 @@ BaseButton.propTypes = {
 	focusBorderColor: PropTypes.string,
 	focusBoxShadowColor: PropTypes.string,
 };
-
-// Kept for classic-runtime consumers; addButtonStyles applies these via .attrs for React 19.
-BaseButton.defaultProps = baseButtonDefaults;
 
 /**
  * Returns a styled Button with set font size.

--- a/packages/components/src/buttons/IconButton.js
+++ b/packages/components/src/buttons/IconButton.js
@@ -33,7 +33,7 @@ function addIconTextStyle( icon ) {
  * @returns {ReactElement} styled icon button.
  */
 const IconButton = ( props ) => {
-	const { children: text, icon, iconColor } = props;
+	const { children: text, icon, iconColor = "#000" } = props;
 
 	let IconComponent = SvgIcon;
 	if ( text ) {
@@ -58,10 +58,6 @@ IconButton.propTypes = {
 		PropTypes.node,
 		PropTypes.string,
 	] ),
-};
-
-IconButton.defaultProps = {
-	iconColor: "#000",
 };
 
 export default IconButton;

--- a/packages/components/src/buttons/IconLabeledButton.js
+++ b/packages/components/src/buttons/IconLabeledButton.js
@@ -68,6 +68,24 @@ const IconLabelledBaseButton = addButtonStyles(
 	`
 );
 
+const iconLabeledButtonDefaults = {
+	type: "button",
+	textColor: colors.$color_blue,
+	textFontSize: "inherit",
+	backgroundColor: "transparent",
+	borderColor: "transparent",
+	hoverColor: colors.$color_white,
+	hoverBackgroundColor: colors.$color_blue,
+	hoverBorderColor: colors.$color_button_border_hover,
+	activeColor: colors.$color_white,
+	activeBackgroundColor: colors.$color_blue,
+	activeBorderColor: colors.$color_button_border_active,
+	focusColor: colors.$color_white,
+	focusBackgroundColor: colors.$color_blue,
+	focusBorderColor: colors.$color_blue,
+	focusBoxShadowColor: colors.$color_blue_dark,
+};
+
 /**
  * Returns an icon button that can optionally contain text.
  *
@@ -75,7 +93,8 @@ const IconLabelledBaseButton = addButtonStyles(
  *
  * @returns {ReactElement} Styled icon button.
  */
-const IconLabeledButton = ( props ) => {
+const IconLabeledButton = ( incomingProps ) => {
+	const props = { ...iconLabeledButtonDefaults, ...incomingProps };
 	const { children, icon, textColor } = props;
 
 	const newProps = omit( props, "icon" );
@@ -110,24 +129,6 @@ IconLabeledButton.propTypes = {
 		PropTypes.node,
 		PropTypes.string,
 	] ).isRequired,
-};
-
-IconLabeledButton.defaultProps = {
-	type: "button",
-	textColor: colors.$color_blue,
-	textFontSize: "inherit",
-	backgroundColor: "transparent",
-	borderColor: "transparent",
-	hoverColor: colors.$color_white,
-	hoverBackgroundColor: colors.$color_blue,
-	hoverBorderColor: colors.$color_button_border_hover,
-	activeColor: colors.$color_white,
-	activeBackgroundColor: colors.$color_blue,
-	activeBorderColor: colors.$color_button_border_active,
-	focusColor: colors.$color_white,
-	focusBackgroundColor: colors.$color_blue,
-	focusBorderColor: colors.$color_blue,
-	focusBoxShadowColor: colors.$color_blue_dark,
 };
 
 export default IconLabeledButton;

--- a/packages/components/src/buttons/LinkButton.js
+++ b/packages/components/src/buttons/LinkButton.js
@@ -59,6 +59,3 @@ LinkButton.propTypes = {
 	focusBorderColor: PropTypes.string,
 	focusBoxShadowColor: PropTypes.string,
 };
-
-// Kept for classic-runtime consumers; the `.attrs` above is what applies these on React 19.
-LinkButton.defaultProps = linkButtonDefaults;

--- a/packages/components/src/buttons/UpsellButton.js
+++ b/packages/components/src/buttons/UpsellButton.js
@@ -86,7 +86,11 @@ export function addButtonStyles( component ) {
  * @returns {ReactElement} The upsell button.
  */
 export const UpsellButtonBase = addButtonStyles(
-	styled( YoastButtonBase )`
+	styled( YoastButtonBase ).attrs( ( {
+		backgroundColor = colors.$color_button_upsell,
+		hoverColor = colors.$color_button_hover_upsell,
+		textColor = colors.$color_black,
+	} ) => ( { backgroundColor, hoverColor, textColor } ) )`
 		color: ${ props => props.textColor };
 		background: ${ props => props.backgroundColor };
 		overflow: visible;
@@ -110,12 +114,6 @@ UpsellButtonBase.propTypes = {
 	backgroundColor: PropTypes.string,
 	hoverColor: PropTypes.string,
 	textColor: PropTypes.string,
-};
-
-UpsellButtonBase.defaultProps = {
-	backgroundColor: colors.$color_button_upsell,
-	hoverColor: colors.$color_button_hover_upsell,
-	textColor: colors.$color_black,
 };
 
 /**

--- a/packages/components/src/buttons/YoastButton.js
+++ b/packages/components/src/buttons/YoastButton.js
@@ -77,7 +77,7 @@ export function addButtonStyles( component ) {
  *
  * @returns {ReactElement} The button with inner span.
  */
-export const YoastButtonBase = ( { className, onClick, type, children, isExpanded } ) => (
+export const YoastButtonBase = ( { className, onClick, type = "button", children, isExpanded } ) => (
 	<button className={ className } onClick={ onClick } type={ type } aria-expanded={ isExpanded }>
 		<span>
 			{ children }
@@ -97,10 +97,6 @@ YoastButtonBase.propTypes = {
 	] ),
 };
 
-YoastButtonBase.defaultProps = {
-	type: "button",
-};
-
 /**
  * Returns a Button with the Yoast button style.
  *
@@ -111,7 +107,11 @@ YoastButtonBase.defaultProps = {
  * @returns {ReactElement} styled button.
  */
 export const YoastButton = addButtonStyles(
-	styled( YoastButtonBase )`
+	styled( YoastButtonBase ).attrs( ( {
+		backgroundColor = colors.$color_green_medium_light,
+		textColor = colors.$color_white,
+		withTextShadow = true,
+	} ) => ( { backgroundColor, textColor, withTextShadow } ) )`
 		color: ${ props => props.textColor };
 		background: ${ props => props.backgroundColor };
 		min-width: 152px;
@@ -137,10 +137,4 @@ YoastButton.propTypes = {
 	backgroundColor: PropTypes.string,
 	textColor: PropTypes.string,
 	withTextShadow: PropTypes.bool,
-};
-
-YoastButton.defaultProps = {
-	backgroundColor: colors.$color_green_medium_light,
-	textColor: colors.$color_white,
-	withTextShadow: true,
 };

--- a/packages/components/src/buttons/YoastLinkButton.js
+++ b/packages/components/src/buttons/YoastLinkButton.js
@@ -16,7 +16,11 @@ import { addButtonStyles } from "./YoastButton";
  * @returns {ReactElement} styled link.
  */
 export const YoastLinkButton = addButtonStyles(
-	styled.a`
+	styled.a.attrs( ( {
+		backgroundColor = colors.$color_green_medium_light,
+		textColor = colors.$color_white,
+		withTextShadow = true,
+	} ) => ( { backgroundColor, textColor, withTextShadow } ) )`
 		text-decoration: none;
 		color: ${ props => props.textColor };
 		background: ${ props => props.backgroundColor };
@@ -29,10 +33,4 @@ YoastLinkButton.propTypes = {
 	backgroundColor: PropTypes.string,
 	textColor: PropTypes.string,
 	withTextShadow: PropTypes.bool,
-};
-
-YoastLinkButton.defaultProps = {
-	backgroundColor: colors.$color_green_medium_light,
-	textColor: colors.$color_white,
-	withTextShadow: true,
 };

--- a/packages/components/src/checkbox/Checkbox.js
+++ b/packages/components/src/checkbox/Checkbox.js
@@ -10,15 +10,15 @@ import "./checkbox.css";
  *
  * @returns {JSX.Element} A React component that wraps around the HTML checkbox.
  */
-export default function Checkbox( props ) {
+export default function Checkbox( { id, label, checked = false, onChange } ) {
 	const handleChange = useCallback( ( event ) => {
-		props.onChange( event.target.value );
-	}, [ props.onChange ] );
+		onChange( event.target.value );
+	}, [ onChange ] );
 
 	return (
 		<FieldGroup wrapperClassName="yoast-field-group yoast-field-group__checkbox">
-			<input type="checkbox" id={ props.id } checked={ props.checked } onChange={ handleChange } />
-			<label htmlFor={ props.id }>{ props.label }</label>
+			<input type="checkbox" id={ id } checked={ checked } onChange={ handleChange } />
+			<label htmlFor={ id }>{ label }</label>
 		</FieldGroup>
 	);
 }
@@ -32,8 +32,4 @@ Checkbox.propTypes = {
 	] ).isRequired,
 	checked: PropTypes.bool,
 	onChange: PropTypes.func.isRequired,
-};
-
-Checkbox.defaultProps = {
-	checked: false,
 };

--- a/packages/components/src/checkbox/CheckboxGroup.js
+++ b/packages/components/src/checkbox/CheckboxGroup.js
@@ -35,7 +35,7 @@ const isChecked = ( id, checkedIds ) => checkedIds.indexOf( id ) !== -1;
  *
  * @returns {React.Component} A React component that wraps around the HTML checkbox.
  */
-const Checkbox = ( { id, label, checked } ) => <Fragment>
+const Checkbox = ( { id, label, checked = false } ) => <Fragment>
 	<input type="checkbox" id={ id } defaultChecked={ checked } />
 	<label htmlFor={ id } className="yoast-field-group__checkbox">{ label }</label>
 </Fragment>;
@@ -44,10 +44,6 @@ Checkbox.propTypes = {
 	label: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
 	checked: PropTypes.bool,
-};
-
-Checkbox.defaultProps = {
-	checked: false,
 };
 
 /**

--- a/packages/components/src/data-model/DataModel.js
+++ b/packages/components/src/data-model/DataModel.js
@@ -44,21 +44,17 @@ DataItem.propTypes = dataItemProps;
  *
  * @returns {HTMLElement} A <ul> with <li> items.
  */
-const DataModel = ( props ) => (
+const DataModel = ( { items = [] } ) => (
 	<ul
 		className="yoast-data-model"
 		aria-label={ __( "Prominent words", "wordpress-seo" ) }
 	>
-		{ props.items.map( DataItem ) }
+		{ items.map( DataItem ) }
 	</ul>
 );
 
 DataModel.propTypes = {
 	items: PropTypes.arrayOf( PropTypes.shape( dataItemProps ) ),
-};
-
-DataModel.defaultProps = {
-	items: [],
 };
 
 export default DataModel;

--- a/packages/components/src/field-group/FieldGroup.js
+++ b/packages/components/src/field-group/FieldGroup.js
@@ -24,14 +24,14 @@ import PremiumBadge from "../premium-badge/PremiumBadge";
  * @returns {React.Component} A div with a label, icon and optional description that renders all children.
  */
 const FieldGroup = ( {
-	htmlFor,
-	label,
-	linkTo,
-	linkText,
-	description,
-	children,
-	wrapperClassName,
-	titleClassName,
+	htmlFor = "",
+	label = "",
+	linkTo = "",
+	linkText = "",
+	description = "",
+	children = [],
+	wrapperClassName = "yoast-field-group",
+	titleClassName = "yoast-field-group__title",
 	hasNewBadge,
 	hasPremiumBadge,
 } ) => {
@@ -82,7 +82,5 @@ export const FieldGroupDefaultProps = {
 };
 
 FieldGroup.propTypes = FieldGroupProps;
-
-FieldGroup.defaultProps = FieldGroupDefaultProps;
 
 export default FieldGroup;

--- a/packages/components/src/help-icon/HelpIcon.js
+++ b/packages/components/src/help-icon/HelpIcon.js
@@ -28,7 +28,7 @@ export const helpIconDefaultProps = {
  *
  * @returns {React.Component} The HelpIcon.
  */
-const HelpIcon = ( { linkTo, linkText } ) => (
+const HelpIcon = ( { linkTo = "", linkText = "" } ) => (
 	<a
 		className="yoast-help"
 		target="_blank"
@@ -56,6 +56,5 @@ const HelpIcon = ( { linkTo, linkText } ) => (
 );
 
 HelpIcon.propTypes = helpIconProps;
-HelpIcon.defaultProps = helpIconDefaultProps;
 
 export default HelpIcon;

--- a/packages/components/src/image-select/ImageSelect.js
+++ b/packages/components/src/image-select/ImageSelect.js
@@ -13,10 +13,28 @@ import Alert from "../Alert";
  *
  * @returns {React.Component} The ImageSelect.
  */
-function ImageSelect( props ) {
-	const imageSelected = props.usingFallback === false && props.imageUrl !== "";
-	const previewImageUrl = props.imageUrl || props.defaultImageUrl || "";
-	const showWarnings = props.warnings.length > 0 && ( imageSelected || props.usingFallback );
+function ImageSelect( {
+	defaultImageUrl = "",
+	imageUrl = "",
+	imageAltText = "",
+	hasPreview,
+	label,
+	onClick = () => {},
+	onMouseEnter = () => {},
+	onMouseLeave = () => {},
+	onRemoveImageClick = () => {},
+	selectImageButtonId = "",
+	replaceImageButtonId = "",
+	removeImageButtonId = "",
+	warnings = [],
+	hasNewBadge = false,
+	isDisabled = false,
+	usingFallback = false,
+	hasPremiumBadge = false,
+} ) {
+	const imageSelected = usingFallback === false && imageUrl !== "";
+	const previewImageUrl = imageUrl || defaultImageUrl || "";
+	const showWarnings = warnings.length > 0 && ( imageSelected || usingFallback );
 	const imageClassNames = [ "yoast-image-select__preview" ];
 	if ( previewImageUrl === "" ) {
 		imageClassNames.push( "yoast-image-select__preview--no-preview" );
@@ -28,12 +46,12 @@ function ImageSelect( props ) {
 
 	const imageSelectButtonsProps = {
 		imageSelected: imageSelected,
-		onClick: props.onClick,
-		onRemoveImageClick: props.onRemoveImageClick,
-		selectImageButtonId: props.selectImageButtonId,
-		replaceImageButtonId: props.replaceImageButtonId,
-		removeImageButtonId: props.removeImageButtonId,
-		isDisabled: props.isDisabled,
+		onClick: onClick,
+		onRemoveImageClick: onRemoveImageClick,
+		selectImageButtonId: selectImageButtonId,
+		replaceImageButtonId: replaceImageButtonId,
+		removeImageButtonId: removeImageButtonId,
+		isDisabled: isDisabled,
 	};
 
 	/**
@@ -54,23 +72,23 @@ function ImageSelect( props ) {
 	return (
 		<div
 			className="yoast-image-select"
-			onMouseEnter={ props.onMouseEnter }
-			onMouseLeave={ props.onMouseLeave }
+			onMouseEnter={ onMouseEnter }
+			onMouseLeave={ onMouseLeave }
 		>
 			<FieldGroup
-				label={ props.label }
-				hasNewBadge={ props.hasNewBadge }
-				hasPremiumBadge={ props.hasPremiumBadge }
+				label={ label }
+				hasNewBadge={ hasNewBadge }
+				hasPremiumBadge={ hasPremiumBadge }
 			>
-				{ props.hasPreview &&
+				{ hasPreview &&
 					<button
 						className={ imageClassNames.join( " " ) }
-						onClick={ props.onClick }
+						onClick={ onClick }
 						type="button"
-						disabled={ props.isDisabled }
+						disabled={ isDisabled }
 					>
 						{ previewImageUrl !== "" &&
-							<img src={ previewImageUrl } alt={ props.imageAltText } className="yoast-image-select__preview--image" />
+							<img src={ previewImageUrl } alt={ imageAltText } className="yoast-image-select__preview--image" />
 						}
 						<ScreenReaderText />
 					</button>
@@ -78,7 +96,7 @@ function ImageSelect( props ) {
 				{
 					showWarnings && <div role="alert">
 						{
-							props.warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
+							warnings.map( ( warning, index ) => <Alert key={ `warning${ index }` } type="warning">
 								{ warning }
 							</Alert> )
 						}
@@ -112,22 +130,4 @@ ImageSelect.propTypes = {
 	isDisabled: PropTypes.bool,
 	usingFallback: PropTypes.bool,
 	hasPremiumBadge: PropTypes.bool,
-};
-
-ImageSelect.defaultProps = {
-	defaultImageUrl: "",
-	imageUrl: "",
-	imageAltText: "",
-	onClick: () => {},
-	onMouseEnter: () => {},
-	onMouseLeave: () => {},
-	onRemoveImageClick: () => {},
-	selectImageButtonId: "",
-	replaceImageButtonId: "",
-	removeImageButtonId: "",
-	warnings: [],
-	hasNewBadge: false,
-	isDisabled: false,
-	usingFallback: false,
-	hasPremiumBadge: false,
 };

--- a/packages/components/src/image-select/ImageSelectButtons.js
+++ b/packages/components/src/image-select/ImageSelectButtons.js
@@ -12,13 +12,13 @@ import PropTypes from "prop-types";
  */
 const ImageSelectButtons = ( props ) => {
 	const {
-		imageSelected,
-		onClick,
-		onRemoveImageClick,
-		selectImageButtonId,
-		replaceImageButtonId,
-		removeImageButtonId,
-		isDisabled,
+		imageSelected = false,
+		onClick = () => {},
+		onRemoveImageClick = () => {},
+		selectImageButtonId = "",
+		replaceImageButtonId = "",
+		removeImageButtonId = "",
+		isDisabled = false,
 	} = props;
 
 	const removeImage = useCallback( ( event ) => {
@@ -64,14 +64,4 @@ ImageSelectButtons.propTypes = {
 	replaceImageButtonId: PropTypes.string,
 	removeImageButtonId: PropTypes.string,
 	isDisabled: PropTypes.bool,
-};
-
-ImageSelectButtons.defaultProps = {
-	imageSelected: false,
-	onClick: () => {},
-	onRemoveImageClick: () => {},
-	selectImageButtonId: "",
-	replaceImageButtonId: "",
-	removeImageButtonId: "",
-	isDisabled: false,
 };

--- a/packages/components/src/inputs/TextArea.js
+++ b/packages/components/src/inputs/TextArea.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FieldGroup, { FieldGroupDefaultProps, FieldGroupProps } from "../field-group/FieldGroup";
+import FieldGroup, { FieldGroupProps } from "../field-group/FieldGroup";
 // Import the required CSS.
 import "./input.css";
 import "../base";
@@ -13,22 +13,32 @@ import "../base";
  * @returns {React.Component} A react component that can be used in our forms.
  */
 const TextArea = ( props ) => {
+	const {
+		id = "",
+		name = "",
+		value = "",
+		ariaDescribedBy = "",
+		onChange = () => {},
+		readOnly = false,
+		placeholder,
+	} = props;
+
 	const fieldGroupProps = { ...props };
-	if ( props.id ) {
-		fieldGroupProps.htmlFor = props.id;
+	if ( id ) {
+		fieldGroupProps.htmlFor = id;
 	}
 
 	return (
 		<FieldGroup { ...fieldGroupProps }>
 			<textarea
-				id={ props.id }
-				name={ props.name }
-				value={ props.value }
+				id={ id }
+				name={ name }
+				value={ value }
 				className="yoast-field-group__textarea"
-				aria-describedby={ props.ariaDescribedBy }
-				onChange={ props.onChange }
-				readOnly={ props.readOnly }
-				placeholder={ props.placeholder }
+				aria-describedby={ ariaDescribedBy }
+				onChange={ onChange }
+				readOnly={ readOnly }
+				placeholder={ placeholder }
 			/>
 		</FieldGroup>
 	);
@@ -43,19 +53,6 @@ TextArea.propTypes = {
 	readOnly: PropTypes.bool,
 	placeholder: PropTypes.string,
 	...FieldGroupProps,
-};
-
-TextArea.defaultProps = {
-	id: "",
-	name: "",
-	value: "",
-	ariaDescribedBy: "",
-	onChange: () => {},
-	readOnly: false,
-	/* eslint-disable no-undefined */
-	placeholder: undefined,
-	/* eslint-enable */
-	...FieldGroupDefaultProps,
 };
 
 export default TextArea;

--- a/packages/components/src/inputs/TextInput.js
+++ b/packages/components/src/inputs/TextInput.js
@@ -55,7 +55,7 @@ const TextInput = ( props ) => {
 		min,
 		max,
 		step,
-		onChange,
+		onChange = () => {},
 	} = props;
 
 	const fieldGroupProps = { ...props };

--- a/packages/components/src/inputs/TextInput.js
+++ b/packages/components/src/inputs/TextInput.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FieldGroup, { FieldGroupDefaultProps, FieldGroupProps } from "../field-group/FieldGroup";
+import FieldGroup, { FieldGroupProps } from "../field-group/FieldGroup";
 // Import the required CSS.
 import "./input.css";
 
@@ -44,26 +44,40 @@ const onChangeHandler = onChange => {
  * @returns {React.Component} Component that can be used inside a form.
  */
 const TextInput = ( props ) => {
+	const {
+		id = "",
+		name = "",
+		value = "",
+		type = "text",
+		ariaDescribedBy = "",
+		placeholder,
+		readOnly = false,
+		min,
+		max,
+		step,
+		onChange,
+	} = props;
+
 	const fieldGroupProps = { ...props };
-	if ( props.id ) {
-		fieldGroupProps.htmlFor = props.id;
+	if ( id ) {
+		fieldGroupProps.htmlFor = id;
 	}
 
 	return (
 		<FieldGroup { ...fieldGroupProps }>
 			<input
-				id={ props.id }
-				name={ props.name }
-				value={ props.value }
-				type={ props.type }
+				id={ id }
+				name={ name }
+				value={ value }
+				type={ type }
 				className="yoast-field-group__inputfield"
-				aria-describedby={ props.ariaDescribedBy }
-				placeholder={ props.placeholder }
-				readOnly={ props.readOnly }
-				min={ props.min }
-				max={ props.max }
-				step={ props.step }
-				onChange={ onChangeHandler( props.onChange ) }
+				aria-describedby={ ariaDescribedBy }
+				placeholder={ placeholder }
+				readOnly={ readOnly }
+				min={ min }
+				max={ max }
+				step={ step }
+				onChange={ onChangeHandler( onChange ) }
 			/>
 		</FieldGroup>
 	);
@@ -82,24 +96,6 @@ TextInput.propTypes = {
 	step: PropTypes.number,
 	onChange: PropTypes.func,
 	...FieldGroupProps,
-};
-
-TextInput.defaultProps = {
-	id: "",
-	name: "",
-	value: "",
-	ariaDescribedBy: "",
-	readOnly: false,
-	type: "text",
-	// React automatically removes these values when passed as props.
-	/* eslint-disable no-undefined */
-	placeholder: undefined,
-	min: undefined,
-	max: undefined,
-	step: undefined,
-	onChange: undefined,
-	/* eslint-enable */
-	...FieldGroupDefaultProps,
 };
 
 export default TextInput;

--- a/packages/components/src/new-badge/NewBadge.js
+++ b/packages/components/src/new-badge/NewBadge.js
@@ -9,7 +9,7 @@ import { __ } from "@wordpress/i18n";
  *
  * @returns {React.Component} The NewBadge.
  */
-const NewBadge = ( { inLabel } ) => (
+const NewBadge = ( { inLabel = false } ) => (
 	<span className={ inLabel ? "yoast-badge yoast-badge__in-label yoast-new-badge" : "yoast-badge yoast-new-badge" }>
 		{ __( "New", "wordpress-seo" ) }
 	</span>
@@ -17,10 +17,6 @@ const NewBadge = ( { inLabel } ) => (
 
 NewBadge.propTypes = {
 	inLabel: PropTypes.bool,
-};
-
-NewBadge.defaultProps = {
-	inLabel: false,
 };
 
 export default NewBadge;

--- a/packages/components/src/premium-badge/PremiumBadge.js
+++ b/packages/components/src/premium-badge/PremiumBadge.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
  *
  * @returns {React.Component} The PremiumBadge.
  */
-const PremiumBadge = ( { inLabel } ) => (
+const PremiumBadge = ( { inLabel = false } ) => (
 	<span className={ inLabel ? "yoast-badge yoast-badge__in-label yoast-premium-badge" : "yoast-badge yoast-premium-badge" }>
 		{ /* We don't want this string to be translatable. */ }
 		Premium
@@ -17,10 +17,6 @@ const PremiumBadge = ( { inLabel } ) => (
 
 PremiumBadge.propTypes = {
 	inLabel: PropTypes.bool,
-};
-
-PremiumBadge.defaultProps = {
-	inLabel: false,
 };
 
 export default PremiumBadge;

--- a/packages/components/src/radiobutton/RadioButtonGroup.js
+++ b/packages/components/src/radiobutton/RadioButtonGroup.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 import { noop } from "lodash";
-import FieldGroup, { FieldGroupDefaultProps, FieldGroupProps } from "../field-group/FieldGroup";
+import FieldGroup, { FieldGroupProps } from "../field-group/FieldGroup";
 import { getId } from "../GenerateId";
 
 import "./radiobutton.css";
@@ -12,10 +12,6 @@ const radioButtonsProps = {
 	groupName: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,
 	selected: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ),
-};
-
-const radioButtonsDefaultProps = {
-	selected: null,
 };
 
 /**
@@ -30,7 +26,7 @@ const radioButtonsDefaultProps = {
  *
  * @returns {React.Component} A single radiobutton field with label.
  */
-const LabeledRadioButton = ( { value, label, checked, onChange, groupName, id } ) => <Fragment>
+const LabeledRadioButton = ( { value, label, checked = false, onChange = noop, groupName, id } ) => <Fragment>
 	<input
 		type="radio"
 		name={ groupName }
@@ -55,11 +51,6 @@ LabeledRadioButton.propTypes = {
 	id: PropTypes.string.isRequired,
 };
 
-LabeledRadioButton.defaultProps = {
-	checked: false,
-	onChange: noop,
-};
-
 /**
  * Returns a set of radiobuttons that are on the same line.
  *
@@ -71,7 +62,7 @@ LabeledRadioButton.defaultProps = {
  *
  * @returns {React.Component} A div with radiobuttons in it.
  */
-const HorizontalRadioButtons = ( { options, onChange, groupName, id, selected } ) => (
+const HorizontalRadioButtons = ( { options, onChange, groupName, id, selected = null } ) => (
 	<div className="yoast-field-group__radiobutton">
 		{ options.map( option => {
 			return (
@@ -89,7 +80,6 @@ const HorizontalRadioButtons = ( { options, onChange, groupName, id, selected } 
 );
 
 HorizontalRadioButtons.propTypes = radioButtonsProps;
-HorizontalRadioButtons.defaultProps = radioButtonsDefaultProps;
 
 /**
  * Returns a set of radiobuttons that are vertically aligned.
@@ -102,7 +92,7 @@ HorizontalRadioButtons.defaultProps = radioButtonsDefaultProps;
  *
  * @returns {React.Component} A lot of divs with one radiobutton in it.
  */
-const VerticalRadioButtons = ( { options, onChange, groupName, id, selected } ) => (
+const VerticalRadioButtons = ( { options, onChange, groupName, id, selected = null } ) => (
 	<div onChange={ onChange }>
 		{ options.map( option => <div
 			className="yoast-field-group__radiobutton yoast-field-group__radiobutton--vertical"
@@ -120,7 +110,6 @@ const VerticalRadioButtons = ( { options, onChange, groupName, id, selected } ) 
 );
 
 VerticalRadioButtons.propTypes = radioButtonsProps;
-VerticalRadioButtons.defaultProps = radioButtonsDefaultProps;
 
 /**
  * Component that generates a group of radio buttons.
@@ -131,12 +120,12 @@ VerticalRadioButtons.defaultProps = radioButtonsDefaultProps;
  */
 const RadioButtonGroup = props => {
 	const {
-		id,
+		id = "",
 		options,
 		groupName,
-		onChange,
-		vertical,
-		selected,
+		onChange = () => {},
+		vertical = false,
+		selected = null,
 		...fieldGroupProps
 	} = props;
 	const componentId = getId( id );
@@ -172,14 +161,6 @@ RadioButtonGroup.propTypes = {
 	onChange: PropTypes.func,
 	vertical: PropTypes.bool,
 	...FieldGroupProps,
-};
-
-RadioButtonGroup.defaultProps = {
-	id: "",
-	vertical: false,
-	selected: null,
-	onChange: () => {},
-	...FieldGroupDefaultProps,
 };
 
 export default RadioButtonGroup;

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -72,10 +72,10 @@ export const YoastReactSelect = ( props ) => {
 		isMulti,
 		isSearchable,
 		inputId,
-		selected,
+		selected = [],
 		options,
-		name,
-		onChange,
+		name = "",
+		onChange = () => {},
 		...fieldGroupProps
 	} = props;
 
@@ -110,7 +110,6 @@ export const YoastReactSelect = ( props ) => {
 };
 
 YoastReactSelect.propTypes = selectProps;
-YoastReactSelect.defaultProps = selectDefaultProps;
 
 /**
  * SingleSelect component.
@@ -119,7 +118,7 @@ YoastReactSelect.defaultProps = selectDefaultProps;
  * @returns {React.Component} The react-select MultiSelect component.
  */
 export const SingleSelect = ( props ) => {
-	const { onChange } = props;
+	const { onChange = () => {} } = props;
 
 	const onChangeHandler = useCallback( selection => onChange( selection.value ) );
 	return <YoastReactSelect
@@ -131,7 +130,6 @@ export const SingleSelect = ( props ) => {
 };
 
 SingleSelect.propTypes = selectProps;
-SingleSelect.defaultProps = selectDefaultProps;
 
 /**
  * MultiSelect component.
@@ -140,7 +138,7 @@ SingleSelect.defaultProps = selectDefaultProps;
  * @returns {React.Component} The react-select MultiSelect component.
  */
 export const MultiSelect = ( props ) => {
-	const { onChange } = props;
+	const { onChange = () => {} } = props;
 
 	const onChangeHandler = useCallback( selection => {
 		// Make sure that selection is always an array.
@@ -161,7 +159,6 @@ export const MultiSelect = ( props ) => {
 };
 
 MultiSelect.propTypes = selectProps;
-MultiSelect.defaultProps = selectDefaultProps;
 
 /**
  * React wrapper for a basic HTML select.

--- a/packages/components/src/table/Cell.js
+++ b/packages/components/src/table/Cell.js
@@ -93,13 +93,6 @@ CellBase.propTypes = {
 	ellipsis: PropTypes.bool,
 };
 
-CellBase.defaultProps = {
-	hideOnMobile: false,
-	hideOnTable: false,
-	separator: false,
-	ellipsis: false,
-};
-
 /*
  * Primary cell, the largest one in a row: can grow, cannot shrink, and the
  * initial width is 200 pixels. In the responsive view, can shrink.

--- a/packages/components/src/table/Row.js
+++ b/packages/components/src/table/Row.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { colors } from "@yoast/style-guide";
 
 // The Rows are flex containers.
-export const Row = styled.li`
+export const Row = styled.li.attrs( ( { background = colors.$color_white, hasHeaderLabels = true } ) => ( { background, hasHeaderLabels } ) )`
 	background: ${ props => props.background };
 	display: flex;
 	min-height: ${ props => props.rowHeight };
@@ -17,11 +17,6 @@ Row.propTypes = {
 	background: PropTypes.string,
 	hasHeaderLabels: PropTypes.bool,
 	rowHeight: PropTypes.string,
-};
-
-Row.defaultProps = {
-	background: colors.$color_white,
-	hasHeaderLabels: true,
 };
 
 /*


### PR DESCRIPTION
## Context

React 19 (shipping in Gutenberg 23.3 / WordPress 7.1) no longer applies `defaultProps` to function and `forwardRef` components through the automatic JSX runtime, so any default declared that way is silently dropped. `@yoast/components` declared defaults this way across ~40 function components and several styled (`forwardRef`) components, which is the source of the flood of "Support for defaultProps will be removed from function components" warnings on React 18.3 and of real, silent breakage on React 19 (dropped colour/size defaults, including `rgba()` interpolations that throw on `undefined`).

This converts the package so its defaults keep working on both React 18 and React 19. It is the last open sub-issue of the `defaultProps` -> ES6 migration; the add-on counterparts (Premium, Video, Local) and `@yoast/ui-library` are already done.

Part of the React 19 readiness work tracked in Yoast/reserved-tasks#235 / Yoast/reserved-tasks#246.

## Summary

This PR can be summarized in the following changelog entry:

* Converts `@yoast/components` function-component `defaultProps` to ES6 default parameters and styled-component defaults to `.attrs`, so component defaults keep working on React 19.

## Relevant technical choices:

* **Function components** now declare their defaults as ES6 default parameters in the destructured signature. ES6 defaults apply only when the incoming prop is `undefined`, matching `defaultProps`, so the change is behaviour-neutral.
* **Styled components** that rely on their defaults (e.g. `Paper`, `ProgressBar`, `table/Row`, the Yoast/Upsell buttons) now supply them at render time via `.attrs` with destructured-default callbacks, which fill only the missing props. Styled buttons that already received their defaults through the `addButtonStyles` / `.attrs` helper (`BaseButton`, `LinkButton`) just had their now-redundant `defaultProps` removed.
* **Components that forward many style props to a styled child** (`IconLabeledButton`, `ChangingIconButton`) merge a defaults object in-component (`{ ...defaults, ...props }`) rather than destructuring a dozen props only to re-spread them.
* **Class-component `defaultProps` are left untouched**, because React 19 still supports them.
* Consumers that forwarded `...FieldGroupDefaultProps` into their own defaults (`TextArea`, `TextInput`, `RadioButtonGroup`, the select components) now rely on `FieldGroup` applying its own ES6 defaults, so the redundant spread was dropped.
* No new tests were added; the package's existing 137 snapshots and 176 tests pass unchanged, which is the behaviour-neutrality check. Package lint is green and the `react/require-default-props` warning count drops (91 -> 69 total warnings).

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. On a current WordPress site (React 18.3) with `SCRIPT_DEBUG` enabled, open a post in the block editor with the browser console open. Interact with the Yoast metabox/sidebar: expand the Yoast SEO collapsibles, open the analysis sections, and view the snippet/social inputs. On `trunk` the console shows a stream of "Support for defaultProps will be removed from function components" warnings naming `@yoast/components` components; with this branch those warnings are gone and every component renders exactly as before (sizes, colours and defaults intact).
2. Open the Yoast SEO **Settings** and **dashboard** pages (which use the same components) and confirm identical rendering with a clean console.
3. On a React 19 build (the Gutenberg 23.3+ plugin active, or WordPress 7.1), repeat steps 1-2. Components must look identical: buttons keep their background/text colours, progress bars, badges and inputs keep their defaults. Without this change React 19 silently drops those defaults (e.g. styled buttons render unstyled, and `rgba()` interpolations can throw).
4. Regression: re-check on a React 18.3 (WP 7.0) site to confirm there is no visual change.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Watch the console for `defaultProps` deprecation warnings (React 18.3) and for rendering errors (React 19); a clean console plus visually unchanged components on both runtimes is the bar.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA tests on a Gutenberg 23.3-RC1 (React 19) build following the acceptance steps above, then re-checks on a React 18.3 (WP 7.0) site to confirm the components render unchanged.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Every Yoast surface that renders `@yoast/components`: the editor metabox/sidebar, Settings, and dashboard. The add-ons consume this package through the `yoast` external, so their component-heavy screens benefit too. The change is behaviour-neutral on React 18 / the classic runtime.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1252
