### PR TITLE
fix(bulk-editor): guard responsive utilities against ai-frontend CSS

### DIFF
--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -24,29 +24,30 @@
 	}
 
 	/* Re-assert the page's responsive utilities so the @yoast/ai-frontend stylesheet cannot clobber
-	 * them when Premium AI is active; the page scope adds the specificity to win it back.
+	 * them when Premium AI is active. ai-frontend re-ships the base utilities as `!important`, so the
+	 * guard needs both the page-scope specificity and `!important` to win (plain `@apply` drops it).
 	 * Temporary stopgap — remove once Yoast/ai-frontend#141 / #124 land the durable fix. */
 	@media (min-width: 640px) {
 		.sm\:yst-block {
-			@apply yst-block;
+			@apply !yst-block;
 		}
 
 		.sm\:yst-flex-row {
-			@apply yst-flex-row;
+			@apply !yst-flex-row;
 		}
 
 		.sm\:yst-table-fixed {
-			@apply yst-table-fixed;
+			@apply !yst-table-fixed;
 		}
 	}
 
 	@media (min-width: 783px) {
 		.min-\[783px\]\:yst-block {
-			@apply yst-block;
+			@apply !yst-block;
 		}
 
 		.min-\[783px\]\:yst-p-8 {
-			@apply yst-p-8;
+			@apply !yst-p-8;
 		}
 	}
 }

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -24,9 +24,8 @@
 	}
 
 	/* Re-assert the page's responsive utilities so the @yoast/ai-frontend stylesheet cannot clobber
-	 * them when Premium AI is active. ai-frontend re-ships the base utilities as `!important`, so the
-	 * guard needs both the page-scope specificity and `!important` to win (plain `@apply` drops it).
-	 * Temporary stopgap — remove once Yoast/ai-frontend#141 / #124 land the durable fix. */
+	 * them when Premium AI is active.
+	 * Temporary stopgap — remove once Yoast/ai-frontend#141 / #124 land the proper fix. */
 	@media (min-width: 640px) {
 		.sm\:yst-block {
 			@apply !yst-block;
@@ -38,6 +37,10 @@
 
 		.sm\:yst-table-fixed {
 			@apply !yst-table-fixed;
+		}
+
+		.sm\:yst-w-80 {
+			@apply !yst-w-80;
 		}
 	}
 

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -24,8 +24,7 @@
 	}
 
 	/* Re-assert the page's responsive utilities so the @yoast/ai-frontend stylesheet cannot clobber
-	 * them when Premium AI is active.
-	 * Temporary stopgap — remove once Yoast/ai-frontend#141 / #124 land the proper fix. */
+	 * them when Premium AI is active. */
 	@media (min-width: 640px) {
 		.sm\:yst-block {
 			@apply !yst-block;

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -24,7 +24,8 @@
 	}
 
 	/* Re-assert the page's responsive utilities so the @yoast/ai-frontend stylesheet cannot clobber
-	 * them when Premium AI is active; the page scope adds the specificity to win it back. */
+	 * them when Premium AI is active; the page scope adds the specificity to win it back.
+	 * Temporary stopgap — remove once Yoast/ai-frontend#141 / #124 land the durable fix. */
 	@media (min-width: 640px) {
 		.sm\:yst-block {
 			@apply yst-block;

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -22,4 +22,30 @@
 	.yst-mobile-navigation__dialog {
 		z-index: 99999;
 	}
+
+	/* Re-assert the page's responsive utilities so the @yoast/ai-frontend stylesheet cannot clobber
+	 * them when Premium AI is active; the page scope adds the specificity to win it back. */
+	@media (min-width: 640px) {
+		.sm\:yst-block {
+			@apply yst-block;
+		}
+
+		.sm\:yst-flex-row {
+			@apply yst-flex-row;
+		}
+
+		.sm\:yst-table-fixed {
+			@apply yst-table-fixed;
+		}
+	}
+
+	@media (min-width: 783px) {
+		.min-\[783px\]\:yst-block {
+			@apply yst-block;
+		}
+
+		.min-\[783px\]\:yst-p-8 {
+			@apply yst-p-8;
+		}
+	}
 }


### PR DESCRIPTION
## Context

Temporary CSS guard for the bulk editor against the `@yoast/ai-frontend` CSS collision (Yoast/reserved-tasks#1323).

When Premium AI is active, `ai-frontend.css` is enqueued on the bulk editor page. It re-ships the host's base Tailwind utilities  as `!important`, and clobbers the responsive variants the page relies on. Symptoms: the content-type sidebar disappears, the tabs/search row stacks, the table loses fixed layout, and the results summary is hidden.

**This is a stopgap.** The durable fix lives in `@yoast/ai-frontend` — tracked in **Yoast/ai-frontend#141** (the CSS-priority collision) with **Yoast/ai-frontend#124** ("Expose CSS without Tailwind") being the right shape of fix. **Remove this guard once that lands.** 

## Summary

This PR can be summarized in the following changelog entry:

* Stops the bulk editor layout from breaking when Premium AI's stylesheet is loaded.

## Relevant technical choices:

* Guard limited to the five plain+responsive same-property pairs that exist on the page today; new such pairs would need adding here until the `@yoast/ai-frontend` fix lands.
* Wins by **specificity**, not cascade layers — layers are unusable here because the utilities are `!important` (verified in-browser).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Setup (required to see the bug at all):**
1. Use a site with **Yoast SEO Premium active** and the **AI features available/consented** — the collision only appears when `ai-frontend.css` is loaded, which Premium AI triggers on the bulk editor page. On Free-only the stylesheet is not enqueued, so there is nothing to reproduce.
2. Make sure `feature/bulk-editor` is checked out with this branch on top. If testing locally, run `grunt build:js && grunt build:css` (or `yarn start`) so the rebuilt `bulk-editor-page.css` is served.
3. Have at least ~20 posts so the table and pagination render.
4. Use a **desktop browser window ≥ 783px wide** for the main checks.

**Verify the layout is correct (desktop, ≥ 783px):**
1. Go to **Yoast SEO → Bulk editor** (`/wp-admin/admin.php?page=wpseo_page_bulk_edit`).
2. **Left sidebar** — the content-type navigation ("Bulk editor" with Posts / Pages / …) is **visible** on the left. *(When broken: it disappears entirely.)*
3. **Tabs + search row** — the "Search appearance" / "Social appearance" tabs and the "Search for posts…" box sit on **one horizontal row**. *(When broken: they stack vertically.)*
4. **Table** — columns are **fixed-width and aligned** with their headers. *(When broken: the table falls back to auto layout and columns shift.)*
5. **Page padding** — the card uses the **roomy desktop padding** (≈32px). *(When broken: the tighter ≈16px mobile padding.)*
6. **Footer** — scroll to the bottom: the **"Showing 1 to 20 of N results"** summary is visible on the left, pagination on the right. *(When broken: the summary is hidden.)*

**Confirm the guard is what fixes it (optional regression check):**
- With Premium AI still active, check out `feature/bulk-editor` **without** this branch (or comment out the new rules in `css/src/bulk-editor-page.css` and rebuild). All five items above break. Re-apply this branch → all five are correct again.

**Mobile sanity (< 640px):**
- Narrow the window below ~640px. The layout is *meant* to stack (tabs/search in a column, full-width pagination, summary hidden). Confirm this still looks right — the guard only re-asserts the desktop overrides and must not change mobile behaviour.

**Cross-browser / RTL:**
- Repeat the desktop checks in a second browser, and in RTL (admin bar → "Switch to RTL"). The layout should mirror correctly; the guard ships RTL variants.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Pure CSS. Test across browsers and in RTL. **Premium with AI active is required** to load `ai-frontend.css` and reproduce the underlying collision; Free-only or non-AI shows nothing to fix.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as the acceptance test above. Prerequisite: Premium with AI active (otherwise the collision this guards against does not occur).

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor page CSS only (`css/src/bulk-editor-page.css`). No JS or PHP changes.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.

Relates to Yoast/reserved-tasks#1323

