### PR TITLE
Fix author meta tag suppressed for CPTs with author support

### DIFF
--- a/src/presenters/meta-author-presenter.php
+++ b/src/presenters/meta-author-presenter.php
@@ -38,7 +38,7 @@ class Meta_Author_Presenter extends Abstract_Indexable_Tag_Presenter {
 	 * @return string The author's display name.
 	 */
 	public function get() {
-		if ( $this->presentation->model->object_sub_type !== 'post' ) {
+		if ( ! \post_type_supports( $this->presentation->model->object_sub_type, 'author' ) ) {
 			return '';
 		}
 

--- a/tests/Unit/Presenters/Meta_Author_Presenter_Test.php
+++ b/tests/Unit/Presenters/Meta_Author_Presenter_Test.php
@@ -93,6 +93,11 @@ final class Meta_Author_Presenter_Test extends TestCase {
 		$this->indexable_presentation->model                  = new Indexable_Mock();
 		$this->indexable_presentation->model->object_sub_type = 'post';
 
+		Monkey\Functions\expect( 'post_type_supports' )
+			->once()
+			->with( 'post', 'author' )
+			->andReturn( true );
+
 		$user_mock               = Mockery::mock( WP_User::class );
 		$user_mock->display_name = 'John Doe';
 
@@ -126,6 +131,11 @@ final class Meta_Author_Presenter_Test extends TestCase {
 		$this->indexable_presentation->model                  = new Indexable_Mock();
 		$this->indexable_presentation->model->object_sub_type = 'post';
 
+		Monkey\Functions\expect( 'post_type_supports' )
+			->once()
+			->with( 'post', 'author' )
+			->andReturn( true );
+
 		Monkey\Functions\expect( 'get_userdata' )
 			->once()
 			->with( 123 )
@@ -142,16 +152,21 @@ final class Meta_Author_Presenter_Test extends TestCase {
 	}
 
 	/**
-	 * Tests the presenter of the meta description when we are not on a post.
+	 * Tests that post types without author support do not output the meta author tag.
 	 *
 	 * @covers ::present
 	 * @covers ::get
 	 *
 	 * @return void
 	 */
-	public function test_present_and_filter_not_a_post() {
+	public function test_present_and_filter_unsupported_post_type() {
 		$this->indexable_presentation->model                  = new Indexable_Mock();
-		$this->indexable_presentation->model->object_sub_type = 'page';
+		$this->indexable_presentation->model->object_sub_type = 'no-author-cpt';
+
+		Monkey\Functions\expect( 'post_type_supports' )
+			->once()
+			->with( 'no-author-cpt', 'author' )
+			->andReturn( false );
 
 		Monkey\Functions\expect( 'get_userdata' )
 			->never();
@@ -166,6 +181,48 @@ final class Meta_Author_Presenter_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that CPTs with author support do output the meta author tag.
+	 *
+	 * Delete-the-fix guard: removing the post_type_supports() check from get() would cause
+	 * the original object_sub_type !== 'post' guard to bail early on this CPT slug, flipping
+	 * this test from green to red.
+	 *
+	 * @covers ::present
+	 * @covers ::get
+	 *
+	 * @return void
+	 */
+	public function test_present_and_filter_supported_cpt() {
+		$this->indexable_presentation->model                  = new Indexable_Mock();
+		$this->indexable_presentation->model->object_sub_type = 'my-article-cpt';
+
+		Monkey\Functions\expect( 'post_type_supports' )
+			->once()
+			->with( 'my-article-cpt', 'author' )
+			->andReturn( true );
+
+		$user_mock               = Mockery::mock( WP_User::class );
+		$user_mock->display_name = 'Jane Smith';
+
+		Monkey\Functions\expect( 'get_userdata' )
+			->once()
+			->with( 123 )
+			->andReturn( $user_mock );
+
+		$this->html
+			->expects( 'smart_strip_tags' )
+			->once()
+			->with( 'Jane Smith' )
+			->andReturn( 'Jane Smith' );
+		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
+
+		$output = '<meta name="author" content="Jane Smith" />';
+
+		Monkey\Filters\expectApplied( 'wpseo_meta_author' );
+		$this->assertSame( $output, $this->instance->present() );
+	}
+
+	/**
 	 * Tests the presenter of the meta description when the admin bar is showing a class is added.
 	 *
 	 * @covers ::present
@@ -176,6 +233,11 @@ final class Meta_Author_Presenter_Test extends TestCase {
 	public function test_present_and_filter_with_class() {
 		$this->indexable_presentation->model                  = new Indexable_Mock();
 		$this->indexable_presentation->model->object_sub_type = 'post';
+
+		Monkey\Functions\expect( 'post_type_supports' )
+			->once()
+			->with( 'post', 'author' )
+			->andReturn( true );
 
 		$user_mock               = Mockery::mock( WP_User::class );
 		$user_mock->display_name = 'John Doe';


### PR DESCRIPTION
## Description

Custom post types configured with `'author'` in their `supports` array do not output the author meta tag, even when using the `wpseo_meta_author` filter — the filter is never reached for any `object_sub_type` that isn't the literal string `'post'`.

**Root cause:** `Meta_Author_Presenter::get()` contains a guard that compares `object_sub_type` against the hardcoded string `'post'` and bails out before the `wpseo_meta_author` filter can fire for any other post type.

Before:

    if ( $this->presentation->model->object_sub_type !== 'post' ) {
        return '';
    }

**Fix:** Replace the hardcoded equality check with `post_type_supports()`:

    if ( ! \post_type_supports( $this->presentation->model->object_sub_type, 'author' ) ) {
        return '';
    }

The tag is now emitted for any post type that declares `'author'` support — including built-in types that already had it and CPTs registered with that support. Types without the feature continue to receive no tag.

## How to test

1. Register a CPT with `'supports' => [ 'title', 'editor', 'author' ]`
2. Create a post of that type and view it on the frontend
3. Check page source — `<meta name="author" content="..." />` should appear
4. Optionally add a `wpseo_meta_author` filter — confirm it fires and the return value is used

## Changelog label

Could a maintainer please apply `changelog: bugfix`? As an external contributor I'm unable to add labels, and I understand `pr-validation.yml` requires one before merge.

## Credits

props @thisismyurl (full disclosure: AI helped me identify the issue and verify my work)

Closes #23193