### PR TITLE
fix(ci): use GITHUB_TOKEN for Coveralls finish build

### DIFF
--- a/.github/workflows/finish-coveralls.yml
+++ b/.github/workflows/finish-coveralls.yml
@@ -104,6 +104,6 @@ jobs:
         env:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
-          github-token: ${{ secrets.COVERALLS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           carryforward: "unit-php-7.4,unit-php-8.3,php-7.4-wp-6.8-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
           parallel-finished: true


### PR DESCRIPTION
The finish-coveralls job was using secrets.COVERALLS_TOKEN while the individual parallel upload steps default to GITHUB_TOKEN. This mismatch prevented Coveralls from connecting the parallel uploads to the finish signal, breaking the coverage report.

## Context

The Coveralls parallel build setup requires all jobs — both the individual coverage uploads and the finish job — to authenticate with the same token. The individual upload steps in `test.yml` and `jstest.yml` do not specify a `github-token`, so they default to `GITHUB_TOKEN`. The finish job in `finish-coveralls.yml` was using `secrets.COVERALLS_TOKEN`, a different secret, causing the finish signal to be unrecognised by Coveralls.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes Coveralls workflow.

## Relevant technical choices:

* `COVERALLS_TOKEN` (also known as `COVERALLS_REPO_TOKEN`) is a repository-specific secret issued by Coveralls itself. It is intended for private repositories or non-GitHub CI systems (e.g. Travis CI, CircleCI) that do not have access to `GITHUB_TOKEN`. For a public repository running on GitHub Actions, the Coveralls-recommended approach is to use `GITHUB_TOKEN`, which is automatically injected into every run and is what `coverallsapp/github-action` is designed to use natively.
* The individual upload steps in `test.yml` and `jstest.yml` already used the default `GITHUB_TOKEN` (no explicit token specified). Changing the finish job to `GITHUB_TOKEN` makes all parallel build jobs consistent, allowing Coveralls to correctly group and finalise the report.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Merge this PR and verify that the next CI run on `trunk` produces a Coveralls coverage report.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — this is a CI configuration change with no user-facing impact.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* CI only — no plugin code is changed.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1222