### PR TITLE
fix: avoid PHP 8.5 null array offset deprecation in memoizers

### DIFF
--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -132,7 +132,10 @@ class Meta_Tags_Context_Memoizer {
 	 * @return Meta_Tags_Context The meta tags context.
 	 */
 	public function get( Indexable $indexable, $page_type ) {
-		if ( ! isset( $this->cache[ $indexable->id ] ) ) {
+		// An unsaved indexable has a null id; normalise it to a stable integer cache key.
+		$cache_key = (int) $indexable->id;
+
+		if ( ! isset( $this->cache[ $cache_key ] ) ) {
 			$blocks = [];
 			$post   = null;
 			if ( $indexable->object_type === 'post' ) {
@@ -151,10 +154,10 @@ class Meta_Tags_Context_Memoizer {
 
 			$context->presentation = $this->presentation_memoizer->get( $indexable, $context, $page_type );
 
-			$this->cache[ $indexable->id ] = $context;
+			$this->cache[ $cache_key ] = $context;
 		}
 
-		return $this->cache[ $indexable->id ];
+		return $this->cache[ $cache_key ];
 	}
 
 	/**

--- a/src/memoizers/presentation-memoizer.php
+++ b/src/memoizers/presentation-memoizer.php
@@ -46,7 +46,10 @@ class Presentation_Memoizer {
 	 * @return Indexable_Presentation The indexable presentation.
 	 */
 	public function get( Indexable $indexable, Meta_Tags_Context $context, $page_type ) {
-		if ( ! isset( $this->cache[ $indexable->id ] ) ) {
+		// An unsaved indexable has a null id; normalise it to a stable integer cache key.
+		$cache_key = (int) $indexable->id;
+
+		if ( ! isset( $this->cache[ $cache_key ] ) ) {
 			$presentation = $this->container->get( "Yoast\WP\SEO\Presentations\Indexable_{$page_type}_Presentation", ContainerInterface::NULL_ON_INVALID_REFERENCE );
 
 			if ( ! $presentation ) {
@@ -60,10 +63,10 @@ class Presentation_Memoizer {
 				],
 			);
 
-			$this->cache[ $indexable->id ] = $context->presentation;
+			$this->cache[ $cache_key ] = $context->presentation;
 		}
 
-		return $this->cache[ $indexable->id ];
+		return $this->cache[ $cache_key ];
 	}
 
 	/**

--- a/tests/Unit/Doubles/Memoizers/Presentation_Memoizer_Double.php
+++ b/tests/Unit/Doubles/Memoizers/Presentation_Memoizer_Double.php
@@ -20,4 +20,13 @@ final class Presentation_Memoizer_Double extends Presentation_Memoizer {
 	public function set_cache( $key, $value ) {
 		$this->cache[ $key ] = $value;
 	}
+
+	/**
+	 * Used to retrieve the internal cache for testing purposes.
+	 *
+	 * @return array<int|string, mixed> The cache.
+	 */
+	public function get_cache() {
+		return $this->cache;
+	}
 }

--- a/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
+++ b/tests/Unit/Memoizers/Meta_Tags_Context_Memoizer_Test.php
@@ -261,6 +261,36 @@ final class Meta_Tags_Context_Memoizer_Test extends TestCase {
 	}
 
 	/**
+	 * Tests getting the meta tags context for an indexable whose id is null, ensuring it is
+	 * cached under a stable integer key instead of a null array offset.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_caches_when_indexable_id_is_null() {
+		$this->indexable->id = null;
+
+		$this->meta_tags_context
+			->expects( 'of' )
+			->once()
+			->andReturn( $this->meta_tags_context_mock );
+
+		$this->presentation_memoizer
+			->expects( 'get' )
+			->once()
+			->with( $this->indexable, $this->meta_tags_context_mock, 'the_page_type' )
+			->andReturn( $this->meta_tags_context_mock->presentation );
+
+		$first  = $this->instance->get( $this->indexable, 'the_page_type' );
+		$second = $this->instance->get( $this->indexable, 'the_page_type' );
+
+		$this->assertEquals( $this->meta_tags_context_mock, $first );
+		$this->assertSame( $first, $second );
+		$this->assertArrayHasKey( 0, $this->instance->get_cache() );
+	}
+
+	/**
 	 * Tests clearing the memoization of a specific indexable.
 	 *
 	 * If the cache is indeed empty, the 'for_current_page' method must call

--- a/tests/Unit/Memoizers/Presentation_Memoizer_Test.php
+++ b/tests/Unit/Memoizers/Presentation_Memoizer_Test.php
@@ -153,6 +153,35 @@ final class Presentation_Memoizer_Test extends TestCase {
 	}
 
 	/**
+	 * Tests getting the presentation of an indexable whose id is null, ensuring it is
+	 * cached under a stable integer key instead of a null array offset.
+	 *
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_get_caches_when_indexable_id_is_null() {
+		$this->indexable->id = null;
+
+		$this->container
+			->expects( 'get' )
+			->once()
+			->andReturn( $this->indexable_presentation );
+
+		$this->indexable_presentation
+			->expects( 'of' )
+			->once()
+			->andReturn( $this->meta_tags_context_mock->presentation );
+
+		$first  = $this->instance->get( $this->indexable, $this->meta_tags_context_mock, 'the_page_type' );
+		$second = $this->instance->get( $this->indexable, $this->meta_tags_context_mock, 'the_page_type' );
+
+		$this->assertSame( $this->meta_tags_context_mock->presentation, $first );
+		$this->assertSame( $first, $second );
+		$this->assertArrayHasKey( 0, $this->instance->get_cache() );
+	}
+
+	/**
 	 * Tests clearing the memoization of an indexable when the indexable is given.
 	 *
 	 * If the cache is indeed empty, the 'get' method must call


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

PHP 8.5 introduced a new deprecation, `Using null as an array offset is deprecated, use an empty string instead`. Yoast's meta memoizers cache their results in a plain array keyed by the indexable's id. When that id is `null`, the array access triggers the deprecation on every call. An indexable id is `null` for any indexable that was built but never saved: the fallback indexable that `Indexable_Repository::for_current_page()` returns (for example while the post editor is loading), and, on non-production sites, every indexable (because indexables are only persisted in production). The result is `debug.log` being flooded with deprecation notices when editing a post, as reported in #23397.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where PHP deprecation notices were logged when editing a post on PHP 8.5 and later.

## Relevant technical choices:

* The deprecation is new in PHP 8.5 and only fires when the `null` key comes from a variable, not a literal (a literal `$array[null]` is folded to `$array['']` at compile time). That is why a quick literal-key test looks clean and the issue was initially hard to reproduce.
* The root cause is in `Meta_Tags_Context_Memoizer::get()` and `Presentation_Memoizer::get()`, which key their cache array by `$indexable->id`. `$indexable->id` is `null` for unsaved indexables.
* The fix normalises the key once with `(int) $indexable->id`. A real id is already an integer and is unchanged; a `null` id becomes `0`. Real indexable ids start at 1, so `0` never collides with a real one, and `0` is a valid array key that does not trigger the deprecation. Behaviour is otherwise identical to before.
* This is a deliberately minimal, behaviour-preserving change. It does not change the pre-existing fact that all unsaved (null-id) indexables share one cache slot; that only matters on non-production sites and is out of scope for this bugfix.
* No constructor signatures changed and no services were added, so the DI container does not need recompiling.
* Coverage is held: a unit test was added for each memoizer covering the null-id path.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Use a test site running PHP 8.5 (the deprecation does not appear on older PHP versions).
* In `wp-config.php`, turn on debug logging by setting both `WP_DEBUG` and `WP_DEBUG_LOG` to `true`.
* Without this change, open any post in the editor (Posts, then edit a post, or add a new one) and then open `wp-content/debug.log`. You will see new lines reading `PHP Deprecated: Using null as an array offset is deprecated` that point at `meta-tags-context-memoizer.php` and `presentation-memoizer.php`.
* With this change applied, empty the log, repeat the same edit-a-post step, and confirm that those deprecation lines no longer appear.
* Confirm the editor and the post's SEO metabox still load and work normally.
* Developers can also run the automated tests: `composer test -- --filter=Memoizer`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
The memoizers serve every indexable type, so it is worth confirming the log stays clean for a post, a page, and a term while viewing them and while editing a post.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Same as the acceptance test steps above, using a PHP 8.5 environment with debug logging enabled.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The meta tags context memoizer and presentation memoizer, which feed front-end meta output (titles, descriptions, canonical, robots, social and schema) and the editor metabox initialisation. Worth a regression check that front-end meta and schema still render correctly for posts, pages, term archives and the home page.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23397
