### PR TITLE
feat(bulk-editor): expose unsaved-edits state to the bulk-actions slot

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -137,10 +137,14 @@ const FreeBulkActions = ( { contentType } ) => {
  * @param {string}   props.contentType        The active content type (also the Free upsell variant).
  * @param {string}   [props.contentTypeLabel] The active content type label (plural), passed to the notices fill for its copy.
  * @param {string}   [props.contentTypeSingularLabel] The active content type singular label, passed to the notices fill.
+ * @param {boolean}  [props.hasUnsavedEdits]  Whether a row has unsaved manual edits, passed to the actions fill so Premium
+ *                                             can disable the AI buttons while edits are in progress.
  *
  * @returns {JSX.Element} The bulk actions row content.
  */
-export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } ) => (
+export const BulkActions = ( {
+	isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
+} ) => (
 	<div className="yst-flex yst-flex-col">
 		{ isActive && (
 			<Slot
@@ -150,7 +154,7 @@ export const BulkActions = ( { isPremium, isActive, selectedIds, activeFieldSet,
 		) }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
 			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
-			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType } } /> }
+			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType, hasUnsavedEdits } } /> }
 		</div>
 	</div>
 );

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -159,6 +159,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								contentType={ contentType }
 								contentTypeLabel={ contentTypeLabel }
 								contentTypeSingularLabel={ contentTypeSingularLabel }
+								hasUnsavedEdits={ hasUnsavedEdits }
 							/>
 						}
 						showBulkActions={ hasSelection }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

In the bulk editor, the AI generate buttons live in a Premium fill that targets the Free `BULK_ACTIONS_SLOT`. To let Premium disable those buttons while a row has unsaved manual inline edits (so generation can't overwrite in-progress edits — [Premium-FE 4] Yoast/reserved-tasks#1317), Free has to expose whether edits are in progress. This is the Free seam for that guard; the Premium behaviour depends on this PR.

## Summary

This PR can be summarized in the following changelog entry:

* Exposes the unsaved-edits state to the bulk editor's bulk-actions slot.

## Relevant technical choices:

* **Slot fill props** — `hasUnsavedEdits` is already derived in `BulkEditorContent` (`Object.keys( editing.editingRows ).length > 0`); it is threaded through `BulkActions` into the `BULK_ACTIONS_SLOT` `fillProps`. No new state.
* **Free is inert** — Free's own AI buttons only open the upsell, so this prop changes nothing user-visible in Free on its own; it is consumed by Premium.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR's behaviour is only observable with Yoast SEO Premium (the matching `bulk-editor/ai-unsaved-guard` branch) active. Acceptance test:

* Activate Yoast SEO Premium (branch `bulk-editor/ai-unsaved-guard`).
* Go to **Yoast SEO → Tools → Bulk editor** and select one or more rows so the AI generate buttons appear.
* Click **Edit** on a row to open its inline editor (this creates an unsaved manual edit).
* Verify the **Generate SEO titles** / **Generate meta descriptions** buttons become disabled and show the tooltip "Save your manual edits to use AI generation".
* Click **Cancel** (or save the row) and verify the buttons become enabled again.
* Without Premium active, verify the Free bulk editor behaves exactly as before (the Free AI buttons still open the upsell).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable on its own — this is internal plumbing verified through the Premium guard (Yoast/reserved-tasks#1317); QA verifies the user-visible behaviour via the Premium PR.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor bulk-action bar (`BulkActions` / `BULK_ACTIONS_SLOT`) — only the slot's fill props changed.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Part of Yoast/reserved-tasks#1317
