### PR TITLE
Fix #4333: Show descriptive permission error in File Editor for users…

### DIFF
--- a/admin/pages/tools.php
+++ b/admin/pages/tools.php
@@ -31,12 +31,20 @@ if ( $tool_page === '' ) {
 		'desc'  => __( 'Import settings from other SEO plugins and export your settings for re-use on (another) site.', 'wordpress-seo' ),
 	];
 
-	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {
+	if ( ! is_multisite() ) {
+	if ( WPSEO_Utils::allow_system_file_edit() === true ) {
 		$tools['file-editor'] = [
 			'title' => __( 'File editor', 'wordpress-seo' ),
 			'desc'  => __( 'This tool allows you to quickly change important files for your SEO, like your robots.txt and, if you have one, your .htaccess file.', 'wordpress-seo' ),
 		];
 	}
+	else {
+		$tools['file-editor'] = [
+			'title' => __( 'File editor', 'wordpress-seo' ),
+			'desc'  => __( 'You do not have sufficient permissions to edit system files.', 'wordpress-seo' ),
+		];
+	}
+}
 
 	$tools['bulk-editor'] = [
 		'title' => __( 'Bulk editor', 'wordpress-seo' ),
@@ -76,11 +84,11 @@ if ( $tool_page === '' ) {
 else {
 	echo '<a href="', esc_url( admin_url( 'admin.php?page=wpseo_tools' ) ), '">', esc_html__( '&laquo; Back to Tools page', 'wordpress-seo' ), '</a>';
 
-	$tool_pages = [ 'bulk-editor', 'import-export' ];
+$tool_pages = [ 'bulk-editor', 'import-export' ];
 
-	if ( WPSEO_Utils::allow_system_file_edit() === true && ! is_multisite() ) {
-		$tool_pages[] = 'file-editor';
-	}
+if ( ! is_multisite() ) {
+    $tool_pages[] = 'file-editor';
+}
 
 	if ( in_array( $tool_page, $tool_pages, true ) ) {
 		require_once WPSEO_PATH . 'admin/views/tool-' . $tool_page . '.php';

--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -21,6 +21,17 @@ if ( ! is_writable( $home_path ) && ! empty( $_SERVER['DOCUMENT_ROOT'] ) ) {
 $robots_file    = $home_path . 'robots.txt';
 $ht_access_file = $home_path . '.htaccess';
 
+
+if ( ! current_user_can( 'edit_files' ) ) {
+
+	echo '<div class="notice notice-error"><p>';
+
+	esc_html_e( 'You do not have sufficient permissions to edit files.', 'wordpress-seo' );
+
+	echo '</p></div>';
+
+	return;}
+
 if ( isset( $_POST['create_robots'] ) ) {
 	if ( ! current_user_can( 'edit_files' ) ) {
 		$die_msg = sprintf(


### PR DESCRIPTION
Context:
Users without the `edit_files` capability who navigate to the Yoast SEO 
File Editor receive no meaningful feedback. The File Editor link is silently 
hidden on the Tools page, and if accessed directly, shows a blank page or 
generic WordPress error. This fix ensures users are clearly informed that 
they lack the necessary permissions.

Summary changelog entry:
Fixes a bug where users without the `edit_files` capability saw a blank page 
or no explanation when accessing the File Editor, caused by the permission 
check silently blocking access without displaying an error message.