### PR TITLE
Prime caches when retrieving posts in the sitemaps

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -566,8 +566,17 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$post_ids[] = $sanitized_post->ID;
 		}
 
-		// Warm the post and term caches in bulk, so permalink building (e.g. %category% structures) doesn't query per post.
-		_prime_post_caches( $post_ids, true, false );
+		/**
+		 * Filter to disable priming the post and term caches for the sitemap.
+		 *
+		 * @since 28.0
+		 *
+		 * @param bool $disable_priming_post_caches Whether to disable priming the post and term caches. Defaults to false.
+		 */
+		if ( ! apply_filters( 'wpseo_disable_priming_post_caches_sitemap', false ) ) {
+			// Warm the post and term caches in bulk, so permalink and image building doesn't query per post.
+			_prime_post_caches( $post_ids, true, false );
+		}
 		update_meta_cache( 'post', $post_ids );
 
 		return $posts;

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -567,17 +567,24 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 		}
 
 		/**
-		 * Filter to disable priming the post and term caches for the sitemap.
+		 * Filter to disable priming the post, term and featured-image caches for the sitemap.
 		 *
 		 * @since 28.0
 		 *
-		 * @param bool $disable_priming_post_caches Whether to disable priming the post and term caches. Defaults to false.
+		 * @param bool $disable_cache_priming Whether to disable priming the caches. Defaults to false.
 		 */
-		if ( ! apply_filters( 'wpseo_disable_priming_post_caches_sitemap', false ) ) {
+		$disable_priming = apply_filters( 'wpseo_disable_xml_sitemap_cache_priming', false );
+
+		if ( ! $disable_priming ) {
 			// Warm the post and term caches in bulk, so permalink and image building doesn't query per post.
 			_prime_post_caches( $post_ids, true, false );
 		}
+
 		update_meta_cache( 'post', $post_ids );
+
+		if ( ! $disable_priming && $this->include_images ) {
+			$this->get_image_parser()->prime_thumbnail_caches( $posts );
+		}
 
 		return $posts;
 	}

--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -566,6 +566,8 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 			$post_ids[] = $sanitized_post->ID;
 		}
 
+		// Warm the post and term caches in bulk, so permalink building (e.g. %category% structures) doesn't query per post.
+		_prime_post_caches( $post_ids, true, false );
 		update_meta_cache( 'post', $post_ids );
 
 		return $posts;

--- a/inc/sitemaps/class-sitemap-image-parser.php
+++ b/inc/sitemaps/class-sitemap-image-parser.php
@@ -79,7 +79,8 @@ class WPSEO_Sitemap_Image_Parser {
 			return $images;
 		}
 
-		$thumbnail_id = get_post_thumbnail_id( $post->ID );
+		// Pass the post object rather than its ID, so the post does not get re-fetched from the database.
+		$thumbnail_id = get_post_thumbnail_id( $post );
 
 		if ( $thumbnail_id ) {
 
@@ -130,6 +131,34 @@ class WPSEO_Sitemap_Image_Parser {
 		}
 
 		return $images;
+	}
+
+	/**
+	 * Primes the meta caches of the featured images of the given posts.
+	 *
+	 * This parser reads each post's featured image file location from the attachment's
+	 * meta individually; warming that meta cache in bulk avoids one query per post on
+	 * setups without a persistent object cache.
+	 *
+	 * @param WP_Post[] $posts The posts to prime the featured-image caches for.
+	 *
+	 * @return void
+	 */
+	public function prime_thumbnail_caches( $posts ) {
+
+		$thumbnail_ids = [];
+
+		foreach ( $posts as $post ) {
+			$thumbnail_id = get_post_thumbnail_id( $post );
+
+			if ( $thumbnail_id ) {
+				$thumbnail_ids[] = $thumbnail_id;
+			}
+		}
+
+		if ( ! empty( $thumbnail_ids ) ) {
+			update_meta_cache( 'post', array_unique( $thumbnail_ids ) );
+		}
 	}
 
 	/**

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -436,13 +436,13 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the cache priming can be disabled through the wpseo_disable_priming_post_caches_sitemap filter.
+	 * Tests that the cache priming can be disabled through the wpseo_disable_xml_sitemap_cache_priming filter.
 	 *
 	 * @covers ::get_sitemap_links
 	 *
 	 * @return void
 	 */
