### PR TITLE
feat: optionally hold back the Premium update until Free is available

### DIFF
--- a/src/conditionals/hold-back-premium-update-conditional.php
+++ b/src/conditionals/hold-back-premium-update-conditional.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoast\WP\SEO\Conditionals;
+
+/**
+ * Conditional for the HOLD_BACK_PREMIUM_UPDATE feature flag.
+ */
+class Hold_Back_Premium_Update_Conditional extends Feature_Flag_Conditional {
+
+	/**
+	 * Returns the name of the feature flag.
+	 *
+	 * @return string The name of the feature flag.
+	 */
+	protected function get_feature_flag() {
+		return 'HOLD_BACK_PREMIUM_UPDATE';
+	}
+}

--- a/src/integrations/hold-back-premium-update.php
+++ b/src/integrations/hold-back-premium-update.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations;
+
+use Yoast\WP\SEO\Conditionals\Hold_Back_Premium_Update_Conditional;
+
+/**
+ * Hides the Yoast SEO Premium update while a compatible Yoast SEO version is not yet available to the site.
+ *
+ * Yoast SEO Premium x.y requires Yoast SEO x.y. When the Premium version offered by the My Yoast API is ahead of the
+ * latest Yoast SEO version the site can currently see, this integration moves the Premium entry out of the available
+ * updates, mirroring how WordPress core silently holds back updates. It runs after the add-on manager has populated
+ * the update list and never modifies the add-on manager itself.
+ */
+class Hold_Back_Premium_Update implements Integration_Interface {
+
+	/**
+	 * The My Yoast slug of Yoast SEO Premium.
+	 *
+	 * @var string
+	 */
+	private const PREMIUM_SLUG = 'yoast-seo-wordpress-premium';
+
+	/**
+	 * Returns the conditionals based on which this integration should be active.
+	 *
+	 * @return array<string> The conditionals.
+	 */
+	public static function get_conditionals() {
+		return [ Hold_Back_Premium_Update_Conditional::class ];
+	}
+
+	/**
+	 * Registers the hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		// Priority 11 so this runs after the add-on manager has populated the update list at the default priority.
+		\add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'hold_back_premium_update' ], 11 );
+	}
+
+	/**
+	 * Hides the Premium update when its version is ahead of the latest Yoast SEO version the site can see.
+	 *
+	 * Patch releases (x.y.z) do not tighten the requirement, so only the major and minor components are compared.
+	 *
+	 * @param mixed $data The value of the update_plugins site transient.
+	 *
+	 * @return mixed The (possibly adjusted) transient value.
+	 */
+	public function hold_back_premium_update( $data ) {
+		if ( ! \is_object( $data ) || empty( $data->response ) || ! \is_array( $data->response ) ) {
+			return $data;
+		}
+
+		$free_version = $this->get_latest_free_version( $data );
+		if ( $free_version === null ) {
+			return $data;
+		}
+
+		foreach ( $data->response as $plugin_file => $plugin_data ) {
+			if ( ! isset( $plugin_data->slug, $plugin_data->new_version ) || $plugin_data->slug !== self::PREMIUM_SLUG ) {
+				continue;
+			}
+
+			if ( ! $this->is_ahead_of_free( $plugin_data->new_version, $free_version ) ) {
+				continue;
+			}
+
+			if ( ! isset( $data->no_update ) || ! \is_array( $data->no_update ) ) {
+				$data->no_update = [];
+			}
+
+			$data->no_update[ $plugin_file ] = $plugin_data;
+			unset( $data->response[ $plugin_file ] );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Reads the latest available Yoast SEO version from the update list.
+	 *
+	 * @param object $data The update_plugins transient value.
+	 *
+	 * @return string|null The latest Yoast SEO version, or null when it is unknown.
+	 */
+	private function get_latest_free_version( $data ) {
+		foreach ( [ 'response', 'no_update' ] as $bucket ) {
+			if ( isset( $data->{$bucket}[ \WPSEO_BASENAME ]->new_version ) ) {
+				return $data->{$bucket}[ \WPSEO_BASENAME ]->new_version;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determines whether an add-on version is ahead of the Yoast SEO version by major.minor.
+	 *
+	 * @param string $addon_version The add-on version offered by the My Yoast API.
+	 * @param string $free_version  The latest available Yoast SEO version.
+	 *
+	 * @return bool True when the add-on is ahead of Yoast SEO.
+	 */
+	private function is_ahead_of_free( $addon_version, $free_version ) {
+		$addon_major_minor = $this->get_major_minor( $addon_version );
+		$free_major_minor  = $this->get_major_minor( $free_version );
+
+		if ( $addon_major_minor === null || $free_major_minor === null ) {
+			return false;
+		}
+
+		return \version_compare( $addon_major_minor, $free_major_minor, '>' );
+	}
+
+	/**
+	 * Extracts the major.minor part of a version string, ignoring any patch or pre-release suffix.
+	 *
+	 * @param string $version The version string.
+	 *
+	 * @return string|null The major.minor version, or null when it cannot be determined.
+	 */
+	private function get_major_minor( $version ) {
+		if ( ! \is_string( $version ) || ! \preg_match( '/^(\d+)\.(\d+)/', $version, $matches ) ) {
+			return null;
+		}
+
+		return $matches[1] . '.' . $matches[2];
+	}
+}

--- a/src/integrations/hold-back-premium-update.php
+++ b/src/integrations/hold-back-premium-update.php
@@ -45,9 +45,9 @@ class Hold_Back_Premium_Update implements Integration_Interface {
 	 *
 	 * Patch releases (x.y.z) do not tighten the requirement, so only the major and minor components are compared.
 	 *
-	 * @param mixed $data The value of the update_plugins site transient.
+	 * @param object $data The value of the update_plugins site transient.
 	 *
-	 * @return mixed The (possibly adjusted) transient value.
+	 * @return object The (possibly adjusted) transient value.
 	 */
 	public function hold_back_premium_update( $data ) {
 		if ( ! \is_object( $data ) || empty( $data->response ) || ! \is_array( $data->response ) ) {
@@ -88,6 +88,10 @@ class Hold_Back_Premium_Update implements Integration_Interface {
 	 */
 	private function get_latest_free_version( $data ) {
 		foreach ( [ 'response', 'no_update' ] as $bucket ) {
+			if ( ! isset( $data->{$bucket} ) || ! \is_array( $data->{$bucket} ) ) {
+				continue;
+			}
+
 			if ( isset( $data->{$bucket}[ \WPSEO_BASENAME ]->new_version ) ) {
 				return $data->{$bucket}[ \WPSEO_BASENAME ]->new_version;
 			}

--- a/src/integrations/hold-back-premium-update.php
+++ b/src/integrations/hold-back-premium-update.php
@@ -45,9 +45,9 @@ class Hold_Back_Premium_Update implements Integration_Interface {
 	 *
 	 * Patch releases (x.y.z) do not tighten the requirement, so only the major and minor components are compared.
 	 *
-	 * @param object $data The value of the update_plugins site transient.
+	 * @param object|false $data The value of the update_plugins site transient.
 	 *
-	 * @return object The (possibly adjusted) transient value.
+	 * @return object|false The transient value, with any held-back Premium update moved out of sight.
 	 */
 	public function hold_back_premium_update( $data ) {
 		if ( ! \is_object( $data ) || empty( $data->response ) || ! \is_array( $data->response ) ) {

--- a/tests/Unit/Conditionals/Hold_Back_Premium_Update_Conditional_Test.php
+++ b/tests/Unit/Conditionals/Hold_Back_Premium_Update_Conditional_Test.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Conditionals;
+
+use Yoast\WP\SEO\Conditionals\Hold_Back_Premium_Update_Conditional;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Hold_Back_Premium_Update_Conditional_Test.
+ *
+ * @group conditionals
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Conditionals\Hold_Back_Premium_Update_Conditional
+ */
+final class Hold_Back_Premium_Update_Conditional_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Hold_Back_Premium_Update_Conditional
+	 */
+	private $instance;
+
+	/**
+	 * Does the setup for testing.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Hold_Back_Premium_Update_Conditional();
+	}
+
+	/**
+	 * Tests that the conditional maps to the expected feature flag.
+	 *
+	 * @covers ::get_feature_flag
+	 *
+	 * @return void
+	 */
+	public function test_get_feature_name() {
+		$this->assertSame( 'HOLD_BACK_PREMIUM_UPDATE', $this->instance->get_feature_name() );
+	}
+
+	/**
+	 * Tests that the conditional is not met when the feature flag constant is not defined.
+	 *
+	 * @covers \Yoast\WP\SEO\Conditionals\Feature_Flag_Conditional::is_met
+	 *
+	 * @return void
+	 */
+	public function test_is_not_met_when_flag_is_not_defined() {
+		$this->assertFalse( $this->instance->is_met() );
+	}
+}

--- a/tests/Unit/Integrations/Hold_Back_Premium_Update_Test.php
+++ b/tests/Unit/Integrations/Hold_Back_Premium_Update_Test.php
@@ -44,7 +44,7 @@ final class Hold_Back_Premium_Update_Test extends TestCase {
 	public function test_get_conditionals() {
 		self::assertEquals(
 			[ Hold_Back_Premium_Update_Conditional::class ],
-			Hold_Back_Premium_Update::get_conditionals()
+			Hold_Back_Premium_Update::get_conditionals(),
 		);
 	}
 
@@ -109,44 +109,69 @@ final class Hold_Back_Premium_Update_Test extends TestCase {
 		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
 
 		$premium = static function ( $version ) use ( $premium_file ) {
-			return [ $premium_file => (object) [ 'slug' => 'yoast-seo-wordpress-premium', 'new_version' => $version ] ];
+			return [
+				$premium_file => (object) [
+					'slug'        => 'yoast-seo-wordpress-premium',
+					'new_version' => $version,
+				],
+			];
 		};
-		$free = static function ( $version ) {
-			return [ \WPSEO_BASENAME => (object) [ 'slug' => 'wordpress-seo', 'new_version' => $version ] ];
+		$free    = static function ( $version ) {
+			return [
+				\WPSEO_BASENAME => (object) [
+					'slug'        => 'wordpress-seo',
+					'new_version' => $version,
+				],
+			];
 		};
 
 		return [
-			'Premium ahead of Free is moved to no_update'      => [
-				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => $free( '27.7' ) ],
+			'Premium ahead of Free is moved to no_update' => [
+				'data'         => (object) [
+					'response'  => $premium( '27.8' ),
+					'no_update' => $free( '27.7' ),
+				],
 				'premium_file' => $premium_file,
 				'expected'     => 'no_update',
 				'message'      => 'Premium 27.8 must be hidden while the site only sees Free 27.7.',
 			],
-			'Premium matching Free stays in response'          => [
-				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => $free( '27.8' ) ],
+			'Premium matching Free stays in response' => [
+				'data'         => (object) [
+					'response'  => $premium( '27.8' ),
+					'no_update' => $free( '27.8' ),
+				],
 				'premium_file' => $premium_file,
 				'expected'     => 'response',
 				'message'      => 'Premium 27.8 must be shown when Free 27.8 is available.',
 			],
 			'Premium patch within Free minor stays in response' => [
-				'data'         => (object) [ 'response' => $premium( '27.8.1' ), 'no_update' => $free( '27.8' ) ],
+				'data'         => (object) [
+					'response'  => $premium( '27.8.1' ),
+					'no_update' => $free( '27.8' ),
+				],
 				'premium_file' => $premium_file,
 				'expected'     => 'response',
 				'message'      => 'Premium patch 27.8.1 must be shown when Free 27.8 is available.',
 			],
 			'Premium shown when Free update of same minor is available' => [
-				'data'         => (object) [ 'response' => \array_merge( $premium( '27.8' ), $free( '27.8' ) ), 'no_update' => [] ],
+				'data'         => (object) [
+					'response'  => \array_merge( $premium( '27.8' ), $free( '27.8' ) ),
+					'no_update' => [],
+				],
 				'premium_file' => $premium_file,
 				'expected'     => 'response',
 				'message'      => 'Premium 27.8 must be shown when Free 27.8 is itself an available update.',
 			],
-			'Unknown Free version leaves Premium untouched'    => [
-				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => [] ],
+			'Unknown Free version leaves Premium untouched' => [
+				'data'         => (object) [
+					'response'  => $premium( '27.8' ),
+					'no_update' => [],
+				],
 				'premium_file' => $premium_file,
 				'expected'     => 'response',
 				'message'      => 'Without a known Free version the update must not be hidden.',
 			],
-			'Non-object transient is returned unchanged'       => [
+			'Non-object transient is returned unchanged' => [
 				'data'         => false,
 				'premium_file' => null,
 				'expected'     => 'unchanged',

--- a/tests/Unit/Integrations/Hold_Back_Premium_Update_Test.php
+++ b/tests/Unit/Integrations/Hold_Back_Premium_Update_Test.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Hold_Back_Premium_Update_Conditional;
+use Yoast\WP\SEO\Integrations\Hold_Back_Premium_Update;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Unit test class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Hold_Back_Premium_Update
+ *
+ * @group integrations
+ */
+final class Hold_Back_Premium_Update_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Hold_Back_Premium_Update
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Hold_Back_Premium_Update();
+	}
+
+	/**
+	 * Tests the conditionals.
+	 *
+	 * @covers ::get_conditionals
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		self::assertEquals(
+			[ Hold_Back_Premium_Update_Conditional::class ],
+			Hold_Back_Premium_Update::get_conditionals()
+		);
+	}
+
+	/**
+	 * Tests the hook registration.
+	 *
+	 * @covers ::register_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Filters\expectAdded( 'pre_set_site_transient_update_plugins' )
+			->with( [ $this->instance, 'hold_back_premium_update' ], 11 )
+			->once();
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests that the Premium update is held back only when it is ahead of the available Yoast SEO version.
+	 *
+	 * @dataProvider hold_back_provider
+	 *
+	 * @covers ::hold_back_premium_update
+	 * @covers ::get_latest_free_version
+	 * @covers ::is_ahead_of_free
+	 * @covers ::get_major_minor
+	 *
+	 * @param mixed       $data         The update_plugins transient value.
+	 * @param string|null $premium_file The Premium plugin file key, or null when the input is not an object.
+	 * @param string      $expected     Where the Premium entry should end up: 'response', 'no_update', or 'unchanged'.
+	 * @param string      $message      Message to show when the test fails.
+	 *
+	 * @return void
+	 */
+	public function test_hold_back_premium_update( $data, $premium_file, $expected, $message ) {
+		$result = $this->instance->hold_back_premium_update( $data );
+
+		if ( $premium_file === null ) {
+			self::assertSame( $data, $result, $message );
+
+			return;
+		}
+
+		if ( $expected === 'no_update' ) {
+			self::assertArrayHasKey( $premium_file, $result->no_update, $message );
+			self::assertArrayNotHasKey( $premium_file, $result->response, $message );
+
+			return;
+		}
+
+		self::assertArrayHasKey( $premium_file, $result->response, $message );
+		self::assertArrayNotHasKey( $premium_file, $result->no_update, $message );
+	}
+
+	/**
+	 * Provides data for the hold-back test.
+	 *
+	 * @return array<string, array<string, mixed>> The test data.
+	 */
+	public static function hold_back_provider() {
+		$premium_file = 'wordpress-seo-premium/wp-seo-premium.php';
+
+		$premium = static function ( $version ) use ( $premium_file ) {
+			return [ $premium_file => (object) [ 'slug' => 'yoast-seo-wordpress-premium', 'new_version' => $version ] ];
+		};
+		$free = static function ( $version ) {
+			return [ \WPSEO_BASENAME => (object) [ 'slug' => 'wordpress-seo', 'new_version' => $version ] ];
+		};
+
+		return [
+			'Premium ahead of Free is moved to no_update'      => [
+				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => $free( '27.7' ) ],
+				'premium_file' => $premium_file,
+				'expected'     => 'no_update',
+				'message'      => 'Premium 27.8 must be hidden while the site only sees Free 27.7.',
+			],
+			'Premium matching Free stays in response'          => [
+				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => $free( '27.8' ) ],
+				'premium_file' => $premium_file,
+				'expected'     => 'response',
+				'message'      => 'Premium 27.8 must be shown when Free 27.8 is available.',
+			],
+			'Premium patch within Free minor stays in response' => [
+				'data'         => (object) [ 'response' => $premium( '27.8.1' ), 'no_update' => $free( '27.8' ) ],
+				'premium_file' => $premium_file,
+				'expected'     => 'response',
+				'message'      => 'Premium patch 27.8.1 must be shown when Free 27.8 is available.',
+			],
+			'Premium shown when Free update of same minor is available' => [
+				'data'         => (object) [ 'response' => \array_merge( $premium( '27.8' ), $free( '27.8' ) ), 'no_update' => [] ],
+				'premium_file' => $premium_file,
+				'expected'     => 'response',
+				'message'      => 'Premium 27.8 must be shown when Free 27.8 is itself an available update.',
+			],
+			'Unknown Free version leaves Premium untouched'    => [
+				'data'         => (object) [ 'response' => $premium( '27.8' ), 'no_update' => [] ],
+				'premium_file' => $premium_file,
+				'expected'     => 'response',
+				'message'      => 'Without a known Free version the update must not be hidden.',
+			],
+			'Non-object transient is returned unchanged'       => [
+				'data'         => false,
+				'premium_file' => null,
+				'expected'     => 'unchanged',
+				'message'      => 'A non-object transient must be returned as-is.',
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Yoast SEO Premium and Yoast SEO (Free) are released together and are built to match: Premium `x.y` expects Free `x.y` alongside it. They reach sites through different channels at different speeds. Free is distributed by the WordPress.org plugin directory, which rolls a new version out gradually over hours; Premium is downloaded immediately from My Yoast through the customer license. In that gap a site can be offered the Premium `x.y` update before Free `x.y` is available to it, and updating Premium then breaks the pairing. This happened with Premium 27.8 and required manually pulling Premium from distribution until Free 27.8 had spread.

This PR adds the ability to hold the Premium update back until the matching Free version is available to that specific site. It is behind a feature flag, so it is off by default and can be switched on when needed.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Hides the Yoast SEO Premium update until a compatible Yoast SEO version is available, when the `YOAST_SEO_HOLD_BACK_PREMIUM_UPDATE` flag is set.

## Relevant technical choices:

* The behaviour lives in a new, self-contained integration (`src/integrations/hold-back-premium-update.php`) with its own feature-flag conditional (`src/conditionals/hold-back-premium-update-conditional.php`). The add-on manager is not touched.
* It is gated by the `YOAST_SEO_HOLD_BACK_PREMIUM_UPDATE` feature flag through the integration's conditional. When the flag is not set, the loader never registers the integration, so no hook is added and behaviour is identical to before, with zero overhead.
* The integration hooks `pre_set_site_transient_update_plugins` at priority 11, after the add-on manager has populated the update list at the default priority. It finds the Premium entry by its slug, reads the latest available Free version from Free's own entry, and moves Premium from `response` to `no_update` when Premium's major.minor is ahead. That hides it from the Updates and Plugins screens and makes the auto-updater skip it, mirroring how WordPress core holds back updates.
* Only the major and minor parts are compared, so patch releases are not held back: Premium `x.y.z` only needs Free `x.y` to be available.
* When the latest Free version cannot be read from the update list, the integration leaves the update untouched, so nothing is hidden on incomplete data.
* Scope is Premium for now. It complements the existing `YOAST_SEO_CHECK_REQUIRED_VERSION` header check, which blocks a manually uploaded incompatible add-on: that handles manual installs, while this hides the offered and automatic update.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

The behaviour is behind a feature flag and only occurs when a newer Premium is available while the matching Free version is not yet available to the site, so the scenario has to be simulated. On a site with Free and Premium installed at the same version (for example both `27.7`):

* Enable the flag by adding to `wp-config.php`: `define( 'YOAST_SEO_HOLD_BACK_PREMIUM_UPDATE', true );`
* Add this temporary must-use plugin in `wp-content/mu-plugins/holdback-test.php`. It makes the license report Premium `27.8` and pins the latest Free the site can see to `27.7`. Set the installed Premium version lower than the offered one (here, `27.7`).

```php
<?php
// TEST ONLY. Simulate "Premium 27.8 released, Free 27.8 not yet available to this site".
add_action( 'admin_init', function () {
	$info = (object) [
		'subscriptions' => [
			(object) [
				'renewal_url' => '',
				'expiry_date' => '2037-01-01T00:00:00.000Z',
				'product'     => (object) [
					'version'      => '27.8',
					'name'         => 'Yoast SEO Premium',
					'slug'         => 'yoast-seo-wordpress-premium',
					'last_updated' => '2037-01-01T00:00:00.000Z',
					'store_url'    => 'https://yoast.com/shop',
					'download'     => 'https://example.com/premium.zip',
					'changelog'    => '',
				],
			],
		],
	];
	set_transient( 'wpseo_site_information', $info, DAY_IN_SECONDS );
	set_transient( 'wpseo_site_information_quick', $info, 60 );
}, 1 );

add_filter( 'pre_set_site_transient_update_plugins', function ( $transient ) {
	if ( is_object( $transient ) ) {
		unset( $transient->response['wordpress-seo/wp-seo.php'] );
		$transient->no_update['wordpress-seo/wp-seo.php'] = (object) [
			'plugin'      => 'wordpress-seo/wp-seo.php',
			'slug'        => 'wordpress-seo',
			'new_version' => '27.7',
			'requires'    => '6.5',
		];
	}
	return $transient;
}, 9 );
```

* Go to Dashboard > Updates, click "Check again", then open the Plugins screen.
* Confirm no update is offered for Yoast SEO Premium on either screen. It is held back, because the site only sees Free `27.7`.
* Change `new_version` in the snippet from `27.7` to `27.8` (the matching Free is now available), click "Check again", and reload the Plugins screen. Confirm the Premium `27.8` update now appears.
* Remove the `YOAST_SEO_HOLD_BACK_PREMIUM_UPDATE` flag (or set it to `false`), click "Check again" with the snippet back at `27.7`. Confirm the Premium `27.8` update appears anyway, proving the default behaviour is unchanged when the flag is off.
* Remove the temporary must-use plugin and the flag when done.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Same as the acceptance test steps above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* With the flag off (the default), nothing changes. With the flag on, the plugin update flow for Yoast SEO Premium is affected: the Updates screen, the Plugins screen, and automatic background updates. Worth confirming that a normal Premium update still appears when the matching Free version is available, and that the other add-ons are unaffected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23374
