### PR TITLE
23408 fix ai consent related classes in the old ai folder structure

### DIFF
--- a/src/ai-authorization/application/token-manager.php
+++ b/src/ai-authorization/application/token-manager.php
@@ -153,7 +153,7 @@ class Token_Manager implements Token_Manager_Interface {
 		}
 
 		// Delete the stored JWT tokens.
-		$this->clear_tokens( $user->ID );
+		$this->clear_tokens( $user_id );
 	}
 
 	/**

--- a/src/ai-authorization/application/token-manager.php
+++ b/src/ai-authorization/application/token-manager.php
@@ -153,8 +153,19 @@ class Token_Manager implements Token_Manager_Interface {
 		}
 
 		// Delete the stored JWT tokens.
-		$this->user_helper->delete_meta( $user_id, '_yoast_wpseo_ai_generator_access_jwt' );
-		$this->user_helper->delete_meta( $user_id, '_yoast_wpseo_ai_generator_refresh_jwt' );
+		$this->clear_tokens( $user->ID );
+	}
+
+	/**
+	 * Clears the user meta tokens for a specific user.
+	 *
+	 * @param int $user_id The user id to delete this for.
+	 *
+	 * @return void
+	 */
+	public function clear_tokens( int $user_id ): void {
+		$this->access_token_repository->delete_token( $user_id );
+		$this->refresh_token_repository->delete_token( $user_id );
 	}
 
 	/**
@@ -294,8 +305,7 @@ class Token_Manager implements Token_Manager_Interface {
 	public function get_or_request_access_token( WP_User $user ): string {
 		// If the site URL has changed since callback URLs were registered, delete stale tokens.
 		if ( $this->have_callback_urls_changed( $user ) ) {
-			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt' );
-			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+			$this->clear_tokens( $user->ID );
 		}
 
 		$access_jwt = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt', true );

--- a/src/ai-consent/application/consent-handler.php
+++ b/src/ai-consent/application/consent-handler.php
@@ -2,6 +2,8 @@
 
 namespace Yoast\WP\SEO\AI_Consent\Application;
 
+use RuntimeException;
+use WP_User;
 use Yoast\WP\SEO\AI_Authorization\Application\Token_Manager;
 use Yoast\WP\SEO\AI_HTTP_Request\Application\Request_Handler;
 use Yoast\WP\SEO\AI_HTTP_Request\Domain\Exceptions\Bad_Request_Exception;
@@ -85,6 +87,7 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 * @throws Too_Many_Requests_Exception     When the AI service responds with 429.
 	 * @throws Unauthorized_Exception          When the AI service responds with 401.
 	 * @throws WP_Request_Exception            When the underlying WordPress HTTP call fails.
+	 * @throws RuntimeException When the user is not found.
 	 */
 	public function grant_consent( int $user_id ) {
 		$user = \get_user_by( 'id', $user_id );
@@ -126,9 +129,14 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 * @throws Too_Many_Requests_Exception     When the AI service responds with 429.
 	 * @throws Unauthorized_Exception          When the AI service responds with 401.
 	 * @throws WP_Request_Exception            When the underlying WordPress HTTP call fails.
+	 * @throws RuntimeException           When the user is not found.
 	 */
 	public function revoke_consent( int $user_id ) {
 		$user = \get_user_by( 'id', $user_id );
+		if ( ! $user instanceof WP_User ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- false positive.
+			throw new RuntimeException( "User not found: $user_id" );
+		}
 		// Local consent is always revoked regardless of remote failures.
 		$this->user_helper->delete_meta( $user_id, '_yoast_wpseo_ai_consent' );
 

--- a/src/ai/authorization/application/token-manager.php
+++ b/src/ai/authorization/application/token-manager.php
@@ -302,8 +302,7 @@ class Token_Manager implements Token_Manager_Interface {
 	public function get_or_request_access_token( WP_User $user ): string {
 		// If the site URL has changed since callback URLs were registered, delete stale tokens.
 		if ( $this->have_callback_urls_changed( $user ) ) {
-			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt' );
-			$this->user_helper->delete_meta( $user->ID, '_yoast_wpseo_ai_generator_refresh_jwt' );
+			$this->clear_tokens( $user->ID );
 		}
 
 		$access_jwt = $this->user_helper->get_meta( $user->ID, '_yoast_wpseo_ai_generator_access_jwt', true );

--- a/src/ai/authorization/application/token-manager.php
+++ b/src/ai/authorization/application/token-manager.php
@@ -117,6 +117,8 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param int $user_id The user ID.
 	 *
+	 * @return void
+	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
 	 * @throws Not_Found_Exception Not_Found_Exception.
@@ -125,7 +127,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Service_Unavailable_Exception Service_Unavailable_Exception.
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws RuntimeException Unable to retrieve the access token.
-	 * @return void
 	 */
 	public function token_invalidate( int $user_id ): void {
 		try {
@@ -176,6 +177,8 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
+	 * @return void
+	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -185,7 +188,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Service_Unavailable_Exception Service_Unavailable_Exception.
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
-	 * @return void
 	 */
 	public function token_request( WP_User $user ): void {
 		// Generate a code verifier and store it in the database.
@@ -221,6 +223,8 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
+	 * @return void
+	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -231,7 +235,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
 	 * @throws RuntimeException Unable to retrieve the refresh token.
-	 * @return void
 	 */
 	public function token_refresh( WP_User $user ): void {
 		$refresh_jwt = $this->refresh_token_repository->get_token( $user->ID );
@@ -287,6 +290,8 @@ class Token_Manager implements Token_Manager_Interface {
 	 *
 	 * @param WP_User $user The WP user.
 	 *
+	 * @return string The access token.
+	 *
 	 * @throws Bad_Request_Exception Bad_Request_Exception.
 	 * @throws Forbidden_Exception Forbidden_Exception.
 	 * @throws Internal_Server_Error_Exception Internal_Server_Error_Exception.
@@ -297,7 +302,6 @@ class Token_Manager implements Token_Manager_Interface {
 	 * @throws Too_Many_Requests_Exception Too_Many_Requests_Exception.
 	 * @throws Unauthorized_Exception Unauthorized_Exception.
 	 * @throws RuntimeException Unable to retrieve the access or refresh token.
-	 * @return string The access token.
 	 */
 	public function get_or_request_access_token( WP_User $user ): string {
 		// If the site URL has changed since callback URLs were registered, delete stale tokens.

--- a/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
+++ b/tests/Unit/AI/Authorization/Application/Token_Manager/Callback_Url_Change_Test.php
@@ -55,15 +55,15 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->once()
 			->andReturn( 'https://example.com/wp-json/yoast/v1/ai_generator/refresh_callback' );
 
-		// Stale tokens should be deleted.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( 123, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Stale tokens should be deleted via the repositories.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( 123 )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( 123, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( 123 )
 			->once();
 
 		// After deletion, get_meta returns empty — triggers token_request.
@@ -180,15 +180,15 @@ final class Callback_Url_Change_Test extends Abstract_Token_Manager_Test {
 			->with( 123, '_yoast_wpseo_ai_generator_callback_url_hash', true )
 			->andReturn( '' );
 
-		// Stale tokens should be deleted.
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( 123, '_yoast_wpseo_ai_generator_access_jwt' )
+		// Stale tokens should be deleted via the repositories.
+		$this->access_token_repository
+			->expects( 'delete_token' )
+			->with( 123 )
 			->once();
 
-		$this->user_helper
-			->expects( 'delete_meta' )
-			->with( 123, '_yoast_wpseo_ai_generator_refresh_jwt' )
+		$this->refresh_token_repository
+			->expects( 'delete_token' )
+			->with( 123 )
 			->once();
 
 		// After deletion, get_meta returns empty — triggers token_request.


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In https://github.com/Yoast/wordpress-seo/issues/23302 we refactored the AI consent flow, but some changes were not mirrored in the old `Yoast\WP\SEO\AI_Consent\Application\Consent_Handler` and `Yoast\WP\SEO\AI_Authorization\Application\Token_Manager` classes. Thee old classes are used in case the use has an old version of Yoast SEO Premium and a recent version of Yoast. 

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Mirrors the changes made in the `Yoast\WP\SEO\AI\` classes in the old `Yoast\WP\SEO\AI_*` ones.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Make sure you have the latest Free trunk and an older version of Premium installed

### Test granting consent from the user profile
* Go to `Users` -> `Profile` and grant consent
  * Confirm now the button says `Revoke consent` and no errors are shown in the browser console network tab
  * Use an AI-based feature (e.g. the AI Optimize) and confirm you're not asked for consent
 
### Test revoking consent from the user profile
* Go to `Users` -> `Profile` and revoke consent
  * Confirm now the button says `Grant consent` and no errors are shown in the browser console network tab
* With a MySQL client open the `wp_usermeta` table
  * ~Verify that there are no lines where the `meta_name` column is `_yoast_wpseo_ai_generator_access_jwt` and the `user_id` column equals to your logged in user id~ ❌ this fails, that's why we created this PR on top: https://github.com/Yoast/wordpress-seo/pull/23425. Same with the below step
  * ~Verify the same for  `meta_name =  _yoast_wpseo_ai_generator_refresh_jwt`~
 
### Test granting consent from the block editor
* Edit a post
* Try to use any AI-based feature
  * Verify you get asked for consent
  * Verify you can use the feature and  no errors are shown in the browser console network tab



#### Relevant test scenarios
* [X] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* One of the changes I made impacts also the Free trunk and Premium trunk scenario: please perform a smoke test by granting consent and using an AI-based feature in that scenario, too.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23408