-	public function test_priming_post_caches_can_be_disabled_via_filter() {
+	public function test_cache_priming_can_be_disabled_via_filter() {
 		$original_structure = \get_option( 'permalink_structure' );
 
 		try {
@@ -452,7 +452,7 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 			$this->create_posts_with_own_category( 3 );
 			$queries_with_priming = $this->count_sitemap_links_queries();
 
-			\add_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+			\add_filter( 'wpseo_disable_xml_sitemap_cache_priming', '__return_true' );
 			$queries_without_priming = $this->count_sitemap_links_queries();
 
 			$this->assertGreaterThan(
@@ -462,8 +462,52 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 			);
 		}
 		finally {
-			\remove_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+			\remove_filter( 'wpseo_disable_xml_sitemap_cache_priming', '__return_true' );
 			$this->set_permalink_structure( $original_structure );
+		}
+	}
+
+	/**
+	 * Tests that generating sitemap links for posts with featured images runs a constant number
+	 * of queries, regardless of the post count.
+	 *
+	 * @covers ::get_sitemap_links
+	 *
+	 * @return void
+	 */
+	public function test_get_sitemap_links_query_count_does_not_grow_with_featured_image_count() {
+		$this->create_posts_with_featured_images( 3 );
+		$queries_for_three_posts = $this->count_sitemap_links_queries();
+
+		$this->create_posts_with_featured_images( 7 );
+		$queries_for_ten_posts = $this->count_sitemap_links_queries();
+
+		$this->assertSame(
+			$queries_for_three_posts,
+			$queries_for_ten_posts,
+			'Generating sitemap links should not run more queries when there are more posts with featured images',
+		);
+	}
+
+	/**
+	 * Creates posts that each have their own featured image.
+	 *
+	 * @param int $count The number of posts to create.
+	 *
+	 * @return void
+	 */
+	private function create_posts_with_featured_images( $count ) {
+		$attachment_data = [
+			'post_mime_type' => 'image/jpeg',
+			'post_title'     => 'Test image',
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$post_id      = $this->factory->post->create();
+			$thumbnail_id = \wp_insert_attachment( $attachment_data, 'featured.jpg', $post_id );
+			\set_post_thumbnail( $post_id, $thumbnail_id );
 		}
 	}
 

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -429,6 +429,31 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the cache priming can be disabled through the wpseo_disable_priming_post_caches_sitemap filter.
+	 *
+	 * @covers ::get_sitemap_links
+	 *
+	 * @return void
+	 */
+	public function test_priming_post_caches_can_be_disabled_via_filter() {
+		// A %category% permalink structure makes get_permalink() look up each post's terms.
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+
+		$this->create_posts_with_own_category( 3 );
+		$queries_with_priming = $this->count_sitemap_links_queries();
+
+		\add_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+		$queries_without_priming = $this->count_sitemap_links_queries();
+		\remove_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+
+		$this->assertGreaterThan(
+			$queries_with_priming,
+			$queries_without_priming,
+			'Disabling the cache priming through the filter should make per-post queries return',
+		);
+	}
+
+	/**
 	 * Creates posts that each have their own category.
 	 *
 	 * @param int $count The number of posts to create.

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -412,20 +412,27 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_get_sitemap_links_query_count_does_not_grow_with_post_count() {
-		// A %category% permalink structure makes get_permalink() look up each post's terms.
-		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$original_structure = \get_option( 'permalink_structure' );
 
-		$this->create_posts_with_own_category( 3 );
-		$queries_for_three_posts = $this->count_sitemap_links_queries();
+		try {
+			// A %category% permalink structure makes get_permalink() look up each post's terms.
+			$this->set_permalink_structure( '/%category%/%postname%/' );
 
-		$this->create_posts_with_own_category( 7 );
-		$queries_for_ten_posts = $this->count_sitemap_links_queries();
+			$this->create_posts_with_own_category( 3 );
+			$queries_for_three_posts = $this->count_sitemap_links_queries();
 
-		$this->assertSame(
-			$queries_for_three_posts,
-			$queries_for_ten_posts,
-			'Generating sitemap links should not run more queries when there are more posts',
-		);
+			$this->create_posts_with_own_category( 7 );
+			$queries_for_ten_posts = $this->count_sitemap_links_queries();
+
+			$this->assertSame(
+				$queries_for_three_posts,
+				$queries_for_ten_posts,
+				'Generating sitemap links should not run more queries when there are more posts',
+			);
+		}
+		finally {
+			$this->set_permalink_structure( $original_structure );
+		}
 	}
 
 	/**

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -405,6 +405,58 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that generating sitemap links runs a constant number of queries, regardless of the post count.
+	 *
+	 * @covers ::get_sitemap_links
+	 *
+	 * @return void
+	 */
+	public function test_get_sitemap_links_query_count_does_not_grow_with_post_count() {
+		// A %category% permalink structure makes get_permalink() look up each post's terms.
+		$this->set_permalink_structure( '/%category%/%postname%/' );
+
+		$this->create_posts_with_own_category( 3 );
+		$queries_for_three_posts = $this->count_sitemap_links_queries();
+
+		$this->create_posts_with_own_category( 7 );
+		$queries_for_ten_posts = $this->count_sitemap_links_queries();
+
+		$this->assertSame(
+			$queries_for_three_posts,
+			$queries_for_ten_posts,
+			'Generating sitemap links should not run more queries when there are more posts',
+		);
+	}
+
+	/**
+	 * Creates posts that each have their own category.
+	 *
+	 * @param int $count The number of posts to create.
+	 *
+	 * @return void
+	 */
+	private function create_posts_with_own_category( $count ) {
+		for ( $i = 0; $i < $count; $i++ ) {
+			$category_id = $this->factory->category->create();
+			$this->factory->post->create( [ 'post_category' => [ $category_id ] ] );
+		}
+	}
+
+	/**
+	 * Counts the number of database queries run to generate the post sitemap links, starting from a cold cache.
+	 *
+	 * @return int The number of queries.
+	 */
+	private function count_sitemap_links_queries() {
+		\wp_cache_flush();
+
+		$queries_before = \get_num_queries();
+		self::$class_instance->get_sitemap_links( 'post', 100, 1 );
+
+		return ( \get_num_queries() - $queries_before );
+	}
+
+	/**
 	 * Filter to exclude desired posts from the sitemap.
 	 *
 	 * @param array $post_ids List of post ids.

--- a/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
+++ b/tests/WP/Sitemaps/Post_Type_Sitemap_Provider_Test.php
@@ -443,21 +443,28 @@ final class Post_Type_Sitemap_Provider_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_priming_post_caches_can_be_disabled_via_filter() {
-		// A %category% permalink structure makes get_permalink() look up each post's terms.
-		$this->set_permalink_structure( '/%category%/%postname%/' );
+		$original_structure = \get_option( 'permalink_structure' );
 
-		$this->create_posts_with_own_category( 3 );
-		$queries_with_priming = $this->count_sitemap_links_queries();
+		try {
+			// A %category% permalink structure makes get_permalink() look up each post's terms.
+			$this->set_permalink_structure( '/%category%/%postname%/' );
 
-		\add_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
-		$queries_without_priming = $this->count_sitemap_links_queries();
-		\remove_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+			$this->create_posts_with_own_category( 3 );
+			$queries_with_priming = $this->count_sitemap_links_queries();
 
-		$this->assertGreaterThan(
-			$queries_with_priming,
-			$queries_without_priming,
-			'Disabling the cache priming through the filter should make per-post queries return',
-		);
+			\add_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+			$queries_without_priming = $this->count_sitemap_links_queries();
+
+			$this->assertGreaterThan(
+				$queries_with_priming,
+				$queries_without_priming,
+				'Disabling the cache priming through the filter should make per-post queries return',
+			);
+		}
+		finally {
+			\remove_filter( 'wpseo_disable_priming_post_caches_sitemap', '__return_true' );
+			$this->set_permalink_structure( $original_structure );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Two sets of optimizations:
* One set that's about priming post caches:
  * Generating the post sitemap ran 2–3 queries per post because of two stacked N+1s. The provider's optimized custom SQL builds partial WP_Post objects that never enter the object cache, so:
    *  The image parser's `get_post_thumbnail_id( $post->ID )` triggers an uncached get_post() → one full post re-fetch per post, on every permalink structure.
    * With %category% in the permalink structure, `get_permalink()` additionally looks up each post's terms → one term query per post.
  * Calling `_prime_post_caches()` on the batch warms both the post and term caches in two bulk queries, making the query count per sitemap page constant instead of scaling with post count. 
  * With this optimization, we can shave up to:
    * potentially 1000 queries per sitemap page on sites with no `%category%` in the permalink structure (actually, up to 998, because we introduce a couple of queries with this fix)
    * potentially 2000 queries per sitemap page on sites with `%category%` in the permalink structure (actually, up to 1998 because we introduce a couple of queries with this fix)
* One set that's about priming attachment caches:
  * For each post with featured image, `WPSEO_Sitemap_Image_Parser::image_url( $thumbnail_id )` reads the featured image's `_wp_attached_file` meta. and that's a query per post on a cold cache. By priming meta for all thumbnails in one go, we warm the cache for that.
  * With this optimization, we can shave up to 990 queries per sitemap page (basically, 99 queries for every 100 posts), one for every post that has a featured image.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Improves the performance of generating XML sitemaps by warming post, term and featured-image caches in bulk.

## Relevant technical choices:

* I considered the effect we might have in increasing storage because we prime post data which means that we're starting storing post data (including post content) in the object cache and COULD be an issue. But my investigation showed that this data was being stored in object cache already in trunk, with images enabled (the default) the image parser calls `get_post_thumbnail_id( $post->ID )` per post, and passing an ID makes WordPress fetch and cache the full post object
  * Regardless, and because of the variance in supported environments, we are introducing the `wpseo_disable_xml_sitemap_cache_priming` filter, to give a way to disable this optimization, in case there are memory issues in the wild.
  * Full disclosure, we actually do increase the stored data in object cache by priming term data as well, but that's expected to be very small increase in storage. My tests showed `~105–147 KB` per 100 posts of term-relationship and term-object data (~1–1.5 KB/post) added and that's with giving every post its own category and three unique tags. Real sites share terms across posts, so the term-object portion is bounded by unique terms and shrinks dramatically; relationships are tens of bytes per post

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Environment prerequisites

- No persistent object cache for parts 1–3: confirm wp-content/object-cache.php does not exist.
- WP_DEBUG and WP_DEBUG_LOG enabled.

#### Query reduction

* Create wp-content/mu-plugins/log-sitemap-queries.php:
```
  <?php
  add_action( 'shutdown', function () {
        if ( strpos( $_SERVER['REQUEST_URI'], 'sitemap' ) !== false ) {
                error_log( sprintf( '[sitemap-queries] %s -> %d queries', $_SERVER['REQUEST_URI'], $GLOBALS['wpdb']->num_queries ) );
        }
  }, PHP_INT_MAX );
```
##### For sites with category in the permalinks

* Set the permalink structure that benefits most: Settings → Permalinks → Custom Structure → /%category%/%postname%/ → Save.
* Create ~150 posts, each in its own category (WP-CLI, inside the WP container):
```
for i in $(seq 1 150); do
    tid=$(./wp.sh term create category "VerifyCat$i" --slug="verify-cat-$i" --porcelain | tr -d '\r')
    ./wp.sh post create --post_title="VerifyPost$i" --post_status=publish --post_category="$tid" --post_content="Verificationcontent$i"
done
```

* Make sure you dont add feature images in the posts yet (we want to measure a different optimization separately later on)
* Have trunk/production version installed in the site
* Visit the post the `/post-sitemap.xml` sitemap twice
* Note the [sitemap-queries] count. Expected: roughly 2–3 queries per post, so several hundred total for 150 posts.
* Now switch to this PR/RC and visit the `/post-sitemap.xml` sitemap twice
* Confirm that the count should now be a small, flat number (a few dozen) that no longer scales with post count. If you want the scaling proof, repeat both branches after adding another 100 posts: trunk grows by ~250, the PR grows minimally.

##### For sites with no category in the permalinks
* Set the permalink structure to something without category: Settings → Permalinks → Custom Structure → /%postname%/ → Save
* Visit the post the `/post-sitemap.xml` sitemap twice
* Note the [sitemap-queries] count. Expected: roughly 1-2 queries per post, so several hundred total for 150 posts.
* Now switch to this PR/RC and visit the `/post-sitemap.xml` sitemap twice
* Confirm that the count should now be a small, flat number (a few dozen) that no longer scales with post count. If you want the scaling proof, repeat both branches after adding another 100 posts: trunk grows by ~100, the PR grows minimally.


##### For the feature image optimization
* Go and add feature images in some of your posts
* Let's say you added 10 different feature images in 10 different posts
* Visit the `/post-sitemap.xml` sitemap twice with this PR/RC and take a note of the second [sitemap-queries] count.
* Switch to trunk/production and visit the `/post-sitemap.xml` sitemap twice. 
* Verify that the second [sitemap-queries] count is even lower than the test above, by 9 more reducted queries (one for each post with a feature image minus one query that warmed the caches).

#### Regression check
* Confirm that the post sitemap is exactly the same with this PR and without. 
  * Try also with all posts have no featured image at all
* Spot-check in the sitemap of this PR that <loc> URLs contain the right category slug  (/verify-cat-42/verify-post-42/) and <lastmod> is present.

#### Persistent object cache — no stale data

This mirrors the staleness test from the WooCommerce PR, since priming now writes posts/terms into a durable cache.

* Install and activate the SQLite Object Cache plugin (or use Redis if your stack has it); confirm wp-content/object-cache.php now exists.
* Load post-sitemap.xml twice — output should be correct, and the second load's query count should be very low (warm cache).
* Now mutate data the prime covered: edit one verify-post
  * change its title and move it to a different category; separately, rename one category's slug. 
  * Also add a feature image there. 
  * Reload the sitemap: the post's <loc> must reflect the new category slug immediately, and <lastmod> must update. The number of images for that post should have been updated too. 
  * Any stale URL/image number here would be a real bug (it would mean core's clean_post_cache/clean_term_cache invalidation isn't covering us).
* Deactivate and delete the object-cache plugin, and confirm the wp-content/object-cache.php drop-in is gone afterwards.
  
#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Sanity-load the other sitemaps once each — sitemap_index.xml, page-sitemap.xml, category-sitemap.xml — they should render normally

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
