### PR TITLE
docs: fix wpseo_sitemap_entry filter parameter documentation

### DIFF
--- a/inc/sitemaps/class-post-type-sitemap-provider.php
+++ b/inc/sitemaps/class-post-type-sitemap-provider.php
@@ -217,9 +217,9 @@ class WPSEO_Post_Type_Sitemap_Provider implements WPSEO_Sitemap_Provider {
 				/**
 				 * Filter URL entry before it gets added to the sitemap.
 				 *
-				 * @param array  $url  Array of URL parts.
-				 * @param string $type URL type.
-				 * @param object $post Data object for the URL.
+				 * @param array  $url  Array of URL entry data, e.g. `loc`, `mod`, `chf` and `pri`.
+				 * @param string $type The object type: `post`, `user` or `term`.
+				 * @param object $post The object the entry is for: a WP_Post, WP_User or WP_Term.
 				 */
 				$url = apply_filters( 'wpseo_sitemap_entry', $url, 'post', $post );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The docblock for the `wpseo_sitemap_entry` filter in `WPSEO_Post_Type_Sitemap_Provider` described its parameters incorrectly, as reported in #23148. This corrects the inline documentation so developers hooking the filter get accurate parameter information.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
-->
This PR can be summarized in the following changelog entry:

* Corrects the inline documentation of the `wpseo_sitemap_entry` filter parameters in the post type sitemap provider.

## Relevant technical choices:

* This is the canonical docblock for the `wpseo_sitemap_entry` filter: the author and taxonomy sitemap providers reference it via `/** This filter is documented at inc/sitemaps/class-post-type-sitemap-provider.php */` and call the filter with different second/third arguments (`'user'`/`WP_User` and `'term'`/`WP_Term`). The parameters are therefore documented generically so the description stays accurate for all three call sites, not only the post case.
* Verified against the code: `$url` is the URL entry data array (e.g. `loc`, `mod`, `chf`, `pri`), `$type` is the object-type string (`post`, `user` or `term`), and `$post` is the `WP_Post`/`WP_User`/`WP_Term` object the entry is for. The existing `object` type and alignment are kept; only the descriptions change.
* No behaviour change, so no unit tests were added and coverage is unaffected.
* `composer check-branch-cs` could not be run locally (full monorepo dependency install was unavailable in this environment); `php -l` passes and the change only edits docblock descriptions. CI will run the coding-standard check.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* This is a documentation-only change with no runtime effect.
* Open `inc/sitemaps/class-post-type-sitemap-provider.php` and find the `wpseo_sitemap_entry` filter.
* Confirm the docblock above it now describes `$url` as the URL entry data array, `$type` as the object type (`post`, `user` or `term`), and `$post` as the `WP_Post`/`WP_User`/`WP_Term` object.
* Optionally, hook the filter and dump the three arguments to confirm they match the documentation.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — documentation-only change with no user-visible behaviour.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* None. This is a comment-only change with no runtime impact.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23148
