### PR TITLE
fix: use the post type or taxonomy slug for settings section URLs

### DIFF
--- a/src/helpers/route-helper.php
+++ b/src/helpers/route-helper.php
@@ -8,19 +8,20 @@ namespace Yoast\WP\SEO\Helpers;
 class Route_Helper {
 
 	/**
-	 * Gets the route from a name, rewrite and rest_base.
+	 * Gets the route from a name and rest_base.
+	 *
+	 * The post type or taxonomy name is used as the route by default, because it is unique and
+	 * stable. The rewrite slug is deliberately not used: it is not guaranteed to be unique (a
+	 * custom type can reuse a built-in type's rewrite slug) and it can change, which would make
+	 * the settings section unreachable or its URL unstable. See https://github.com/Yoast/wordpress-seo/issues/20864.
 	 *
 	 * @param string $name      The name.
-	 * @param array  $rewrite   The rewrite data.
 	 * @param string $rest_base The rest base.
 	 *
 	 * @return string The route.
 	 */
-	public function get_route( $name, $rewrite, $rest_base ) {
+	public function get_route( $name, $rest_base ) {
 		$route = $name;
-		if ( isset( $rewrite['slug'] ) ) {
-			$route = $rewrite['slug'];
-		}
 		if ( ! empty( $rest_base ) ) {
 			$route = $rest_base;
 		}

--- a/src/integrations/settings-integration.php
+++ b/src/integrations/settings-integration.php
@@ -994,7 +994,7 @@ class Settings_Integration implements Integration_Interface {
 		foreach ( $post_types as $post_type ) {
 			$transformed[ $post_type->name ] = [
 				'name'                 => $post_type->name,
-				'route'                => $this->route_helper->get_route( $post_type->name, $post_type->rewrite, $post_type->rest_base ),
+				'route'                => $this->route_helper->get_route( $post_type->name, $post_type->rest_base ),
 				'label'                => $post_type->label,
 				'singularLabel'        => $post_type->labels->singular_name,
 				'hasArchive'           => $this->post_type_helper->has_archive( $post_type ),
@@ -1047,7 +1047,7 @@ class Settings_Integration implements Integration_Interface {
 		foreach ( $taxonomies as $taxonomy ) {
 			$transformed[ $taxonomy->name ] = [
 				'name'          => $taxonomy->name,
-				'route'         => $this->route_helper->get_route( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base ),
+				'route'         => $this->route_helper->get_route( $taxonomy->name, $taxonomy->rest_base ),
 				'label'         => $taxonomy->label,
 				'showUi'        => $taxonomy->show_ui,
 				'singularLabel' => $taxonomy->labels->singular_name,

--- a/src/task-list/application/tasks/set-search-appearance-templates.php
+++ b/src/task-list/application/tasks/set-search-appearance-templates.php
@@ -100,7 +100,7 @@ class Set_Search_Appearance_Templates extends Abstract_Post_Type_Task {
 		$post_type = \get_post_type_object( $this->get_post_type() );
 		$link      = \sprintf(
 			'admin.php?page=wpseo_page_settings#/post-type/%s',
-			$this->route_helper->get_route( $post_type->name, $post_type->rewrite, $post_type->rest_base ),
+			$this->route_helper->get_route( $post_type->name, $post_type->rest_base ),
 		);
 
 		return \self_admin_url( $link );

--- a/tests/Unit/Helpers/Route_Helper_Test.php
+++ b/tests/Unit/Helpers/Route_Helper_Test.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Helpers;
+
+use Yoast\WP\SEO\Helpers\Route_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Unit Test Class.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Helpers\Route_Helper
+ *
+ * @group helpers
+ */
+final class Route_Helper_Test extends TestCase {
+
+	/**
+	 * The instance to test.
+	 *
+	 * @var Route_Helper
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Route_Helper();
+	}
+
+	/**
+	 * Tests that the route is built from the name, falling back to the rest base, with leading
+	 * slashes stripped.
+	 *
+	 * @covers ::get_route
+	 *
+	 * @dataProvider provider_get_route
+	 *
+	 * @param string $name      The name.
+	 * @param string $rest_base The rest base.
+	 * @param string $expected  The expected route.
+	 *
+	 * @return void
+	 */
+	public function test_get_route( $name, $rest_base, $expected ) {
+		$this->assertSame( $expected, $this->instance->get_route( $name, $rest_base ) );
+	}
+
+	/**
+	 * Data provider for test_get_route.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public static function provider_get_route() {
+		return [
+			'Uses the name when no rest base is set' => [
+				'name'      => 'my-post-type',
+				'rest_base' => '',
+				'expected'  => 'my-post-type',
+			],
+			'Uses the rest base when it is set' => [
+				'name'      => 'my-post-type',
+				'rest_base' => 'my-rest-base',
+				'expected'  => 'my-rest-base',
+			],
+			'Strips a leading slash from the name' => [
+				'name'      => '/my-post-type',
+				'rest_base' => '',
+				'expected'  => 'my-post-type',
+			],
+			'Strips multiple leading slashes from the rest base' => [
+				'name'      => 'my-post-type',
+				'rest_base' => '///my-rest-base',
+				'expected'  => 'my-rest-base',
+			],
+		];
+	}
+}

--- a/tests/Unit/Integrations/Settings_Integration_Test.php
+++ b/tests/Unit/Integrations/Settings_Integration_Test.php
@@ -393,7 +393,7 @@ final class Settings_Integration_Test extends TestCase {
 		$post_type = $post_types['book'];
 		$this->route_helper
 			->expects( 'get_route' )
-			->with( $post_type->name, $post_type->rewrite, $post_type->rest_base )
+			->with( $post_type->name, $post_type->rest_base )
 			->andReturn( $post_type->rewrite['slug'] );
 		$result = $this->instance_double->transform_post_types( $post_types );
 
@@ -486,7 +486,7 @@ final class Settings_Integration_Test extends TestCase {
 		$taxonomy = $taxonomies['book_category'];
 		$this->route_helper
 			->expects( 'get_route' )
-			->with( $taxonomy->name, $taxonomy->rewrite, $taxonomy->rest_base )
+			->with( $taxonomy->name, $taxonomy->rest_base )
 			->andReturn( $taxonomy->rewrite['slug'] );
 
 		$result = $this->instance_double->transform_taxonomies( $taxonomies, $post_type_names );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The Settings page builds the deep links to each post type and taxonomy section (`#/post-type/<route>` and `#/taxonomy/<route>`) from the rewrite slug. The rewrite slug is not guaranteed to be unique — a custom post type or taxonomy can reuse a built-in type's rewrite slug — and it can change over time. As reported in #20864 (and the merged #20016 / #20341), this makes some sections unreachable: e.g. with Tutor LMS the Lessons, Quizzes and Assignments sections all resolve to the same URL, and with Directorist the taxonomy tags section opens the categories section. This PR builds the route from the unique, stable post type/taxonomy slug instead.

Note: for a content type whose rewrite slug differs from its name and which has no custom `rest_base`, the section URL changes. An old bookmark using the previous (rewrite-slug-based) URL will no longer match and the settings app falls back to its default section. This is the intended trade-off for stable, unique and always-reachable URLs.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a Settings section could open the wrong content type when a custom post type or taxonomy reused a built-in type's rewrite slug.

## Relevant technical choices:

* `Route_Helper::get_route()` now derives the route from the post type/taxonomy name, which is unique and stable, instead of the rewrite slug, which is neither. The leading-slash stripping and the `rest_base` handling are unchanged.
* The `rest_base` override is kept on purpose: a custom `rest_base` is required by the REST API to be unique, and when it is not set it defaults to the name, so it does not reintroduce the collision the rewrite slug caused. Happy to drop it as well if maintainers prefer the route to always be the name.
* The `route` value is only used to build the client-side Settings deep link (the `packages/js` settings router: `/post-type/${route}` and `/taxonomy/${route}`). It is not a REST route and not a storage key — the settings data is keyed by the post type/taxonomy name — so this change has no data-migration, front-end or SEO impact.
* The now-unused `$rewrite` parameter was removed from `Route_Helper::get_route()` and its three callers were updated (`Settings_Integration` post types and taxonomies, and the `Set_Search_Appearance_Templates` task link). `Route_Helper` is an internal helper, not a documented hook.
* Added unit tests for `Route_Helper::get_route()` (the class had none).
* I could not run `composer test` / `composer check-branch-cs` locally (full monorepo dependency install was unavailable in this environment). `php -l` passes on all changed files and the `get_route()` logic was verified against the four covered cases. CI will run the full suite.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Install Yoast SEO and a plugin that registers post types whose rewrite slug collides with another type — for example Tutor LMS (Lessons, Quizzes, Assignments).
* Go to **Yoast SEO > Settings** and open the **Content Types** group in the menu.
* Click **Lessons**, then **Quizzes**, then **Assignments** in turn.
* **Expected:** each click opens that content type's own settings section (before this change they all opened the same section).
* The same can be checked for taxonomies with a plugin like Directorist (its tags vs. categories sections).

#### Relevant test scenarios
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!-- Test with custom post types/taxonomies whose rewrite slug differs from (or collides with) their name, and with types that set a custom rest_base. -->

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Settings page deep links for post type and taxonomy sections.
* The "Set search appearance templates" task link (task list), which builds the same deep link.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #20864
