### PR TITLE
fix: guard null timestamp query result in indexable builders

### DIFF
--- a/src/builders/indexable-author-builder.php
+++ b/src/builders/indexable-author-builder.php
@@ -103,8 +103,8 @@ class Indexable_Author_Builder {
 		$this->handle_social_images( $indexable );
 
 		$timestamps                      = $this->get_object_timestamps( $user_id );
-		$indexable->object_published_at  = $timestamps->published_at;
-		$indexable->object_last_modified = $timestamps->last_modified;
+		$indexable->object_published_at  = ( $timestamps->published_at ?? null );
+		$indexable->object_last_modified = ( $timestamps->last_modified ?? null );
 
 		$indexable->version = $this->version;
 
@@ -180,7 +180,8 @@ class Indexable_Author_Builder {
 	 *
 	 * @param int $author_id The author ID.
 	 *
-	 * @return object An object with last_modified and published_at timestamps.
+	 * @return object|null An object with last_modified and published_at timestamps, or null
+	 *                     when the query fails or returns no row.
 	 */
 	protected function get_object_timestamps( $author_id ) {
 		global $wpdb;

--- a/src/builders/indexable-home-page-builder.php
+++ b/src/builders/indexable-home-page-builder.php
@@ -102,8 +102,8 @@ class Indexable_Home_Page_Builder {
 		}
 
 		$timestamps                      = $this->get_object_timestamps();
-		$indexable->object_published_at  = $timestamps->published_at;
-		$indexable->object_last_modified = $timestamps->last_modified;
+		$indexable->object_published_at  = ( $timestamps->published_at ?? null );
+		$indexable->object_last_modified = ( $timestamps->last_modified ?? null );
 
 		$indexable->version = $this->version;
 
@@ -113,7 +113,8 @@ class Indexable_Home_Page_Builder {
 	/**
 	 * Returns the timestamps for the homepage.
 	 *
-	 * @return object An object with last_modified and published_at timestamps.
+	 * @return object|null An object with last_modified and published_at timestamps, or null
+	 *                     when the query fails or returns no row.
 	 */
 	protected function get_object_timestamps() {
 		global $wpdb;

--- a/src/builders/indexable-post-type-archive-builder.php
+++ b/src/builders/indexable-post-type-archive-builder.php
@@ -90,8 +90,8 @@ class Indexable_Post_Type_Archive_Builder {
 		$indexable->version           = $this->version;
 
 		$timestamps                      = $this->get_object_timestamps( $post_type );
-		$indexable->object_published_at  = $timestamps->published_at;
-		$indexable->object_last_modified = $timestamps->last_modified;
+		$indexable->object_published_at  = ( $timestamps->published_at ?? null );
+		$indexable->object_last_modified = ( $timestamps->last_modified ?? null );
 
 		return $indexable;
 	}
@@ -132,7 +132,8 @@ class Indexable_Post_Type_Archive_Builder {
 	 *
 	 * @param string $post_type The post type.
 	 *
-	 * @return object An object with last_modified and published_at timestamps.
+	 * @return object|null An object with last_modified and published_at timestamps, or null
+	 *                     when the query fails or returns no row.
 	 */
 	protected function get_object_timestamps( $post_type ) {
 		global $wpdb;

--- a/src/builders/indexable-term-builder.php
+++ b/src/builders/indexable-term-builder.php
@@ -128,8 +128,8 @@ class Indexable_Term_Builder {
 		$indexable->is_robots_nosnippet    = null;
 
 		$timestamps                      = $this->get_object_timestamps( $term_id, $term->taxonomy );
-		$indexable->object_published_at  = $timestamps->published_at;
-		$indexable->object_last_modified = $timestamps->last_modified;
+		$indexable->object_published_at  = ( $timestamps->published_at ?? null );
+		$indexable->object_last_modified = ( $timestamps->last_modified ?? null );
 
 		$indexable->version = $this->version;
 
@@ -242,7 +242,8 @@ class Indexable_Term_Builder {
 	 * @param int    $term_id  The term ID.
 	 * @param string $taxonomy The taxonomy.
 	 *
-	 * @return object An object with last_modified and published_at timestamps.
+	 * @return object|null An object with last_modified and published_at timestamps, or null
+	 *                     when the query fails or returns no row.
 	 */
 	protected function get_object_timestamps( $term_id, $taxonomy ) {
 		global $wpdb;

--- a/tests/Unit/Builders/Indexable_Author_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Author_Builder_Test.php
@@ -228,6 +228,78 @@ final class Indexable_Author_Builder_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the build does not error when the timestamp query returns no row.
+	 *
+	 * @covers ::build
+	 *
+	 * @return void
+	 */
+	public function test_build_with_null_timestamps() {
+		$this->author_archive
+			->expects( 'author_has_public_posts_wp' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_title', 1 )->andReturn( 'title' );
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_metadesc', 1 )->andReturn( 'description' );
+		Monkey\Functions\expect( 'get_the_author_meta' )->once()->with( 'wpseo_noindex_author', 1 )->andReturn( 'on' );
+
+		$this->indexable_mock = $this->mock_indexable();
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'title', 'title' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'description' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', true );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'version', 2 );
+
+		$this->indexable_mock->orm->expects( 'get' )->once()->with( 'open_graph_image' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'open_graph_image_id' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'open_graph_image_source' );
+		$this->indexable_mock->orm->expects( 'get' )->twice()->with( 'twitter_image' );
+		$this->indexable_mock->orm->expects( 'get' )->times( 3 )->with( 'twitter_image_id' );
+		$this->indexable_mock->orm->expects( 'get' )->with( 'object_id' );
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image', 'avatar_image.jpg' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'gravatar-image' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'avatar_image.jpg' );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'gravatar-image' );
+
+		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		Monkey\Filters\expectApplied( 'wpseo_should_build_and_save_user_indexable' )
+			->with( 1 )
+			->andReturn( null );
+
+		$this->author_archive
+			->expects( 'author_has_public_posts' )
+			->with( 1 )
+			->once()
+			->andReturn( true );
+		$this->author_archive
+			->expects( 'are_disabled' )
+			->andReturn( false );
+
+		$this->options_helper
+			->expects( 'get' )
+			->with( 'noindex-author-noposts-wpseo', false )
+			->andReturn( true );
+
+		$GLOBALS['wpdb'] = $this->wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended override for test purpose.
+
+		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'PREPARED_QUERY' );
+		$this->wpdb->expects( 'get_row' )->once()->with( 'PREPARED_QUERY' )->andReturnNull();
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', null );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', null );
+
+		Monkey\Functions\expect( 'get_avatar_url' )
+			->once()
+			->andReturn( 'avatar_image.jpg' );
+
+		$this->instance->build( 1, $this->indexable_mock );
+	}
+
+	/**
 	 * Tests whether the author is being built when it is explicitly included by the `'wpseo_should_build_and_save_user_indexable'` filter.
 	 *
 	 * @covers ::build

--- a/tests/Unit/Builders/Indexable_Home_Page_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Home_Page_Builder_Test.php
@@ -241,6 +241,39 @@ final class Indexable_Home_Page_Builder_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the build does not error when the timestamp query returns no row.
+	 *
+	 * @covers ::build
+	 *
+	 * @return void
+	 */
+	public function test_build_with_null_timestamps() {
+		// Provide stubs.
+		$image_meta_mock_json = WPSEO_Utils::format_json_encode( $this->image_meta_mock );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_meta', $image_meta_mock_json );
+		$this->open_graph_image_mock->allows( 'get_image_by_id' )->with( 1337 )->andReturn( $this->image_meta_mock );
+
+		$this->options_mock->expects( 'get' )->with( 'metadesc-home-wpseo' )->andReturn( 'home_meta_description' );
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'description', 'home_meta_description' );
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+
+		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		$GLOBALS['wpdb'] = $this->wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended override for test purpose.
+
+		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'PREPARED_QUERY' );
+		$this->wpdb->expects( 'get_row' )->once()->with( 'PREPARED_QUERY' )->andReturnNull();
+
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_published_at', null );
+		$this->indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', null );
+
+		$this->instance->build( $this->indexable_mock );
+	}
+
+	/**
 	 * Tests the formatting of the indexable data when no meta description for the homepage is set.
 	 *
 	 * @covers ::build

--- a/tests/Unit/Builders/Indexable_Post_Type_Archive_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Post_Type_Archive_Builder_Test.php
@@ -111,6 +111,62 @@ final class Indexable_Post_Type_Archive_Builder_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the build does not error when the timestamp query returns no row.
+	 *
+	 * @covers ::build
+	 *
+	 * @return void
+	 */
+	public function test_build_with_null_timestamps() {
+		$options_mock = Mockery::mock( Options_Helper::class );
+		$options_mock->expects( 'get' )->with( 'title-ptarchive-my-post-type' )->andReturn( 'my_post_type_title' );
+		$options_mock->expects( 'get' )->with( 'metadesc-ptarchive-my-post-type' )->andReturn( 'my_post_type_meta_description' );
+		$options_mock->expects( 'get' )->with( 'bctitle-ptarchive-my-post-type' )->andReturn( 'my_post_type_breadcrumb_title' );
+		$options_mock->expects( 'get' )->with( 'noindex-ptarchive-my-post-type' )->andReturn( false );
+		Monkey\Functions\expect( 'get_post_type_archive_link' )->with( 'my-post-type' )->andReturn( 'https://permalink' );
+
+		$versions = Mockery::mock( Indexable_Builder_Versions::class );
+		$versions
+			->expects( 'get_latest_version_for_type' )
+			->with( 'post-type-archive' )
+			->andReturn( 1 );
+
+		$post_helper = Mockery::mock( Post_Helper::class );
+		$post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		$post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$post_type_helper->expects( 'is_post_type_archive_indexable' )->andReturnTrue();
+
+		$wpdb            = Mockery::mock( wpdb::class );
+		$wpdb->posts     = 'wp_posts';
+		$GLOBALS['wpdb'] = $wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended override for test purpose.
+
+		$wpdb->expects( 'prepare' )->once()->andReturn( 'PREPARED_QUERY' );
+		$wpdb->expects( 'get_row' )->once()->with( 'PREPARED_QUERY' )->andReturnNull();
+
+		$indexable_mock      = Mockery::mock( Indexable::class );
+		$indexable_mock->orm = Mockery::mock( ORM::class );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_type', 'post-type-archive' );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_sub_type', 'my-post-type' );
+		$indexable_mock->orm->expects( 'set' )->with( 'title', 'my_post_type_title' );
+		$indexable_mock->orm->expects( 'set' )->with( 'breadcrumb_title', 'my_post_type_breadcrumb_title' );
+		$indexable_mock->orm->expects( 'set' )->with( 'permalink', 'https://permalink' );
+		$indexable_mock->orm->expects( 'set' )->with( 'description', 'my_post_type_meta_description' );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_robots_noindex', false );
+		$indexable_mock->orm->expects( 'set' )->with( 'is_public', true );
+		$indexable_mock->orm->expects( 'get' )->with( 'is_robots_noindex' )->andReturnFalse();
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'version', 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_published_at', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', null );
+
+		$builder = new Indexable_Post_Type_Archive_Builder( $options_mock, $versions, $post_helper, $post_type_helper, $wpdb );
+		$builder->build( 'my-post-type', $indexable_mock );
+	}
+
+	/**
 	 * Tests the formatting of the indexable data.
 	 *
 	 * @covers ::build

--- a/tests/Unit/Builders/Indexable_Term_Builder_Test.php
+++ b/tests/Unit/Builders/Indexable_Term_Builder_Test.php
@@ -380,6 +380,151 @@ final class Indexable_Term_Builder_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the build does not error when the timestamp query returns no row.
+	 *
+	 * @covers ::build
+	 *
+	 * @return void
+	 */
+	public function test_build_with_null_timestamps() {
+		$term = (object) [
+			'taxonomy'    => 'category',
+			'term_id'     => 1,
+			'name'        => 'some_category',
+			'description' => 'description',
+		];
+
+		Monkey\Functions\expect( 'get_term' )->once()->with( 1 )->andReturn( $term );
+		Monkey\Functions\expect( 'get_term_link' )
+			->once()
+			->with( $term, 'category' )
+			->andReturn( 'https://example.org/category/1' );
+		Monkey\Functions\expect( 'is_wp_error' )->twice()->andReturn( false );
+		$this->taxonomy->expects( 'get_indexable_taxonomies' )->andReturn( [ 'category' ] );
+
+		$this->taxonomy->expects( 'get_term_meta' )
+			->once()
+			->with( $term )
+			->andReturn(
+				[
+					'wpseo_focuskw'                  => 'focuskeyword',
+					'wpseo_linkdex'                  => '75',
+					'wpseo_noindex'                  => 'noindex',
+					'wpseo_meta-robots-adv'          => '',
+					'wpseo_content_score'            => '50',
+					'wpseo_inclusive_language_score' => '42',
+					'wpseo_canonical'                => 'https://canonical-term',
+					'wpseo_meta-robots-nofollow'     => '1',
+					'wpseo_title'                    => 'title',
+					'wpseo_desc'                     => 'description',
+					'wpseo_opengraph-title'          => 'open_graph_title',
+					'wpseo_opengraph-image'          => 'open_graph_image',
+					'wpseo_opengraph-image-id'       => 'open_graph_image_id',
+					'wpseo_opengraph-description'    => 'open_graph_description',
+					'wpseo_twitter-title'            => 'twitter_title',
+					'wpseo_twitter-image'            => 'twitter_image',
+					'wpseo_twitter-image-id'         => 'twitter_image_id',
+					'wpseo_twitter-description'      => 'twitter_description',
+				],
+			);
+		$this->post_helper->expects( 'get_public_post_statuses' )->once()->andReturn( [ 'publish' ] );
+
+		$GLOBALS['wpdb'] = $this->wpdb; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Intended override for test purpose.
+
+		$this->wpdb->expects( 'prepare' )->once()->andReturn( 'PREPARED_QUERY' );
+		$this->wpdb->expects( 'get_row' )->once()->with( 'PREPARED_QUERY' )->andReturnNull();
+
+		$indexable_mock      = Mockery::mock( Indexable::class );
+		$indexable_mock->orm = Mockery::mock( ORM::class );
+
+		$indexable_expectations = [
+			'object_id'                   => 1,
+			'object_type'                 => 'term',
+			'object_sub_type'             => 'category',
+			'permalink'                   => 'https://example.org/category/1',
+			'canonical'                   => 'https://canonical-term',
+			'title'                       => 'title',
+			'breadcrumb_title'            => 'some_category',
+			'description'                 => 'description',
+			'open_graph_title'            => 'open_graph_title',
+			'open_graph_image'            => 'open_graph_image',
+			'open_graph_image_id'         => 'open_graph_image_id',
+			'open_graph_description'      => 'open_graph_description',
+			'twitter_title'               => 'twitter_title',
+			'twitter_image'               => 'twitter_image',
+			'twitter_image_id'            => 'twitter_image_id',
+			'twitter_description'         => 'twitter_description',
+			'is_cornerstone'              => false,
+			'is_robots_noindex'           => true,
+			'is_robots_nofollow'          => null,
+			'is_robots_noarchive'         => null,
+			'is_robots_noimageindex'      => null,
+			'is_robots_nosnippet'         => null,
+			'primary_focus_keyword'       => 'focuskeyword',
+			'primary_focus_keyword_score' => 75,
+			'readability_score'           => 50,
+			'inclusive_language_score'    => 42,
+			'version'                     => 1,
+		];
+
+		$this->set_indexable_set_expectations( $indexable_mock, $indexable_expectations );
+
+		// Reset all social images first.
+		$this->set_indexable_set_expectations(
+			$indexable_mock,
+			[
+				'open_graph_image'        => null,
+				'open_graph_image_id'     => null,
+				'open_graph_image_source' => null,
+				'open_graph_image_meta'   => null,
+				'twitter_image'           => null,
+				'twitter_image_id'        => null,
+				'twitter_image_source'    => null,
+			],
+		);
+
+		$image_meta = [
+			'width'  => 640,
+			'height' => 480,
+			'url'    => 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg',
+			'path'   => '/var/www/html/wp-content/uploads/2020/07/WordPress5.jpg',
+			'size'   => 'full',
+			'id'     => 13,
+			'alt'    => '',
+			'pixels' => 307_200,
+			'type'   => 'image/jpeg',
+		];
+
+		// Mock that the open graph and twitter images have been set by the user.
+		$this->open_graph_image_set_by_user( $indexable_mock, $image_meta );
+		$this->twitter_image_set_by_user( $indexable_mock );
+
+		// We expect the open graph image, its source and its metadata to be set.
+		$indexable_mock->orm->expects( 'set' )->with( 'open_graph_image_source', 'set-by-user' );
+		$indexable_mock->orm->expects( 'set' )
+			->with( 'open_graph_image', 'http://basic.wordpress.test/wp-content/uploads/2020/07/WordPress5.jpg' );
+		$indexable_mock->orm->expects( 'set' )
+			->with( 'open_graph_image_meta', \json_encode( $image_meta, ( \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE ) ) );
+
+		// We expect the twitter image and its source to be set.
+		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image_source', 'set-by-user' );
+		$indexable_mock->orm->expects( 'set' )->with( 'twitter_image', 'twitter_image' );
+
+		$indexable_mock->orm->expects( 'offsetExists' )->once()->with( 'breadcrumb_title' )->andReturnFalse();
+		$indexable_mock->orm->expects( 'set' )->once()->with( 'breadcrumb_title', null );
+
+		$indexable_mock->orm->expects( 'get' )->twice()->with( 'is_robots_noindex' )->andReturn( true );
+		$indexable_mock->orm->expects( 'set' )->once()->with( 'is_public', false );
+
+		Monkey\Functions\expect( 'get_current_blog_id' )->once()->andReturn( 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'blog_id', 1 );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_published_at', null );
+		$indexable_mock->orm->expects( 'set' )->with( 'object_last_modified', null );
+
+		$this->instance->build( 1, $indexable_mock );
+	}
+
+	/**
 	 * Tests that build throws an exception when no term was returned.
 	 *
 	 * @covers ::build


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Rendering breadcrumb/Schema output for a post-type archive without an indexable triggers
an on-the-fly indexable build that crashes with `Attempt to read property "last_modified"
on null` (see #23414). `Indexable_Post_Type_Archive_Builder::build()` dereferences the
result of `get_object_timestamps()` directly, but `wpdb::get_row()` returns `null` when the
timestamp query fails — for example with `%i` identifier placeholders on WordPress < 6.2, or
when `Post_Helper::get_public_post_statuses()` is empty and the `IN ( … )` clause collapses
to invalid SQL. The same unguarded pattern (and the same misleading `@return object`
docblock) exists in the author, term and home-page builders, so all four are hardened here.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a PHP warning was triggered when the timestamp query for an indexable archive returned no row.

## Relevant technical choices:

* The reads are coalesced as `( $timestamps->property ?? null )`, which safely covers both a
  `null` result object and null properties (isset semantics, no warning); the parentheses
  follow the YoastCS operator-bracket rule. `object_published_at` / `object_last_modified` are
  nullable columns, so `null` is a valid fallback.
* The `get_object_timestamps()` return type docblock is corrected from `object` to
  `object|null` in all four builders to match the actual `wpdb::get_row()` contract.
* The touched files carry pre-existing CS findings (e.g. escaping and docblock-annotation
  notices) that are already counted in the CS threshold baseline and sit outside this diff.
  The lines added by this PR introduce no new findings, so the CS threshold check stays at
  baseline and passes; the only red check is the labels/milestone validation, which is the
  maintainer's to resolve.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Register a custom post type that has its archive enabled but contains no published posts
  (or run on a site where the public post-status set is filtered to empty / WordPress older
  than 6.2).
* Visit that post-type archive URL on the front end with `WP_DEBUG` enabled.
* Before this change a `Attempt to read property "last_modified" on null` warning is emitted
  while building the archive indexable; after this change the page renders without the warning.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
The fix covers four indexable types: post-type archive, author, term and home-page. Worth
exercising an archive/author/term with no published posts behind it.
-->

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Indexable building for post-type archives, author archives, term archives and the home page.
* Front-end Schema and breadcrumb output, which can trigger on-the-fly indexable builds.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

## Disclosure

Claude (Anthropic) assisted in producing this change. The human author reviewed the diff and
takes responsibility for it. The unit tests were run locally (`composer test`, 31 tests in
the four affected builder suites passing); `composer lint-branch` and `composer
check-branch-cs` were run as described under *Relevant technical choices*.

Fixes #23414

