### PR TITLE
chore: Fix return type for Pagination_Helper::get_page_number_from_query_loop()

### DIFF
--- a/src/helpers/pagination-helper.php
+++ b/src/helpers/pagination-helper.php
@@ -187,7 +187,7 @@ class Pagination_Helper {
 	/**
 	 * Returns the page number from the query loop.
 	 *
-	 * @return string The page number from the query loop.
+	 * @return int|string The page number from the query loop, or an empty string when none applies.
 	 */
 	public function get_page_number_from_query_loop() {
 		$key_query_loop = $this->get_key_query_loop();

--- a/tests/Unit/Helpers/Pagination_Helper_Test.php
+++ b/tests/Unit/Helpers/Pagination_Helper_Test.php
@@ -623,4 +623,24 @@ final class Pagination_Helper_Test extends TestCase {
 
 		$this->assertEquals( $expects, $this->instance->get_page_number_from_query_loop() );
 	}
+
+	/**
+	 * @covers ::get_page_number_from_query_loop
+	 *
+	 * @return void
+	 */
+	public function test_query_loop_page_number_returns_int_when_above_one() {
+		$_GET = [ 'query-1-page' => '2' ];
+		$this->assertSame( 2, $this->instance->get_page_number_from_query_loop() );
+	}
+
+	/**
+	 * @covers ::get_page_number_from_query_loop
+	 *
+	 * @return void
+	 */
+	public function test_query_loop_page_number_returns_empty_string_when_absent() {
+		$_GET = [];
+		$this->assertSame( '', $this->instance->get_page_number_from_query_loop() );
+	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `Pagination_Helper::get_page_number_from_query_loop()` method was documented as returning a `string`, but it returns an `int` when successfully matching a query loop page, and an empty `string` otherwise. This type-annotation mismatch causes static analysis violations (like Psalm/PHPStan) when consuming methods that properly declare an `int` return type pass this value through. This PR fixes the PHPDoc and adds unit tests to strictly pin the expected `int|string` return types.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* `changelog: non-user-facing`
* Corrects the return type documentation for `Pagination_Helper::get_page_number_from_query_loop()` to reflect its actual `int|string` behavior.

## Relevant technical choices:

* Updated the PHPDoc to `@return int|string` to match what the code actually outputs.
* Added `test_query_loop_page_number_returns_int_when_above_one` and `test_query_loop_page_number_returns_empty_string_when_absent` to pin the runtime behavior, ensuring future clean-ups do not silently change the contract.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Since this is a code-level change only, verify that the automated CI pipelines (PHPUnit and PHPCS checks) pass successfully for this PR.
* Alternatively, run the test suite locally using `composer test-wp-env` or by running `vendor/bin/phpunit tests/Unit/Helpers/Pagination_Helper_Test.php`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* No user-facing behavior impact; this purely corrects internal type-hinting for static analysis tooling.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #