### PR TITLE
feat(bulk-editor): add focus keyphrase to the bulk update endpoints

### DIFF
--- a/src/bulk-editor/application/updates/bulk-updater.php
+++ b/src/bulk-editor/application/updates/bulk-updater.php
@@ -97,6 +97,10 @@ class Bulk_Updater implements LoggerAwareInterface {
 			if ( $update->has_description() ) {
 				$this->meta_writer->write_description( $type, $post_id, $update->get_description() );
 			}
+
+			if ( $update->has_focus_keyphrase() ) {
+				$this->meta_writer->write_focus_keyphrase( $post_id, $update->get_focus_keyphrase() );
+			}
 		} catch ( Exception $exception ) {
 			$this->logger->warning(
 				'Bulk update failed to save post {post_id}: {error}',

--- a/src/bulk-editor/application/updates/meta-writer-interface.php
+++ b/src/bulk-editor/application/updates/meta-writer-interface.php
@@ -6,7 +6,7 @@ namespace Yoast\WP\SEO\Bulk_Editor\Application\Updates;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Updates\Update_Type;
 
 /**
- * Describes how the bulk updater persists a title and description for a post.
+ * Describes how the bulk updater persists a title, description and focus keyphrase for a post.
  */
 interface Meta_Writer_Interface {
 
@@ -31,4 +31,15 @@ interface Meta_Writer_Interface {
 	 * @return void
 	 */
 	public function write_description( Update_Type $type, int $post_id, string $description ): void;
+
+	/**
+	 * Writes the focus keyphrase for a post. The focus keyphrase is channel-agnostic,
+	 * so it does not depend on the update type.
+	 *
+	 * @param int    $post_id         The ID of the post.
+	 * @param string $focus_keyphrase The focus keyphrase to write.
+	 *
+	 * @return void
+	 */
+	public function write_focus_keyphrase( int $post_id, string $focus_keyphrase ): void;
 }

--- a/src/bulk-editor/domain/updates/post-update.php
+++ b/src/bulk-editor/domain/updates/post-update.php
@@ -4,7 +4,7 @@
 namespace Yoast\WP\SEO\Bulk_Editor\Domain\Updates;
 
 /**
- * This class describes a title and/or description update for a single post.
+ * This class describes a title, description and/or focus keyphrase update for a single post.
  */
 class Post_Update {
 
@@ -30,16 +30,25 @@ class Post_Update {
 	private $description;
 
 	/**
+	 * The new focus keyphrase, or null when the focus keyphrase should be left untouched.
+	 *
+	 * @var string|null
+	 */
+	private $focus_keyphrase;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param int         $post_id     The ID of the post to update.
-	 * @param string|null $title       The new title, or null to leave the title untouched.
-	 * @param string|null $description The new description, or null to leave the description untouched.
+	 * @param int         $post_id         The ID of the post to update.
+	 * @param string|null $title           The new title, or null to leave the title untouched.
+	 * @param string|null $description     The new description, or null to leave the description untouched.
+	 * @param string|null $focus_keyphrase The new focus keyphrase, or null to leave the focus keyphrase untouched.
 	 */
-	public function __construct( int $post_id, ?string $title, ?string $description ) {
-		$this->post_id     = $post_id;
-		$this->title       = $title;
-		$this->description = $description;
+	public function __construct( int $post_id, ?string $title, ?string $description, ?string $focus_keyphrase ) {
+		$this->post_id         = $post_id;
+		$this->title           = $title;
+		$this->description     = $description;
+		$this->focus_keyphrase = $focus_keyphrase;
 	}
 
 	/**
@@ -70,6 +79,15 @@ class Post_Update {
 	}
 
 	/**
+	 * Gets the new focus keyphrase.
+	 *
+	 * @return string|null The new focus keyphrase, or null when the focus keyphrase should be left untouched.
+	 */
+	public function get_focus_keyphrase(): ?string {
+		return $this->focus_keyphrase;
+	}
+
+	/**
 	 * Whether this update carries a title. An empty string is a value: it clears the title.
 	 *
 	 * @return bool Whether this update carries a title.
@@ -85,5 +103,14 @@ class Post_Update {
 	 */
 	public function has_description(): bool {
 		return $this->description !== null;
+	}
+
+	/**
+	 * Whether this update carries a focus keyphrase. An empty string is a value: it clears the focus keyphrase.
+	 *
+	 * @return bool Whether this update carries a focus keyphrase.
+	 */
+	public function has_focus_keyphrase(): bool {
+		return $this->focus_keyphrase !== null;
 	}
 }

--- a/src/bulk-editor/infrastructure/updates/meta-writer.php
+++ b/src/bulk-editor/infrastructure/updates/meta-writer.php
@@ -10,7 +10,7 @@ use Yoast\WP\SEO\Bulk_Editor\Domain\Updates\Update_Type;
 use Yoast\WP\SEO\Helpers\Meta_Helper;
 
 /**
- * Persists a title and description to Yoast post meta.
+ * Persists a title, description and focus keyphrase to Yoast post meta.
  *
  * Writing through the meta helper triggers the post meta watcher, so the
  * indexable of the post is rebuilt through the normal flow.
@@ -59,6 +59,19 @@ class Meta_Writer implements Meta_Writer_Interface {
 	public function write_description( Update_Type $type, int $post_id, string $description ): void {
 		$key = $type->is_social() ? 'opengraph-description' : 'metadesc';
 		$this->write( $key, $post_id, $description );
+	}
+
+	/**
+	 * Writes the focus keyphrase for a post. The focus keyphrase is channel-agnostic,
+	 * so it does not depend on the update type.
+	 *
+	 * @param int    $post_id         The ID of the post.
+	 * @param string $focus_keyphrase The focus keyphrase to write.
+	 *
+	 * @return void
+	 */
+	public function write_focus_keyphrase( int $post_id, string $focus_keyphrase ): void {
+		$this->write( 'focuskw', $post_id, $focus_keyphrase );
 	}
 
 	/**

--- a/src/bulk-editor/user-interface/abstract-bulk-update-route.php
+++ b/src/bulk-editor/user-interface/abstract-bulk-update-route.php
@@ -18,7 +18,7 @@ use YoastSEO_Vendor\Psr\Log\LoggerAwareTrait;
 use YoastSEO_Vendor\Psr\Log\NullLogger;
 
 /**
- * Registers a route that applies a batch of per-post title and description updates.
+ * Registers a route that applies a batch of per-post title, description and focus keyphrase updates.
  */
 abstract class Abstract_Bulk_Update_Route implements Route_Interface, LoggerAwareInterface {
 
@@ -86,6 +86,17 @@ abstract class Abstract_Bulk_Update_Route implements Route_Interface, LoggerAwar
 	abstract protected function get_description_arg_name(): string;
 
 	/**
+	 * Gets the name of the focus keyphrase argument in the request.
+	 *
+	 * The focus keyphrase is channel-agnostic, so the argument is the same for every route.
+	 *
+	 * @return string The name of the focus keyphrase argument.
+	 */
+	protected function get_focus_keyphrase_arg_name(): string {
+		return 'focus_keyphrase';
+	}
+
+	/**
 	 * Registers routes with WordPress.
 	 *
 	 * @return void
@@ -146,15 +157,17 @@ abstract class Abstract_Bulk_Update_Route implements Route_Interface, LoggerAwar
 				return $this->reject( 'rest_invalid_item_id', 'Each item must contain an integer id.' );
 			}
 
-			$title_key       = $this->get_title_arg_name();
-			$description_key = $this->get_description_arg_name();
+			$title_key           = $this->get_title_arg_name();
+			$description_key     = $this->get_description_arg_name();
+			$focus_keyphrase_key = $this->get_focus_keyphrase_arg_name();
 
 			if ( ! \array_key_exists( $title_key, $item )
 				&& ! \array_key_exists( $description_key, $item )
+				&& ! \array_key_exists( $focus_keyphrase_key, $item )
 			) {
 				return $this->reject(
 					'rest_no_fields_to_update',
-					\sprintf( 'Each item must contain at least a %s or a %s.', $title_key, $description_key ),
+					\sprintf( 'Each item must contain at least a %s, a %s or a %s.', $title_key, $description_key, $focus_keyphrase_key ),
 				);
 			}
 
@@ -164,6 +177,10 @@ abstract class Abstract_Bulk_Update_Route implements Route_Interface, LoggerAwar
 
 			if ( \array_key_exists( $description_key, $item ) && ! \is_string( $item[ $description_key ] ) ) {
 				return $this->reject( 'rest_invalid_item_field', \sprintf( 'The %s field must be a string.', $description_key ) );
+			}
+
+			if ( \array_key_exists( $focus_keyphrase_key, $item ) && ! \is_string( $item[ $focus_keyphrase_key ] ) ) {
+				return $this->reject( 'rest_invalid_item_field', \sprintf( 'The %s field must be a string.', $focus_keyphrase_key ) );
 			}
 		}
 
@@ -212,6 +229,7 @@ abstract class Abstract_Bulk_Update_Route implements Route_Interface, LoggerAwar
 					// Use array_key_exists, not isset: an empty string is a value that clears the field.
 					( \array_key_exists( $this->get_title_arg_name(), $item ) ) ? (string) $item[ $this->get_title_arg_name() ] : null,
 					( \array_key_exists( $this->get_description_arg_name(), $item ) ) ? (string) $item[ $this->get_description_arg_name() ] : null,
+					( \array_key_exists( $this->get_focus_keyphrase_arg_name(), $item ) ) ? (string) $item[ $this->get_focus_keyphrase_arg_name() ] : null,
 				),
 			);
 		}

--- a/tests/Unit/Bulk_Editor/Application/Updates/Bulk_Updater_Logging_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Updates/Bulk_Updater_Logging_Test.php
@@ -36,7 +36,7 @@ final class Bulk_Updater_Logging_Test extends Abstract_Bulk_Updater_Test {
 		);
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$this->instance->update( $type, $updates );
 	}
@@ -54,7 +54,7 @@ final class Bulk_Updater_Logging_Test extends Abstract_Bulk_Updater_Test {
 		$this->logger->expects( 'warning' )->never();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$this->instance->update( $type, $updates );
 	}

--- a/tests/Unit/Bulk_Editor/Application/Updates/Bulk_Updater_Update_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Updates/Bulk_Updater_Update_Test.php
@@ -27,7 +27,7 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->post_access_checker->expects( 'exists' )->with( 123 )->andReturnFalse();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$this->assertSame(
 			[
@@ -53,7 +53,7 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->post_access_checker->expects( 'is_supported_type' )->with( 123 )->andReturnFalse();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$results = $this->instance->update( Update_Type::search(), $updates )->to_array();
 
@@ -71,7 +71,7 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->post_access_checker->expects( 'can_edit' )->with( 123 )->andReturnFalse();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$results = $this->instance->update( Update_Type::search(), $updates )->to_array();
 
@@ -88,9 +88,10 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->expect_editable_post( 123 );
 		$this->meta_writer->expects( 'write_title' )->with( $type, 123, 'The title' );
 		$this->meta_writer->expects( 'write_description' )->never();
+		$this->meta_writer->expects( 'write_focus_keyphrase' )->never();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$results = $this->instance->update( $type, $updates )->to_array();
 
@@ -107,9 +108,10 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->expect_editable_post( 123 );
 		$this->meta_writer->expects( 'write_title' )->never();
 		$this->meta_writer->expects( 'write_description' )->with( $type, 123, 'The description' );
+		$this->meta_writer->expects( 'write_focus_keyphrase' )->never();
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, null, 'The description' ) );
+		$updates->add( new Post_Update( 123, null, 'The description', null ) );
 
 		$results = $this->instance->update( $type, $updates )->to_array();
 
@@ -128,11 +130,68 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->meta_writer->expects( 'write_description' )->with( $type, 123, '' );
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', '' ) );
+		$updates->add( new Post_Update( 123, 'The title', '', null ) );
 
 		$results = $this->instance->update( $type, $updates )->to_array();
 
 		$this->assertTrue( $results['results'][0]['success'] );
+	}
+
+	/**
+	 * Tests an update carrying only a focus keyphrase writes only the focus keyphrase.
+	 *
+	 * @return void
+	 */
+	public function test_update_focus_keyphrase_only() {
+		$type = Update_Type::search();
+		$this->expect_editable_post( 123 );
+		$this->meta_writer->expects( 'write_title' )->never();
+		$this->meta_writer->expects( 'write_description' )->never();
+		$this->meta_writer->expects( 'write_focus_keyphrase' )->with( 123, 'The keyphrase' );
+
+		$updates = new Post_Update_Collection();
+		$updates->add( new Post_Update( 123, null, null, 'The keyphrase' ) );
+
+		$results = $this->instance->update( $type, $updates )->to_array();
+
+		$this->assertTrue( $results['results'][0]['success'] );
+	}
+
+	/**
+	 * Tests the focus keyphrase is written without the update type: it is the same
+	 * regardless of the appearance the update targets.
+	 *
+	 * @return void
+	 */
+	public function test_update_focus_keyphrase_is_channel_agnostic() {
+		$type = Update_Type::social();
+		$this->expect_editable_post( 123 );
+		$this->meta_writer->expects( 'write_focus_keyphrase' )->with( 123, 'The keyphrase' );
+
+		$updates = new Post_Update_Collection();
+		$updates->add( new Post_Update( 123, null, null, 'The keyphrase' ) );
+
+		$results = $this->instance->update( $type, $updates )->to_array();
+
+		$this->assertTrue( $results['results'][0]['success'] );
+	}
+
+	/**
+	 * Tests a throwing focus keyphrase write fails the update with save_failed.
+	 *
+	 * @return void
+	 */
+	public function test_update_focus_keyphrase_save_failed() {
+		$type = Update_Type::search();
+		$this->expect_editable_post( 123 );
+		$this->meta_writer->expects( 'write_focus_keyphrase' )->with( 123, 'The keyphrase' )->andThrow( new Exception( 'Database error.' ) );
+
+		$updates = new Post_Update_Collection();
+		$updates->add( new Post_Update( 123, null, null, 'The keyphrase' ) );
+
+		$results = $this->instance->update( $type, $updates )->to_array();
+
+		$this->assertSame( Update_Error::SAVE_FAILED, $results['results'][0]['error'] );
 	}
 
 	/**
@@ -146,7 +205,7 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->meta_writer->expects( 'write_title' )->with( $type, 123, 'The title' );
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$results = $this->instance->update( $type, $updates )->to_array();
 
@@ -164,7 +223,7 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->meta_writer->expects( 'write_title' )->with( $type, 123, 'The title' )->andThrow( new Exception( 'Database error.' ) );
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 123, 'The title', null ) );
+		$updates->add( new Post_Update( 123, 'The title', null, null ) );
 
 		$results = $this->instance->update( $type, $updates )->to_array();
 
@@ -183,8 +242,8 @@ final class Bulk_Updater_Update_Test extends Abstract_Bulk_Updater_Test {
 		$this->meta_writer->expects( 'write_title' )->with( $type, 2, 'Second title' );
 
 		$updates = new Post_Update_Collection();
-		$updates->add( new Post_Update( 1, 'First title', null ) );
-		$updates->add( new Post_Update( 2, 'Second title', null ) );
+		$updates->add( new Post_Update( 1, 'First title', null, null ) );
+		$updates->add( new Post_Update( 2, 'Second title', null, null ) );
 
 		$this->assertSame(
 			[

--- a/tests/Unit/Bulk_Editor/Domain/Updates/Post_Update_Collection_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Updates/Post_Update_Collection_Test.php
@@ -29,8 +29,8 @@ final class Post_Update_Collection_Test extends TestCase {
 
 		$this->assertSame( [], $instance->get() );
 
-		$first  = new Post_Update( 1, 'First', null );
-		$second = new Post_Update( 2, null, 'Second' );
+		$first  = new Post_Update( 1, 'First', null, null );
+		$second = new Post_Update( 2, null, 'Second', null );
 
 		$instance->add( $first );
 		$instance->add( $second );

--- a/tests/Unit/Bulk_Editor/Domain/Updates/Post_Update_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Updates/Post_Update_Test.php
@@ -22,15 +22,17 @@ final class Post_Update_Test extends TestCase {
 	 * @covers ::get_post_id
 	 * @covers ::get_title
 	 * @covers ::get_description
+	 * @covers ::get_focus_keyphrase
 	 *
 	 * @return void
 	 */
 	public function test_getters() {
-		$instance = new Post_Update( 123, 'The title', 'The description' );
+		$instance = new Post_Update( 123, 'The title', 'The description', 'The keyphrase' );
 
 		$this->assertSame( 123, $instance->get_post_id() );
 		$this->assertSame( 'The title', $instance->get_title() );
 		$this->assertSame( 'The description', $instance->get_description() );
+		$this->assertSame( 'The keyphrase', $instance->get_focus_keyphrase() );
 	}
 
 	/**
@@ -41,9 +43,9 @@ final class Post_Update_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_has_title() {
-		$this->assertTrue( ( new Post_Update( 1, 'The title', null ) )->has_title() );
-		$this->assertTrue( ( new Post_Update( 1, '', null ) )->has_title() );
-		$this->assertFalse( ( new Post_Update( 1, null, 'The description' ) )->has_title() );
+		$this->assertTrue( ( new Post_Update( 1, 'The title', null, null ) )->has_title() );
+		$this->assertTrue( ( new Post_Update( 1, '', null, null ) )->has_title() );
+		$this->assertFalse( ( new Post_Update( 1, null, 'The description', null ) )->has_title() );
 	}
 
 	/**
@@ -54,8 +56,21 @@ final class Post_Update_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_has_description() {
-		$this->assertTrue( ( new Post_Update( 1, null, 'The description' ) )->has_description() );
-		$this->assertTrue( ( new Post_Update( 1, null, '' ) )->has_description() );
-		$this->assertFalse( ( new Post_Update( 1, 'The title', null ) )->has_description() );
+		$this->assertTrue( ( new Post_Update( 1, null, 'The description', null ) )->has_description() );
+		$this->assertTrue( ( new Post_Update( 1, null, '', null ) )->has_description() );
+		$this->assertFalse( ( new Post_Update( 1, 'The title', null, null ) )->has_description() );
+	}
+
+	/**
+	 * Tests has_focus_keyphrase distinguishes null from an empty string.
+	 *
+	 * @covers ::has_focus_keyphrase
+	 *
+	 * @return void
+	 */
+	public function test_has_focus_keyphrase() {
+		$this->assertTrue( ( new Post_Update( 1, null, null, 'The keyphrase' ) )->has_focus_keyphrase() );
+		$this->assertTrue( ( new Post_Update( 1, null, null, '' ) )->has_focus_keyphrase() );
+		$this->assertFalse( ( new Post_Update( 1, 'The title', null, null ) )->has_focus_keyphrase() );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Updates/Meta_Writer_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Updates/Meta_Writer_Test.php
@@ -140,6 +140,18 @@ final class Meta_Writer_Test extends TestCase {
 	}
 
 	/**
+	 * Tests the focus keyphrase is sanitized and written to the focuskw meta key.
+	 *
+	 * @return void
+	 */
+	public function test_write_focus_keyphrase() {
+		$this->meta_helper->expects( 'set_value' )
+			->with( 'focuskw', 'The keyphrase', 123 );
+
+		$this->instance->write_focus_keyphrase( 123, "  The \t keyphrase  " );
+	}
+
+	/**
 	 * Tests an empty string is written as-is, clearing the meta value.
 	 *
 	 * @dataProvider provide_title_cases
@@ -154,6 +166,18 @@ final class Meta_Writer_Test extends TestCase {
 			->with( $title_key, '', 123 );
 
 		$this->instance->write_title( $type, 123, '' );
+	}
+
+	/**
+	 * Tests an empty focus keyphrase is written as-is, clearing the meta value.
+	 *
+	 * @return void
+	 */
+	public function test_write_empty_focus_keyphrase() {
+		$this->meta_helper->expects( 'set_value' )
+			->with( 'focuskw', '', 123 );
+
+		$this->instance->write_focus_keyphrase( 123, '' );
 	}
 
 	/**
@@ -189,5 +213,34 @@ final class Meta_Writer_Test extends TestCase {
 			->with( $title_key, 'The title', 123 );
 
 		$this->instance->write_title( $type, 123, '  The title  ' );
+	}
+
+	/**
+	 * Tests the registered focus keyphrase field is routed through the canonical meta
+	 * sanitizer, so the field-specific handling and the `wpseo_sanitize_post_meta_*` filter run.
+	 *
+	 * @return void
+	 */
+	public function test_write_focus_keyphrase_routes_registered_field_through_canonical_sanitizer() {
+		$meta_key = WPSEO_Meta::$meta_prefix . 'focuskw';
+
+		WPSEO_Meta::$fields_index[ $meta_key ] = [
+			'subset' => 'general',
+			'key'    => 'focuskw',
+		];
+		WPSEO_Meta::$defaults[ $meta_key ]     = '';
+
+		Monkey\Filters\expectApplied( 'wpseo_sanitize_post_meta_' . $meta_key )
+			->once()
+			->andReturnUsing(
+				static function ( $clean ) {
+					return $clean;
+				},
+			);
+
+		$this->meta_helper->expects( 'set_value' )
+			->with( 'focuskw', 'The keyphrase', 123 );
+
+		$this->instance->write_focus_keyphrase( 123, '  The keyphrase  ' );
 	}
 }

--- a/tests/Unit/Bulk_Editor/User_Interface/Search_Bulk_Update_Route_Update_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Search_Bulk_Update_Route_Update_Test.php
@@ -51,10 +51,15 @@ final class Search_Bulk_Update_Route_Update_Test extends Abstract_Search_Bulk_Up
 						'id'               => 1,
 						'seo_title'        => 'The title',
 						'meta_description' => '',
+						'focus_keyphrase'  => 'The keyphrase',
 					],
 					[
 						'id'               => 2,
 						'meta_description' => 'The description',
+					],
+					[
+						'id'              => 3,
+						'focus_keyphrase' => '',
 					],
 				],
 			);
@@ -62,6 +67,7 @@ final class Search_Bulk_Update_Route_Update_Test extends Abstract_Search_Bulk_Up
 		$results = new Update_Result_Collection();
 		$results->add( Update_Result::for_success( 1 ) );
 		$results->add( Update_Result::for_success( 2 ) );
+		$results->add( Update_Result::for_success( 3 ) );
 
 		$this->bulk_updater->expects( 'update' )
 			->with(
@@ -72,13 +78,17 @@ final class Search_Bulk_Update_Route_Update_Test extends Abstract_Search_Bulk_Up
 				),
 				Mockery::on(
 					static function ( $updates ) {
-						if ( ! $updates instanceof Post_Update_Collection || \count( $updates->get() ) !== 2 ) {
+						if ( ! $updates instanceof Post_Update_Collection || \count( $updates->get() ) !== 3 ) {
 							return false;
 						}
-						list( $first, $second ) = $updates->get();
+						list( $first, $second, $third ) = $updates->get();
 
 						return $first->get_post_id() === 1 && $first->get_title() === 'The title' && $first->get_description() === ''
-							&& $second->get_post_id() === 2 && $second->has_title() === false && $second->get_description() === 'The description';
+							&& $first->get_focus_keyphrase() === 'The keyphrase'
+							&& $second->get_post_id() === 2 && $second->has_title() === false && $second->get_description() === 'The description'
+							&& $second->has_focus_keyphrase() === false
+							&& $third->get_post_id() === 3 && $third->has_title() === false && $third->has_description() === false
+							&& $third->get_focus_keyphrase() === '';
 					},
 				),
 			)

--- a/tests/Unit/Bulk_Editor/User_Interface/Search_Bulk_Update_Route_Validate_Items_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Search_Bulk_Update_Route_Validate_Items_Test.php
@@ -51,6 +51,38 @@ final class Search_Bulk_Update_Route_Validate_Items_Test extends Abstract_Search
 	}
 
 	/**
+	 * Tests an item carrying only a focus keyphrase passes validation.
+	 *
+	 * @return void
+	 */
+	public function test_validate_items_focus_keyphrase_only() {
+		$items = [
+			[
+				'id'              => 1,
+				'focus_keyphrase' => 'The keyphrase',
+			],
+		];
+
+		$this->assertTrue( $this->instance->validate_items( $items ) );
+	}
+
+	/**
+	 * Tests an item with a non-string focus keyphrase fails validation.
+	 *
+	 * @return void
+	 */
+	public function test_validate_items_non_string_focus_keyphrase() {
+		$items = [
+			[
+				'id'              => 1,
+				'focus_keyphrase' => 123,
+			],
+		];
+
+		$this->assertInstanceOf( WP_Error::class, $this->instance->validate_items( $items ) );
+	}
+
+	/**
 	 * Tests a non-array value fails validation.
 	 *
 	 * @return void


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We also need to save focus keyphrase from the bulk editor screen.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds focus keyphrase support to the bulk update endpoints of the Bulk editor.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Log in to wp-admin as an administrator on a site running this branch and note the ID of a post (for example `123` — replace it in the snippets below).
* Open any wp-admin page, open the browser console, and run:
  ```js
  await wp.apiFetch( { path: "/yoast/v1/bulk_editor/update_search", method: "POST", data: { items: [ { id: 123, focus_keyphrase: "search keyphrase" } ] } } );
  ```
* Verify the response is `{ results: [ { id: 123, success: true } ] }`.
* Open the post in the editor and verify the Yoast metabox/sidebar shows "search keyphrase" as the focus keyphrase.
* Run the same snippet against the social route (channel-agnostic check):
  ```js
  await wp.apiFetch( { path: "/yoast/v1/bulk_editor/update_social", method: "POST", data: { items: [ { id: 123, focus_keyphrase: "social keyphrase" } ] } } );
  ```
* Verify the same post's focus keyphrase is now "social keyphrase" — the social route writes the same field.
* Send an item **without** a keyphrase, e.g. `{ items: [ { id: 123, seo_title: "A title" } ] }`, and verify the keyphrase is left untouched.
* Send an explicit empty string, `{ items: [ { id: 123, focus_keyphrase: "" } ] }`, and verify the focus keyphrase is cleared in the editor.
* Send a non-string keyphrase, `{ items: [ { id: 123, focus_keyphrase: 5 } ] }`, and verify the request fails with a 400 error.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
* The console is the testing tool here: there is no UI for this yet, so the endpoints are exercised via `wp.apiFetch` as described above.
* The endpoints accept any indexable post type (not taxonomies), so it is worth repeating one happy-path call for a page and a custom post type.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The focus keyphrase drives the SEO analysis, so a keyphrase saved through the endpoints should behave exactly like one saved in the post editor (analysis picks it up after opening the post).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1292
