### PR TITLE
feat(bulk-editor): add row-indicator/notices slots and singular label

### DIFF
--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -30,15 +30,16 @@ const getHeaderCopy = ( contentType ) => {
 };
 
 /**
- * Resolves the id and label of the active content type, falling back to empty strings when there is none.
+ * Resolves the id and labels of the active content type, falling back to empty strings when there is none.
  *
- * @param {Object} [contentType] The content type ({ id, label }), if any.
+ * @param {Object} [contentType] The content type ({ id, label, singularLabel }), if any.
  *
- * @returns {{id: string, label: string}} The active content type id and label.
+ * @returns {{id: string, label: string, singularLabel: string}} The active content type id and labels.
  */
 const getActiveContentTypeFields = ( contentType ) => ( {
 	id: contentType ? contentType.id : "",
 	label: contentType ? contentType.label : "",
+	singularLabel: contentType ? contentType.singularLabel : "",
 } );
 
 /**
@@ -56,9 +57,10 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
 	const { setActiveContentType } = useDispatch( STORE_NAME );
 
-	const contentTypes = dataProvider.getContentTypes().map( ( { name, label } ) => ( { id: name, label } ) );
+	const contentTypes = dataProvider.getContentTypes().map( ( { name, label, singularLabel } ) => ( { id: name, label, singularLabel } ) );
 	const activeContentType = contentTypes.find( ( { id } ) => id === activeContentTypeName ) ?? contentTypes[ 0 ];
-	const { id: activeContentTypeId, label: activeContentTypeLabel } = getActiveContentTypeFields( activeContentType );
+	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
+		getActiveContentTypeFields( activeContentType );
 
 	const { title, description } = getHeaderCopy( activeContentType );
 	// Fall back to the WP admin home when the data provider has no link.
@@ -98,6 +100,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 							remoteDataProvider={ remoteDataProvider }
 							contentType={ activeContentTypeId }
 							contentTypeLabel={ activeContentTypeLabel }
+							contentTypeSingularLabel={ activeContentTypeSingularLabel }
 						/>
 					</Paper>
 				</div>

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -135,13 +135,14 @@ const FreeBulkActions = ( { contentType } ) => {
  * @param {number[]} props.selectedIds      The ids of the selected rows.
  * @param {string}   props.activeFieldSet     The active tab/field set (Search or Social), which drives the buttons.
  * @param {string}   props.contentType        The active content type (also the Free upsell variant).
- * @param {string}   [props.contentTypeLabel] The active content type label, passed to the notices fill for its copy.
+ * @param {string}   [props.contentTypeLabel] The active content type label (plural), passed to the notices fill for its copy.
+ * @param {string}   [props.contentTypeSingularLabel] The active content type singular label, passed to the notices fill.
  *
  * @returns {JSX.Element} The bulk actions row content.
  */
-export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel } ) => (
+export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } ) => (
 	<div className="yst-flex yst-flex-col">
-		{ isActive && <Slot name={ BULK_NOTICES_SLOT } fillProps={ { contentTypeLabel } } /> }
+		{ isActive && <Slot name={ BULK_NOTICES_SLOT } fillProps={ { contentTypeLabel, contentTypeSingularLabel } } /> }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
 			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
 			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType } } /> }

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -142,7 +142,12 @@ const FreeBulkActions = ( { contentType } ) => {
  */
 export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } ) => (
 	<div className="yst-flex yst-flex-col">
-		{ isActive && <Slot name={ BULK_NOTICES_SLOT } fillProps={ { contentTypeLabel, contentTypeSingularLabel } } /> }
+		{ isActive && (
+			<Slot
+				name={ BULK_NOTICES_SLOT }
+				fillProps={ { selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } }
+			/>
+		) }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
 			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
 			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType } } /> }

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -4,7 +4,7 @@ import { useMemo } from "@wordpress/element";
 import { applyFilters } from "@wordpress/hooks";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Checkbox, DropdownMenu, useSvgAria, useToggleState } from "@yoast/ui-library";
-import { BULK_ACTIONS_SLOT, SELECT_MENU_ITEMS_FILTER } from "../constants";
+import { BULK_ACTIONS_SLOT, BULK_NOTICES_SLOT, SELECT_MENU_ITEMS_FILTER } from "../constants";
 import { useAiUpsell } from "../hooks/use-ai-upsell";
 import { UpsellModal } from "./upsell-modal";
 
