### PR TITLE
fix(ai-content-planner): skip empty paragraph insertion when post type has a block template

### DIFF
--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -58,14 +58,17 @@ export function insertFirstParagraph( blocks, insertBlock, isBannerRendered ) {
 export const ContentPlannerEditorPlugin = () => {
 	const hasInserted = useRef( false );
 
-	const { isNewPost, postType, blocks, minPostsMet, isBannerRendered } = useSelect( select => {
+	const { isNewPost, postType, blocks, minPostsMet, isBannerRendered, hasBlockTemplate } = useSelect( select => {
 		const coreEditor = select( "core/editor" );
+		const currentPostType = coreEditor.getCurrentPostType();
+		const postTypeObject = select( "core" ).getPostType( currentPostType );
 		return {
 			isNewPost: coreEditor.isEditedPostNew(),
-			postType: coreEditor.getCurrentPostType(),
+			postType: currentPostType,
 			blocks: select( "core/block-editor" ).getBlocks(),
 			minPostsMet: select( CONTENT_PLANNER_STORE ).selectIsMinPostsMet(),
 			isBannerRendered: select( CONTENT_PLANNER_STORE ).selectIsBannerRendered(),
+			hasBlockTemplate: Array.isArray( postTypeObject?.template ) && postTypeObject.template.length > 0,
 		};
 	}, [] );
 	const hasAiStore = useSelect( select => isObject( select( STORE_NAME_AI ) ), [] );
@@ -76,12 +79,12 @@ export const ContentPlannerEditorPlugin = () => {
 	useYoastMetaSync();
 
 	useEffect( () => {
-		if ( hasInserted.current || ! isNewPost || postType !== "post" || ! minPostsMet ) {
+		if ( hasInserted.current || ! isNewPost || postType !== "post" || ! minPostsMet || hasBlockTemplate ) {
 			return;
 		}
 
 		hasInserted.current = insertFirstParagraph( blocks, insertBlock, isBannerRendered );
-	}, [ blocks, isNewPost, postType, insertBlock, minPostsMet ] );
+	}, [ blocks, isNewPost, postType, insertBlock, minPostsMet, hasBlockTemplate ] );
 
 	if ( ! hasAiStore ) {
 		return null;

--- a/packages/js/tests/ai-content-planner/initialize.test.js
+++ b/packages/js/tests/ai-content-planner/initialize.test.js
@@ -1,48 +1,36 @@
 import { render } from "../test-utils";
-import { ContentPlannerEditorPlugin, registerInlineBanner } from "../../src/ai-content-planner/initialize";
+import { ContentPlannerEditorPlugin, insertFirstParagraph, registerInlineBanner } from "../../src/ai-content-planner/initialize";
 import { addFilter } from "@wordpress/hooks";
 
 const mockSelectHasAiGeneratorConsent = jest.fn( () => false );
 const mockSelectIsMinPostsMet = jest.fn( () => false );
 const mockSelectIsBannerRendered = jest.fn( () => false );
 
+const buildMockSelect = ( { postTypeTemplate = null } = {} ) => {
+	const storeMap = {
+		"yoast-seo/ai-generator": { selectHasAiGeneratorConsent: mockSelectHasAiGeneratorConsent },
+		"yoast-seo/content-planner": {
+			selectIsMinPostsMet: mockSelectIsMinPostsMet,
+			selectIsBannerRendered: mockSelectIsBannerRendered,
+		},
+		"core/editor": {
+			isEditedPostNew: () => false,
+			getCurrentPostType: () => "post",
+			getEditedPostAttribute: () => "",
+		},
+		"core/block-editor": { getBlocks: () => [] },
+		core: { getPostType: () => ( { template: postTypeTemplate } ) },
+		"yoast-seo/editor": { getSnippetEditorTemplates: () => ( { title: "", description: "" } ) },
+	};
+	return ( storeName ) => storeMap[ storeName ] ?? {};
+};
+
 jest.mock( "@wordpress/data", () => ( {
 	dispatch: jest.fn( () => ( {
 		updateData: jest.fn(),
 		setFocusKeyword: jest.fn(),
 	} ) ),
-	useSelect: jest.fn( ( mapSelect ) => {
-		const mockSelect = ( storeName ) => {
-			if ( storeName === "yoast-seo/ai-generator" ) {
-				return {
-					selectHasAiGeneratorConsent: mockSelectHasAiGeneratorConsent,
-				};
-			}
-			if ( storeName === "yoast-seo/content-planner" ) {
-				return {
-					selectIsMinPostsMet: mockSelectIsMinPostsMet,
-					selectIsBannerRendered: mockSelectIsBannerRendered,
-				};
-			}
-			if ( storeName === "core/editor" ) {
-				return {
-					isEditedPostNew: () => false,
-					getCurrentPostType: () => "post",
-					getEditedPostAttribute: () => "",
-				};
-			}
-			if ( storeName === "core/block-editor" ) {
-				return {
-					getBlocks: () => [],
-				};
-			}
-			if ( storeName === "yoast-seo/editor" ) {
-				return { getSnippetEditorTemplates: () => ( { title: "", description: "" } ) };
-			}
-			return {};
-		};
-		return mapSelect( mockSelect );
-	} ),
+	useSelect: jest.fn( ( mapSelect ) => mapSelect( buildMockSelect() ) ),
 	useDispatch: jest.fn( () => ( {
 		insertBlock: jest.fn(),
 		updateData: jest.fn(),
@@ -107,35 +95,15 @@ describe( "ContentPlannerEditorPlugin", () => {
 
 	test( "renders null when the AI generator store is not registered", () => {
 		const { useSelect } = require( "@wordpress/data" );
-		useSelect.mockImplementation( ( mapSelect ) => {
-			const mockSelect = ( storeName ) => {
-				if ( storeName === "yoast-seo/ai-generator" ) {
-					// Unregistered store returns undefined.
-					return undefined;
-				}
-				if ( storeName === "yoast-seo/content-planner" ) {
-					return {
-						selectIsMinPostsMet: () => false,
-						selectIsBannerRendered: () => false,
-					};
-				}
-				if ( storeName === "core/editor" ) {
-					return {
-						isEditedPostNew: () => false,
-						getCurrentPostType: () => "post",
-						getEditedPostAttribute: () => "",
-					};
-				}
-				if ( storeName === "core/block-editor" ) {
-					return { getBlocks: () => [] };
-				}
-				if ( storeName === "yoast-seo/editor" ) {
-					return { getSnippetEditorTemplates: () => ( { title: "", description: "" } ) };
-				}
-				return {};
-			};
-			return mapSelect( mockSelect );
-		} );
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( buildMockSelect() ) );
+
+		// Override only the ai-generator store to simulate it being absent.
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( ( storeName ) => {
+			if ( storeName === "yoast-seo/ai-generator" ) {
+				return undefined;
+			}
+			return buildMockSelect()( storeName );
+		} ) );
 
 		const { container } = render( <ContentPlannerEditorPlugin /> );
 		expect( container.firstChild ).toBeNull();
@@ -145,34 +113,7 @@ describe( "ContentPlannerEditorPlugin", () => {
 		mockSelectHasAiGeneratorConsent.mockReturnValue( true );
 
 		const { useSelect } = require( "@wordpress/data" );
-		useSelect.mockImplementation( ( mapSelect ) => {
-			const mockSelect = ( storeName ) => {
-				if ( storeName === "yoast-seo/ai-generator" ) {
-					return { selectHasAiGeneratorConsent: mockSelectHasAiGeneratorConsent };
-				}
-				if ( storeName === "yoast-seo/content-planner" ) {
-					return {
-						selectIsMinPostsMet: () => false,
-						selectIsBannerRendered: () => false,
-					};
-				}
-				if ( storeName === "core/editor" ) {
-					return {
-						isEditedPostNew: () => false,
-						getCurrentPostType: () => "post",
-						getEditedPostAttribute: () => "",
-					};
-				}
-				if ( storeName === "core/block-editor" ) {
-					return { getBlocks: () => [] };
-				}
-				if ( storeName === "yoast-seo/editor" ) {
-					return { getSnippetEditorTemplates: () => ( { title: "", description: "" } ) };
-				}
-				return {};
-			};
-			return mapSelect( mockSelect );
-		} );
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( buildMockSelect() ) );
 
 		const { getByTestId } = render( <ContentPlannerEditorPlugin /> );
 		expect( getByTestId( "app" ).dataset.hasConsent ).toBe( "true" );
@@ -185,6 +126,77 @@ describe( "ContentPlannerEditorPlugin", () => {
 
 		const { getByTestId } = render( <ContentPlannerEditorPlugin /> );
 		expect( getByTestId( "app" ).dataset.hasConsent ).toBe( "false" );
+	} );
+} );
+
+describe( "insertFirstParagraph", () => {
+	const mockInsertBlock = jest.fn();
+
+	beforeEach( () => {
+		mockInsertBlock.mockClear();
+	} );
+
+	test( "returns true immediately when the banner is already rendered", () => {
+		const result = insertFirstParagraph( [], mockInsertBlock, true );
+
+		expect( result ).toBe( true );
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+	} );
+
+	test( "inserts a paragraph and returns false when the canvas is empty", () => {
+		const result = insertFirstParagraph( [], mockInsertBlock, false );
+
+		expect( mockInsertBlock ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toBe( false );
+	} );
+
+	test( "returns true without inserting when the canvas already has a paragraph", () => {
+		const blocks = [ { name: "core/paragraph" } ];
+
+		const result = insertFirstParagraph( blocks, mockInsertBlock, false );
+
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+		expect( result ).toBe( true );
+	} );
+
+	test( "returns false without inserting when blocks exist but none is a paragraph", () => {
+		const blocks = [ { name: "core/heading" } ];
+
+		const result = insertFirstParagraph( blocks, mockInsertBlock, false );
+
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+		expect( result ).toBe( false );
+	} );
+} );
+
+describe( "ContentPlannerEditorPlugin — block template guard", () => {
+	const mockInsertBlock = jest.fn();
+
+	beforeEach( () => {
+		mockInsertBlock.mockClear();
+	} );
+
+	test( "does not insert a paragraph when the post type has a block template", () => {
+		const { useSelect, useDispatch } = require( "@wordpress/data" );
+
+		mockSelectIsMinPostsMet.mockReturnValue( true );
+		useDispatch.mockImplementation( () => ( { insertBlock: mockInsertBlock, updateData: jest.fn(), setFocusKeyword: jest.fn() } ) );
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( ( storeName ) => {
+			if ( storeName === "core/editor" ) {
+				return {
+					isEditedPostNew: () => true,
+					getCurrentPostType: () => "post",
+					getEditedPostAttribute: () => "",
+				};
+			}
+			return buildMockSelect( { postTypeTemplate: [ [ "core/group", {} ] ] } )( storeName );
+		} ) );
+
+		render( <ContentPlannerEditorPlugin /> );
+
+		expect( mockInsertBlock ).not.toHaveBeenCalled();
+
+		mockSelectIsMinPostsMet.mockReturnValue( false );
 	} );
 } );
 


### PR DESCRIPTION
When a post type registers a block template, insertFirstParagraph would race against Gutenberg's template application: the effect fired while blocks was still [] (before the template blocks landed), inserting a stray core/paragraph at position 0.

The fix reads the template from select('core').getPostType(), which is populated from the REST API preload cache synchronously before React renders, unlike getSettings().template which is written by BlockEditorProvider inside a useEffect (one tick too late).

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: "Fixes a bug where... happened when/was caused by ..."
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the AI Content Planner inserted an empty paragraph block before the template blocks when a post type had a block template registered.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Setup:** Save the following snippet in snippets plugin of functions.php:
```php
<?php
add_action( 'init', function () {
	$post_type_object = get_post_type_object( 'post' );
	$post_type_object->template = [
		[
			'core/group',
			[
				'align'     => 'left',
				'className' => 'post-content',
				'metadata'  => [ 'name' => 'Post Content' ],
				'layout'    => [
					'type'           => 'constrained',
					'contentSize'    => '1140px',
					'wideSize'       => '1140px',
					'inherit'        => true,
					'justifyContent' => 'center',
				],
			],
		],
	];
}, 20 );
```

**With a block template (the bug fix)**
* Create a new post.
* If you have recently created posts, Confirm the AI Content Planner banner appears above the `core/group` block and there is no paragraph block under it.
* Otherwise check that there is no new paragraph block.

**Without a block template (regression)**
5. Remove or disable the PHP snippet.
6. Create a new post.
7. Confirm the AI Content Planner banner still appears at the top of the empty canvas.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23398