### PR TITLE
feat(bulk-editor): row-level Save/Cancel and unsaved-changes tab-switch modal

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useCallback, useMemo } from "@wordpress/element";
+import { useCallback, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { STORE_NAME } from "../constants";
 import { getFieldSets } from "../field-sets";
@@ -7,6 +7,7 @@ import { useInlineEdit } from "../hooks/use-inline-edit";
 import { usePosts } from "../services/use-posts";
 import { BulkEditorTable } from "./table/bulk-editor-table";
 import { BulkEditorTabPanel, BulkEditorTabs } from "./bulk-editor-tabs";
+import { UnsavedChangesModal } from "./unsaved-changes-modal";
 
 /**
  * The bulk editor content: the Search/Social appearance tab bar and the tab panels with the field-set table.
@@ -30,10 +31,40 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 	const { data: items = [], isPending, updateItem } = usePosts( { dataProvider, remoteDataProvider, contentType } );
 	const { editing, stopEditing } = useInlineEdit( { dataProvider, remoteDataProvider, fieldSets, activeFieldSet, items, updateItem } );
 
+	// The tab the user wants to switch to while rows still have unsaved edits; drives the confirmation modal.
+	const [ pendingTab, setPendingTab ] = useState( null );
+	const hasUnsavedEdits = Object.keys( editing.editingRows ).length > 0;
+
 	const onChangeTab = useCallback( ( id ) => {
-		stopEditing();
+		if ( id === activeFieldSet ) {
+			return;
+		}
+		// Guard the switch when edits are in progress; otherwise switch straight away.
+		if ( Object.keys( editing.editingRows ).length > 0 ) {
+			setPendingTab( id );
+			return;
+		}
 		setActiveFieldSet( id );
-	}, [ stopEditing, setActiveFieldSet ] );
+	}, [ activeFieldSet, editing.editingRows, setActiveFieldSet ] );
+
+	const onSaveAndSwitch = useCallback( () => {
+		// Fire the save for every open field; each reads its draft synchronously, so clearing the edit state
+		// right after still posts the captured values while leaving the new tab clean.
+		Object.entries( editing.editingRows ).forEach( ( [ id, row ] ) =>
+			row.openFields.forEach( ( key ) => editing.onApplyField( { id: Number( id ), key } ) )
+		);
+		stopEditing();
+		setActiveFieldSet( pendingTab );
+		setPendingTab( null );
+	}, [ editing, stopEditing, pendingTab, setActiveFieldSet ] );
+
+	const onDiscardAndSwitch = useCallback( () => {
+		stopEditing();
+		setActiveFieldSet( pendingTab );
+		setPendingTab( null );
+	}, [ stopEditing, pendingTab, setActiveFieldSet ] );
+
+	const onCancelSwitch = useCallback( () => setPendingTab( null ), [] );
 
 	return (
 		<div className="yst-p-8 yst-space-y-8">
@@ -48,6 +79,12 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 					<BulkEditorTable items={ items } fieldSet={ fieldSets[ tab.id ] } editing={ editing } isLoading={ isPending } />
 				</BulkEditorTabPanel>
 			) ) }
+			<UnsavedChangesModal
+				isOpen={ hasUnsavedEdits && pendingTab !== null }
+				onSave={ onSaveAndSwitch }
+				onDiscard={ onDiscardAndSwitch }
+				onClose={ onCancelSwitch }
+			/>
 		</div>
 	);
 };

--- a/packages/js/src/bulk-editor/components/bulk-editor-tabs.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-tabs.js
@@ -116,7 +116,7 @@ export const BulkEditorTabs = ( { tabs, activeTab, onChange, label } ) => {
 	}, [ tabs, activeTab, onChange ] );
 
 	return (
-		<div ref={ listRef } role="tablist" aria-label={ label } className="yst-flex yst-gap-2">
+		<div ref={ listRef } role="tablist" aria-label={ label } className="yst-flex yst-gap-4">
 			{ tabs.map( ( tab ) => (
 				<Tab
 					key={ tab.id }

--- a/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
+++ b/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
@@ -15,15 +15,14 @@ import { getColumnCount } from "./table-helpers";
  * @property {Function}  [onToggleAll]   Called when the header "select all" checkbox is toggled.
  */
 /**
- * The bulk editor inline-edit props. Editing is per field and several rows can edit at once: a row's Edit opens
- * its field-set fields, and each open field is applied (saved on its own) or discarded independently.
+ * The bulk editor inline-edit props. Several rows can edit at once: a row's Edit opens its field-set fields,
+ * then the row's Save saves every open field and Cancel discards all of them at once.
  *
  * @typedef {Object} BulkEditorEditing
  * @property {Object}   [editingRows]    Edit state keyed by item id: `{ [id]: { openFields, draft, savingFields } }`.
  * @property {Function} [onStartEdit]    Called with an item id to enter edit mode.
  * @property {Function} [onChangeField]  Called with `{ id, key, value }` when a field changes.
  * @property {Function} [onApplyField]   Called with `{ id, key }` to save that field.
- * @property {Function} [onDiscardField] Called with `{ id, key }` to discard that field's changes.
  * @property {Function} [onCancelEdit]   Called with an item id to cancel all of its open fields at once.
  */
 
@@ -49,7 +48,6 @@ export const BulkEditorTable = ( { items, fieldSet, selection = {}, editing = {}
 		onStartEdit: noop,
 		onChangeField: noop,
 		onApplyField: noop,
-		onDiscardField: noop,
 		onCancelEdit: noop,
 		...editing,
 	};

--- a/packages/js/src/bulk-editor/components/table/table-cells.js
+++ b/packages/js/src/bulk-editor/components/table/table-cells.js
@@ -51,7 +51,7 @@ export const EditableFieldCell = ( { field, itemId, itemTitle, value, isSaving, 
 				value={ value }
 				onChange={ handleChange }
 				disabled={ isSaving }
-				className="yst-resize-none yst-bg-primary-50 yst-ring-primary-300"
+				className="yst-resize-none"
 				/* translators: %1$s expands to the field label, %2$s to the content item title. */
 				aria-label={ sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
 			/>

--- a/packages/js/src/bulk-editor/components/table/table-cells.js
+++ b/packages/js/src/bulk-editor/components/table/table-cells.js
@@ -1,7 +1,8 @@
-import { useCallback } from "@wordpress/element";
+import { useCallback, useEffect, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Table, Textarea } from "@yoast/ui-library";
 import { getStatusLabel } from "./table-helpers";
+import AnimateHeight from "react-animate-height";
 
 /**
  * The title cell (the row header).
@@ -37,24 +38,31 @@ export const TitleCell = ( { item } ) => {
  * @param {string}        props.value     The current draft value.
  * @param {boolean}       props.isSaving  Whether the row is being saved (disables the input).
  * @param {Function}      props.onChange  Called with { key, value } when the value changes.
+ * @param {boolean}       props.isOpen    Whether the field is open for editing.
  *
  * @returns {JSX.Element} The cell.
  */
-export const EditableFieldCell = ( { field, itemId, itemTitle, value, isSaving, onChange } ) => {
+export const EditableFieldCell = ( { field, itemId, itemTitle, value, isSaving, onChange, isOpen } ) => {
 	const handleChange = useCallback( ( event ) => onChange( { key: field.key, value: event.target.value } ), [ onChange, field.key ] );
+
+	// Row expand/collapse animation helper.
+	const [ height, setHeight ] = useState( 0 );
+	useEffect( () => setHeight( isOpen ? "auto" : 0 ), [ isOpen ] );
 
 	return (
 		<Table.Cell>
-			<Textarea
-				id={ `bulk-editor-edit-${ itemId }-${ field.key }` }
-				rows={ 2 }
-				value={ value }
-				onChange={ handleChange }
-				disabled={ isSaving }
-				className="yst-resize-none"
-				/* translators: %1$s expands to the field label, %2$s to the content item title. */
-				aria-label={ sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
-			/>
+			<AnimateHeight easing="ease-in-out" duration={ 300 } height={ height } animateOpacity={ true }>
+				<Textarea
+					id={ `bulk-editor-edit-${ itemId }-${ field.key }` }
+					rows={ 2 }
+					value={ value }
+					onChange={ handleChange }
+					disabled={ isSaving }
+					className="yst-resize-none"
+					/* translators: %1$s expands to the field label, %2$s to the content item title. */
+					aria-label={ sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
+				/>
+			</AnimateHeight>
 		</Table.Cell>
 	);
 };

--- a/packages/js/src/bulk-editor/components/table/table-cells.js
+++ b/packages/js/src/bulk-editor/components/table/table-cells.js
@@ -1,8 +1,6 @@
-import CheckIcon from "@heroicons/react/outline/CheckIcon";
-import XIcon from "@heroicons/react/outline/XIcon";
 import { useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Button, Table, Textarea } from "@yoast/ui-library";
+import { Table, Textarea } from "@yoast/ui-library";
 import { getStatusLabel } from "./table-helpers";
 
 /**
@@ -29,65 +27,34 @@ export const TitleCell = ( { item } ) => {
 };
 
 /**
- * An open field cell: the input plus its Apply and Discard actions. Each field is saved or discarded on its own.
+ * An open field cell: an editable textarea. The row's Save and Cancel actions save or
+ * discard all of the row's open fields at once.
  *
  * @param {Object}        props           The props.
  * @param {FieldSetField} props.field     The field this cell edits.
  * @param {number}        props.itemId    The item id, to keep the input id unique across rows.
- * @param {string}        props.itemTitle The item title, for the accessible names.
+ * @param {string}        props.itemTitle The item title, for the accessible name.
  * @param {string}        props.value     The current draft value.
- * @param {boolean}       props.isSaving  Whether this field is being saved (disables the controls).
+ * @param {boolean}       props.isSaving  Whether the row is being saved (disables the input).
  * @param {Function}      props.onChange  Called with { key, value } when the value changes.
- * @param {Function}      props.onApply   Called with the field key to save it.
- * @param {Function}      props.onDiscard Called with the field key to discard its changes.
  *
  * @returns {JSX.Element} The cell.
  */
-export const EditableFieldCell = ( { field, itemId, itemTitle, value, isSaving, onChange, onApply, onDiscard } ) => {
+export const EditableFieldCell = ( { field, itemId, itemTitle, value, isSaving, onChange } ) => {
 	const handleChange = useCallback( ( event ) => onChange( { key: field.key, value: event.target.value } ), [ onChange, field.key ] );
-	const handleApply = useCallback( () => onApply( field.key ), [ onApply, field.key ] );
-	const handleDiscard = useCallback( () => onDiscard( field.key ), [ onDiscard, field.key ] );
 
 	return (
 		<Table.Cell>
-			<div className="yst-flex yst-flex-col yst-gap-2">
-				<Textarea
-					id={ `bulk-editor-edit-${ itemId }-${ field.key }` }
-					rows={ 2 }
-					value={ value }
-					onChange={ handleChange }
-					disabled={ isSaving }
-					className="yst-resize-none yst-bg-primary-50 yst-ring-primary-300"
-					/* translators: %1$s expands to the field label, %2$s to the content item title. */
-					aria-label={ sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
-				/>
-				<div className="yst-flex yst-gap-2">
-					<Button
-						variant="secondary"
-						size="small"
-						className="yst-gap-1.5"
-						onClick={ handleApply }
-						disabled={ isSaving }
-						/* translators: %1$s expands to the field label, %2$s to the content item title. */
-						aria-label={ sprintf( __( "Apply %1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
-					>
-						<CheckIcon className="yst-h-4 yst-w-4 yst-text-green-500" aria-hidden="true" />
-						{ __( "Apply", "wordpress-seo" ) }
-					</Button>
-					<Button
-						variant="secondary"
-						size="small"
-						className="yst-gap-1.5"
-						onClick={ handleDiscard }
-						disabled={ isSaving }
-						/* translators: %1$s expands to the field label, %2$s to the content item title. */
-						aria-label={ sprintf( __( "Discard %1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
-					>
-						<XIcon className="yst-h-4 yst-w-4 yst-text-red-500" aria-hidden="true" />
-						{ __( "Discard", "wordpress-seo" ) }
-					</Button>
-				</div>
-			</div>
+			<Textarea
+				id={ `bulk-editor-edit-${ itemId }-${ field.key }` }
+				rows={ 2 }
+				value={ value }
+				onChange={ handleChange }
+				disabled={ isSaving }
+				className="yst-resize-none yst-bg-primary-50 yst-ring-primary-300"
+				/* translators: %1$s expands to the field label, %2$s to the content item title. */
+				aria-label={ sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, itemTitle ) }
+			/>
 		</Table.Cell>
 	);
 };

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -64,6 +64,7 @@ export const BulkEditorRow = ( { item, fields, isSelected, onToggleRow, edit, ed
 						value={ draft[ field.key ] ?? "" }
 						isSaving={ isSaving }
 						onChange={ handleChangeField }
+						isOpen={ isEditing }
 					/>
 				)
 				: <Table.Cell key={ field.key }>{ item[ field.key ] }</Table.Cell>

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -6,7 +6,7 @@ import { getRowEditState } from "./table-helpers";
 
 /**
  * A content row. Each field-set cell renders as plain text, or — when the row is in edit mode and the field is
- * open — as an editable cell with its own Apply/Discard.
+ * open — as an editable cell. The Actions column then shows the row's Save and Cancel buttons.
  *
  * @param {Object}            props             The props.
  * @param {BulkEditorItem}    props.item        The item data.
@@ -20,17 +20,22 @@ import { getRowEditState } from "./table-helpers";
  */
 export const BulkEditorRow = ( { item, fields, isSelected, onToggleRow, edit, editing } ) => {
 	const { isEditing, openFields, draft, savingFields } = getRowEditState( edit );
-	const { onStartEdit, onChangeField, onApplyField, onDiscardField, onCancelEdit } = editing;
+	const { onStartEdit, onChangeField, onApplyField, onCancelEdit } = editing;
+	const isSaving = Object.keys( savingFields ).length > 0;
 
 	const handleToggle = useCallback( () => onToggleRow( item.id ), [ onToggleRow, item.id ] );
 	const handleEdit = useCallback( () => onStartEdit( item.id ), [ onStartEdit, item.id ] );
 	const handleCancel = useCallback( () => onCancelEdit( item.id ), [ onCancelEdit, item.id ] );
 	const handleChangeField = useCallback( ( { key, value } ) => onChangeField( { id: item.id, key, value } ), [ onChangeField, item.id ] );
-	const handleApplyField = useCallback( ( key ) => onApplyField( { id: item.id, key } ), [ onApplyField, item.id ] );
-	const handleDiscardField = useCallback( ( key ) => onDiscardField( { id: item.id, key } ), [ onDiscardField, item.id ] );
+	const handleSave = useCallback(
+		() => openFields.forEach( ( key ) => onApplyField( { id: item.id, key } ) ),
+		[ openFields, onApplyField, item.id ]
+	);
 
 	/* translators: %s expands to the content item title. */
 	const editLabel = sprintf( __( "Edit %s", "wordpress-seo" ), item.title );
+	/* translators: %s expands to the content item title. */
+	const saveLabel = sprintf( __( "Save %s", "wordpress-seo" ), item.title );
 	/* translators: %s expands to the content item title. */
 	const cancelLabel = sprintf( __( "Cancel editing %s", "wordpress-seo" ), item.title );
 
@@ -57,26 +62,51 @@ export const BulkEditorRow = ( { item, fields, isSelected, onToggleRow, edit, ed
 						itemId={ item.id }
 						itemTitle={ item.title }
 						value={ draft[ field.key ] ?? "" }
-						isSaving={ Boolean( savingFields[ field.key ] ) }
+						isSaving={ isSaving }
 						onChange={ handleChangeField }
-						onApply={ handleApplyField }
-						onDiscard={ handleDiscardField }
 					/>
 				)
 				: <Table.Cell key={ field.key }>{ item[ field.key ] }</Table.Cell>
 			) ) }
 			<Table.Cell>
-				<span className="yst-flex yst-justify-end">
-					<Button
-						variant="tertiary"
-						size="small"
-						className="yst--me-2.5"
-						onClick={ isEditing ? handleCancel : handleEdit }
-						aria-label={ isEditing ? cancelLabel : editLabel }
-					>
-						{ isEditing ? __( "Cancel", "wordpress-seo" ) : __( "Edit", "wordpress-seo" ) }
-					</Button>
-				</span>
+				{ isEditing
+					? (
+						<span className="yst-flex yst-flex-col yst-items-end yst-gap-1.5 yst--me-2.5">
+							<Button
+								variant="tertiary"
+								size="small"
+								onClick={ handleSave }
+								disabled={ isSaving }
+								aria-label={ saveLabel }
+							>
+								{ __( "Save", "wordpress-seo" ) }
+							</Button>
+							<span aria-hidden="true" className="yst-w-full yst-border-t yst-border-slate-200" />
+							<Button
+								variant="tertiary"
+								size="small"
+								onClick={ handleCancel }
+								disabled={ isSaving }
+								aria-label={ cancelLabel }
+							>
+								{ __( "Cancel", "wordpress-seo" ) }
+							</Button>
+						</span>
+					)
+					: (
+						<span className="yst-flex yst-justify-end">
+							<Button
+								variant="tertiary"
+								size="small"
+								className="yst--me-2.5"
+								onClick={ handleEdit }
+								aria-label={ editLabel }
+							>
+								{ __( "Edit", "wordpress-seo" ) }
+							</Button>
+						</span>
+					)
+				}
 			</Table.Cell>
 		</Table.Row>
 	);

--- a/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
+++ b/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
@@ -22,7 +22,7 @@ export const UnsavedChangesModal = ( { isOpen, onSave = noop, onDiscard = noop, 
 
 	return (
 		<Modal isOpen={ isOpen } onClose={ onClose } initialFocus={ saveRef }>
-			<Modal.Panel className="yst-max-w-md">
+			<Modal.Panel className="yst-max-w-md" hasCloseButton={ false }>
 				<div className="yst-flex yst-items-start yst-gap-4">
 					<div className="yst-flex yst-flex-shrink-0 yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100">
 						<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />

--- a/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
+++ b/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
@@ -27,7 +27,7 @@ export const UnsavedChangesModal = ( { isOpen, onSave = noop, onDiscard = noop, 
 					<div className="yst-flex yst-flex-shrink-0 yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100">
 						<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 					</div>
-					<div className="yst-flex yst-flex-col yst-gap-2">
+					<div className="yst-flex yst-flex-col yst-gap-2 yst-max-w-xs">
 						<Modal.Title className="yst-text-lg yst-font-medium yst-text-slate-900">
 							{ __( "Unsaved changes", "wordpress-seo" ) }
 						</Modal.Title>

--- a/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
+++ b/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
@@ -1,0 +1,53 @@
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
+import { useRef } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { Button, Modal, useSvgAria } from "@yoast/ui-library";
+import { noop } from "lodash";
+
+/**
+ * The confirmation modal shown when switching tabs while rows have unsaved inline edits. It offers to save the
+ * edits, discard them, or stay on the current tab.
+ *
+ * @param {Object}   props             The props.
+ * @param {boolean}  props.isOpen      Whether the modal is open.
+ * @param {Function} [props.onSave]    Saves all edits and then switches tab (Save changes).
+ * @param {Function} [props.onDiscard] Discards all edits and then switches tab (Continue without saving).
+ * @param {Function} [props.onClose]   Closes the modal and stays on the current tab (Cancel / dismiss).
+ *
+ * @returns {JSX.Element} The modal.
+ */
+export const UnsavedChangesModal = ( { isOpen, onSave = noop, onDiscard = noop, onClose = noop } ) => {
+	const svgAriaProps = useSvgAria();
+	const saveRef = useRef( null );
+
+	return (
+		<Modal isOpen={ isOpen } onClose={ onClose } initialFocus={ saveRef }>
+			<Modal.Panel className="yst-max-w-md">
+				<div className="yst-flex yst-items-start yst-gap-4">
+					<div className="yst-flex yst-flex-shrink-0 yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100">
+						<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
+					</div>
+					<div className="yst-flex yst-flex-col yst-gap-2">
+						<Modal.Title className="yst-text-lg yst-font-medium yst-text-slate-900">
+							{ __( "Unsaved changes", "wordpress-seo" ) }
+						</Modal.Title>
+						<Modal.Description className="yst-text-sm yst-text-slate-600">
+							{ __( "If you leave now, any changes you made will be lost. Would you like to save before continuing?", "wordpress-seo" ) }
+						</Modal.Description>
+					</div>
+				</div>
+				<div className="yst-flex yst-flex-col yst-gap-2 yst-mt-6">
+					<Button ref={ saveRef } type="button" variant="primary" onClick={ onSave }>
+						{ __( "Save changes", "wordpress-seo" ) }
+					</Button>
+					<Button type="button" variant="secondary" onClick={ onDiscard }>
+						{ __( "Continue without saving", "wordpress-seo" ) }
+					</Button>
+					<Button type="button" variant="tertiary" onClick={ onClose }>
+						{ __( "Cancel", "wordpress-seo" ) }
+					</Button>
+				</div>
+			</Modal.Panel>
+		</Modal>
+	);
+};

--- a/packages/js/src/bulk-editor/hooks/use-inline-edit.js
+++ b/packages/js/src/bulk-editor/hooks/use-inline-edit.js
@@ -40,8 +40,6 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 		startEdit( { id, draft: draftValues } );
 	}, [ items, fieldSets, activeFieldSet, startEdit ] );
 
-	const onDiscardField = useCallback( ( { id, key } ) => closeField( { id, key } ), [ closeField ] );
-
 	const onCancelEdit = useCallback( ( id ) => discardEdit( { id } ), [ discardEdit ] );
 
 	const onApplyField = useCallback( async( { id, key } ) => {
@@ -75,9 +73,8 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 		onStartEdit,
 		onChangeField: updateDraftField,
 		onApplyField,
-		onDiscardField,
 		onCancelEdit,
-	} ), [ editingRows, onStartEdit, updateDraftField, onApplyField, onDiscardField, onCancelEdit ] );
+	} ), [ editingRows, onStartEdit, updateDraftField, onApplyField, onCancelEdit ] );
 
 	return { editing, stopEditing: stopEdit };
 };

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -105,20 +105,77 @@ describe( "App", () => {
 		expect( screen.getByRole( "columnheader", { name: "Social description" } ) ).toBeInTheDocument();
 	} );
 
-	it( "discards an in-progress edit when switching tabs", async() => {
-		render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+	describe( "switching tabs with unsaved edits", () => {
 		const rowTitle = "What Is SEO and How It Works";
 
-		fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
-		expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+		// Opens an edit on the Search tab, then clicks the Social tab to trigger the guard.
+		const openEditAndSwitch = async() => {
+			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+			fireEvent.click( screen.getByRole( "tab", { name: "Social appearance" } ) );
+		};
 
-		// Switching tabs changes the editable fields, so the edit is discarded.
-		fireEvent.click( screen.getByRole( "tab", { name: "Social appearance" } ) );
-		expect( screen.queryByRole( "textbox", { name: `Social title for ${ rowTitle }` } ) ).not.toBeInTheDocument();
-		// Back on Search the row is no longer in edit mode either.
-		fireEvent.click( screen.getByRole( "tab", { name: "Search appearance" } ) );
-		expect( screen.queryByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( "button", { name: `Edit ${ rowTitle }` } ) ).toBeEnabled();
+		it( "shows the confirmation modal and stays on the current tab", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			await openEditAndSwitch();
+
+			expect( screen.getByText( "Unsaved changes" ) ).toBeInTheDocument();
+			// The tab has not switched while the modal is open.
+			expect( screen.getByRole( "tab", { name: "Search appearance" } ) ).toHaveAttribute( "aria-selected", "true" );
+			expect( screen.getByRole( "tab", { name: "Social appearance" } ) ).toHaveAttribute( "aria-selected", "false" );
+		} );
+
+		it( "keeps the edit and stays when Cancel is clicked", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			await openEditAndSwitch();
+			fireEvent.click( screen.getByRole( "button", { name: "Cancel" } ) );
+
+			expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( "tab", { name: "Search appearance" } ) ).toHaveAttribute( "aria-selected", "true" );
+			// The edit is preserved.
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+		} );
+
+		it( "discards the edit and switches when Continue without saving is clicked", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			await openEditAndSwitch();
+			fireEvent.click( screen.getByRole( "button", { name: "Continue without saving" } ) );
+
+			expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( "tab", { name: "Social appearance" } ) ).toHaveAttribute( "aria-selected", "true" );
+			// Back on Search the row is no longer in edit mode.
+			fireEvent.click( screen.getByRole( "tab", { name: "Search appearance" } ) );
+			expect( screen.queryByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( "button", { name: `Edit ${ rowTitle }` } ) ).toBeEnabled();
+		} );
+
+		it( "saves the edits and switches when Save changes is clicked", async() => {
+			const searchSet = getFieldSets()[ FIELD_SET_SEARCH ];
+			const endpointUrl = "https://example.com/wp-json/yoast/v1/bulk_editor/update_search";
+			const savingDataProvider = new DataProvider( {
+				contentTypes: [ { name: "post", label: "Posts" } ],
+				endpoints: { posts: "https://example.com/wp-json/yoast/v1/bulk_editor/posts", [ searchSet.endpoint ]: endpointUrl },
+				links: {},
+			} );
+			const remote = buildRemote( () => Promise.resolve( {} ) );
+			render( <App dataProvider={ savingDataProvider } remoteDataProvider={ remote } /> );
+
+			await openEditAndSwitch();
+			fireEvent.click( screen.getByRole( "button", { name: "Save changes" } ) );
+
+			// The open fields are posted to the active tab's save endpoint.
+			expect( remote.fetchJson ).toHaveBeenCalledWith(
+				endpointUrl,
+				{},
+				expect.objectContaining( { method: "POST" } )
+			);
+			expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument();
+			// Await the switch so the saves settle (updateItem/closeField) within act().
+			await waitFor( () => expect( screen.getByRole( "tab", { name: "Social appearance" } ) ).toHaveAttribute( "aria-selected", "true" ) );
+		} );
 	} );
 
 	it( "edits multiple rows at once without disabling the other rows' Edit", async() => {

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -136,7 +136,7 @@ describe( "App", () => {
 		expect( screen.getByRole( "textbox", { name: "SEO title for Keyword Research for Beginners" } ) ).toBeInTheDocument();
 	} );
 
-	describe( "saving a field (Apply)", () => {
+	describe( "saving a row (Save)", () => {
 		const searchSet = getFieldSets()[ FIELD_SET_SEARCH ];
 		const seoTitleParam = searchSet.fields.find( ( field ) => field.key === "seoTitle" ).param;
 		const endpointUrl = "https://example.com/wp-json/yoast/v1/bulk_editor/update_search";
@@ -156,7 +156,7 @@ describe( "App", () => {
 				screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ),
 				{ target: { value: "New SEO title" } }
 			);
-			fireEvent.click( screen.getByRole( "button", { name: `Apply SEO title for ${ rowTitle }` } ) );
+			fireEvent.click( screen.getByRole( "button", { name: `Save ${ rowTitle }` } ) );
 
 			expect( remote.fetchJson ).toHaveBeenCalledWith(
 				endpointUrl,
@@ -172,7 +172,7 @@ describe( "App", () => {
 			render( <App dataProvider={ savingDataProvider } remoteDataProvider={ remote } /> );
 
 			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
-			fireEvent.click( screen.getByRole( "button", { name: `Apply SEO title for ${ rowTitle }` } ) );
+			fireEvent.click( screen.getByRole( "button", { name: `Save ${ rowTitle }` } ) );
 
 			// The field stays open and becomes editable again once the failed save settles.
 			await waitFor( () => expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeEnabled() );
@@ -183,7 +183,7 @@ describe( "App", () => {
 			render( <App dataProvider={ dataProvider } remoteDataProvider={ remote } /> );
 
 			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
-			fireEvent.click( screen.getByRole( "button", { name: `Apply SEO title for ${ rowTitle }` } ) );
+			fireEvent.click( screen.getByRole( "button", { name: `Save ${ rowTitle }` } ) );
 
 			// The active tab's save endpoint is not configured, so no POST is made and the field stays open.
 			expect( remote.fetchJson ).not.toHaveBeenCalledWith(

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -126,7 +126,7 @@ describe( "BulkEditorTable", () => {
 		expect( screen.getByText( "No content found." ) ).toBeInTheDocument();
 	} );
 
-	it( "renders an input with its own Apply and Discard for each open field", () => {
+	it( "renders a textarea per open field with a single row-level Save and Cancel", () => {
 		render(
 			<BulkEditorTable
 				items={ items }
@@ -148,15 +148,14 @@ describe( "BulkEditorTable", () => {
 		expect( description.tagName ).toBe( "TEXTAREA" );
 		expect( title ).toHaveAttribute( "rows", "2" );
 
-		// Each field has its own Apply and Discard; there is no row-level Save.
-		expect( screen.getByRole( "button", { name: "Apply SEO title for On-Page SEO Checklist" } ) ).toBeInTheDocument();
-		expect( screen.getByRole( "button", { name: "Discard SEO title for On-Page SEO Checklist" } ) ).toBeInTheDocument();
-		expect( screen.getByRole( "button", { name: "Apply Meta description for On-Page SEO Checklist" } ) ).toBeInTheDocument();
-		expect( screen.getByRole( "button", { name: "Discard Meta description for On-Page SEO Checklist" } ) ).toBeInTheDocument();
-
-		// The editing row's Edit turns into an active Cancel.
-		expect( screen.queryByRole( "button", { name: "Edit On-Page SEO Checklist" } ) ).not.toBeInTheDocument();
+		// No per-field Apply/Discard: the row has a single Save and Cancel.
+		expect( screen.queryByRole( "button", { name: "Apply SEO title for On-Page SEO Checklist" } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( "button", { name: "Discard SEO title for On-Page SEO Checklist" } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Save On-Page SEO Checklist" } ) ).toBeEnabled();
 		expect( screen.getByRole( "button", { name: "Cancel editing On-Page SEO Checklist" } ) ).toBeEnabled();
+
+		// The editing row no longer offers Edit.
+		expect( screen.queryByRole( "button", { name: "Edit On-Page SEO Checklist" } ) ).not.toBeInTheDocument();
 	} );
 
 	it( "cancels all of a row's open fields at once through the editing seam", () => {
@@ -187,7 +186,7 @@ describe( "BulkEditorTable", () => {
 
 		const input = screen.getByRole( "textbox", { name: "Focus keyphrase for On-Page SEO Checklist" } );
 		expect( input ).toHaveValue( "draft keyphrase" );
-		expect( screen.getByRole( "button", { name: "Apply Focus keyphrase for On-Page SEO Checklist" } ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Save On-Page SEO Checklist" } ) ).toBeInTheDocument();
 	} );
 
 	it( "renders only the open fields as inputs, the rest as text", () => {
@@ -204,19 +203,17 @@ describe( "BulkEditorTable", () => {
 		expect( screen.queryByRole( "textbox", { name: "SEO title for On-Page SEO Checklist" } ) ).not.toBeInTheDocument();
 	} );
 
-	it( "calls the per-field editing seams, tagged with the row id, on change, apply and discard", () => {
+	it( "calls onChangeField on input, and onApplyField for every open field when Save is clicked", () => {
 		const onChangeField = jest.fn();
 		const onApplyField = jest.fn();
-		const onDiscardField = jest.fn();
 		render(
 			<BulkEditorTable
 				items={ items }
 				fieldSet={ searchFieldSet }
 				editing={ {
-					editingRows: { 2: { openFields: [ "seoTitle" ], draft: { seoTitle: "Draft title" }, savingFields: {} } },
+					editingRows: { 2: { openFields: [ "seoTitle", "metaDescription" ], draft: { seoTitle: "Draft title", metaDescription: "Draft description" }, savingFields: {} } },
 					onChangeField,
 					onApplyField,
-					onDiscardField,
 				} }
 			/>
 		);
@@ -227,14 +224,14 @@ describe( "BulkEditorTable", () => {
 		);
 		expect( onChangeField ).toHaveBeenCalledWith( { id: 2, key: "seoTitle", value: "Changed" } );
 
-		fireEvent.click( screen.getByRole( "button", { name: "Apply SEO title for On-Page SEO Checklist" } ) );
+		// Save saves every open field on the row.
+		fireEvent.click( screen.getByRole( "button", { name: "Save On-Page SEO Checklist" } ) );
+		expect( onApplyField ).toHaveBeenCalledTimes( 2 );
 		expect( onApplyField ).toHaveBeenCalledWith( { id: 2, key: "seoTitle" } );
-
-		fireEvent.click( screen.getByRole( "button", { name: "Discard SEO title for On-Page SEO Checklist" } ) );
-		expect( onDiscardField ).toHaveBeenCalledWith( { id: 2, key: "seoTitle" } );
+		expect( onApplyField ).toHaveBeenCalledWith( { id: 2, key: "metaDescription" } );
 	} );
 
-	it( "disables only the saving field's input and actions", () => {
+	it( "disables the row's inputs and actions while it is saving", () => {
 		render(
 			<BulkEditorTable
 				items={ items }
@@ -247,11 +244,11 @@ describe( "BulkEditorTable", () => {
 			/>
 		);
 
+		// While any field on the row is saving, the whole row is locked.
 		expect( screen.getByRole( "textbox", { name: "SEO title for On-Page SEO Checklist" } ) ).toBeDisabled();
-		expect( screen.getByRole( "button", { name: "Apply SEO title for On-Page SEO Checklist" } ) ).toBeDisabled();
-		// The other open field is unaffected.
-		expect( screen.getByRole( "textbox", { name: "Meta description for On-Page SEO Checklist" } ) ).toBeEnabled();
-		expect( screen.getByRole( "button", { name: "Apply Meta description for On-Page SEO Checklist" } ) ).toBeEnabled();
+		expect( screen.getByRole( "textbox", { name: "Meta description for On-Page SEO Checklist" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Save On-Page SEO Checklist" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Cancel editing On-Page SEO Checklist" } ) ).toBeDisabled();
 	} );
 
 	it( "leaves other rows' Edit enabled while one row is being edited", () => {


### PR DESCRIPTION
## Context

Updates the inline-edit row UX to the latest design. The issue bundles two related changes; this PR covers the two Free-side ones:

1. **Row-level Save/Cancel** — the per-field Apply/Discard buttons are replaced by a single **Save** and **Cancel** in the Actions column ([desing](https://www.figma.com/design/hbzvViD3uZMAZN2fuRZokJ/Bulk-editor?node-id=876-16957)).
2. **Unsaved-changes tab-switch modal** — switching the Search/Social tab while rows have unsaved edits now confirms via a modal instead of silently discarding ([design](https://www.figma.com/design/hbzvViD3uZMAZN2fuRZokJ/Bulk-editor?node-id=767-15852)).

## Summary

This PR can be summarized in the following changelog entry:

* Replaces the bulk editor's per-field inline-edit buttons with a row-level Save and Cancel, and confirms before discarding unsaved edits on a tab switch.

## Relevant technical choices:

* **Row Save = save-all** — Save fires the existing per-field save for every open field on the row; the row locks while any field is saving.
* **Tab-switch guard** — `bulk-editor-content` gates the switch on `hasUnsavedEdits` via a local `pendingTab` state; the modal lives alongside it (no store change).
* **Synchronous capture** — Save-changes reads each field's draft before its first `await`, so clearing the edit state right after still posts the captured values.
* **Modal initial focus** — focus opens on **Save changes** (the safe, non-destructive action) per the ARIA dialog pattern.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

* Check out this branch, run `yarn install` + `grunt build:js`, and open **SEO → Bulk editor** (`admin.php?page=wpseo_page_bulk_edit`).

**Row-level Save/Cancel**
* Click **Edit** on a row — the field cells become editable textareas, and the Actions column shows **Save** and **Cancel** (both magenta tertiary buttons) split by a thin separator line. There are no per-field Apply/Discard buttons.
* Change a field and click **Save** — the row's edits are saved and the row returns to read-only with the new values.
* Edit another row and click **Cancel** — the edits are discarded and the row returns to read-only.
* While a row is saving, its inputs and the Save/Cancel buttons are disabled.

**Unsaved-changes tab-switch modal**
* Click **Edit** on a row (don't save), then click the **Social appearance** (or **Search appearance**) tab.
* A modal appears — "Unsaved changes" — with **Save changes**, **Continue without saving**, and **Cancel**; the tab does **not** switch yet.
* **Cancel** → the modal closes, you stay on the current tab, and the edit is preserved.
* Re-trigger, then **Continue without saving** → the edits are discarded and the tab switches.
* Re-trigger, then make changes -> **Save changes** → the open edits are saved and the tab switches. Check also the changes are correctly saved in the Post/Page in the editor. 
* Check space between tabs is 16px.

#### Accessibility / focus checks
* **Modal layout** matches the design: the icon sits to the left of a left-aligned title + description; the three buttons are stacked full-width.
* **Initial focus** lands on **Save changes** when the modal opens (not on the destructive "Continue without saving", and not the close X).
* **Keyboard:** with a row in edit mode, moving to another tab with the arrow keys (ArrowLeft/Right on the focused tab) also opens the modal. `Tab` cycles within the modal; `Esc` and the close **X** both dismiss it (same as Cancel).
* **Screen reader (VoiceOver/NVDA):** the modal is announced as a dialog named "Unsaved changes" with its description; the warning icon is not announced (decorative). The row Save/Cancel buttons expose per-row accessible names ("Save <title>" / "Cancel editing <title>").
* Known minor: after dismissing via an arrow-key-triggered switch, focus returns to the adjacent (still-inactive) tab — focus is not lost; out of scope to refactor the tablist focus model here.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor inline-edit row and the Search/Social tab switching.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [x] I have written documentation for this change. (Code comments.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to the WBSO document.

## Notes for the reviewer / merger

* **`EditableFieldCell` conflicts with #23367.** This PR rewrites `EditableFieldCell` on `feature/bulk-editor`, which doesn't yet have #23367's gradient-border / AnimateHeight tweaks to the same component. Whichever lands second will conflict — take care not to silently drop those styles or re-introduce the removed per-field Apply/Discard.
* **Save-changes failure path:** the modal's "Save changes" clears the edit state and switches regardless of save outcome, so a rejected save is dropped silently (unlike the normal row Save, which keeps the field open on failure). Acceptable for a "you're leaving anyway" decision; flagged as a deliberate choice.

Fixes Yoast/reserved-tasks#1310
