### PR TITLE
fix: write data-type/data-id on links added from a suggestion

### DIFF
--- a/packages/js/src/inline-links/edit-link.js
+++ b/packages/js/src/inline-links/edit-link.js
@@ -30,8 +30,9 @@ export const link = {
 	className: null,
 	attributes: {
 		url: "href",
-		type: "type",
-		id: "id",
+		type: "data-type",
+		id: "data-id",
+		_id: "id",
 		target: "target",
 		rel: "rel",
 		"class": "class",

--- a/packages/js/src/inline-links/edit-link.js
+++ b/packages/js/src/inline-links/edit-link.js
@@ -32,6 +32,7 @@ export const link = {
 		url: "href",
 		type: "data-type",
 		id: "data-id",
+		// _id matches WP core: reads the HTML id attribute on anchors but is never written by our link format.
 		_id: "id",
 		target: "target",
 		rel: "rel",

--- a/packages/js/tests/inline-links/utils.test.js
+++ b/packages/js/tests/inline-links/utils.test.js
@@ -1,4 +1,8 @@
+import { link } from "../../src/inline-links/edit-link";
 import { createLinkFormat, isValidHref } from "../../src/inline-links/utils";
+
+// The test suite mocks @wordpress/rich-text with a bare stub, so pull the real implementation for serialization.
+const { applyFormat, create, registerFormatType, toHTMLString } = jest.requireActual( "@wordpress/rich-text" );
 
 describe( "createLinkFormat", () => {
 	it( "creates a basic link format with just a URL", () => {
@@ -116,6 +120,25 @@ describe( "createLinkFormat", () => {
 		expect( result.attributes.target ).toBeUndefined();
 		expect( result.attributes.rel ).toBeUndefined();
 		expect( result.attributes.class ).toBeUndefined();
+	} );
+} );
+
+describe( "core/link format serialization", () => {
+	beforeAll( () => {
+		registerFormatType( link.name, link );
+	} );
+
+	it( "serializes the link entity type and id as data-type and data-id, not raw type and id", () => {
+		// Mirrors selecting a link suggestion in the popover, which submits type and id alongside the URL.
+		const format = createLinkFormat( { url: "tel:12345", type: "tel", id: "tel:12345" } );
+		const value = applyFormat( create( { text: "test" } ), format, 0, "test".length );
+
+		const html = toHTMLString( { value } );
+
+		expect( html ).toBe( '<a href="tel:12345" data-type="tel" data-id="tel:12345">test</a>' );
+		// Guard against the raw attributes regressing; the leading space avoids matching the data- prefixed ones.
+		expect( html ).not.toContain( ' type="tel"' );
+		expect( html ).not.toContain( ' id="tel:12345"' );
 	} );
 } );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Yoast replaces WordPress core's `core/link` rich-text format with its own (it has to: some blocks restrict their RichText to `core/link`, so registering a separate format would not apply there). The replacement gained `type`/`id`/`class` support in #22822 (first released in 26.8), but its attribute map mapped the entity `type` and `id` to **raw** HTML `type` and `id` attributes instead of core's `data-type` and `data-id`. As a result, adding a link by selecting a suggestion in the block editor link popover (e.g. `tel:`, `mailto:`, or an internal page) wrote invalid `type`/`id` attributes onto the `<a>` — which also collides with the common CSS practice of lowering specificity via `[type="tel"] { … }`. This PR restores parity with WordPress core.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where raw `type` and `id` attributes were written on a link instead of `data-type` and `data-id`, when the link was added by selecting a suggestion in the block editor link popover.

## Relevant technical choices:

* The bug lived entirely in the attribute map of Yoast's `core/link` format definition in `packages/js/src/inline-links/edit-link.js`. The map's keys are logical rich-text attribute names and the values are the HTML attribute names they serialize to. It mapped `type → type` and `id → id`; it now maps `type → data-type`, `id → data-id`, and adds `_id → id`, exactly matching WordPress core's `core/link`. Core's definition is here: [`@wordpress/format-library` → `link/index.js`, L226-L232](https://github.com/WordPress/gutenberg/blob/c34d60a7614eb8d3c36822503f4c6aee783c5810/packages/format-library/src/link/index.js#L226-L232) — this is the package WordPress bundles into core as `wp-includes/js/dist/format-library.js`.
* `createLinkFormat` in `packages/js/src/inline-links/utils.js` keeps building the format object with logical `type` and `id` keys — this is also what core does, so no change was needed there. The logical-to-HTML mapping is the format registration's responsibility.
* `_id → id` is intentional and matches core: the rich-text `id` is the linked-entity id (serialized as `data-id`), while a genuine HTML `id` attribute on the anchor is read into `_id`.
* This is a JS-only change in the main bundle. I verified it against a local `wordpress-develop` checkout's `format-library` to confirm the mapping matches core. Automated checks (Jest + ESLint) pass; I did not run a full live block-editor QA pass — see test instructions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure Yoast SEO is active and open a post or page in the block editor.
* Type some text in a paragraph and select it.
* Press Cmd/Ctrl+K to open the link popover.
* Type `tel:12345` in the link field.
* Click the "tel:12345 — Press ENTER to add this link" suggestion in the dropdown (or highlight it with the arrow keys and press Enter).
* Open the editor's Code editor view (or save and inspect the post HTML) and confirm the link is `<a href="tel:12345" data-type="tel" data-id="tel:12345">…</a>` — with `data-type`/`data-id`, **not** raw `type`/`id`.
* Repeat by searching for an existing page title and selecting that suggestion; confirm the anchor gets `data-type="post"` and `data-id="<id>"`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
The serialized attributes depend on the kind of suggestion selected, so test across link targets: a `tel:` URL, a `mailto:` URL, and an internal post/page. This only affects the Block/Gutenberg editor's inline link UI — the Classic and Elementor editors use a different link path and are not impacted.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* See the acceptance steps above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Inserting and editing inline links in the block editor (Yoast's replacement of the `core/link` rich-text format), including the nofollow/sponsored/open-in-new-tab/CSS-class options and the serialized link HTML on the front end. Yoast's internal-link counting reads only the `href`, so it is unaffected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23347

🤖 Generated with [Claude Code](https://claude.com/claude-code)