@@ -125,21 +125,26 @@ const FreeBulkActions = ( { contentType } ) => {
 
 /**
  * The AI generate buttons toolbar row, shown when rows are selected. In Premium the active tab's slot is filled
- * with the AI buttons (the fill receives `fillProps`); in Free they open the upsell modal.
+ * with the AI buttons (the fill receives `fillProps`); in Free they open the upsell modal. The notices slot above
+ * it is full-bleed (outside the padded band), so Premium can fill it with a full-width row (e.g. an alert).
  *
  * @param {Object}   props                The props.
  * @param {boolean}  props.isPremium      Whether Premium is active.
- * @param {boolean}  props.isActive       Whether this is the active tab. Only the active tab renders the slot, so the
+ * @param {boolean}  props.isActive       Whether this is the active tab. Only the active tab renders the slots, so the
  *                                        Premium fill has a single slot to target (each tab renders its own bar).
- * @param {number[]} props.selectedIds    The ids of the selected rows.
- * @param {string}   props.activeFieldSet The active tab/field set (Search or Social), which drives the buttons.
- * @param {string}   props.contentType    The active content type (also the Free upsell variant).
+ * @param {number[]} props.selectedIds      The ids of the selected rows.
+ * @param {string}   props.activeFieldSet     The active tab/field set (Search or Social), which drives the buttons.
+ * @param {string}   props.contentType        The active content type (also the Free upsell variant).
+ * @param {string}   [props.contentTypeLabel] The active content type label, passed to the notices fill for its copy.
  *
  * @returns {JSX.Element} The bulk actions row content.
  */
-export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType } ) => (
-	<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
-		{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
-		{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType } } /> }
+export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel } ) => (
+	<div className="yst-flex yst-flex-col">
+		{ isActive && <Slot name={ BULK_NOTICES_SLOT } fillProps={ { contentTypeLabel } } /> }
+		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
+			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
+			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType } } /> }
+		</div>
 	</div>
 );

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -156,6 +156,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								selectedIds={ selectedIds }
 								activeFieldSet={ activeFieldSet }
 								contentType={ contentType }
