### PR TITLE
Verify MyYoast redirect URIs per-URL and gate registration behind explicit opt-in

### DIFF
--- a/src/ai/authentication/application/ai-request-sender-factory.php
+++ b/src/ai/authentication/application/ai-request-sender-factory.php
@@ -70,11 +70,26 @@ class AI_Request_Sender_Factory implements LoggerAwareInterface {
 	 * @return AI_Request_Sender The configured sender.
 	 */
 	public function create( WP_User $user ): AI_Request_Sender {
-		if ( $this->should_use_oauth( $user ) ) {
-			$sender = new AI_Request_Sender( $this->oauth_strategy, $this->token_strategy );
-		}
-		else {
-			$sender = new AI_Request_Sender( $this->token_strategy );
+		$forced = $this->get_filter_override( $user );
+		switch ( $forced ) {
+			case Auth_Method::OAUTH:
+				$this->logger->debug( 'AI auth: wpseo_ai_auth_method filter pinned oauth.' );
+				$sender = new AI_Request_Sender( $this->oauth_strategy );
+				break;
+			case Auth_Method::TOKEN:
+				$this->logger->debug( 'AI auth: wpseo_ai_auth_method filter pinned token.' );
+				$sender = new AI_Request_Sender( $this->token_strategy );
+				break;
+			default:
+				if ( $this->myyoast_connection_conditional->is_met() ) {
+					$this->logger->debug( 'AI auth: routing to oauth strategy (feature flag on) with a fallback to legacy token auth.' );
+					$sender = new AI_Request_Sender( $this->oauth_strategy, $this->token_strategy );
+				}
+				else {
+					$this->logger->debug( 'AI auth: routing to token strategy (MYYOAST_CONNECTION feature flag is off).' );
+					$sender = new AI_Request_Sender( $this->token_strategy );
+				}
+				break;
 		}
 
 		// Logger_Aware_Pass only auto-wires container-registered services; the sender is hand-built
@@ -82,33 +97,6 @@ class AI_Request_Sender_Factory implements LoggerAwareInterface {
 		$sender->setLogger( $this->logger );
 
 		return $sender;
-	}
-
-	/**
-	 * Whether the OAuth strategy should be the primary for this request.
-	 *
-	 * @param WP_User $user The WP user.
-	 *
-	 * @return bool True to use OAuth (with Token fallback); false to use Token alone.
-	 */
-	private function should_use_oauth( WP_User $user ): bool {
-		$forced = $this->get_filter_override( $user );
-		if ( $forced === Auth_Method::OAUTH ) {
-			$this->logger->debug( 'AI auth: wpseo_ai_auth_method filter pinned oauth.' );
-			return true;
-		}
-		if ( $forced === Auth_Method::TOKEN ) {
-			$this->logger->debug( 'AI auth: wpseo_ai_auth_method filter pinned token.' );
-			return false;
-		}
-
-		if ( ! $this->myyoast_connection_conditional->is_met() ) {
-			$this->logger->debug( 'AI auth: routing to token strategy (MYYOAST_CONNECTION feature flag is off).' );
-			return false;
-		}
-
-		$this->logger->debug( 'AI auth: routing to oauth strategy (feature flag on).' );
-		return true;
 	}
 
 	/**
@@ -122,9 +110,11 @@ class AI_Request_Sender_Factory implements LoggerAwareInterface {
 		/**
 		 * Filter: 'wpseo_ai_auth_method' - Pin a specific AI auth strategy for QA / staged rollout.
 		 *
-		 * Return 'oauth' to force MyYoast OAuth (runtime fallback to the Token strategy on persistent OAuth failure still applies).
+		 * Return 'oauth' to force MyYoast OAuth.
 		 * Return 'token' to force the legacy access_jwt flow.
-		 * Return any other value (including the default null) to let the factory's normal selection logic run.
+		 * Return any other value (including the default null) to let the factory's normal selection logic run:
+		 * If OAuth is available, it will be the primary strategy with a fallback to the legacy token flow.
+		 * If OAuth is unavailable, the legacy token flow will be used exclusively.
 		 *
 		 * @internal
 		 *

--- a/src/myyoast-client/application/authorization-code-handler.php
+++ b/src/myyoast-client/application/authorization-code-handler.php
@@ -11,13 +11,13 @@ use Yoast\WP\SEO\Expiring_Store\Domain\Key_Not_Found_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Authorization_Flow_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Discovery_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\ID_Token_Validation_Exception;
-use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Registration_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Server_Capability_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Request_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Grants\Authorization_Code_Grant;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Discovery_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\ID_Token_Validator_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Redirect_URI_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Auth_Flow_State;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Token_Set;
@@ -74,27 +74,37 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 	private $expiring_store;
 
 	/**
+	 * The redirect URI provider port.
+	 *
+	 * @var Redirect_URI_Provider_Interface
+	 */
+	private $redirect_uri_provider;
+
+	/**
 	 * Authorization_Code_Handler constructor.
 	 *
-	 * @param Discovery_Interface           $discovery           The discovery port.
-	 * @param Client_Registration_Interface $client_registration The client registration port.
-	 * @param OAuth_Grant_Handler           $grant_handler       The OAuth grant handler.
-	 * @param ID_Token_Validator_Interface  $id_token_validator  The ID token validator port.
-	 * @param Expiring_Store                $expiring_store      The expiring store.
+	 * @param Discovery_Interface             $discovery             The discovery port.
+	 * @param Client_Registration_Interface   $client_registration   The client registration port.
+	 * @param OAuth_Grant_Handler             $grant_handler         The OAuth grant handler.
+	 * @param ID_Token_Validator_Interface    $id_token_validator    The ID token validator port.
+	 * @param Expiring_Store                  $expiring_store        The expiring store.
+	 * @param Redirect_URI_Provider_Interface $redirect_uri_provider The redirect URI provider port.
 	 */
 	public function __construct(
 		Discovery_Interface $discovery,
 		Client_Registration_Interface $client_registration,
 		OAuth_Grant_Handler $grant_handler,
 		ID_Token_Validator_Interface $id_token_validator,
-		Expiring_Store $expiring_store
+		Expiring_Store $expiring_store,
+		Redirect_URI_Provider_Interface $redirect_uri_provider
 	) {
-		$this->discovery           = $discovery;
-		$this->client_registration = $client_registration;
-		$this->grant_handler       = $grant_handler;
-		$this->id_token_validator  = $id_token_validator;
-		$this->expiring_store      = $expiring_store;
-		$this->logger              = new NullLogger();
+		$this->discovery             = $discovery;
+		$this->client_registration   = $client_registration;
+		$this->grant_handler         = $grant_handler;
+		$this->id_token_validator    = $id_token_validator;
+		$this->expiring_store        = $expiring_store;
+		$this->redirect_uri_provider = $redirect_uri_provider;
+		$this->logger                = new NullLogger();
 	}
 
 	/**
@@ -103,7 +113,6 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 	 * Generates PKCE challenge, state, and nonce, and stores them in the expiring store.
 	 *
 	 * @param int                $user_id            The WordPress user ID.
-	 * @param string             $redirect_uri       The callback redirect URI.
 	 * @param string[]           $scopes             The scopes to request.
 	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the issued token should be bound to.
 	 * @param string|null        $return_url         The URL to return the user to after authorization completes.
@@ -112,17 +121,25 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 	 *
 	 * @throws Authorization_Flow_Exception If any of the auth flow prerequisites (registration, discovery, random number generation, or state parameter validation) fails.
 	 */
-	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes, Resource_Indicator $resource_indicator, ?string $return_url = null ): string {
+	public function get_authorization_url( int $user_id, array $scopes, Resource_Indicator $resource_indicator, ?string $return_url = null ): string {
 		if ( $user_id <= 0 ) {
 			throw new Authorization_Flow_Exception( 'invalid_user', 'A valid WordPress user ID is required to start the authorization flow.' );
 		}
 
-		try {
-			$registered_client = $this->client_registration->ensure_registered( [ $redirect_uri ] );
-		} catch ( Registration_Failed_Exception $e ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
-			throw new Authorization_Flow_Exception( 'registration_failed', $e->getMessage(), 0, $e );
+		// Registration is a prerequisite handled by the connect flow; this method never triggers DCR.
+		$registered_client = $this->client_registration->get_registered_client();
+		if ( $registered_client === null ) {
+			throw new Authorization_Flow_Exception( 'not_registered', 'Site is not registered with MyYoast; complete the registration first.' );
 		}
+
+		// Resolve which registered redirect URI to embed in this request (the server matches it exactly).
+		$redirect_uri = $this->redirect_uri_provider->get_authorization_redirect_uri(
+			$registered_client,
+			$user_id,
+			$scopes,
+			$resource_indicator,
+			$return_url,
+		);
 
 		try {
 			$auth_endpoint = $this->discovery->get_document()->get_authorization_endpoint();
@@ -195,7 +212,7 @@ class Authorization_Code_Handler implements LoggerAwareInterface {
 	 *
 	 * @return Token_Set The obtained tokens.
 	 *
-	 * @throws Registration_Failed_Exception|Token_Request_Failed_Exception If client registration or exchange fails.
+	 * @throws Token_Request_Failed_Exception If the site is not registered or the exchange fails.
 	 */
 	public function exchange_code( int $user_id, string $code, string $state ): Token_Set {
 		if ( $user_id <= 0 ) {

--- a/src/myyoast-client/application/myyoast-client.php
+++ b/src/myyoast-client/application/myyoast-client.php
@@ -14,6 +14,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\Grants\Client_Credentials_Grant;
 use Yoast\WP\SEO\MyYoast_Client\Application\Grants\Refresh_Token_Grant;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\OAuth_Server_Client_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Redirect_URI_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Site_URL_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
@@ -104,17 +105,25 @@ class MyYoast_Client implements LoggerAwareInterface {
 	private $site_url_provider;
 
 	/**
+	 * The redirect URI provider port.
+	 *
+	 * @var Redirect_URI_Provider_Interface
+	 */
+	private $redirect_uri_provider;
+
+	/**
 	 * MyYoast_Client constructor.
 	 *
-	 * @param Client_Registration_Interface $client_registration The client registration port.
-	 * @param Authorization_Code_Handler    $auth_code_handler   The authorization code handler.
-	 * @param OAuth_Grant_Handler           $grant_handler       The OAuth grant handler.
-	 * @param Token_Revocation_Handler      $revocation_handler  The token revocation handler.
-	 * @param OAuth_Server_Client_Interface $http_client         The OAuth server client port.
-	 * @param Lock_Helper                   $lock_helper         The lock helper.
-	 * @param Token_Storage_Interface       $token_storage       The site-level token storage port.
-	 * @param User_Token_Storage_Interface  $user_token_storage  The user-level token storage port.
-	 * @param Site_URL_Provider_Interface   $site_url_provider   The site URL provider port.
+	 * @param Client_Registration_Interface   $client_registration   The client registration port.
+	 * @param Authorization_Code_Handler      $auth_code_handler     The authorization code handler.
+	 * @param OAuth_Grant_Handler             $grant_handler         The OAuth grant handler.
+	 * @param Token_Revocation_Handler        $revocation_handler    The token revocation handler.
+	 * @param OAuth_Server_Client_Interface   $http_client           The OAuth server client port.
+	 * @param Lock_Helper                     $lock_helper           The lock helper.
+	 * @param Token_Storage_Interface         $token_storage         The site-level token storage port.
+	 * @param User_Token_Storage_Interface    $user_token_storage    The user-level token storage port.
+	 * @param Site_URL_Provider_Interface     $site_url_provider     The site URL provider port.
+	 * @param Redirect_URI_Provider_Interface $redirect_uri_provider The redirect URI provider port.
 	 */
 	public function __construct(
 		Client_Registration_Interface $client_registration,
@@ -125,42 +134,51 @@ class MyYoast_Client implements LoggerAwareInterface {
 		Lock_Helper $lock_helper,
 		Token_Storage_Interface $token_storage,
 		User_Token_Storage_Interface $user_token_storage,
-		Site_URL_Provider_Interface $site_url_provider
+		Site_URL_Provider_Interface $site_url_provider,
+		Redirect_URI_Provider_Interface $redirect_uri_provider
 	) {
-		$this->client_registration = $client_registration;
-		$this->auth_code_handler   = $auth_code_handler;
-		$this->grant_handler       = $grant_handler;
-		$this->revocation_handler  = $revocation_handler;
-		$this->http_client         = $http_client;
-		$this->lock_helper         = $lock_helper;
-		$this->token_storage       = $token_storage;
-		$this->user_token_storage  = $user_token_storage;
-		$this->site_url_provider   = $site_url_provider;
-		$this->logger              = new NullLogger();
+		$this->client_registration   = $client_registration;
+		$this->auth_code_handler     = $auth_code_handler;
+		$this->grant_handler         = $grant_handler;
+		$this->revocation_handler    = $revocation_handler;
+		$this->http_client           = $http_client;
+		$this->lock_helper           = $lock_helper;
+		$this->token_storage         = $token_storage;
+		$this->user_token_storage    = $user_token_storage;
+		$this->site_url_provider     = $site_url_provider;
+		$this->redirect_uri_provider = $redirect_uri_provider;
+		$this->logger                = new NullLogger();
 	}
 
 	/**
-	 * Ensures the plugin is registered as an OAuth client.
-	 *
-	 * @param string[] $redirect_uris The OAuth redirect URIs to register with.
+	 * Ensures the plugin is registered as an OAuth client with the provider's redirect URIs.
 	 *
 	 * @return Registered_Client The registered client.
 	 *
 	 * @throws Registration_Failed_Exception If registration fails.
 	 */
-	public function ensure_registered( array $redirect_uris = [] ): Registered_Client {
-		return $this->client_registration->ensure_registered( $redirect_uris );
+	public function ensure_registered(): Registered_Client {
+		return $this->client_registration->ensure_registered( $this->redirect_uri_provider->get_redirect_uris() );
+	}
+
+	/**
+	 * Returns the stored registered client, or null if not registered.
+	 *
+	 * The returned client exposes per-URI verification state via Registered_Client::is_uri_validated().
+	 *
+	 * @return Registered_Client|null The registered client, or null if not registered.
+	 */
+	public function get_registered_client(): ?Registered_Client {
+		return $this->client_registration->get_registered_client();
 	}
 
 	/**
 	 * Whether the plugin is registered as an OAuth client.
 	 *
-	 * @param string[] $redirect_uris Optional redirect URIs to verify against the stored registration.
-	 *
 	 * @return bool
 	 */
-	public function is_registered( array $redirect_uris = [] ): bool {
-		return $this->client_registration->is_registered( $redirect_uris );
+	public function is_registered(): bool {
+		return $this->client_registration->get_registered_client() !== null;
 	}
 
 	/**
@@ -207,7 +225,6 @@ class MyYoast_Client implements LoggerAwareInterface {
 	 * Builds the authorization URL for the user authorization flow.
 	 *
 	 * @param int         $user_id            The WordPress user ID.
-	 * @param string      $redirect_uri       The callback redirect URI.
 	 * @param string[]    $scopes             The scopes to request.
 	 * @param string|null $resource_indicator The RFC 8707 resource indicator the issued token should be bound to.
 	 * @param string|null $return_url         The URL to return the user to after authorization completes.
@@ -217,8 +234,8 @@ class MyYoast_Client implements LoggerAwareInterface {
 	 * @throws Authorization_Flow_Exception If registration, discovery, or parameter validation fails.
 	 * @throws Invalid_Resource_Exception     If the resource indicator is malformed.
 	 */
-	public function get_authorization_url( int $user_id, string $redirect_uri, array $scopes = [], ?string $resource_indicator = null, ?string $return_url = null ): string {
-		return $this->auth_code_handler->get_authorization_url( $user_id, $redirect_uri, $scopes, new Resource_Indicator( $resource_indicator ), $return_url );
+	public function get_authorization_url( int $user_id, array $scopes = [], ?string $resource_indicator = null, ?string $return_url = null ): string {
+		return $this->auth_code_handler->get_authorization_url( $user_id, $scopes, new Resource_Indicator( $resource_indicator ), $return_url );
 	}
 
 	/**
@@ -473,18 +490,5 @@ class MyYoast_Client implements LoggerAwareInterface {
 			$token_set->get_token_type(),
 			$options,
 		);
-	}
-
-	/**
-	 * Whether at least one redirect URI has completed the OAuth authorization-code flow on this site.
-	 *
-	 * Required because MyYoast only embeds the site_url claim in client_credentials tokens after the
-	 * client has at least one verified redirect URI — i.e. after a user has completed the auth-code
-	 * flow on this site. The state lives on the stored registration and resets on deregister.
-	 *
-	 * @return bool
-	 */
-	public function has_validated_redirect_uri(): bool {
-		return $this->client_registration->has_validated_redirect_uri();
 	}
 }

--- a/src/myyoast-client/application/oauth-grant-handler.php
+++ b/src/myyoast-client/application/oauth-grant-handler.php
@@ -95,7 +95,12 @@ class OAuth_Grant_Handler implements LoggerAwareInterface {
 	 * @throws Token_Request_Failed_Exception If the token request fails.
 	 */
 	public function request_token( Grant_Interface $grant, Resource_Indicator $resource_indicator ): Token_Set {
-		$registered_client = $this->client_registration->ensure_registered();
+		// A token request requires an existing registration; it never triggers DCR or a
+		// redirect-URI update — that is the connect flow's responsibility.
+		$registered_client = $this->client_registration->get_registered_client();
+		if ( $registered_client === null ) {
+			throw new Token_Request_Failed_Exception( 'not_registered', 'Site is not registered with MyYoast; complete the connect flow first.' );
+		}
 
 		try {
 			$token_endpoint = $this->discovery->get_document()->get_token_endpoint();

--- a/src/myyoast-client/application/ports/client-registration-interface.php
+++ b/src/myyoast-client/application/ports/client-registration-interface.php
@@ -12,15 +12,18 @@ use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
 interface Client_Registration_Interface {
 
 	/**
-	 * Ensures the plugin is registered, performing DCR if needed.
+	 * Ensures the registration's redirect URIs exactly match the given set.
 	 *
-	 * @param string[] $redirect_uris The OAuth redirect URIs to register with.
+	 * Performs DCR when not yet registered; when registered with a different set, updates the
+	 * registration in place via RFC 7592 (preserving the client_id) rather than re-registering.
+	 *
+	 * @param string[] $redirect_uris The exact set of OAuth redirect URIs the registration should have.
 	 *
 	 * @return Registered_Client The client credentials.
 	 *
 	 * @throws Registration_Failed_Exception If registration fails.
 	 */
-	public function ensure_registered( array $redirect_uris = [] ): Registered_Client;
+	public function ensure_registered( array $redirect_uris ): Registered_Client;
 
 	/**
 	 * Returns the stored registered client, or null if not registered.
@@ -28,18 +31,6 @@ interface Client_Registration_Interface {
 	 * @return Registered_Client|null
 	 */
 	public function get_registered_client(): ?Registered_Client;
-
-	/**
-	 * Whether the plugin is registered as an OAuth client.
-	 *
-	 * When redirect URIs are provided, also verifies that all of them
-	 * are included in the stored registration.
-	 *
-	 * @param string[] $redirect_uris Optional redirect URIs to verify against the stored registration.
-	 *
-	 * @return bool
-	 */
-	public function is_registered( array $redirect_uris = [] ): bool;
 
 	/**
 	 * Reads the current client registration from the server.
@@ -81,15 +72,17 @@ interface Client_Registration_Interface {
 	public function rotate_dpop_keys(): void;
 
 	/**
-	 * Whether at least one redirect URI has completed the OAuth authorization-code flow on this site.
+	 * Whether the given redirect URI has completed the OAuth authorization-code flow on this site.
 	 *
-	 * True once any user on this site has completed the auth-code flow against the current
-	 * registration. The state lives on the stored registration, so it resets when the registration is
-	 * forgotten (deregister, stale-redirect-URI re-registration, or full local-data wipe).
+	 * Per-URI verification state lives on the stored registration. It is pruned to the current
+	 * redirect-URI set whenever the registration's redirect URIs change, and reset when the
+	 * registration is forgotten (deregister or full local-data wipe).
+	 *
+	 * @param string $redirect_uri The redirect URI to check.
 	 *
 	 * @return bool
 	 */
-	public function has_validated_redirect_uri(): bool;
+	public function is_uri_validated( string $redirect_uri ): bool;
 
 	/**
 	 * Records that the given redirect URI has completed the authorization-code flow.

--- a/src/myyoast-client/application/ports/redirect-uri-provider-interface.php
+++ b/src/myyoast-client/application/ports/redirect-uri-provider-interface.php
@@ -9,7 +9,7 @@ use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
 /**
  * Port for resolving the OAuth redirect URIs for this site.
  *
- * Splits the two distinct redirect-URI concerns: the full set to register with the
+ * Separates the two distinct redirect-URI concerns: the full set to register with the
  * authorization server (Dynamic Client Registration), and the single URI to embed in a
  * given authorization request (which OAuth requires to match one of the registered URIs
  * exactly).
@@ -19,10 +19,7 @@ interface Redirect_URI_Provider_Interface {
 	/**
 	 * Returns the redirect URIs to register this client with.
 	 *
-	 * This is the full allow-list sent to the authorization server during registration. It
-	 * defaults to the site's canonical admin callback URL; site owners or plugins may extend,
-	 * remove, or replace it for non-standard setups (reverse proxies, alternate admin URLs,
-	 * headless, ...).
+	 * This is the full allow-list sent to the authorization server during registration.
 	 *
 	 * @return string[] The redirect URIs to register. Never empty.
 	 */
@@ -31,9 +28,10 @@ interface Redirect_URI_Provider_Interface {
 	/**
 	 * Returns the single redirect URI to embed in an authorization request.
 	 *
-	 * The returned value is guaranteed to be one of the URIs in the given client's registered
-	 * redirect_uris, so the authorization server's exact-match check on `redirect_uri` cannot
-	 * fail because of this provider.
+	 * OAuth requires the embedded `redirect_uri` to exactly match one of the client's registered
+	 * redirect URIs. Implementations therefore SHOULD return one of the given client's registered
+	 * redirect URIs whenever it has any. Returning an URL that is not registered will likely result
+	 * in an authorization error.
 	 *
 	 * @param Registered_Client  $client             The registered client whose redirect_uris bound the result.
 	 * @param int                $user_id            The WordPress user ID starting the flow.
@@ -41,7 +39,7 @@ interface Redirect_URI_Provider_Interface {
 	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the token will be bound to.
 	 * @param string|null        $return_url         The URL the user returns to after authorization, or null.
 	 *
-	 * @return string A redirect URI guaranteed to be present in $client's registered redirect_uris.
+	 * @return string A redirect URI to embed; one of $client's registered redirect URIs when it has any.
 	 */
 	public function get_authorization_redirect_uri(
 		Registered_Client $client,

--- a/src/myyoast-client/application/ports/redirect-uri-provider-interface.php
+++ b/src/myyoast-client/application/ports/redirect-uri-provider-interface.php
@@ -1,0 +1,53 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\MyYoast_Client\Application\Ports;
+
+use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
+
+/**
+ * Port for resolving the OAuth redirect URIs for this site.
+ *
+ * Splits the two distinct redirect-URI concerns: the full set to register with the
+ * authorization server (Dynamic Client Registration), and the single URI to embed in a
+ * given authorization request (which OAuth requires to match one of the registered URIs
+ * exactly).
+ */
+interface Redirect_URI_Provider_Interface {
+
+	/**
+	 * Returns the redirect URIs to register this client with.
+	 *
+	 * This is the full allow-list sent to the authorization server during registration. It
+	 * defaults to the site's canonical admin callback URL; site owners or plugins may extend,
+	 * remove, or replace it for non-standard setups (reverse proxies, alternate admin URLs,
+	 * headless, ...).
+	 *
+	 * @return string[] The redirect URIs to register. Never empty.
+	 */
+	public function get_redirect_uris(): array;
+
+	/**
+	 * Returns the single redirect URI to embed in an authorization request.
+	 *
+	 * The returned value is guaranteed to be one of the URIs in the given client's registered
+	 * redirect_uris, so the authorization server's exact-match check on `redirect_uri` cannot
+	 * fail because of this provider.
+	 *
+	 * @param Registered_Client  $client             The registered client whose redirect_uris bound the result.
+	 * @param int                $user_id            The WordPress user ID starting the flow.
+	 * @param string[]           $scopes             The scopes being requested.
+	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the token will be bound to.
+	 * @param string|null        $return_url         The URL the user returns to after authorization, or null.
+	 *
+	 * @return string A redirect URI guaranteed to be present in $client's registered redirect_uris.
+	 */
+	public function get_authorization_redirect_uri(
+		Registered_Client $client,
+		int $user_id,
+		array $scopes,
+		Resource_Indicator $resource_indicator,
+		?string $return_url = null
+	): string;
+}

--- a/src/myyoast-client/domain/registered-client.php
+++ b/src/myyoast-client/domain/registered-client.php
@@ -120,12 +120,68 @@ class Registered_Client {
 	}
 
 	/**
+	 * Returns the redirect URIs this client is registered with.
+	 *
+	 * @return string[]
+	 */
+	public function get_redirect_uris(): array {
+		$redirect_uris = ( $this->metadata['redirect_uris'] ?? [] );
+
+		return ( \is_array( $redirect_uris ) ) ? \array_values( $redirect_uris ) : [];
+	}
+
+	/**
+	 * Whether this client's registered redirect URIs exactly match the given set (order-insensitive),
+	 * so both additions and removals count as a mismatch.
+	 *
+	 * @param string[] $redirect_uris The redirect-URI set to compare against.
+	 *
+	 * @return bool
+	 */
+	public function has_redirect_uris( array $redirect_uris ): bool {
+		$wanted = \array_unique( $redirect_uris );
+		$stored = \array_unique( $this->get_redirect_uris() );
+		\sort( $wanted );
+		\sort( $stored );
+
+		return $wanted === $stored;
+	}
+
+	/**
 	 * Returns the redirect URIs that have completed the authorization-code flow on this site.
 	 *
 	 * @return string[]
 	 */
 	public function get_validated_uris(): array {
 		return $this->validated_uris;
+	}
+
+	/**
+	 * Whether the given redirect URI has completed the authorization-code flow on this site.
+	 *
+	 * @param string $redirect_uri The redirect URI to check.
+	 *
+	 * @return bool
+	 */
+	public function is_uri_validated( string $redirect_uri ): bool {
+		return \in_array( $redirect_uri, $this->validated_uris, true );
+	}
+
+	/**
+	 * Returns a copy of this client with its validated redirect URIs replaced.
+	 *
+	 * @param string[] $validated_uris The redirect URIs that have completed the auth-code flow.
+	 *
+	 * @return self
+	 */
+	public function with_validated_uris( array $validated_uris ): self {
+		return new self(
+			$this->client_id,
+			$this->registration_access_token,
+			$this->registration_client_uri,
+			$this->metadata,
+			$validated_uris,
+		);
 	}
 
 	/**

--- a/src/myyoast-client/infrastructure/registration/client-registration.php
+++ b/src/myyoast-client/infrastructure/registration/client-registration.php
@@ -187,51 +187,33 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 	}
 
 	/**
-	 * Whether the plugin is registered as an OAuth client.
+	 * Ensures the registration's redirect URIs exactly match the given set.
 	 *
-	 * When redirect URIs are provided, also verifies that all of them
-	 * are included in the stored registration.
+	 * Performs DCR when not yet registered; when registered with a different set, updates the
+	 * registration in place via RFC 7592 (preserving the client_id, RAT, and key pair, and the
+	 * verification state of unchanged URIs) rather than re-registering.
 	 *
-	 * @param string[] $redirect_uris Optional redirect URIs to verify against the stored registration.
-	 *
-	 * @return bool
-	 */
-	public function is_registered( array $redirect_uris = [] ): bool {
-		$registered_client = $this->get_registered_client();
-		if ( $registered_client === null ) {
-			return false;
-		}
-
-		if ( $redirect_uris === [] ) {
-			return true;
-		}
-
-		$stored_uris = ( $registered_client->get_metadata()['redirect_uris'] ?? [] );
-
-		return \array_diff( $redirect_uris, $stored_uris ) === [];
-	}
-
-	/**
-	 * Ensures the plugin is registered, performing DCR if needed.
-	 *
-	 * @param string[] $redirect_uris The OAuth redirect URIs to register with.
+	 * @param string[] $redirect_uris The exact set of OAuth redirect URIs the registration should have.
 	 *
 	 * @return Registered_Client The client credentials.
 	 *
 	 * @throws Registration_Failed_Exception If registration fails.
 	 */
-	public function ensure_registered( array $redirect_uris = [] ): Registered_Client {
-		if ( $this->is_registered( $redirect_uris ) ) {
-			return $this->get_registered_client();
-		}
+	public function ensure_registered( array $redirect_uris ): Registered_Client {
+		$registered_client = $this->get_registered_client();
 
-		// Registered with stale redirect URIs — deregister first.
-		if ( $this->get_registered_client() !== null ) {
-			$this->deregister();
+		if ( $registered_client !== null && $registered_client->has_redirect_uris( $redirect_uris ) ) {
+			return $registered_client;
 		}
 
 		if ( $redirect_uris === [] ) {
 			throw new Registration_Failed_Exception( 'At least one redirect URI is required for initial registration.' );
+		}
+
+		// Registered, but the redirect-URI set differs — update in place (RFC 7592 PUT) so the
+		// client_id survives and unchanged URIs keep their verification state and tokens.
+		if ( $registered_client !== null ) {
+			return $this->update_redirect_uris( $redirect_uris );
 		}
 
 		return $this->register( $redirect_uris );
@@ -357,6 +339,66 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 	}
 
 	/**
+	 * Updates the registered redirect URIs in place (RFC 7592 PUT).
+	 *
+	 * Preserves the client_id, registration access token, and key pair. Verification state for
+	 * URIs that remain in the set is preserved; URIs no longer present are dropped.
+	 *
+	 * @param string[] $redirect_uris The new exact set of redirect URIs.
+	 *
+	 * @return Registered_Client The updated credentials.
+	 *
+	 * @throws Registration_Failed_Exception If the update fails.
+	 */
+	private function update_redirect_uris( array $redirect_uris ): Registered_Client {
+		$registered_client = $this->get_registered_client();
+		if ( $registered_client === null ) {
+			throw new Registration_Failed_Exception( 'Not registered.' );
+		}
+
+		// Per RFC 7592 §2.2, server-assigned fields MUST NOT be included; keep the existing key pair.
+		$request_body                       = $this->build_update_request_body( $registered_client->get_metadata() );
+		$request_body['redirect_uris']      = \array_values( $redirect_uris );
+		$request_body['software_statement'] = $this->issuer_config->get_software_statement();
+
+		// phpcs:ignore Yoast.Yoast.JsonEncodeAlternative.Found -- Encoding for HTTP request body, not user-facing output.
+		$json = \wp_json_encode( $request_body );
+		if ( $json === false ) {
+			throw new Registration_Failed_Exception( 'Failed to JSON-encode registration request body.' );
+		}
+
+		$result = $this->http_client->authenticated_request(
+			'PUT',
+			$registered_client->get_registration_client_uri(),
+			$registered_client->get_registration_access_token(),
+			Auth_Token_Type::BEARER,
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+					'Accept'       => 'application/json',
+				],
+				'body'    => $json,
+				'timeout' => 15,
+			],
+		);
+
+		if ( ! $result->is_successful() ) {
+			$error_message = (string) $result->get_body_value( 'error_description', $result->get_body_value( 'error', '' ) );
+			throw new Registration_Failed_Exception(
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Internal exception message.
+				\sprintf( 'Redirect URI update returned HTTP %d: %s', $result->get_status(), $error_message ),
+			);
+		}
+
+		$body = $result->get_body();
+		if ( ! \is_array( $body ) || empty( $body['client_id'] ) ) {
+			throw new Registration_Failed_Exception( 'Redirect URI update returned invalid response.' );
+		}
+
+		return $this->store_credentials( $body );
+	}
+
+	/**
 	 * Deletes the client registration from the server (RFC 7592 DELETE) and clears local data.
 	 *
 	 * @return bool True if deleted or already not registered, false on network failure.
@@ -415,17 +457,19 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 	}
 
 	/**
-	 * Whether at least one redirect URI has completed the OAuth authorization-code flow on this site.
+	 * Whether the given redirect URI has completed the OAuth authorization-code flow on this site.
 	 *
-	 * The state lives on the stored registration, so it is invalidated automatically when the client
-	 * is deregistered or replaced (e.g. after a redirect-URI change).
+	 * The state lives on the stored registration: it is pruned to the current redirect-URI set
+	 * whenever those change, and invalidated when the client is deregistered.
+	 *
+	 * @param string $redirect_uri The redirect URI to check.
 	 *
 	 * @return bool
 	 */
-	public function has_validated_redirect_uri(): bool {
+	public function is_uri_validated( string $redirect_uri ): bool {
 		$registered_client = $this->get_registered_client();
 
-		return $registered_client !== null && $registered_client->get_validated_uris() !== [];
+		return $registered_client !== null && $registered_client->is_uri_validated( $redirect_uri );
 	}
 
 	/**
@@ -458,13 +502,7 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 			\update_option( $option_key, $stored, false );
 		}
 
-		$this->cached_registered_clients[ $option_key ] = new Registered_Client(
-			$registered_client->get_client_id(),
-			$registered_client->get_registration_access_token(),
-			$registered_client->get_registration_client_uri(),
-			$registered_client->get_metadata(),
-			$validated_uris,
-		);
+		$this->cached_registered_clients[ $option_key ] = $registered_client->with_validated_uris( $validated_uris );
 	}
 
 	/**
@@ -485,12 +523,15 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 		$metadata = $response_body;
 		unset( $metadata['registration_access_token'] );
 
-		// Preserve validation state across a key rotation (same client_id), but reset it for a fresh
-		// registration: a new client_id means the redirect URIs must be re-validated from scratch.
+		// Preserve validation state across an in-place update or key rotation (same client_id), but
+		// reset it for a fresh registration: a new client_id means the redirect URIs must be
+		// re-validated from scratch. Always prune to the new redirect-URI set so a removed URI loses
+		// its verification and an added one starts unverified.
 		$existing       = $this->get_registered_client();
 		$validated_uris = [];
 		if ( $existing !== null && $existing->get_client_id() === $response_body['client_id'] ) {
-			$validated_uris = $existing->get_validated_uris();
+			$new_redirect_uris = ( $metadata['redirect_uris'] ?? [] );
+			$validated_uris    = \array_values( \array_intersect( $existing->get_validated_uris(), $new_redirect_uris ) );
 		}
 
 		\update_option(

--- a/src/myyoast-client/infrastructure/registration/client-registration.php
+++ b/src/myyoast-client/infrastructure/registration/client-registration.php
@@ -531,7 +531,9 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 		$validated_uris = [];
 		if ( $existing !== null && $existing->get_client_id() === $response_body['client_id'] ) {
 			$new_redirect_uris = ( $metadata['redirect_uris'] ?? [] );
-			$validated_uris    = \array_values( \array_intersect( $existing->get_validated_uris(), $new_redirect_uris ) );
+			if ( \is_array( $new_redirect_uris ) ) {
+				$validated_uris = \array_values( \array_intersect( $existing->get_validated_uris(), $new_redirect_uris ) );
+			}
 		}
 
 		\update_option(

--- a/src/myyoast-client/infrastructure/wordpress/redirect-uri-provider.php
+++ b/src/myyoast-client/infrastructure/wordpress/redirect-uri-provider.php
@@ -52,13 +52,19 @@ class Redirect_URI_Provider implements Redirect_URI_Provider_Interface {
 	/**
 	 * Returns the single redirect URI to embed in an authorization request.
 	 *
+	 * Prefers the canonical admin callback URL when the client has it registered, otherwise the
+	 * first registered redirect URI. The choice may then be overridden through the
+	 * `wpseo_myyoast_authorization_redirect_uri` filter, but a filtered value that is not among the
+	 * client's registered redirect URIs is ignored to keep the contract's exact-match guarantee.
+	 * When the client has no registered redirect URIs, the canonical admin callback URL is returned.
+	 *
 	 * @param Registered_Client  $client             The registered client whose redirect_uris bound the result.
 	 * @param int                $user_id            The WordPress user ID starting the flow.
 	 * @param string[]           $scopes             The scopes being requested.
 	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the token will be bound to.
 	 * @param string|null        $return_url         The URL the user returns to after authorization, or null.
 	 *
-	 * @return string A redirect URI guaranteed to be present in $client's registered redirect_uris.
+	 * @return string One of $client's registered redirect URIs, or the canonical admin callback URL when it has none.
 	 */
 	public function get_authorization_redirect_uri(
 		Registered_Client $client,
@@ -136,13 +142,13 @@ class Redirect_URI_Provider implements Redirect_URI_Provider_Interface {
 	}
 
 	/**
-	 * Filters untrusted input down to its non-empty string values, preserving order.
+	 * Filters untrusted input down to its trimmed, non-empty string values, preserving order.
 	 *
 	 * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- Untrusted filter/metadata input.
 	 *
 	 * @param mixed $uris The candidate URIs (untrusted filter or metadata input).
 	 *
-	 * @return string[] The non-empty string URIs.
+	 * @return string[] The trimmed, non-empty string URIs.
 	 *
 	 * phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
 	 */
@@ -153,8 +159,13 @@ class Redirect_URI_Provider implements Redirect_URI_Provider_Interface {
 
 		$valid = [];
 		foreach ( $uris as $uri ) {
-			if ( \is_string( $uri ) && $uri !== '' ) {
-				$valid[] = $uri;
+			if ( ! \is_string( $uri ) ) {
+				continue;
+			}
+
+			$trimmed = \trim( $uri );
+			if ( $trimmed !== '' ) {
+				$valid[] = $trimmed;
 			}
 		}
 

--- a/src/myyoast-client/infrastructure/wordpress/redirect-uri-provider.php
+++ b/src/myyoast-client/infrastructure/wordpress/redirect-uri-provider.php
@@ -1,0 +1,174 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\MyYoast_Client\Infrastructure\WordPress;
+
+use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
+use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Redirect_URI_Provider_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
+
+/**
+ * WordPress implementation of the redirect URI provider.
+ *
+ * The canonical redirect URI is the Yoast admin page with the OAuth callback marker query
+ * var. Site owners and plugins can register additional URIs and override the per-flow embed
+ * URI through filters.
+ */
+class Redirect_URI_Provider implements Redirect_URI_Provider_Interface {
+
+	/**
+	 * Returns the redirect URIs to register this client with.
+	 *
+	 * Defaults to the canonical admin callback URL, which the `wpseo_myyoast_redirect_uris` filter
+	 * may extend, remove, or replace. Always returns at least one URI.
+	 *
+	 * @return string[] The redirect URIs to register.
+	 */
+	public function get_redirect_uris(): array {
+		$canonical = $this->get_canonical_redirect_uri();
+
+		/**
+		 * Filters the redirect URIs registered with MyYoast for this site.
+		 *
+		 * Use this to register additional OAuth callback URLs for non-standard setups (reverse
+		 * proxies, alternate admin URLs, ...), or to replace the default callback URL entirely. The
+		 * canonical admin callback URL is passed as the default and may be removed or replaced.
+		 *
+		 * @param string[] $redirect_uris The redirect URIs to register. Defaults to the canonical admin callback URL.
+		 */
+		$filtered = \apply_filters( 'wpseo_myyoast_redirect_uris', [ $canonical ] );
+
+		$redirect_uris = $this->unique( $this->only_valid_uris( $filtered ) );
+
+		// At least one redirect URI is required to register; fall back to the canonical URL when the filter empties the set.
+		if ( $redirect_uris === [] ) {
+			return [ $canonical ];
+		}
+
+		return $redirect_uris;
+	}
+
+	/**
+	 * Returns the single redirect URI to embed in an authorization request.
+	 *
+	 * @param Registered_Client  $client             The registered client whose redirect_uris bound the result.
+	 * @param int                $user_id            The WordPress user ID starting the flow.
+	 * @param string[]           $scopes             The scopes being requested.
+	 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the token will be bound to.
+	 * @param string|null        $return_url         The URL the user returns to after authorization, or null.
+	 *
+	 * @return string A redirect URI guaranteed to be present in $client's registered redirect_uris.
+	 */
+	public function get_authorization_redirect_uri(
+		Registered_Client $client,
+		int $user_id,
+		array $scopes,
+		Resource_Indicator $resource_indicator,
+		?string $return_url = null
+	): string {
+		$registered = $this->registered_redirect_uris( $client );
+		$canonical  = $this->get_canonical_redirect_uri();
+
+		// Prefer the canonical URL when it is registered; otherwise fall back to the first
+		// registered URI so the value always matches one of the registered redirect_uris. When the
+		// client has no registered URIs at all, default to the canonical as a last resort.
+		if ( $registered === [] || \in_array( $canonical, $registered, true ) ) {
+			$chosen = $canonical;
+		}
+		else {
+			$chosen = $registered[0];
+		}
+
+		/**
+		 * Filters the redirect URI embedded in a single MyYoast authorization request.
+		 *
+		 * The returned value must be one of the client's registered redirect URIs; a value that
+		 * is not registered is ignored to avoid an OAuth redirect_uri mismatch, and the computed
+		 * default is used instead.
+		 *
+		 * @param string             $redirect_uri       The redirect URI to embed. Must be one of $client's registered redirect_uris.
+		 * @param Registered_Client  $client             The registered client for this flow.
+		 * @param int                $user_id            The WordPress user ID starting the flow.
+		 * @param string[]           $scopes             The scopes being requested.
+		 * @param Resource_Indicator $resource_indicator The RFC 8707 resource indicator the token will be bound to.
+		 * @param string|null        $return_url         The URL the user returns to after authorization, or null.
+		 */
+		$filtered = \apply_filters(
+			'wpseo_myyoast_authorization_redirect_uri',
+			$chosen,
+			$client,
+			$user_id,
+			$scopes,
+			$resource_indicator,
+			$return_url,
+		);
+
+		// Honor the filtered value only when it is actually registered, to prevent a mismatch.
+		if ( \is_string( $filtered ) && \in_array( $filtered, $registered, true ) ) {
+			return $filtered;
+		}
+
+		return $chosen;
+	}
+
+	/**
+	 * Returns the canonical admin callback redirect URI for this site.
+	 *
+	 * @return string The canonical redirect URI.
+	 */
+	private function get_canonical_redirect_uri(): string {
+		return \get_admin_url(
+			null,
+			'admin.php?page=' . General_Page_Integration::PAGE . '&yoast_myyoast_oauth_callback=1',
+		);
+	}
+
+	/**
+	 * Returns the client's registered redirect URIs as a set, preserving their stored order.
+	 *
+	 * @param Registered_Client $client The registered client.
+	 *
+	 * @return string[] The registered redirect URIs; empty when the client has none stored.
+	 */
+	private function registered_redirect_uris( Registered_Client $client ): array {
+		return $this->unique( $this->only_valid_uris( $client->get_redirect_uris() ) );
+	}
+
+	/**
+	 * Filters untrusted input down to its non-empty string values, preserving order.
+	 *
+	 * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- Untrusted filter/metadata input.
+	 *
+	 * @param mixed $uris The candidate URIs (untrusted filter or metadata input).
+	 *
+	 * @return string[] The non-empty string URIs.
+	 *
+	 * phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+	 */
+	private function only_valid_uris( $uris ): array {
+		if ( ! \is_array( $uris ) ) {
+			return [];
+		}
+
+		$valid = [];
+		foreach ( $uris as $uri ) {
+			if ( \is_string( $uri ) && $uri !== '' ) {
+				$valid[] = $uri;
+			}
+		}
+
+		return $valid;
+	}
+
+	/**
+	 * Reduces a list of URIs to a set (unique values), preserving first-seen order.
+	 *
+	 * @param string[] $uris The URIs.
+	 *
+	 * @return string[] The unique URIs, reindexed.
+	 */
+	private function unique( array $uris ): array {
+		return \array_values( \array_unique( $uris ) );
+	}
+}

--- a/src/myyoast-client/user-interface/auth-command.php
+++ b/src/myyoast-client/user-interface/auth-command.php
@@ -8,7 +8,6 @@ use WP_CLI\ExitException;
 use WP_CLI\Utils;
 use Yoast\WP\SEO\Commands\Command_Interface;
 use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
-use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
 use Yoast\WP\SEO\Loadable_Interface;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client;
@@ -249,8 +248,7 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 		}
 
 		try {
-			$redirect_uri = \get_admin_url( null, 'admin.php?page=' . General_Page_Integration::PAGE . '&yoast_myyoast_oauth_callback=1' );
-			$client       = $this->myyoast_client->ensure_registered( [ $redirect_uri ] );
+			$client = $this->myyoast_client->ensure_registered();
 		} catch ( Exception $e ) {
 			WP_CLI::error( 'Registration failed: ' . $e->getMessage() );
 			return;
@@ -714,11 +712,13 @@ final class Auth_Command implements Command_Interface, Loadable_Interface {
 			WP_CLI::error( 'Both --code and --state are required for code exchange.' );
 		}
 
-		// Phase 1: generate the authorization URL.
-		$redirect_uri = \get_admin_url( null, 'admin.php?page=' . General_Page_Integration::PAGE . '&yoast_myyoast_oauth_callback=1' );
+		// Phase 1: generate the authorization URL. Registration is a prerequisite.
+		if ( ! $this->myyoast_client->is_registered() ) {
+			WP_CLI::error( 'Not registered. Run "wp yoast auth register" first.' );
+		}
 
 		try {
-			$url = $this->myyoast_client->get_authorization_url( $user_id, $redirect_uri, $scopes, $resource_indicator );
+			$url = $this->myyoast_client->get_authorization_url( $user_id, $scopes, $resource_indicator );
 		} catch ( Exception $e ) {
 			WP_CLI::error( 'Failed to generate authorization URL: ' . $e->getMessage() );
 			return;

--- a/tests/Unit/AI/Authentication/Application/AI_Request_Sender_Factory/AI_Request_Sender_Factory_Test.php
+++ b/tests/Unit/AI/Authentication/Application/AI_Request_Sender_Factory/AI_Request_Sender_Factory_Test.php
@@ -116,7 +116,7 @@ final class AI_Request_Sender_Factory_Test extends TestCase {
 	}
 
 	/**
-	 * Filter pinning 'oauth' bypasses the feature-flag check and returns OAuth + Token fallback.
+	 * Filter pinning 'oauth' bypasses the feature-flag check and returns OAuth only, with no fallback.
 	 *
 	 * @covers ::create
 	 *
@@ -129,7 +129,7 @@ final class AI_Request_Sender_Factory_Test extends TestCase {
 		$sender = $this->instance->create( $this->user );
 
 		$this->assertSame( $this->oauth_strategy, $this->getPropertyValue( $sender, 'primary' ) );
-		$this->assertSame( $this->token_strategy, $this->getPropertyValue( $sender, 'fallback' ) );
+		$this->assertNull( $this->getPropertyValue( $sender, 'fallback' ) );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
@@ -6,12 +6,14 @@ use Mockery;
 use Yoast\WP\SEO\Expiring_Store\Application\Expiring_Store;
 use Yoast\WP\SEO\Expiring_Store\Domain\Key_Not_Found_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Authorization_Code_Handler;
+use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Authorization_Flow_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Token_Request_Failed_Exception;
 use Yoast\WP\SEO\MyYoast_Client\Application\Grants\Authorization_Code_Grant;
 use Yoast\WP\SEO\MyYoast_Client\Application\OAuth_Grant_Handler;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Discovery_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\ID_Token_Validator_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Redirect_URI_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Discovery_Document;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
@@ -68,6 +70,13 @@ final class Authorization_Code_Handler_Test extends TestCase {
 	private $expiring_store;
 
 	/**
+	 * The redirect URI provider mock.
+	 *
+	 * @var Redirect_URI_Provider_Interface|Mockery\MockInterface
+	 */
+	private $redirect_uri_provider;
+
+	/**
 	 * Set up the test fixtures.
 	 *
 	 * @return void
@@ -75,11 +84,15 @@ final class Authorization_Code_Handler_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->discovery           = Mockery::mock( Discovery_Interface::class );
-		$this->client_registration = Mockery::mock( Client_Registration_Interface::class );
-		$this->grant_handler       = Mockery::mock( OAuth_Grant_Handler::class );
-		$this->id_token_validator  = Mockery::mock( ID_Token_Validator_Interface::class );
-		$this->expiring_store      = Mockery::mock( Expiring_Store::class );
+		$this->discovery             = Mockery::mock( Discovery_Interface::class );
+		$this->client_registration   = Mockery::mock( Client_Registration_Interface::class );
+		$this->grant_handler         = Mockery::mock( OAuth_Grant_Handler::class );
+		$this->id_token_validator    = Mockery::mock( ID_Token_Validator_Interface::class );
+		$this->expiring_store        = Mockery::mock( Expiring_Store::class );
+		$this->redirect_uri_provider = Mockery::mock( Redirect_URI_Provider_Interface::class );
+
+		$this->redirect_uri_provider->allows( 'get_redirect_uris' )->andReturn( [ 'https://example.com/callback' ] );
+		$this->redirect_uri_provider->allows( 'get_authorization_redirect_uri' )->andReturn( 'https://example.com/callback' );
 
 		$this->instance = new Authorization_Code_Handler(
 			$this->discovery,
@@ -87,6 +100,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 			$this->grant_handler,
 			$this->id_token_validator,
 			$this->expiring_store,
+			$this->redirect_uri_provider,
 		);
 	}
 
@@ -101,7 +115,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
 
 		$this->client_registration
-			->expects( 'ensure_registered' )
+			->expects( 'get_registered_client' )
 			->andReturn( $registered_client );
 
 		$document = new Discovery_Document( $this->get_valid_discovery_response() );
@@ -115,7 +129,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 			->once()
 			->with( 'myyoast_current_authorization_state', Mockery::type( 'array' ), 600, 1 );
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], Resource_Indicator::default() );
+		$url = $this->instance->get_authorization_url( 1, [ 'profile' ], Resource_Indicator::default() );
 
 		$this->assertStringStartsWith( 'https://my.yoast.com/api/oauth/auth?', $url );
 		$this->assertStringContainsString( 'response_type=code', $url );
@@ -125,6 +139,32 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->assertStringContainsString( 'state=', $url );
 		$this->assertStringNotContainsString( 'nonce=', $url );
 		$this->assertStringNotContainsString( 'resource=', $url );
+	}
+
+	/**
+	 * Tests that get_authorization_url throws when the site is not registered, without triggering
+	 * DCR or contacting discovery.
+	 *
+	 * @covers ::get_authorization_url
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_url_throws_when_not_registered() {
+		$this->client_registration
+			->expects( 'get_registered_client' )
+			->once()
+			->andReturn( null );
+
+		$this->discovery->shouldNotReceive( 'get_document' );
+		$this->expiring_store->shouldNotReceive( 'persist_for_user' );
+
+		try {
+			$this->instance->get_authorization_url( 1, [ 'profile' ], Resource_Indicator::default() );
+			$this->fail( 'Expected Authorization_Flow_Exception.' );
+		}
+		catch ( Authorization_Flow_Exception $exception ) {
+			$this->assertSame( 'not_registered', $exception->get_error_code() );
+		}
 	}
 
 	/**
@@ -138,7 +178,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
 
 		$this->client_registration
-			->expects( 'ensure_registered' )
+			->expects( 'get_registered_client' )
 			->andReturn( $registered_client );
 
 		$document = new Discovery_Document( $this->get_valid_discovery_response() );
@@ -163,7 +203,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 				1,
 			);
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'openid', 'profile' ], Resource_Indicator::default() );
+		$url = $this->instance->get_authorization_url( 1, [ 'openid', 'profile' ], Resource_Indicator::default() );
 
 		$this->assertStringContainsString( 'nonce=', $url );
 	}
@@ -179,7 +219,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
 
 		$this->client_registration
-			->expects( 'ensure_registered' )
+			->expects( 'get_registered_client' )
 			->andReturn( $registered_client );
 
 		$document = new Discovery_Document( $this->get_valid_discovery_response() );
@@ -203,7 +243,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 				1,
 			);
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], Resource_Indicator::default(), 'https://example.com/settings' );
+		$url = $this->instance->get_authorization_url( 1, [ 'profile' ], Resource_Indicator::default(), 'https://example.com/settings' );
 
 		$this->assertStringStartsWith( 'https://my.yoast.com/api/oauth/auth?', $url );
 	}
@@ -537,7 +577,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
 
 		$this->client_registration
-			->expects( 'ensure_registered' )
+			->expects( 'get_registered_client' )
 			->andReturn( $registered_client );
 
 		$document = new Discovery_Document( $this->get_valid_discovery_response() );
@@ -558,7 +598,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 				1,
 			);
 
-		$url = $this->instance->get_authorization_url( 1, 'https://example.com/callback', [ 'profile' ], new Resource_Indicator( 'https://ai.yoa.st' ) );
+		$url = $this->instance->get_authorization_url( 1, [ 'profile' ], new Resource_Indicator( 'https://ai.yoa.st' ) );
 
 		$this->assertStringContainsString( 'resource=https%3A%2F%2Fai.yoa.st', $url );
 	}

--- a/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/Authorization_Code_Handler_Test.php
@@ -92,7 +92,7 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->redirect_uri_provider = Mockery::mock( Redirect_URI_Provider_Interface::class );
 
 		$this->redirect_uri_provider->allows( 'get_redirect_uris' )->andReturn( [ 'https://example.com/callback' ] );
-		$this->redirect_uri_provider->allows( 'get_authorization_redirect_uri' )->andReturn( 'https://example.com/callback' );
+		$this->redirect_uri_provider->allows( 'get_authorization_redirect_uri' )->andReturn( 'https://example.com/callback' )->byDefault();
 
 		$this->instance = new Authorization_Code_Handler(
 			$this->discovery,
@@ -139,6 +139,40 @@ final class Authorization_Code_Handler_Test extends TestCase {
 		$this->assertStringContainsString( 'state=', $url );
 		$this->assertStringNotContainsString( 'nonce=', $url );
 		$this->assertStringNotContainsString( 'resource=', $url );
+	}
+
+	/**
+	 * Tests that get_authorization_url embeds the redirect URI resolved by the provider from the
+	 * registered client.
+	 *
+	 * @covers ::get_authorization_url
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_url_embeds_provider_resolved_redirect_uri() {
+		$registered_client = new Registered_Client( 'client-123', 'rat', 'https://my.yoast.com/reg/client-123' );
+
+		$this->client_registration
+			->expects( 'get_registered_client' )
+			->andReturn( $registered_client );
+
+		// Override the blanket set_up stub: assert the provider receives the registered client and
+		// flow context, and that its returned URI is the one embedded in the authorization URL.
+		$this->redirect_uri_provider
+			->expects( 'get_authorization_redirect_uri' )
+			->once()
+			->with( $registered_client, 1, [ 'profile' ], Mockery::type( Resource_Indicator::class ), null )
+			->andReturn( 'https://proxy.example/cb' );
+
+		$this->discovery
+			->expects( 'get_document' )
+			->andReturn( new Discovery_Document( $this->get_valid_discovery_response() ) );
+
+		$this->expiring_store->expects( 'persist_for_user' )->once();
+
+		$url = $this->instance->get_authorization_url( 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertStringContainsString( 'redirect_uri=' . \rawurlencode( 'https://proxy.example/cb' ), $url );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
@@ -94,6 +94,13 @@ final class MyYoast_Client_Test extends TestCase {
 	private $http_client;
 
 	/**
+	 * The redirect URI provider mock.
+	 *
+	 * @var Redirect_URI_Provider_Interface|Mockery\MockInterface
+	 */
+	private $redirect_uri_provider;
+
+	/**
 	 * Set up the test fixtures.
 	 *
 	 * @return void

--- a/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/MyYoast_Client_Test.php
@@ -12,6 +12,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client;
 use Yoast\WP\SEO\MyYoast_Client\Application\OAuth_Grant_Handler;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\OAuth_Server_Client_Interface;
+use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Redirect_URI_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Site_URL_Provider_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Token_Storage_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\User_Token_Storage_Interface;
@@ -112,6 +113,9 @@ final class MyYoast_Client_Test extends TestCase {
 		$site_url_provider = Mockery::mock( Site_URL_Provider_Interface::class );
 		$site_url_provider->allows( 'get' )->andReturn( 'https://example.com/' );
 
+		$this->redirect_uri_provider = Mockery::mock( Redirect_URI_Provider_Interface::class );
+		$this->redirect_uri_provider->allows( 'get_redirect_uris' )->andReturn( [ 'https://example.com/callback' ] );
+
 		$this->instance = new MyYoast_Client(
 			$this->client_registration,
 			$this->auth_code_handler,
@@ -122,6 +126,7 @@ final class MyYoast_Client_Test extends TestCase {
 			$this->token_storage,
 			$this->user_token_storage,
 			$site_url_provider,
+			$this->redirect_uri_provider,
 		);
 	}
 
@@ -139,7 +144,7 @@ final class MyYoast_Client_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that is_registered delegates to client_registration.
+	 * Tests that is_registered reflects whether a registered client is stored.
 	 *
 	 * @covers ::is_registered
 	 *
@@ -147,11 +152,12 @@ final class MyYoast_Client_Test extends TestCase {
 	 */
 	public function test_is_registered() {
 		$this->client_registration
-			->expects( 'is_registered' )
-			->once()
-			->andReturn( true );
+			->expects( 'get_registered_client' )
+			->twice()
+			->andReturn( new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' ), null );
 
 		$this->assertTrue( $this->instance->is_registered() );
+		$this->assertFalse( $this->instance->is_registered() );
 	}
 
 	/**
@@ -376,7 +382,7 @@ final class MyYoast_Client_Test extends TestCase {
 			->once()
 			->andReturn( null );
 
-		$this->client_registration->expects( 'is_registered' )->once()->andReturn( true );
+		$this->client_registration->expects( 'get_registered_client' )->once()->andReturn( new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' ) );
 		$this->client_registration->shouldNotReceive( 'ensure_registered' );
 
 		$fresh = new Token_Set( 'new-site-token', ( \time() + 900 ) );
@@ -521,7 +527,7 @@ final class MyYoast_Client_Test extends TestCase {
 			->once()
 			->andReturn( $cached );
 
-		$this->client_registration->expects( 'is_registered' )->once()->andReturn( true );
+		$this->client_registration->expects( 'get_registered_client' )->once()->andReturn( new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' ) );
 		$this->client_registration->shouldNotReceive( 'ensure_registered' );
 
 		$fresh = new Token_Set( 'new-token', ( \time() + 900 ), 'DPoP', null, null, 'service:licenses:read service:subscriptions:read' );
@@ -553,7 +559,7 @@ final class MyYoast_Client_Test extends TestCase {
 	public function test_get_site_token_throws_when_site_not_registered() {
 		$this->token_storage->expects( 'get' )->once()->andReturn( null );
 
-		$this->client_registration->expects( 'is_registered' )->once()->andReturn( false );
+		$this->client_registration->expects( 'get_registered_client' )->once()->andReturn( null );
 		$this->client_registration->shouldNotReceive( 'ensure_registered' );
 
 		$this->grant_handler->shouldNotReceive( 'request_token' );
@@ -696,6 +702,7 @@ final class MyYoast_Client_Test extends TestCase {
 
 		$this->client_registration
 			->expects( 'ensure_registered' )
+			->with( [ 'https://example.com/callback' ] )
 			->once()
 			->andReturn( $registered );
 
@@ -763,19 +770,21 @@ final class MyYoast_Client_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that has_validated_redirect_uri delegates to the client registration port.
+	 * Tests that get_registered_client delegates to the client registration port.
 	 *
-	 * @covers ::has_validated_redirect_uri
+	 * @covers ::get_registered_client
 	 *
 	 * @return void
 	 */
-	public function test_has_validated_redirect_uri() {
-		$this->client_registration
-			->expects( 'has_validated_redirect_uri' )
-			->once()
-			->andReturn( true );
+	public function test_get_registered_client_delegates() {
+		$registered = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
 
-		$this->assertTrue( $this->instance->has_validated_redirect_uri() );
+		$this->client_registration
+			->expects( 'get_registered_client' )
+			->once()
+			->andReturn( $registered );
+
+		$this->assertSame( $registered, $this->instance->get_registered_client() );
 	}
 
 	/**
@@ -801,9 +810,9 @@ final class MyYoast_Client_Test extends TestCase {
 			->andReturn( null );
 
 		$this->client_registration
-			->expects( 'is_registered' )
+			->expects( 'get_registered_client' )
 			->once()
-			->andReturn( true );
+			->andReturn( new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' ) );
 
 		$fresh = ( new Token_Set( 'ai-tok', ( \time() + 900 ) ) )->with_resource_indicator( new Resource_Indicator( 'https://ai.yoa.st' ) );
 

--- a/tests/Unit/MyYoast_Client/Application/OAuth_Grant_Handler_Test.php
+++ b/tests/Unit/MyYoast_Client/Application/OAuth_Grant_Handler_Test.php
@@ -94,7 +94,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_success() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 
 		$this->client_authenticator
 			->expects( 'create_client_assertion' )
@@ -148,7 +148,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_sends_resource_indicator_in_body_and_stamps_result() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
 
 		$grant = Mockery::mock( Grant_Interface::class );
@@ -194,7 +194,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_omits_resource_when_null() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
 
 		$grant = Mockery::mock( Grant_Interface::class );
@@ -244,7 +244,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_ignores_as_echoed_resource() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 		$this->client_authenticator->expects( 'create_client_assertion' )->andReturn( 'jwt' );
 
 		$grant = Mockery::mock( Grant_Interface::class );
@@ -280,7 +280,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_throws_on_error() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 
 		$this->client_authenticator
 			->expects( 'create_client_assertion' )
@@ -316,7 +316,7 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 	 */
 	public function test_request_token_throws_on_non_json_error() {
 		$credentials = new Registered_Client( 'cid', 'rat', 'https://my.yoast.com/reg/cid' );
-		$this->client_registration->expects( 'ensure_registered' )->andReturn( $credentials );
+		$this->client_registration->expects( 'get_registered_client' )->andReturn( $credentials );
 
 		$this->client_authenticator
 			->expects( 'create_client_assertion' )
@@ -339,6 +339,31 @@ final class OAuth_Grant_Handler_Test extends TestCase {
 		$this->expectException( Token_Request_Failed_Exception::class );
 		$this->expectExceptionMessage( 'HTTP 500' );
 		$this->instance->request_token( $grant, Resource_Indicator::default() );
+	}
+
+	/**
+	 * Tests that request_token throws not_registered when the site has no stored registration,
+	 * without triggering DCR or contacting the token endpoint.
+	 *
+	 * @covers ::request_token
+	 *
+	 * @return void
+	 */
+	public function test_request_token_throws_when_not_registered() {
+		$this->client_registration->expects( 'get_registered_client' )->once()->andReturn( null );
+
+		$this->client_authenticator->shouldNotReceive( 'create_client_assertion' );
+		$this->token_endpoint_client->shouldNotReceive( 'request' );
+
+		$grant = Mockery::mock( Grant_Interface::class );
+
+		try {
+			$this->instance->request_token( $grant, Resource_Indicator::default() );
+			$this->fail( 'Expected Token_Request_Failed_Exception.' );
+		}
+		catch ( Token_Request_Failed_Exception $exception ) {
+			$this->assertSame( 'not_registered', $exception->get_error_code() );
+		}
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Domain/Registered_Client_Test.php
+++ b/tests/Unit/MyYoast_Client/Domain/Registered_Client_Test.php
@@ -77,6 +77,106 @@ final class Registered_Client_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that get_redirect_uris returns the registered redirect URIs from metadata.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris() {
+		$with_uris = new Registered_Client(
+			'cid',
+			'rat',
+			'https://example.com/reg/cid',
+			[ 'redirect_uris' => [ 'https://a.example/cb', 'https://b.example/cb' ] ],
+		);
+		$without   = new Registered_Client( 'cid', 'rat', 'https://example.com/reg/cid' );
+
+		$this->assertSame( [ 'https://a.example/cb', 'https://b.example/cb' ], $with_uris->get_redirect_uris() );
+		$this->assertSame( [], $without->get_redirect_uris() );
+	}
+
+	/**
+	 * Tests that has_redirect_uris compares the registered set exactly (order-insensitive), so
+	 * both additions and removals count as a mismatch.
+	 *
+	 * @covers ::__construct
+	 * @covers ::has_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_has_redirect_uris() {
+		$client = new Registered_Client(
+			'cid',
+			'rat',
+			'https://example.com/reg/cid',
+			[ 'redirect_uris' => [ 'https://a.example/cb', 'https://b.example/cb' ] ],
+		);
+
+		// Same set, different order — match.
+		$this->assertTrue( $client->has_redirect_uris( [ 'https://b.example/cb', 'https://a.example/cb' ] ) );
+
+		// A removal — mismatch.
+		$this->assertFalse( $client->has_redirect_uris( [ 'https://a.example/cb' ] ) );
+
+		// An addition — mismatch.
+		$this->assertFalse(
+			$client->has_redirect_uris( [ 'https://a.example/cb', 'https://b.example/cb', 'https://c.example/cb' ] ),
+		);
+	}
+
+	/**
+	 * Tests that is_uri_validated reflects the stored validated URIs.
+	 *
+	 * @covers ::__construct
+	 * @covers ::is_uri_validated
+	 *
+	 * @return void
+	 */
+	public function test_is_uri_validated() {
+		$dto = new Registered_Client(
+			'cid',
+			'rat',
+			'https://example.com/reg/cid',
+			[],
+			[ 'https://example.com/callback' ],
+		);
+
+		$this->assertTrue( $dto->is_uri_validated( 'https://example.com/callback' ) );
+		$this->assertFalse( $dto->is_uri_validated( 'https://other.example/callback' ) );
+	}
+
+	/**
+	 * Tests that with_validated_uris returns a copy with the URIs replaced, leaving the original intact.
+	 *
+	 * @covers ::__construct
+	 * @covers ::with_validated_uris
+	 * @covers ::get_validated_uris
+	 *
+	 * @return void
+	 */
+	public function test_with_validated_uris() {
+		$dto = new Registered_Client(
+			'cid',
+			'rat',
+			'https://example.com/reg/cid',
+			[ 'key' => 'val' ],
+			[ 'https://a.example/callback' ],
+		);
+
+		$copy = $dto->with_validated_uris( [ 'https://b.example/callback' ] );
+
+		$this->assertNotSame( $dto, $copy );
+		$this->assertSame( [ 'https://a.example/callback' ], $dto->get_validated_uris(), 'The original is unchanged.' );
+		$this->assertSame( [ 'https://b.example/callback' ], $copy->get_validated_uris() );
+		$this->assertSame( 'cid', $copy->get_client_id() );
+		$this->assertSame( 'rat', $copy->get_registration_access_token() );
+		$this->assertSame( 'https://example.com/reg/cid', $copy->get_registration_client_uri() );
+		$this->assertSame( [ 'key' => 'val' ], $copy->get_metadata() );
+	}
+
+	/**
 	 * Tests that the constructor throws when client_id is empty.
 	 *
 	 * @covers ::__construct

--- a/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
@@ -522,6 +522,28 @@ final class Client_Registration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that ensure_registered throws when not registered and no redirect URIs are given,
+	 * so a token/auth flow can never silently register an empty client.
+	 *
+	 * @covers ::ensure_registered
+	 *
+	 * @return void
+	 */
+	public function test_ensure_registered_throws_when_not_registered_and_no_uris() {
+		Functions\expect( 'get_option' )
+			->with( self::OPTION_KEY, false )
+			->andReturn( false );
+
+		$this->http_client->expects( 'request' )->never();
+		$this->http_client->expects( 'authenticated_request' )->never();
+
+		$this->expectException( Registration_Failed_Exception::class );
+		$this->expectExceptionMessage( 'At least one redirect URI is required' );
+
+		$this->instance->ensure_registered( [] );
+	}
+
+	/**
 	 * Tests that ensure_registered updates the registration in place (RFC 7592 PUT, no
 	 * deregister/re-register) when the redirect-URI set differs, preserving the client_id and
 	 * pruning the validated URIs to the new set.
@@ -590,6 +612,70 @@ final class Client_Registration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that store_credentials resets validated_uris when the server returns a different
+	 * client_id, since a new client must re-validate every redirect URI from scratch.
+	 *
+	 * @covers ::store_credentials
+	 *
+	 * @return void
+	 */
+	public function test_store_credentials_resets_validated_uris_for_a_new_client_id() {
+		// Registered as "old-cid" with A validated.
+		Functions\expect( 'get_option' )
+			->with( self::OPTION_KEY, Mockery::any() )
+			->andReturn(
+				[
+					'client_id'               => 'old-cid',
+					'encrypted_rat'           => 'encrypted-rat',
+					'registration_client_uri' => 'https://my.yoast.com/api/oauth/reg/old-cid',
+					'metadata'                => [ 'redirect_uris' => [ 'https://a.example/cb' ] ],
+					'validated_uris'          => [ 'https://a.example/cb' ],
+				],
+			);
+
+		$this->encryption->allows( 'decrypt' )->andReturn( 'decrypted-rat' );
+		$this->encryption->allows( 'encrypt' )->andReturn( 'encrypted-rat' );
+		$this->issuer_config->expects( 'get_software_statement' )->andReturn( 'fresh-ss-jwt' );
+		Functions\expect( 'wp_json_encode' )->andReturn( '{}' );
+
+		// The server responds with a different client_id and the same redirect URI.
+		$this->http_client
+			->expects( 'authenticated_request' )
+			->once()
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'client_id'                 => 'new-cid',
+						'registration_access_token' => 'rat',
+						'registration_client_uri'   => 'https://my.yoast.com/api/oauth/reg/new-cid',
+						'redirect_uris'             => [ 'https://a.example/cb' ],
+					],
+				),
+			);
+
+		// A was validated under the old client_id, but the new client_id resets all verification.
+		Functions\expect( 'update_option' )
+			->once()
+			->with(
+				self::OPTION_KEY,
+				Mockery::on(
+					static function ( $option ) {
+						return ( $option['validated_uris'] ?? null ) === [];
+					},
+				),
+				false,
+			)
+			->andReturn( true );
+
+		$result = $this->instance->ensure_registered( [ 'https://b.example/cb' ] );
+
+		$this->assertSame( 'new-cid', $result->get_client_id() );
+		$this->assertSame( [], $result->get_validated_uris() );
+	}
+
+	/**
 	 * Tests that mark_uri_validated appends the redirect URI to the stored registration.
 	 *
 	 * @covers ::mark_uri_validated
@@ -623,6 +709,34 @@ final class Client_Registration_Test extends TestCase {
 				false,
 			)
 			->andReturn( true );
+
+		$this->instance->mark_uri_validated( 'https://example.com/callback' );
+	}
+
+	/**
+	 * Tests that mark_uri_validated is idempotent: re-marking an already-validated URI does not
+	 * persist a duplicate.
+	 *
+	 * @covers ::mark_uri_validated
+	 *
+	 * @return void
+	 */
+	public function test_mark_uri_validated_is_idempotent() {
+		Functions\expect( 'get_option' )
+			->with( self::OPTION_KEY, false )
+			->andReturn(
+				[
+					'client_id'               => 'cid',
+					'encrypted_rat'           => 'encrypted-rat',
+					'registration_client_uri' => 'https://my.yoast.com/api/oauth/reg/cid',
+					'metadata'                => [],
+					'validated_uris'          => [ 'https://example.com/callback' ],
+				],
+			);
+
+		$this->encryption->expects( 'decrypt' )->andReturn( 'decrypted-rat' );
+
+		Functions\expect( 'update_option' )->never();
 
 		$this->instance->mark_uri_validated( 'https://example.com/callback' );
 	}

--- a/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
@@ -161,21 +161,6 @@ final class Client_Registration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that is_registered returns correct values.
-	 *
-	 * @covers ::is_registered
-	 *
-	 * @return void
-	 */
-	public function test_is_registered() {
-		Functions\expect( 'get_option' )
-			->with( self::OPTION_KEY, false )
-			->andReturn( false );
-
-		$this->assertFalse( $this->instance->is_registered() );
-	}
-
-	/**
 	 * Tests that register throws when another registration is in progress.
 	 *
 	 * @covers ::register
@@ -463,42 +448,42 @@ final class Client_Registration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that has_validated_redirect_uri returns false when the site is not registered.
+	 * Tests that is_uri_validated returns false when the site is not registered.
 	 *
-	 * @covers ::has_validated_redirect_uri
+	 * @covers ::is_uri_validated
 	 *
 	 * @return void
 	 */
-	public function test_has_validated_redirect_uri_returns_false_when_not_registered() {
+	public function test_is_uri_validated_returns_false_when_not_registered() {
 		Functions\expect( 'get_option' )
 			->once()
 			->with( self::OPTION_KEY, false )
 			->andReturn( false );
 
-		$this->assertFalse( $this->instance->has_validated_redirect_uri() );
+		$this->assertFalse( $this->instance->is_uri_validated( 'https://example.com/callback' ) );
 	}
 
 	/**
-	 * Tests that has_validated_redirect_uri returns false when no redirect URI has been validated yet.
+	 * Tests that is_uri_validated returns false when the URI has not been validated yet.
 	 *
-	 * @covers ::has_validated_redirect_uri
+	 * @covers ::is_uri_validated
 	 *
 	 * @return void
 	 */
-	public function test_has_validated_redirect_uri_returns_false_when_none_validated() {
+	public function test_is_uri_validated_returns_false_when_uri_not_validated() {
 		$this->mock_get_client();
 
-		$this->assertFalse( $this->instance->has_validated_redirect_uri() );
+		$this->assertFalse( $this->instance->is_uri_validated( 'https://example.com/callback' ) );
 	}
 
 	/**
-	 * Tests that has_validated_redirect_uri returns true when a redirect URI has been validated.
+	 * Tests that is_uri_validated returns true only for a redirect URI that has been validated.
 	 *
-	 * @covers ::has_validated_redirect_uri
+	 * @covers ::is_uri_validated
 	 *
 	 * @return void
 	 */
-	public function test_has_validated_redirect_uri_returns_true_when_a_uri_is_validated() {
+	public function test_is_uri_validated_returns_true_for_a_validated_uri() {
 		Functions\expect( 'get_option' )
 			->with( self::OPTION_KEY, false )
 			->andReturn(
@@ -513,7 +498,95 @@ final class Client_Registration_Test extends TestCase {
 
 		$this->encryption->expects( 'decrypt' )->andReturn( 'decrypted-rat' );
 
-		$this->assertTrue( $this->instance->has_validated_redirect_uri() );
+		$this->assertTrue( $this->instance->is_uri_validated( 'https://example.com/callback' ) );
+		$this->assertFalse( $this->instance->is_uri_validated( 'https://other.example/callback' ) );
+	}
+
+	/**
+	 * Tests that ensure_registered is a no-op (no HTTP, returns the stored client) when the
+	 * redirect-URI set already matches.
+	 *
+	 * @covers ::ensure_registered
+	 *
+	 * @return void
+	 */
+	public function test_ensure_registered_is_noop_when_set_matches() {
+		$this->mock_get_client( [ 'redirect_uris' => [ 'https://example.com/callback' ] ] );
+
+		$this->http_client->expects( 'authenticated_request' )->never();
+		$this->http_client->expects( 'request' )->never();
+
+		$result = $this->instance->ensure_registered( [ 'https://example.com/callback' ] );
+
+		$this->assertSame( 'cid', $result->get_client_id() );
+	}
+
+	/**
+	 * Tests that ensure_registered updates the registration in place (RFC 7592 PUT, no
+	 * deregister/re-register) when the redirect-URI set differs, preserving the client_id and
+	 * pruning the validated URIs to the new set.
+	 *
+	 * @covers ::ensure_registered
+	 * @covers ::update_redirect_uris
+	 * @covers ::store_credentials
+	 *
+	 * @return void
+	 */
+	public function test_ensure_registered_updates_in_place_and_prunes_validated_uris() {
+		// Registered with A + B, both validated.
+		Functions\expect( 'get_option' )
+			->with( self::OPTION_KEY, Mockery::any() )
+			->andReturn(
+				[
+					'client_id'               => 'cid',
+					'encrypted_rat'           => 'encrypted-rat',
+					'registration_client_uri' => 'https://my.yoast.com/api/oauth/reg/cid',
+					'metadata'                => [ 'redirect_uris' => [ 'https://a.example/cb', 'https://b.example/cb' ] ],
+					'validated_uris'          => [ 'https://a.example/cb', 'https://b.example/cb' ],
+				],
+			);
+
+		$this->encryption->allows( 'decrypt' )->andReturn( 'decrypted-rat' );
+		$this->encryption->allows( 'encrypt' )->andReturn( 'encrypted-rat' );
+		$this->issuer_config->expects( 'get_software_statement' )->andReturn( 'fresh-ss-jwt' );
+		Functions\expect( 'wp_json_encode' )->andReturn( '{}' );
+
+		// A single in-place PUT — never a DELETE or a POST register.
+		$this->http_client
+			->expects( 'authenticated_request' )
+			->once()
+			->with( 'PUT', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any() )
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'client_id'                 => 'cid',
+						'registration_access_token' => 'rat',
+						'registration_client_uri'   => 'https://my.yoast.com/api/oauth/reg/cid',
+						'redirect_uris'             => [ 'https://a.example/cb', 'https://c.example/cb' ],
+					],
+				),
+			);
+
+		// B is pruned (removed from the set); C is not validated (newly added); A is kept.
+		Functions\expect( 'update_option' )
+			->once()
+			->with(
+				self::OPTION_KEY,
+				Mockery::on(
+					static function ( $option ) {
+						return ( $option['validated_uris'] ?? null ) === [ 'https://a.example/cb' ];
+					},
+				),
+				false,
+			)
+			->andReturn( true );
+
+		$result = $this->instance->ensure_registered( [ 'https://a.example/cb', 'https://c.example/cb' ] );
+
+		$this->assertSame( 'cid', $result->get_client_id() );
+		$this->assertSame( [ 'https://a.example/cb' ], $result->get_validated_uris() );
 	}
 
 	/**

--- a/tests/Unit/MyYoast_Client/Infrastructure/WordPress/Redirect_URI_Provider_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/WordPress/Redirect_URI_Provider_Test.php
@@ -1,0 +1,258 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Infrastructure\WordPress;
+
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
+use Yoast\WP\SEO\MyYoast_Client\Domain\Resource_Indicator;
+use Yoast\WP\SEO\MyYoast_Client\Infrastructure\WordPress\Redirect_URI_Provider;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Redirect_URI_Provider class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\MyYoast_Client\Infrastructure\WordPress\Redirect_URI_Provider
+ */
+final class Redirect_URI_Provider_Test extends TestCase {
+
+	/**
+	 * The canonical admin callback URL the provider builds.
+	 *
+	 * @var string
+	 */
+	private const CANONICAL = 'https://example.com/wp-admin/admin.php?page=wpseo_dashboard&yoast_myyoast_oauth_callback=1';
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Redirect_URI_Provider
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Redirect_URI_Provider();
+
+		Functions\stubs(
+			[
+				'get_admin_url' => static function ( $blog_id, $path ) {
+					return 'https://example.com/wp-admin/' . $path;
+				},
+			],
+		);
+	}
+
+	/**
+	 * Tests that get_redirect_uris returns the canonical URL when the filter does not change it.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_returns_canonical() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->with( 'wpseo_myyoast_redirect_uris', [ self::CANONICAL ] )
+			->andReturnFirstArg();
+
+		$this->assertSame( [ self::CANONICAL ], $this->instance->get_redirect_uris() );
+	}
+
+	/**
+	 * Tests that get_redirect_uris honors a filter that adds a URI, dropping empties and duplicates.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_honors_filter_additions() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( [ self::CANONICAL, 'https://proxy.example/cb', '', self::CANONICAL ] );
+
+		// Empty strings and duplicates are dropped; first-seen order is preserved.
+		$this->assertSame(
+			[ self::CANONICAL, 'https://proxy.example/cb' ],
+			$this->instance->get_redirect_uris(),
+		);
+	}
+
+	/**
+	 * Tests that get_redirect_uris collapses duplicate URIs returned by the filter into a set.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_deduplicates() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn(
+				[
+					'https://proxy.example/cb',
+					'https://proxy.example/cb',
+					'https://other.example/cb',
+				],
+			);
+
+		$this->assertSame(
+			[ 'https://proxy.example/cb', 'https://other.example/cb' ],
+			$this->instance->get_redirect_uris(),
+		);
+	}
+
+	/**
+	 * Tests that get_redirect_uris lets the filter remove and replace the canonical URL entirely.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_allows_replacing_canonical() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( [ 'https://custom.example/cb' ] );
+
+		$this->assertSame(
+			[ 'https://custom.example/cb' ],
+			$this->instance->get_redirect_uris(),
+		);
+	}
+
+	/**
+	 * Tests that get_redirect_uris falls back to the canonical URL when the filter empties the set,
+	 * since at least one redirect URI is required to register.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_falls_back_to_canonical_when_filter_empties_set() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( [] );
+
+		$this->assertSame( [ self::CANONICAL ], $this->instance->get_redirect_uris() );
+	}
+
+	/**
+	 * Tests that get_authorization_redirect_uri returns the canonical URL when it is registered.
+	 *
+	 * @covers ::get_authorization_redirect_uri
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_redirect_uri_prefers_canonical() {
+		$client = $this->make_client( [ self::CANONICAL, 'https://proxy.example/cb' ] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturnFirstArg();
+
+		$result = $this->instance->get_authorization_redirect_uri( $client, 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertSame( self::CANONICAL, $result );
+	}
+
+	/**
+	 * Tests that get_authorization_redirect_uri falls back to the first registered URI when the
+	 * canonical URL is not registered.
+	 *
+	 * @covers ::get_authorization_redirect_uri
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_redirect_uri_falls_back_to_first_registered() {
+		$client = $this->make_client( [ 'https://proxy.example/cb', 'https://other.example/cb' ] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturnFirstArg();
+
+		$result = $this->instance->get_authorization_redirect_uri( $client, 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertSame( 'https://proxy.example/cb', $result );
+	}
+
+	/**
+	 * Tests that get_authorization_redirect_uri ignores a filtered value that is not registered,
+	 * keeping the computed default to avoid an OAuth redirect_uri mismatch.
+	 *
+	 * @covers ::get_authorization_redirect_uri
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_redirect_uri_ignores_unregistered_filter_value() {
+		$client = $this->make_client( [ self::CANONICAL, 'https://proxy.example/cb' ] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( 'https://evil.example/cb' );
+
+		$result = $this->instance->get_authorization_redirect_uri( $client, 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertSame( self::CANONICAL, $result );
+	}
+
+	/**
+	 * Tests that get_authorization_redirect_uri honors a filtered value that is registered.
+	 *
+	 * @covers ::get_authorization_redirect_uri
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_redirect_uri_honors_registered_filter_value() {
+		$client = $this->make_client( [ self::CANONICAL, 'https://proxy.example/cb' ] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn( 'https://proxy.example/cb' );
+
+		$result = $this->instance->get_authorization_redirect_uri( $client, 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertSame( 'https://proxy.example/cb', $result );
+	}
+
+	/**
+	 * Tests that get_authorization_redirect_uri defaults to the canonical URL when the client has
+	 * no registered redirect URIs at all.
+	 *
+	 * @covers ::get_authorization_redirect_uri
+	 *
+	 * @return void
+	 */
+	public function test_get_authorization_redirect_uri_defaults_to_canonical_when_none_registered() {
+		$client = $this->make_client( [] );
+
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturnFirstArg();
+
+		$result = $this->instance->get_authorization_redirect_uri( $client, 1, [ 'profile' ], Resource_Indicator::default() );
+
+		$this->assertSame( self::CANONICAL, $result );
+	}
+
+	/**
+	 * Builds a Registered_Client with the given registered redirect URIs.
+	 *
+	 * @param string[] $redirect_uris The registered redirect URIs.
+	 *
+	 * @return Registered_Client
+	 */
+	private function make_client( array $redirect_uris ): Registered_Client {
+		return new Registered_Client(
+			'cid',
+			'rat',
+			'https://my.yoast.com/api/oauth/reg/cid',
+			[ 'redirect_uris' => $redirect_uris ],
+		);
+	}
+}

--- a/tests/Unit/MyYoast_Client/Infrastructure/WordPress/Redirect_URI_Provider_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/WordPress/Redirect_URI_Provider_Test.php
@@ -85,6 +85,29 @@ final class Redirect_URI_Provider_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that get_redirect_uris trims surrounding whitespace and drops whitespace-only URIs.
+	 *
+	 * @covers ::get_redirect_uris
+	 *
+	 * @return void
+	 */
+	public function test_get_redirect_uris_trims_and_drops_blank_uris() {
+		Functions\expect( 'apply_filters' )
+			->once()
+			->andReturn(
+				[
+					'  https://proxy.example/cb  ',
+					'   ',
+				],
+			);
+
+		$this->assertSame(
+			[ 'https://proxy.example/cb' ],
+			$this->instance->get_redirect_uris(),
+		);
+	}
+
+	/**
 	 * Tests that get_redirect_uris collapses duplicate URIs returned by the filter into a set.
 	 *
 	 * @covers ::get_redirect_uris


### PR DESCRIPTION
Ref Yoast/reserved-tasks#1207, #23265

## Context

In the (unreleased) MyYoast OAuth client, a site registers one client with many redirect URIs, and a URL becomes "verified" once a user completes an authorization-code flow against it. Verification was effectively client-level — the API only answered "has *any* URL been verified?" — and changing the redirect-URI set re-registered the client (new `client_id`), wiping all verification and all tokens. On top of that, building an authorization URL or requesting a token could implicitly trigger registration (DCR), which creates a real MyYoast connection that must only happen on a deliberate, capability-gated opt-in (ref Yoast/reserved-tasks#1168). This PR reshapes the API so verification is per-URL, registration is reconciled in place, and the read-style flows can never register a connection by accident. It also makes the AI auth-method filter able to pin a single strategy without a fallback.

## Summary

This PR can be summarized in the following changelog entry:

* Reshapes the unreleased MyYoast OAuth client to verify redirect URIs per-URL and to register only on explicit opt-in.

## Relevant technical choices:

* Per-URL verification lives on the `Registered_Client` model (`is_uri_validated()`, `with_validated_uris()`); the registration's validated URIs are always pruned to the intersection with the current redirect-URI set, so updating or removing-then-restoring a URL re-requires verification of that URL while untouched URLs keep their verification and tokens.
* A changed redirect-URI set is reconciled in place via RFC 7592 PUT (preserving the `client_id`, RAT, and key pair) instead of deregister + re-register; `ensure_registered()` takes a required exact set, and `Registered_Client::has_redirect_uris()` decides no-op vs. in-place update.
* Redirect URIs are no longer passed by consumers — an injected `Redirect_URI_Provider` supplies the registration set (`wpseo_myyoast_redirect_uris` filter, which may extend, remove, or replace the canonical admin callback) and selects the per-flow embed URI (`wpseo_myyoast_authorization_redirect_uri` filter, guarded to a registered URI).
* Registration (DCR) creates a real connection, so it must never be a side effect: `get_authorization_url()` and `request_token()` now only read existing registration via `get_registered_client()` and throw `not_registered` when absent; the only path that triggers DCR is the deliberate `ensure_registered()` (WP-CLI `auth register`). The ambiguous `is_registered($uris)` was dropped from the port.
* The `wpseo_ai_auth_method` filter now pins a single strategy exclusively — pinning `oauth` no longer keeps a token fallback; only the default unforced path stays OAuth-primary-with-token-fallback.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

It can be acceptance tested by following these steps:
* On a site that you have previously used staging-AI on (tracked consent on the AI server is required):
* Use the Yoast Test helper to switch to Staging Yoast AI.
* Force the AI features into using OAuth with: `add_filter( 'wpseo_ai_auth_method', static fn() => \Yoast\WP\SEO\AI\Authentication\Domain\Auth_Method::OAUTH );`
* On a site with the MyYoast connection feature flag on (`define( 'YOAST_SEO_MYYOAST_CONNECTION', true );`), run `wp yoast auth status` and confirm it reports not registered.
* Run `wp yoast auth authorize --user=admin --scopes=profile` *before* registering and confirm it errors with "Not registered. Run \"wp yoast auth register\" first." (it must not create a connection).
* Run `wp yoast auth register`.
* Try to use the AI features: get an error.
* `wp yoast auth authorize --user=admin` and confirm an authorization URL is produced whose `redirect_uri` is the admin callback URL.
* Complete the flow (`--code`/`--state`) and confirm the redirect URI is now verified for that client by using AI again - it should now work as usual.


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

QA can test this PR by following these steps:

* Not applicable — this is an internal change to an unreleased feature with no user-facing behavior at RC time.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The MyYoast OAuth client (`src/myyoast-client`) — registration, redirect-URI verification, and the authorization-code/token flows.
* AI authentication strategy selection (`src/ai/authentication`) — which auth strategy the AI request sender uses, including the `wpseo_ai_auth_method` filter override.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
