### PR TITLE
feat: hold back the Premium update until matching Free is available

### DIFF
--- a/inc/class-addon-manager.php
+++ b/inc/class-addon-manager.php
@@ -349,7 +349,9 @@ class WPSEO_Addon_Manager {
 					continue;
 				}
 
-				if ( version_compare( $plugin_data->requires, $wp_version, '<=' ) ) {
+				if ( version_compare( $plugin_data->requires, $wp_version, '<=' )
+					&& ! $this->is_held_back_until_free_available( $subscription_slug, $plugin_data->new_version, $yoast_free_data )
+				) {
 					// The add-on has an available update *and* the Yoast Free requirements for the WP version are also met, so go ahead and show the upgrade info to the user.
 					$is_no_update                   = false;
 					$data->response[ $plugin_file ] = $plugin_data;
@@ -390,6 +392,52 @@ class WPSEO_Addon_Manager {
 		}
 
 		return (object) [];
+	}
+
+	/**
+	 * Determines whether an add-on update should be hidden because the matching Yoast SEO Free version is not yet available to this site.
+	 *
+	 * Premium x.y requires Free x.y, while patch releases (x.y.z) do not tighten that requirement, so only the major and minor components are compared.
+	 *
+	 * @param string        $subscription_slug The add-on's subscription slug.
+	 * @param string        $addon_version     The add-on version offered by the My Yoast API.
+	 * @param stdClass|null $yoast_free_data   Yoast Free's entry from the wp.org update data.
+	 *
+	 * @return bool True when the add-on update should be held back.
+	 */
+	private function is_held_back_until_free_available( $subscription_slug, $addon_version, $yoast_free_data ) {
+		if ( $subscription_slug !== self::PREMIUM_SLUG ) {
+			return false;
+		}
+
+		// Without the latest available Free version we cannot tell whether the pairing is met, so we do not hold the update back.
+		if ( ! isset( $yoast_free_data->new_version ) ) {
+			return false;
+		}
+
+		$addon_major_minor = $this->get_major_minor( $addon_version );
+		$free_major_minor  = $this->get_major_minor( $yoast_free_data->new_version );
+
+		if ( $addon_major_minor === null || $free_major_minor === null ) {
+			return false;
+		}
+
+		return version_compare( $addon_major_minor, $free_major_minor, '>' );
+	}
+
+	/**
+	 * Extracts the major.minor part of a version string, ignoring any patch or pre-release suffix.
+	 *
+	 * @param string $version The version string.
+	 *
+	 * @return string|null The major.minor version, or null when it cannot be determined.
+	 */
+	private function get_major_minor( $version ) {
+		if ( ! is_string( $version ) || ! preg_match( '/^(\d+)\.(\d+)/', $version, $matches ) ) {
+			return null;
+		}
+
+		return $matches[1] . '.' . $matches[2];
 	}
 
 	/**

--- a/tests/Unit/Inc/Addon_Manager_Test.php
+++ b/tests/Unit/Inc/Addon_Manager_Test.php
@@ -591,6 +591,80 @@ final class Addon_Manager_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that a Premium update is held back until the matching Yoast SEO Free version is available.
+	 *
+	 * @dataProvider holds_back_premium_provider
+	 *
+	 * @covers ::check_for_updates
+	 * @covers ::is_held_back_until_free_available
+	 * @covers ::get_major_minor
+	 *
+	 * @param string $plugin_file       The add-on plugin file.
+	 * @param string $slug              The add-on subscription slug.
+	 * @param string $installed_version The installed add-on version.
+	 * @param string $offered_version   The add-on version offered by the My Yoast API.
+	 * @param string $free_new_version  The latest Yoast SEO Free version the site can see.
+	 * @param string $expected_location Where the add-on should end up: 'response' or 'no_update'.
+	 * @param string $message           Message to show when the test fails.
+	 *
+	 * @return void
+	 */
+	public function test_check_for_updates_holds_back_premium_until_free_available( $plugin_file, $slug, $installed_version, $offered_version, $free_new_version, $expected_location, $message ) {
+		$this->stubTranslationFunctions();
+
+		$addons = [ $plugin_file => [ 'Version' => $installed_version ] ];
+
+		$this->instance
+			->shouldReceive( 'get_installed_addons' )
+			->andReturn( $addons );
+
+		$this->instance
+			->shouldReceive( 'get_subscriptions' )
+			->andReturn( $this->build_subscriptions( $plugin_file, $slug, $offered_version ) );
+
+		$this->instance
+			->shouldReceive( 'extract_yoast_data' )
+			->andReturn(
+				(object) [
+					'requires'    => \YOAST_SEO_WP_REQUIRED,
+					'new_version' => $free_new_version,
+				],
+			);
+
+		$product_helper_mock = Mockery::mock( Product_Helper::class );
+		$product_helper_mock->shouldReceive( 'is_premium' )->andReturn( false );
+
+		$container = $this->create_container_with(
+			[
+				Product_Helper::class => $product_helper_mock,
+			],
+		);
+
+		Monkey\Functions\expect( 'YoastSEO' )
+			->zeroOrMoreTimes()
+			->andReturn( (object) [ 'helpers' => $this->create_helper_surface( $container ) ] );
+
+		global $wp_version;
+		$wp_version = \YOAST_SEO_WP_REQUIRED;
+
+		$data = (object) [
+			'response'  => [],
+			'no_update' => [],
+		];
+
+		$result = $this->instance->check_for_updates( $data );
+
+		if ( $expected_location === 'response' ) {
+			$this->assertArrayHasKey( $plugin_file, $result->response, $message );
+			$this->assertArrayNotHasKey( $plugin_file, $result->no_update, $message );
+		}
+		else {
+			$this->assertArrayHasKey( $plugin_file, $result->no_update, $message );
+			$this->assertArrayNotHasKey( $plugin_file, $result->response, $message );
+		}
+	}
+
+	/**
 	 * Tests checking if given value is a Yoast addon.
 	 *
 	 * @covers ::is_yoast_addon
@@ -971,6 +1045,52 @@ final class Addon_Manager_Test extends TestCase {
 	}
 
 	/**
+	 * Provides data to the Premium hold-back test.
+	 *
+	 * @return array<string, array<string, string>> Values for the test.
+	 */
+	public static function holds_back_premium_provider() {
+		return [
+			'Premium ahead of Free is hidden'                 => [
+				'plugin_file'       => 'wp-seo-premium.php',
+				'slug'              => 'yoast-seo-wordpress-premium',
+				'installed_version' => '9.0',
+				'offered_version'   => '10.0',
+				'free_new_version'  => '9.0',
+				'expected_location' => 'no_update',
+				'message'           => 'Premium 10.0 must be hidden while Free is only 9.0.',
+			],
+			'Premium matching Free is shown'                  => [
+				'plugin_file'       => 'wp-seo-premium.php',
+				'slug'              => 'yoast-seo-wordpress-premium',
+				'installed_version' => '9.0',
+				'offered_version'   => '10.0',
+				'free_new_version'  => '10.0',
+				'expected_location' => 'response',
+				'message'           => 'Premium 10.0 must be shown once Free 10.0 is available.',
+			],
+			'Premium patch with matching Free minor is shown' => [
+				'plugin_file'       => 'wp-seo-premium.php',
+				'slug'              => 'yoast-seo-wordpress-premium',
+				'installed_version' => '10.0',
+				'offered_version'   => '10.0.1',
+				'free_new_version'  => '10.0',
+				'expected_location' => 'response',
+				'message'           => 'Premium patch 10.0.1 must be shown when Free 10.0 is available.',
+			],
+			'Non-Premium add-on ahead of Free is shown'       => [
+				'plugin_file'       => 'wpseo-news.php',
+				'slug'              => 'yoast-seo-news',
+				'installed_version' => '9.0',
+				'offered_version'   => '10.0',
+				'free_new_version'  => '9.0',
+				'expected_location' => 'response',
+				'message'           => 'Only Premium is held back, so News must still be shown.',
+			],
+		];
+	}
+
+	/**
 	 * Provides data to the get_plugin_information test.
 	 *
 	 * @return array Values for the test.
@@ -1060,6 +1180,37 @@ final class Addon_Manager_Test extends TestCase {
 							'version'      => '10.0',
 							'name'         => 'Extension',
 							'slug'         => 'yoast-seo-news',
+							'last_updated' => 'yesterday',
+							'store_url'    => 'https://example.org/store',
+							'download'     => 'https://example.org/extension.zip',
+							'changelog'    => 'changelog',
+						],
+					],
+				],
+			),
+			false,
+		);
+	}
+
+	/**
+	 * Builds a single-subscription object mirroring the My Yoast API response.
+	 *
+	 * @param string $plugin_file The add-on plugin file.
+	 * @param string $slug        The add-on subscription slug.
+	 * @param string $version     The add-on version offered by the API.
+	 *
+	 * @return stdClass The subscriptions object.
+	 */
+	protected function build_subscriptions( $plugin_file, $slug, $version ) {
+		return \json_decode(
+			WPSEO_Utils::format_json_encode(
+				[
+					$plugin_file => [
+						'expiry_date' => $this->get_future_date(),
+						'product'     => [
+							'version'      => $version,
+							'name'         => 'Extension',
+							'slug'         => $slug,
 							'last_updated' => 'yesterday',
 							'store_url'    => 'https://example.org/store',
 							'download'     => 'https://example.org/extension.zip',


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Yoast SEO Premium and Yoast SEO (Free) are released together and are built to match: Premium `x.y` expects Free `x.y` alongside it. They reach sites through different channels at different speeds. Free is distributed by the WordPress.org plugin directory, which rolls a new version out gradually over hours; Premium is downloaded immediately from My Yoast through the customer license. In that gap a site can be offered the Premium `x.y` update before Free `x.y` is available to it, and updating Premium then breaks the pairing. This happened with Premium 27.8 and required manually pulling Premium from distribution until Free 27.8 had spread.

This PR holds the Premium update back until the matching Free version is available to that specific site. It keys off the real Free availability each site sees, so it self-corrects per site with no fixed timer and no server-side coordination, mirroring how WordPress core silently holds back updates.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the Yoast SEO Premium update until a compatible Yoast SEO version is available.

## Relevant technical choices:

* The decision lives in `WPSEO_Addon_Manager::check_for_updates()`, the method that already chooses, per add-on, between the `response` bucket (an update is shown and can auto-install) and the `no_update` bucket (nothing shown). The new guard keeps a held-back Premium update in `no_update`.
* Placing it in `no_update` rather than failing the install mirrors how WordPress core holds back updates: nothing appears on the Updates screen, and the auto-updater skips it too, since it only acts on entries in `response`.
* Only the major and minor version parts are compared, so patch releases are not held back: Premium `x.y.z` only needs Free `x.y` to be available.
* The latest available Free version is read from Free's own entry in WordPress's update list (`new_version`); when it is absent the guard fails open, so updates are never hidden on incomplete data.
* Limited to Premium for now via a single helper. Yoast WooCommerce SEO will need the same later, but its version line does not track Free's `x.y`, so it stays out until the required Free version can be provided per product (ideally from the licensing API).
* This complements the existing `YOAST_SEO_CHECK_REQUIRED_VERSION` header check, which blocks a manually uploaded incompatible add-on. That handles manual installs; this hides the offered and automatic update.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The behaviour only occurs when a newer Premium is available while the matching Free version is not yet available to the site, so the scenario has to be simulated. On a site with Free and Premium installed at the same version (for example both `27.7`):

* Drop this temporary must-use plugin in `wp-content/mu-plugins/holdback-test.php`. It makes the license report Premium `27.8` and pins the latest Free the site can see to `27.7`. Make sure the installed Premium version is lower than the offered one (here, set the Premium plugin's installed version to `27.7`).

```php
<?php
// TEST ONLY. Simulate "Premium 27.8 released, Free 27.8 not yet available to this site".
add_action( 'admin_init', function () {
	$info = (object) [
		'subscriptions' => [
			(object) [
				'renewal_url' => '',
				'expiry_date' => '2037-01-01T00:00:00.000Z',
				'product'     => (object) [
					'version'      => '27.8',
					'name'         => 'Yoast SEO Premium',
					'slug'         => 'yoast-seo-wordpress-premium',
					'last_updated' => '2037-01-01T00:00:00.000Z',
					'store_url'    => 'https://yoast.com/shop',
					'download'     => 'https://example.com/premium.zip',
					'changelog'    => '',
				],
			],
		],
	];
	set_transient( 'wpseo_site_information', $info, DAY_IN_SECONDS );
	set_transient( 'wpseo_site_information_quick', $info, 60 );
}, 1 );

add_filter( 'pre_set_site_transient_update_plugins', function ( $transient ) {
	if ( is_object( $transient ) ) {
		unset( $transient->response['wordpress-seo/wp-seo.php'] );
		$transient->no_update['wordpress-seo/wp-seo.php'] = (object) [
			'plugin'      => 'wordpress-seo/wp-seo.php',
			'slug'        => 'wordpress-seo',
			'new_version' => '27.7',
			'requires'    => '6.5',
		];
	}
	return $transient;
}, 9 );
```

* Go to Dashboard > Updates and click "Check again", then open the Plugins screen.
* Confirm that no update is offered for Yoast SEO Premium on either screen. It is held back, because the site only sees Free `27.7`.
* Now change `new_version` in the snippet from `27.7` to `27.8` (the matching Free is now available), click "Check again", and reload the Plugins screen.
* Confirm the Premium `27.8` update now appears normally.
* Remove the temporary must-use plugin when done.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Same as the acceptance test steps above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The plugin update flow for Yoast SEO Premium: the Updates screen, the Plugins screen, and automatic background updates. Worth confirming that a normal Premium update still appears when the matching Free version is available, and that the other add-ons (News, Video, WooCommerce, Local) are unaffected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23374