+								contentTypeLabel={ contentTypeLabel }
 							/>
 						}
 						showBulkActions={ hasSelection }

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -43,11 +43,12 @@ const getSelectionView = ( isLoading, selectedIds, items, total ) => {
  * @param {import("../services").DataProvider} props.dataProvider       The data provider (config + endpoints).
  * @param {Object}                             props.remoteDataProvider The remote data provider (HTTP), used to fetch and save.
  * @param {string}                             props.contentType        The active content type to fetch posts for.
- * @param {string}             props.contentTypeLabel   The active content type label, used in the search placeholder.
+ * @param {string}                             props.contentTypeLabel   The active content type label, used in the search placeholder.
+ * @param {string}                             props.contentTypeSingularLabel The active content type singular label, passed to the bulk actions.
  *
  * @returns {JSX.Element} The content.
  */
-export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentType, contentTypeLabel } ) => {
+export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentType, contentTypeLabel, contentTypeSingularLabel } ) => {
 	const fieldSets = useMemo( () => getFieldSets(), [] );
 	const tabs = useMemo(
 		() => Object.values( fieldSets ).map( ( { id, label } ) => ( { id, label } ) ),
@@ -157,6 +158,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								activeFieldSet={ activeFieldSet }
 								contentType={ contentType }
 								contentTypeLabel={ contentTypeLabel }
+								contentTypeSingularLabel={ contentTypeSingularLabel }
 							/>
 						}
 						showBulkActions={ hasSelection }

--- a/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
+++ b/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
@@ -122,6 +122,7 @@ export const BulkEditorTable = ( {
 					<BulkEditorBody
 						items={ items }
 						fields={ fieldSet.fields }
+						fieldSetId={ fieldSet.id }
 						columnCount={ columnCount }
 						selection={ selectionState }
 						editing={ editingState }

--- a/packages/js/src/bulk-editor/components/table/table-body.js
+++ b/packages/js/src/bulk-editor/components/table/table-body.js
@@ -33,6 +33,7 @@ const SkeletonRows = ( { columnCount } ) => (
  * @param {Object}              props             The props.
  * @param {BulkEditorItem[]}    props.items       The items to render.
  * @param {FieldSetField[]}     props.fields      The active field set's editable columns.
+ * @param {string}              props.fieldSetId  The active field set's id, used to scope the per-row indicator slot.
  * @param {number}              props.columnCount The total number of columns.
  * @param {BulkEditorSelection} props.selection   The selection props.
  * @param {BulkEditorEditing}   props.editing     The inline-edit props.
@@ -40,7 +41,7 @@ const SkeletonRows = ( { columnCount } ) => (
  *
  * @returns {JSX.Element} The body rows.
  */
-export const BulkEditorBody = ( { items, fields, columnCount, selection, editing, isLoading } ) => {
+export const BulkEditorBody = ( { items, fields, fieldSetId, columnCount, selection, editing, isLoading } ) => {
 	const { selectedIds, onToggleRow } = selection;
 
 	if ( isLoading && items.length === 0 ) {
@@ -62,6 +63,7 @@ export const BulkEditorBody = ( { items, fields, columnCount, selection, editing
 			key={ item.id }
 			item={ item }
 			fields={ fields }
+			fieldSetId={ fieldSetId }
 			isSelected={ selectedIds.includes( item.id ) }
 			onToggleRow={ onToggleRow }
 			edit={ editing.editingRows[ item.id ] }

--- a/packages/js/src/bulk-editor/components/table/table-cells.js
+++ b/packages/js/src/bulk-editor/components/table/table-cells.js
@@ -1,27 +1,35 @@
+import { Slot } from "@wordpress/components";
 import { useCallback, useEffect, useState } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Table, Textarea } from "@yoast/ui-library";
+import { TABLE_ROW_INDICATOR_SLOT } from "../../constants";
 import { getFieldTextClasses, getStatusLabel } from "./table-helpers";
 import AnimateHeight from "react-animate-height";
 
 /**
  * The title cell (the row header).
  *
- * @param {Object}         props      The props.
- * @param {BulkEditorItem} props.item The item data.
+ * @param {Object}         props            The props.
+ * @param {BulkEditorItem} props.item       The item data.
+ * @param {string}         props.fieldSetId The active field set's id, used to scope the per-row indicator slot.
  *
  * @returns {JSX.Element} The title cell.
  */
-export const TitleCell = ( { item } ) => {
+export const TitleCell = ( { item, fieldSetId } ) => {
 	const statusLabel = getStatusLabel( item.status );
 
 	return (
 		<Table.Header scope="row" className="yst-text-left !yst-text-[13px] !yst-text-slate-800">
-			<div className="yst-flex yst-flex-col">
-				<span>{ item.title }</span>
-				{ statusLabel && (
-					<span className="yst-mt-1 yst-font-normal yst-text-slate-500">{ `- ${ statusLabel }` }</span>
-				) }
+			<div className="yst-flex yst-items-start yst-gap-1.5">
+				<Slot name={ `${ TABLE_ROW_INDICATOR_SLOT }/${ fieldSetId }/${ item.id }` }>
+					{ ( fills ) => fills }
+				</Slot>
+				<div className="yst-flex yst-flex-col">
+					<span>{ item.title }</span>
+					{ statusLabel && (
+						<span className="yst-mt-1 yst-font-normal yst-text-slate-500">{ `- ${ statusLabel }` }</span>
+					) }
+				</div>
 			</div>
 		</Table.Header>
 	);

--- a/packages/js/src/bulk-editor/components/table/table-cells.js
+++ b/packages/js/src/bulk-editor/components/table/table-cells.js
@@ -21,7 +21,7 @@ export const TitleCell = ( { item, fieldSetId } ) => {
 	return (
 		<Table.Header scope="row" className="yst-text-left !yst-text-[13px] !yst-text-slate-800">
 			<div className="yst-flex yst-items-start yst-gap-1.5">
-				<Slot name={ `${ TABLE_ROW_INDICATOR_SLOT }/${ fieldSetId }/${ item.id }` }>
+				<Slot name={ `${ TABLE_ROW_INDICATOR_SLOT }/${ fieldSetId }/${ item.id }` } fillProps={ { item, fieldSetId } }>
 					{ ( fills ) => fills }
 				</Slot>
 				<div className="yst-flex yst-flex-col">

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -13,6 +13,7 @@ import { getFieldTextClasses, getRowEditState } from "./table-helpers";
  * @param {Object}            props             The props.
  * @param {BulkEditorItem}    props.item        The item data.
  * @param {FieldSetField[]}   props.fields      The active field set's editable columns.
+ * @param {string}            props.fieldSetId  The active field set's id, used to scope the per-row indicator slot.
  * @param {boolean}           props.isSelected  Whether this item is selected.
  * @param {Function}          props.onToggleRow Called with the item id when its checkbox is toggled.
  * @param {Object}            [props.edit]      This row's edit state ({ openFields, draft, savingFields }), or undefined when not editing.
@@ -20,7 +21,7 @@ import { getFieldTextClasses, getRowEditState } from "./table-helpers";
  *
  * @returns {JSX.Element} The row.
  */
-export const BulkEditorRow = ( { item, fields, isSelected, onToggleRow, edit, editing } ) => {
+export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleRow, edit, editing } ) => {
 	const { isEditing, openFields, draft, savingFields } = getRowEditState( edit );
 	const { onStartEdit, onChangeField, onApplyField, onCancelEdit, onDiscardField } = editing;
 	const isSaving = Object.keys( savingFields ).length > 0;
@@ -60,7 +61,7 @@ export const BulkEditorRow = ( { item, fields, isSelected, onToggleRow, edit, ed
 					onChange={ handleToggle }
 				/>
 			</Table.Cell>
-			<TitleCell item={ item } />
+			<TitleCell item={ item } fieldSetId={ fieldSetId } />
 			{ fields.map( ( field ) => {
 				return (
 					<Fragment key={ field.key }>

--- a/packages/js/src/bulk-editor/constants.js
+++ b/packages/js/src/bulk-editor/constants.js
@@ -21,6 +21,10 @@ export const FOCUS_KEYPHRASE_KEY = "focusKeyphrase";
 // The SlotFill name Premium fills with its bulk actions.
 export const BULK_ACTIONS_SLOT = "yoast.bulkEditor.bulkActions";
 
+// The SlotFill name Premium fills with a full-width notice (e.g. the missing-keyphrase alert), shown as its own
+// row above the bulk-actions buttons.
+export const BULK_NOTICES_SLOT = "yoast.bulkEditor.bulkNotices";
+
 // The PluginArea scope Premium registers its fills under, so they mount inside this page's React tree.
 export const PLUGIN_SCOPE = "yoast-seo-bulk-editor";
 
@@ -31,6 +35,11 @@ export const SELECT_MENU_ITEMS_FILTER = "yoast.bulkEditor.selectMenuItems";
 // The rendered slot name is `${TABLE_CELL_FIELD_SLOT}/${field.key}/${item.id}` (one slot per cell).
 // fillProps: { field, item, value, isSaving, onSaveField, onDiscardField }.
 export const TABLE_CELL_FIELD_SLOT = "yoast.bulkEditor.TableCellWithField";
+
+// The slot base name Premium fills with a per-row indicator shown before the row title (e.g. an AI status icon).
+// The rendered slot name is `${TABLE_ROW_INDICATOR_SLOT}/${fieldSetId}/${item.id}`. Generic so any row-level marker (the missing-keyphrase
+// info icon, a generation-error icon) can fill the same spot.
+export const TABLE_ROW_INDICATOR_SLOT = "yoast.bulkEditor.TableRowIndicator";
 
 // The WooCommerce product post type.
 export const PRODUCT_CONTENT_TYPE = "product";

--- a/packages/js/src/bulk-editor/services/data-provider.js
+++ b/packages/js/src/bulk-editor/services/data-provider.js
@@ -1,7 +1,8 @@
 /**
  * @typedef {Object} ContentType A content type.
  * @property {string} name The name of the content type.
- * @property {string} label The label of the content type.
+ * @property {string} label The label of the content type (plural).
+ * @property {string} singularLabel The singular label of the content type.
  */
 
 /**

--- a/src/bulk-editor/domain/content-types/content-type.php
+++ b/src/bulk-editor/domain/content-types/content-type.php
@@ -23,14 +23,23 @@ class Content_Type {
 	private $label;
 
 	/**
+	 * The singular label of the content type.
+	 *
+	 * @var string
+	 */
+	private $singular_label;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param string $name  The name of the content type.
-	 * @param string $label The label of the content type.
+	 * @param string $name           The name of the content type.
+	 * @param string $label          The label of the content type.
+	 * @param string $singular_label The singular label of the content type.
 	 */
-	public function __construct( string $name, string $label ) {
-		$this->name  = $name;
-		$this->label = $label;
+	public function __construct( string $name, string $label, string $singular_label ) {
+		$this->name           = $name;
+		$this->label          = $label;
+		$this->singular_label = $singular_label;
 	}
 
 	/**
@@ -49,5 +58,14 @@ class Content_Type {
 	 */
 	public function get_label(): string {
 		return $this->label;
+	}
+
+	/**
+	 * Gets the singular label of the content type.
+	 *
+	 * @return string The singular label of the content type.
+	 */
+	public function get_singular_label(): string {
+		return $this->singular_label;
 	}
 }

--- a/src/bulk-editor/domain/content-types/content-types-list.php
+++ b/src/bulk-editor/domain/content-types/content-types-list.php
@@ -44,8 +44,9 @@ class Content_Types_List {
 		$array = [];
 		foreach ( $this->content_types as $content_type ) {
 			$array[] = [
-				'name'  => $content_type->get_name(),
-				'label' => $content_type->get_label(),
+				'name'          => $content_type->get_name(),
+				'label'         => $content_type->get_label(),
+				'singularLabel' => $content_type->get_singular_label(),
 			];
 		}
 

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -41,7 +41,7 @@ class Content_Types_Collector {
 			if ( $post_type_object->show_ui === false ) {
 				continue;
 			}
-			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label );
+			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label, $post_type_object->labels->singular_name );
 			$content_types_list->add( $content_type );
 		}
 

--- a/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Application/Content_Types/Content_Types_Repository/Get_Content_Types_Test.php
@@ -23,7 +23,7 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Repository_Tes
 	 */
 	public function test_get_content_types() {
 		$content_types_list = new Content_Types_List();
-		$content_types_list->add( new Content_Type( 'post', 'Posts' ) );
+		$content_types_list->add( new Content_Type( 'post', 'Posts', 'Post' ) );
 
 		$this->content_types_collector
 			->expects( 'get_content_types' )
@@ -33,8 +33,9 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Repository_Tes
 		$this->assertSame(
 			[
 				[
-					'name'  => 'post',
-					'label' => 'Posts',
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
 				],
 			],
 			$this->instance->get_content_types(),

--- a/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Type_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Type_Test.php
@@ -31,7 +31,7 @@ final class Content_Type_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = new Content_Type( 'post', 'Posts' );
+		$this->instance = new Content_Type( 'post', 'Posts', 'Post' );
 	}
 
 	/**
@@ -50,5 +50,14 @@ final class Content_Type_Test extends TestCase {
 	 */
 	public function test_get_label() {
 		$this->assertSame( 'Posts', $this->instance->get_label() );
+	}
+
+	/**
+	 * Tests getting the singular label.
+	 *
+	 * @return void
+	 */
+	public function test_get_singular_label() {
+		$this->assertSame( 'Post', $this->instance->get_singular_label() );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Types_List_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Content_Types/Content_Types_List_Test.php
@@ -41,7 +41,7 @@ final class Content_Types_List_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_add_and_get() {
-		$content_type = new Content_Type( 'post', 'Posts' );
+		$content_type = new Content_Type( 'post', 'Posts', 'Post' );
 
 		$this->instance->add( $content_type );
 
@@ -54,9 +54,9 @@ final class Content_Types_List_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_add_overwrites_same_name() {
-		$this->instance->add( new Content_Type( 'post', 'Posts' ) );
+		$this->instance->add( new Content_Type( 'post', 'Posts', 'Post' ) );
 
-		$overwriting_content_type = new Content_Type( 'post', 'Articles' );
+		$overwriting_content_type = new Content_Type( 'post', 'Articles', 'Article' );
 		$this->instance->add( $overwriting_content_type );
 
 		$this->assertSame( [ 'post' => $overwriting_content_type ], $this->instance->get() );
@@ -68,18 +68,20 @@ final class Content_Types_List_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_to_array() {
-		$this->instance->add( new Content_Type( 'post', 'Posts' ) );
-		$this->instance->add( new Content_Type( 'page', 'Pages' ) );
+		$this->instance->add( new Content_Type( 'post', 'Posts', 'Post' ) );
+		$this->instance->add( new Content_Type( 'page', 'Pages', 'Page' ) );
 
 		$this->assertSame(
 			[
 				[
-					'name'  => 'post',
-					'label' => 'Posts',
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
 				],
 				[
-					'name'  => 'page',
-					'label' => 'Pages',
+					'name'          => 'page',
+					'label'         => 'Pages',
+					'singularLabel' => 'Page',
 				],
 			],
 			$this->instance->to_array(),

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -49,22 +49,26 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 					(object) [
 						'name'    => 'post',
 						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
 						'show_ui' => true,
 					],
 					(object) [
 						'name'    => 'page',
 						'label'   => 'Pages',
+						'labels'  => (object) [ 'singular_name' => 'Page' ],
 						'show_ui' => true,
 					],
 				],
 				'expected'                    => [
 					[
-						'name'  => 'post',
-						'label' => 'Posts',
+						'name'          => 'post',
+						'label'         => 'Posts',
+						'singularLabel' => 'Post',
 					],
 					[
-						'name'  => 'page',
-						'label' => 'Pages',
+						'name'          => 'page',
+						'label'         => 'Pages',
+						'singularLabel' => 'Page',
 					],
 				],
 			],
@@ -73,18 +77,21 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 					(object) [
 						'name'    => 'post',
 						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
 						'show_ui' => true,
 					],
 					(object) [
 						'name'    => 'hidden',
 						'label'   => 'Hidden',
+						'labels'  => (object) [ 'singular_name' => 'Hidden item' ],
 						'show_ui' => false,
 					],
 				],
 				'expected'                    => [
 					[
-						'name'  => 'post',
-						'label' => 'Posts',
+						'name'          => 'post',
+						'label'         => 'Posts',
+						'singularLabel' => 'Post',
 					],
 				],
 			],

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
@@ -30,8 +30,9 @@ final class Enqueue_Assets_Test extends Abstract_Bulk_Editor_Integration_Test {
 
 		$content_types = [
 			[
-				'name'  => 'post',
-				'label' => 'Posts',
+				'name'          => 'post',
+				'label'         => 'Posts',
+				'singularLabel' => 'Post',
 			],
 		];
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
The bulk editor needs extension points so Yoast SEO Premium can mark rows and show notices during AI bulk generation (see Yoast/wordpress-seo-premium#4999). This adds those SlotFill seams, plus each content type's singular label, which Premium needs for grammatically correct copy.

## Summary
<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
-->
This PR can be summarized in the following changelog entry:

* Adds bulk editor extension points and exposes each content type's singular label.

## Relevant technical choices:

* **Per-row indicator slot** — `TableRowIndicator/{fieldSet}/{itemId}`, scoped by field set because both tab tables render at once (the inactive one hidden); an unscoped name would resolve into the hidden table.
* **Notices slot** — a full-bleed row above the bulk-action buttons, rendered outside the padded band so a fill spans edge-to-edge.
* **Singular label** — `Content_Type` now carries `singular_name` and serializes `singularLabel`, mirroring the existing plural `label`; threaded through to the bulk-actions fill props.
* **No Free-visible change** — the slots are empty without Premium, so behaviour is unchanged for Free users.

## Test instructions
<!--
Please provide step-by-step instructions aimed at non-tech-savvy users.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR adds extension points with no visible change in Free alone; the goal is to confirm no regression. End-to-end of the slots is covered by the Premium PR #4999.

This PR can be acceptance tested by following these steps:

1. With **only Yoast SEO (Free)** active, go to **SEO → Tools → Bulk editor**.
2. In the left navigation, switch between content types (Posts, Pages, Products, …). For each, verify:
   * the heading reads "Bulk editor: <Type>" (e.g. "Bulk editor: Products");
   * the description reads "The bulk editor for <type> …" (e.g. "… for products …");
   * the search box placeholder reads "Search for <type>…" (e.g. "Search for products…").
3. Select one or more rows and verify the count reads "N of M <type> selected" (e.g. "2 of 30 products selected") with the correct content type noun.
4. Verify the bulk-action bar appears on selection, with the AI buttons (upsell in Free), and that there is **no empty extra row** above the buttons and **no gap** before the row titles.
5. Switch between the **Search appearance** and **Social appearance** tabs and confirm selection, layout, and inline editing still behave as before.
6. Deselect all and confirm the bulk-action bar collapses.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open — watch for React/SlotFill warnings.
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies — verify the singular and plural content type labels are correct (including a custom post type).
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
The bulk editor is a standalone admin page, so editor/browser/multisite specifics are not relevant here; content-type coverage is.
-->

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above, ideally together with Premium PR #4999 so the slots are actually filled.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor toolbar/table layout (a flex-column wrapper around the bulk-action bar, a flex wrapper in the title cell) and the localized content-type data (added `singularLabel`). No other screens are affected.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [x] I have written documentation for this change. (Code comments on the new slots and the singular label.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
* [x] I have written this PR in accordance with my team's definition of done.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [X] This PR falls under an innovation project. I have attached the `innovation` label.
* [X] I have added my hours to [the WBSO document](http://yoa.st/wbso).
