### PR TITLE
feat(ai): nudge users to connect to MyYoast when Yoast AI can't reach the site

### DIFF
--- a/packages/js/src/ai-generator/components/ai-error-modal.js
+++ b/packages/js/src/ai-generator/components/ai-error-modal.js
@@ -1,0 +1,97 @@
+/* eslint-disable complexity */
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import {
+	BadWPRequestModal,
+	GenericModal,
+	NotEnoughContentModal,
+	RateLimitModal,
+	SeoAnalysisInactiveModal,
+	SiteUnreachableModal,
+	SubscriptionModal,
+	TimeoutModal,
+	UnethicalRequestModal,
+	UpgradeModal,
+} from "./errors";
+
+/**
+ * Renders an AI generator error as a danger modal.
+ *
+ * This is the modal counterpart to `SuggestionError` (which renders the same
+ * error categories as an inline alert and remains in use by other consumers).
+ * Both route on the same (errorCode, errorIdentifier) pairs and draw their copy
+ * from `./errors/messages`; they keep separate routing so the modal and the
+ * inline alert can evolve independently. A drift-guardrail test keeps the case
+ * coverage aligned.
+ *
+ * @param {number} errorCode The error code.
+ * @param {string} [errorIdentifier=""] The error identifier.
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {string[]} [invalidSubscriptions=[]] The products with an invalid subscription.
+ * @param {boolean} [showActions=false] Whether to show retry/close actions for retryable errors.
+ * @param {function} [onRetry=noop] Called to retry the request.
+ * @param {string} [errorMessage=""] The raw error message (WP request errors).
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const AIErrorModal = ( {
+	errorCode,
+	errorIdentifier = "",
+	isOpen = true,
+	invalidSubscriptions = [],
+	showActions = false,
+	onRetry = noop,
+	errorMessage = "",
+	onClose = noop,
+} ) => {
+	if ( errorIdentifier === "SEO_ANALYSIS_INACTIVE" ) {
+		return <SeoAnalysisInactiveModal isOpen={ isOpen } onClose={ onClose } />;
+	}
+	if ( errorCode === 402 || ( errorCode === 429 && errorIdentifier === "USAGE_LIMIT_REACHED" ) ) {
+		return <SubscriptionModal isOpen={ isOpen } invalidSubscriptions={ invalidSubscriptions } onClose={ onClose } />;
+	}
+
+	switch ( errorCode ) {
+		case 400:
+			switch ( errorIdentifier ) {
+				case "AI_CONTENT_FILTER":
+					return <UnethicalRequestModal isOpen={ isOpen } onClose={ onClose } />;
+				case "NOT_ENOUGH_CONTENT":
+					return <NotEnoughContentModal isOpen={ isOpen } onClose={ onClose } />;
+				case "SITE_UNREACHABLE":
+					return <SiteUnreachableModal isOpen={ isOpen } onClose={ onClose } />;
+				case "WP_HTTP_REQUEST_ERROR":
+					return (
+						<BadWPRequestModal
+							isOpen={ isOpen }
+							errorMessage={ errorMessage }
+							showActions={ showActions }
+							onRetry={ onRetry }
+							onClose={ onClose }
+						/>
+					);
+				default:
+					return <GenericModal isOpen={ isOpen } showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />;
+			}
+		case 408:
+			return <TimeoutModal isOpen={ isOpen } showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />;
+		case 429:
+			return <RateLimitModal isOpen={ isOpen } onClose={ onClose } />;
+		case 410:
+			return <UpgradeModal isOpen={ isOpen } onClose={ onClose } />;
+		case 403:
+		case 503:
+		default:
+			return <GenericModal isOpen={ isOpen } showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />;
+	}
+};
+AIErrorModal.propTypes = {
+	errorCode: PropTypes.number.isRequired,
+	errorIdentifier: PropTypes.string,
+	isOpen: PropTypes.bool,
+	invalidSubscriptions: PropTypes.arrayOf( PropTypes.string ),
+	showActions: PropTypes.bool,
+	onRetry: PropTypes.func,
+	errorMessage: PropTypes.string,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -174,6 +174,14 @@ export const App = ( { onUseAi } ) => {
 
 	const dismissErrorModal = useCallback( () => setErrorModal( null ), [] );
 
+	// Retry a fatal generate-flow error: dismiss the danger modal and reopen the AI
+	// modal. ModalContent remounts (it only renders while generating), resetting its
+	// initialFetch state to "" and re-running the initial fetch from scratch.
+	const handleErrorModalRetry = useCallback( () => {
+		setErrorModal( null );
+		setDisplay( DISPLAY.generate );
+	}, [] );
+
 	// Surfaces a feature-precondition error as a danger modal and closes the AI
 	// modal. The descriptor mirrors what the old inline FeatureError chose to render.
 	const showFeatureError = useCallback( () => {
@@ -436,6 +444,8 @@ export const App = ( { onUseAi } ) => {
 					errorIdentifier={ errorModal.errorIdentifier }
 					invalidSubscriptions={ errorModal.invalidSubscriptions }
 					errorMessage={ errorModal.errorMessage }
+					showActions={ true }
+					onRetry={ handleErrorModalRetry }
 					onClose={ dismissErrorModal }
 				/>
 			) }

--- a/packages/js/src/ai-generator/components/app.js
+++ b/packages/js/src/ai-generator/components/app.js
@@ -13,9 +13,9 @@ import {
 	STORE_NAME_EDITOR,
 } from "../constants";
 import { focusFocusKeyphraseInput, isConsideredEmpty } from "../helpers";
-import { useLocation, useMeasuredRef, useModalTitle, useTypeContext } from "../hooks";
+import { useFeatureErrorDescriptor, useLocation, useMeasuredRef, useModalTitle, useTypeContext } from "../hooks";
 import { FETCH_USAGE_COUNT_ERROR_ACTION_NAME } from "../store/usage-count";
-import { FeatureError } from "./feature-error";
+import { AIErrorModal } from "./ai-error-modal";
 import { Introduction } from "./introduction";
 import { ModalContent } from "./modal-content";
 import { UpsellModalContent } from "./upsell-modal-content";
@@ -101,7 +101,6 @@ export const DISPLAY = {
 	inactive: "inactive",
 	askConsent: "askConsent",
 	upsell: "upsell",
-	error: "error",
 	generate: "generate",
 };
 
@@ -163,7 +162,29 @@ export const App = ( { onUseAi } ) => {
 	const handlePanelMeasureChange = useCallback( entry => setPanelHeight( entry.borderBoxSize[ 0 ].blockSize ), [ setPanelHeight ] );
 	const panelRef = useMeasuredRef( handlePanelMeasureChange );
 
+	// The fatal/precondition error shown as a danger modal that replaces the AI
+	// modal. Kept in App state (not the AI modal) so it survives that modal
+	// closing — a fatal error closes the AI modal and surfaces the error instead.
+	const [ errorModal, setErrorModal ] = useState( null );
+	const resolveFeatureError = useFeatureErrorDescriptor();
+
 	const closeModal = useCallback( () => {
+		setDisplay( DISPLAY.inactive );
+	}, [] );
+
+	const dismissErrorModal = useCallback( () => setErrorModal( null ), [] );
+
+	// Surfaces a feature-precondition error as a danger modal and closes the AI
+	// modal. The descriptor mirrors what the old inline FeatureError chose to render.
+	const showFeatureError = useCallback( () => {
+		setErrorModal( resolveFeatureError( { currentSubscriptions, isSeoAnalysisActive } ) );
+		setDisplay( DISPLAY.inactive );
+	}, [ resolveFeatureError, currentSubscriptions, isSeoAnalysisActive ] );
+
+	// A fatal error from the generate flow (failed initial fetch / subscription
+	// error): close the AI modal and surface the error as a danger modal.
+	const handleModalFatalError = useCallback( ( descriptor ) => {
+		setErrorModal( descriptor );
 		setDisplay( DISPLAY.inactive );
 	}, [] );
 
@@ -203,7 +224,7 @@ export const App = ( { onUseAi } ) => {
 
 		// The analysis feature is not active, so we cannot use AI.
 		if ( ! isSeoAnalysisActive ) {
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
@@ -219,14 +240,14 @@ export const App = ( { onUseAi } ) => {
 
 		// User has no subscription, but premium and woo are installed and it a product entity.
 		if ( ! subscriptions && isPremium && isWooSeoActive && isWooProductEntity ) {
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
 		// User has no subscription but premium or woo is installed.
 		if ( ! subscriptions && isPremium && ! isWooProductEntity ) {
 			// Let the user know that they need to activate their subscription.
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
@@ -246,7 +267,7 @@ export const App = ( { onUseAi } ) => {
 
 		setLoading( false );
 		if ( rateLimited ) {
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 		// User revoked consent on a different window after clicking on the "Try for free" AI button or has subscription.
@@ -257,13 +278,13 @@ export const App = ( { onUseAi } ) => {
 
 		// The usage count endpoint returned an error that is not related to the limit or consent.
 		if ( type === FETCH_USAGE_COUNT_ERROR_ACTION_NAME && payload?.errorCode !== 429 && payload?.errorCode !== 403 ) {
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
 		if ( type === FETCH_USAGE_COUNT_ERROR_ACTION_NAME && payload?.errorCode === 429 && subscriptions ) {
 			// If the user has a subscription, but the usage count limit is reached, we show the error.
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
@@ -297,6 +318,7 @@ export const App = ( { onUseAi } ) => {
 		isSeoAnalysisActive,
 		checkFocusKeyphrase,
 		showFocusKeyphrase,
+		showFeatureError,
 		usageCountEndpoint,
 		fetchUsageCount,
 		isWooSeoActive,
@@ -322,12 +344,12 @@ export const App = ( { onUseAi } ) => {
 
 		if ( type === FETCH_USAGE_COUNT_ERROR_ACTION_NAME ) {
 			// User revoked consent after clicking on the "Try for free" AI button.
-			setDisplay( DISPLAY.error );
+			showFeatureError();
 			return;
 		}
 
 		setDisplay( DISPLAY.generate );
-	}, [ setDisplay, usageCountEndpoint, fetchUsageCount, checkSubscriptions, isWooProductEntity ] );
+	}, [ setDisplay, showFeatureError, usageCountEndpoint, fetchUsageCount, checkSubscriptions, isWooProductEntity ] );
 
 	/**
 	 * Callback to activate free sparks on the upsell modal
@@ -386,16 +408,11 @@ export const App = ( { onUseAi } ) => {
 
 			<MainModal
 				{ ...commonModalProps }
-				isOpen={ [ DISPLAY.error, DISPLAY.generate ].includes( display ) }
+				isOpen={ display === DISPLAY.generate }
 				aiModalHelperLink={ aiModalHelperLink }
 				panelRef={ panelRef }
 				title={ title }
 			>
-				{ display === DISPLAY.error && (
-					<Modal.Container.Content className="yst-pt-6">
-						<FeatureError currentSubscriptions={ currentSubscriptions } isSeoAnalysisActive={ isSeoAnalysisActive } />
-					</Modal.Container.Content>
-				) }
 				{ display === DISPLAY.generate && (
 					<>
 						<UsageCounter
@@ -406,10 +423,22 @@ export const App = ( { onUseAi } ) => {
 							mentionBetaInTooltip={ isPremium }
 							mentionResetInTooltip={ isPremium }
 						/>
-						<ModalContent height={ panelHeight } />
+						<ModalContent height={ panelHeight } onFatalError={ handleModalFatalError } />
 					</>
 				) }
 			</MainModal>
+
+			{ /* The error modal lives outside the AI modal so a fatal error can close it and still show. */ }
+			{ errorModal && (
+				<AIErrorModal
+					isOpen={ true }
+					errorCode={ errorModal.errorCode }
+					errorIdentifier={ errorModal.errorIdentifier }
+					invalidSubscriptions={ errorModal.invalidSubscriptions }
+					errorMessage={ errorModal.errorMessage }
+					onClose={ dismissErrorModal }
+				/>
+			) }
 		</>
 	);
 };

--- a/packages/js/src/ai-generator/components/errors/bad-wp-request-alert.js
+++ b/packages/js/src/ai-generator/components/errors/bad-wp-request-alert.js
@@ -1,46 +1,17 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
 import PropTypes from "prop-types";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/bad-wp-request";
 
 /**
  * @param {string} [errorMessage=""] The error message to display.
  * @returns {JSX.Element} The element.
  */
-export const BadWPRequestAlert = ( { errorMessage = "" } ) => {
-	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Something went wrong", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{
-					sprintf(
-						/* translators: %s is the error response of the request. */
-						__( "The request came back with the following error: '%s'.", "wordpress-seo" ),
-						errorMessage
-					)
-				}
-			</p>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
-						__( "Please try again later. If the issue persists, please %1$scontact our support team%2$s.", "wordpress-seo" ),
-						"<a>",
-						"</a>"
-					),
-					{
-						a: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const BadWPRequestAlert = ( { errorMessage = "" } ) => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body errorMessage={ errorMessage } />
+	</Alert>
+);
 
 BadWPRequestAlert.propTypes = {
 	errorMessage: PropTypes.string,

--- a/packages/js/src/ai-generator/components/errors/bad-wp-request-modal.js
+++ b/packages/js/src/ai-generator/components/errors/bad-wp-request-modal.js
@@ -1,0 +1,28 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/bad-wp-request";
+import { DangerModal, ModalDescription, RetryableActions } from "./modal-parts";
+
+/**
+ * The bad-WP-request error (400 / WP_HTTP_REQUEST_ERROR) as a danger modal.
+ *
+ * @param {string} [errorMessage=""] The raw error message returned by the request.
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {boolean} [showActions=false] Whether to show the Try again / Close actions.
+ * @param {function} [onRetry=noop] Retries the request.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const BadWPRequestModal = ( { errorMessage = "", isOpen = true, showActions = false, onRetry = noop, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body errorMessage={ errorMessage } /></ModalDescription>
+		<RetryableActions showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />
+	</DangerModal>
+);
+BadWPRequestModal.propTypes = {
+	errorMessage: PropTypes.string,
+	isOpen: PropTypes.bool,
+	showActions: PropTypes.bool,
+	onRetry: PropTypes.func,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/generic-alert.js
+++ b/packages/js/src/ai-generator/components/errors/generic-alert.js
@@ -1,10 +1,7 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
 import PropTypes from "prop-types";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
 import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/generic";
 
 /**
  * @param {string} [linkStoreName] The store to read the common-errors and support links from.
@@ -15,33 +12,12 @@ import { STORE_NAME_EDITOR } from "../../constants";
  *
  * @returns {JSX.Element} The element.
  */
-export const GenericAlert = ( { linkStoreName = STORE_NAME_EDITOR, className = "" } ) => {
-	const commonErrorsLink = useSelect( select => select( linkStoreName ).selectLink( "https://yoa.st/ai-common-errors" ), [ linkStoreName ] );
-	const supportLink = useSelect( select => select( linkStoreName ).selectAdminLink( "?page=wpseo_page_support" ), [ linkStoreName ] );
-
-	return (
-		<Alert variant="error" className={ className }>
-			<span className="yst-block yst-font-medium">{ __( "Something went wrong", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
-						__(
-							"Please try again later. If this issue persists, you can learn more about possible reasons for this error on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.", "wordpress-seo" ),
-						"<a1>",
-						"</a1>",
-						"<a2>",
-						"</a2>"
-					),
-					{
-						a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
-						a2: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const GenericAlert = ( { linkStoreName = STORE_NAME_EDITOR, className = "" } ) => (
+	<Alert variant="error" className={ className }>
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body linkStoreName={ linkStoreName } />
+	</Alert>
+);
 GenericAlert.propTypes = {
 	linkStoreName: PropTypes.string,
 	className: PropTypes.string,

--- a/packages/js/src/ai-generator/components/errors/generic-modal.js
+++ b/packages/js/src/ai-generator/components/errors/generic-modal.js
@@ -1,0 +1,27 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/generic";
+import { DangerModal, ModalDescription, RetryableActions } from "./modal-parts";
+
+/**
+ * The generic fallback error (400 default, 403, 503, and any unmapped code) as a
+ * danger modal.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {boolean} [showActions=false] Whether to show the Try again / Close actions.
+ * @param {function} [onRetry=noop] Retries the request.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const GenericModal = ( { isOpen = true, showActions = false, onRetry = noop, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<RetryableActions showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />
+	</DangerModal>
+);
+GenericModal.propTypes = {
+	isOpen: PropTypes.bool,
+	showActions: PropTypes.bool,
+	onRetry: PropTypes.func,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/index.js
+++ b/packages/js/src/ai-generator/components/errors/index.js
@@ -1,3 +1,4 @@
+// Inline alerts (rendered inside the AI modal and other inline surfaces).
 export { GenericAlert } from "./generic-alert";
 export { NotEnoughContentAlert } from "./not-enough-content-alert";
 export { SeoAnalysisInactiveError } from "./seo-analysis-inactive-error";
@@ -7,3 +8,15 @@ export { TimeoutAlert } from "./timeout-alert";
 export { UnethicalRequestAlert } from "./unethical-request-alert";
 export { BadWPRequestAlert } from "./bad-wp-request-alert";
 export { UpgradeAlert } from "./upgrade-alert";
+
+// Danger modals (the counterparts to the alerts above; same copy via ./messages).
+export { GenericModal } from "./generic-modal";
+export { TimeoutModal } from "./timeout-modal";
+export { BadWPRequestModal } from "./bad-wp-request-modal";
+export { NotEnoughContentModal } from "./not-enough-content-modal";
+export { UnethicalRequestModal } from "./unethical-request-modal";
+export { RateLimitModal } from "./rate-limit-modal";
+export { UpgradeModal } from "./upgrade-modal";
+export { SubscriptionModal } from "./subscription-modal";
+export { SeoAnalysisInactiveModal } from "./seo-analysis-inactive-modal";
+export { SiteUnreachableModal } from "./site-unreachable-modal";

--- a/packages/js/src/ai-generator/components/errors/messages/bad-wp-request.js
+++ b/packages/js/src/ai-generator/components/errors/messages/bad-wp-request.js
@@ -1,0 +1,43 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import PropTypes from "prop-types";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "Something went wrong", "wordpress-seo" );
+
+/**
+ * The copy for the bad-WP-request error (400 / WP_HTTP_REQUEST_ERROR).
+ *
+ * @param {string} [errorMessage=""] The raw error message returned by the request.
+ * @returns {JSX.Element} The element.
+ */
+export const Body = ( { errorMessage = "" } ) => {
+	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
+
+	return (
+		<>
+			<Paragraph>
+				{ sprintf(
+					/* translators: %s is the error response of the request. */
+					__( "The request came back with the following error: '%s'.", "wordpress-seo" ),
+					errorMessage
+				) }
+			</Paragraph>
+			<Paragraph>
+				{ safeCreateInterpolateElement(
+					sprintf(
+						/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
+						__( "Please try again later. If the issue persists, please %1$scontact our support team%2$s.", "wordpress-seo" ),
+						"<a>",
+						"</a>"
+					),
+					{ a: <OutboundLink variant="error" href={ supportLink } /> }
+				) }
+			</Paragraph>
+		</>
+	);
+};
+Body.propTypes = { errorMessage: PropTypes.string };

--- a/packages/js/src/ai-generator/components/errors/messages/generic.js
+++ b/packages/js/src/ai-generator/components/errors/messages/generic.js
@@ -1,0 +1,47 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import PropTypes from "prop-types";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "Something went wrong", "wordpress-seo" );
+
+/**
+ * The copy for the generic fallback error (400 default, 403, 503, and any
+ * unmapped code).
+ *
+ * @param {string} [linkStoreName] The store to read the common-errors and support links from.
+ *                                  Defaults to the block editor's store; pass a different store
+ *                                  name when rendering outside the block editor (e.g. the AI
+ *                                  consent screen on the user profile page).
+ * @returns {JSX.Element} The element.
+ */
+export const Body = ( { linkStoreName = STORE_NAME_EDITOR } ) => {
+	const commonErrorsLink = useSelect( select => select( linkStoreName ).selectLink( "https://yoa.st/ai-common-errors" ), [ linkStoreName ] );
+	const supportLink = useSelect( select => select( linkStoreName ).selectAdminLink( "?page=wpseo_page_support" ), [ linkStoreName ] );
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
+					__(
+						"Please try again later. If this issue persists, you can learn more about possible reasons for this error on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
+						"wordpress-seo"
+					),
+					"<a1>",
+					"</a1>",
+					"<a2>",
+					"</a2>"
+				),
+				{
+					a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
+					a2: <OutboundLink variant="error" href={ supportLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};
+Body.propTypes = { linkStoreName: PropTypes.string };

--- a/packages/js/src/ai-generator/components/errors/messages/index.js
+++ b/packages/js/src/ai-generator/components/errors/messages/index.js
@@ -1,0 +1,19 @@
+/**
+ * The single source of truth for AI generator error copy.
+ *
+ * Each message exports a `title` string and a `Body` component that renders the
+ * paragraph copy (with its own link reads and interpolation) — and nothing else:
+ * no alert box, no modal shell, no action buttons. The inline alerts
+ * (`../*-alert.js`) and the danger modals (`../*-modal.js`) both wrap these so
+ * the copy lives in one place.
+ */
+export * as genericMessage from "./generic";
+export * as timeoutMessage from "./timeout";
+export * as notEnoughContentMessage from "./not-enough-content";
+export * as siteUnreachableMessage from "./site-unreachable";
+export * as rateLimitMessage from "./rate-limit";
+export * as unethicalRequestMessage from "./unethical-request";
+export * as badWpRequestMessage from "./bad-wp-request";
+export * as upgradeMessage from "./upgrade";
+export * as subscriptionMessage from "./subscription";
+export * as seoAnalysisInactiveMessage from "./seo-analysis-inactive";

--- a/packages/js/src/ai-generator/components/errors/messages/not-enough-content.js
+++ b/packages/js/src/ai-generator/components/errors/messages/not-enough-content.js
@@ -1,0 +1,37 @@
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { Paragraph, useHelpLinks } from "./parts";
+
+export const title = __( "Not enough content", "wordpress-seo" );
+
+/**
+ * The copy for the not-enough-content error (400 / NOT_ENOUGH_CONTENT).
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const { commonErrorsLink, supportLink } = useHelpLinks();
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
+					__(
+						"Please add more content to ensure a valuable AI suggestion. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
+						"wordpress-seo"
+					),
+					"<a1>",
+					"</a1>",
+					"<a2>",
+					"</a2>"
+				),
+				{
+					a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
+					a2: <OutboundLink variant="error" href={ supportLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/parts.js
+++ b/packages/js/src/ai-generator/components/errors/messages/parts.js
@@ -1,0 +1,28 @@
+import { useSelect } from "@wordpress/data";
+import PropTypes from "prop-types";
+import { STORE_NAME_EDITOR } from "../../../constants";
+
+/**
+ * A single paragraph of error copy with the standard top margin.
+ *
+ * Shared by every message `Body` so the inline alert and the danger modal
+ * render identical paragraph spacing.
+ *
+ * @param {JSX.node} children The paragraph content.
+ * @returns {JSX.Element} The element.
+ */
+export const Paragraph = ( { children } ) => <p className="yst-mt-2">{ children }</p>;
+Paragraph.propTypes = { children: PropTypes.node.isRequired };
+
+/**
+ * Reads the help/support links shared by several message bodies.
+ *
+ * @returns {{commonErrorsLink: string, supportLink: string}} The links.
+ */
+export const useHelpLinks = () => useSelect( ( select ) => {
+	const editorSelect = select( STORE_NAME_EDITOR );
+	return {
+		commonErrorsLink: editorSelect.selectLink( "https://yoa.st/ai-common-errors" ),
+		supportLink: editorSelect.selectAdminLink( "?page=wpseo_page_support" ),
+	};
+}, [] );

--- a/packages/js/src/ai-generator/components/errors/messages/rate-limit.js
+++ b/packages/js/src/ai-generator/components/errors/messages/rate-limit.js
@@ -1,0 +1,34 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "You've reached the Yoast AI rate limit", "wordpress-seo" );
+
+/**
+ * The copy for the rate-limit error (429, without USAGE_LIMIT_REACHED).
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const rateLimitLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-rate-limit-help" ), [] );
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
+					__(
+						"You might have reached your Yoast AI rate limit for a specific time frame or your sparks limit for this month. If you have reached your rate limit, please reduce the frequency of your requests to continue using Yoast AI features. Our %1$shelp article%2$s provides guidance on effectively planning and pacing your requests for an optimized workflow.",
+						"wordpress-seo"
+					),
+					"<a>",
+					"</a>"
+				),
+				{ a: <OutboundLink variant="error" href={ rateLimitLink } /> }
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/seo-analysis-inactive.js
+++ b/packages/js/src/ai-generator/components/errors/messages/seo-analysis-inactive.js
@@ -1,0 +1,45 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "SEO analysis required", "wordpress-seo" );
+
+/**
+ * The copy for the SEO-analysis-inactive error (SEO_ANALYSIS_INACTIVE).
+ *
+ * The "Refresh page" action that accompanies this error lives in the alert and
+ * modal chrome, not here.
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const seoAnalysisFeatureToggleLink = useSelect( select => select( STORE_NAME_EDITOR )
+		.selectAdminLink( "?page=wpseo_page_settings#/site-features#card-wpseo-keyword_analysis_active" ), [] );
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/**
+					 * translators:
+					 * %1$s expands to Yoast SEO.
+					 * %2$s and %3$s expand to an opening and closing anchor tag, respectively, that links to the settings page.
+					 * %4$s expands to Yoast AI.
+					 */
+					__(
+						"%4$s requires the SEO analysis to be enabled. To enable it, please navigate to %2$sSite features%3$s in %1$s, turn on the SEO analysis, and click 'Save changes'. If it's disabled in your WordPress user profile, access your profile and enable it there. Please contact your administrator if you don't have access to these settings.",
+						"wordpress-seo"
+					),
+					"Yoast SEO",
+					"<a>",
+					"</a>",
+					"Yoast AI"
+				),
+				{ a: <OutboundLink variant="error" href={ seoAnalysisFeatureToggleLink } /> }
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/site-unreachable.js
+++ b/packages/js/src/ai-generator/components/errors/messages/site-unreachable.js
@@ -1,0 +1,41 @@
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { Paragraph, useHelpLinks } from "./parts";
+
+export const title = __( "Yoast AI cannot reach your site", "wordpress-seo" );
+
+/**
+ * The copy for the site-unreachable error (400 / SITE_UNREACHABLE).
+ *
+ * This is the informational-only variant used by the inline alert. The danger
+ * modal renders three connection-aware variants instead (nudging the user to
+ * connect to MyYoast); that variant logic lives in the modal, not here.
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const { commonErrorsLink, supportLink } = useHelpLinks();
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
+					__(
+						"To use this feature, your site must be publicly accessible. This applies to both test sites and instances where your REST API is password-protected. Please ensure your site is accessible to the public and try again. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
+						"wordpress-seo"
+					),
+					"<a1>",
+					"</a1>",
+					"<a2>",
+					"</a2>"
+				),
+				{
+					a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
+					a2: <OutboundLink variant="error" href={ supportLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/subscription.js
+++ b/packages/js/src/ai-generator/components/errors/messages/subscription.js
@@ -41,6 +41,32 @@ export const Body = ( { invalidSubscriptions = [] } ) => {
 		newSubscriptionLink = newPremiumLink;
 	}
 
+	// Without an identified product the sprintf copy below would render the literal
+	// "undefined" and href="undefined"; fall back to a generic activation message.
+	if ( ! addonProduct ) {
+		return (
+			<Paragraph>
+				{ safeCreateInterpolateElement(
+					sprintf(
+						/**
+						 * translators:
+						 * %1$s expands to MyYoast.
+						 * %2$s and %3$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
+						 **/
+						__(
+							"To access this feature, you need an active subscription. Please %2$sactivate your subscription in %1$s%3$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
+							"wordpress-seo"
+						),
+						"MyYoast",
+						"<Activate>",
+						"</Activate>"
+					),
+					{ Activate: <OutboundLink variant="error" href={ activatePremiumLink } /> }
+				) }
+			</Paragraph>
+		);
+	}
+
 	return (
 		<Paragraph>
 			{ safeCreateInterpolateElement(

--- a/packages/js/src/ai-generator/components/errors/messages/subscription.js
+++ b/packages/js/src/ai-generator/components/errors/messages/subscription.js
@@ -1,0 +1,74 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import PropTypes from "prop-types";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "Subscription required", "wordpress-seo" );
+
+/**
+ * The copy for the subscription-required error (402, and 429 / USAGE_LIMIT_REACHED).
+ *
+ * The "Refresh page" action that accompanies this error lives in the alert and
+ * modal chrome, not here.
+ *
+ * @param {string[]} [invalidSubscriptions=[]] The products with an invalid subscription.
+ * @returns {JSX.Element} The element.
+ */
+export const Body = ( { invalidSubscriptions = [] } ) => {
+	const { newYoastWooLink, activateYoastWooLink, newPremiumLink, activatePremiumLink } = useSelect( ( select ) => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			newYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-yoast-woocommerce" ),
+			activateYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-yoast-woocommerce" ),
+			newPremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-premium" ),
+			activatePremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-premium" ),
+		};
+	}, [] );
+
+	let addonProduct;
+	let activateSubscriptionLink;
+	let newSubscriptionLink;
+	if ( invalidSubscriptions.includes( "Yoast WooCommerce SEO" ) ) {
+		addonProduct = "Yoast WooCommerce SEO";
+		activateSubscriptionLink = activateYoastWooLink;
+		newSubscriptionLink = newYoastWooLink;
+	} else if ( invalidSubscriptions.includes( "Yoast SEO Premium" ) ) {
+		addonProduct = "Yoast SEO Premium";
+		activateSubscriptionLink = activatePremiumLink;
+		newSubscriptionLink = newPremiumLink;
+	}
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/**
+					 * translators:
+					 * %1$s expands to Yoast SEO Premium or Yoast WooCommerce SEO.
+					 * %2$s expands to MyYoast.
+					 * %3$s and %4$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
+					 * %5$s and %6$s expand to an opening and closing anchor tag, respectively, to get a new subscription.
+					 **/
+					__(
+						"To access this feature, you need an active %1$s subscription. Please %3$sactivate your subscription in %2$s%4$s or %5$sget a new %1$s subscription%6$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
+						"wordpress-seo"
+					),
+					addonProduct,
+					"MyYoast",
+					"<Activate>",
+					"</Activate>",
+					"<New>",
+					"</New>"
+				),
+				{
+					Activate: <OutboundLink variant="error" href={ activateSubscriptionLink } />,
+					New: <OutboundLink variant="error" href={ newSubscriptionLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};
+Body.propTypes = { invalidSubscriptions: PropTypes.arrayOf( PropTypes.string ) };

--- a/packages/js/src/ai-generator/components/errors/messages/timeout.js
+++ b/packages/js/src/ai-generator/components/errors/messages/timeout.js
@@ -1,0 +1,37 @@
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { Paragraph, useHelpLinks } from "./parts";
+
+export const title = __( "Connection timeout", "wordpress-seo" );
+
+/**
+ * The copy for the connection-timeout error (408).
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const { commonErrorsLink, supportLink } = useHelpLinks();
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
+					__(
+						"It seems that a connection timeout has occurred. Please check your internet connection and try again later. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
+						"wordpress-seo"
+					),
+					"<a1>",
+					"</a1>",
+					"<a2>",
+					"</a2>"
+				),
+				{
+					a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
+					a2: <OutboundLink variant="error" href={ supportLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/unethical-request.js
+++ b/packages/js/src/ai-generator/components/errors/messages/unethical-request.js
@@ -1,0 +1,40 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "Usage policy violation", "wordpress-seo" );
+
+/**
+ * The copy for the content-filter error (400 / AI_CONTENT_FILTER).
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s, %2$s, %3$s, %4$s are anchor tags. %5$s expands to OpenAI. */
+					__(
+						"Due to %5$s's strict ethical guidelines and %1$susage policies%2$s, we cannot generate suggestions for the content on this page. If you intend to use AI, kindly avoid the use of explicit, violent, copyrighted, or sexually explicit content. In case you need further help, please %3$scontact our support team%4$s.",
+						"wordpress-seo"
+					),
+					"<a1>",
+					"</a1>",
+					"<a2>",
+					"</a2>",
+					"OpenAI"
+				),
+				{
+					a1: <OutboundLink variant="error" href="https://openai.com/policies/usage-policies" />,
+					a2: <OutboundLink variant="error" href={ supportLink } />,
+				}
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/messages/upgrade.js
+++ b/packages/js/src/ai-generator/components/errors/messages/upgrade.js
@@ -1,0 +1,32 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { safeCreateInterpolateElement } from "../../../../helpers/i18n";
+import { OutboundLink } from "../../../../shared-admin/components";
+import { STORE_NAME_EDITOR } from "../../../constants";
+import { Paragraph } from "./parts";
+
+export const title = __( "Something went wrong", "wordpress-seo" );
+
+/**
+ * The copy for the outdated-version error (410).
+ *
+ * @returns {JSX.Element} The element.
+ */
+export const Body = () => {
+	const pluginsLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "plugins.php" ), [] );
+
+	return (
+		<Paragraph>
+			{ safeCreateInterpolateElement(
+				sprintf(
+					/* translators: %1$s expands to Yoast SEO Premium. %2$s expands to an opening link tag. %3$s expands to a closing link tag. */
+					__( "The version of %1$s is outdated. Please upgrade %1$s %2$shere%3$s!", "wordpress-seo" ),
+					"Yoast SEO Premium",
+					"<a>",
+					"</a>"
+				),
+				{ a: <OutboundLink variant="error" href={ pluginsLink } /> }
+			) }
+		</Paragraph>
+	);
+};

--- a/packages/js/src/ai-generator/components/errors/modal-parts.js
+++ b/packages/js/src/ai-generator/components/errors/modal-parts.js
@@ -26,7 +26,7 @@ ModalDescription.propTypes = { children: PropTypes.node.isRequired };
  * @returns {JSX.Element} The element.
  */
 export const Actions = ( { children } ) => (
-	<div className="yst-mt-6 yst-flex yst-flex-col sm:yst-flex-row-reverse yst-gap-3 yst-place-content-start">
+	<div className="yst-mt-6 yst-flex yst-flex-row yst-justify-end yst-gap-3">
 		{ children }
 	</div>
 );
@@ -39,7 +39,7 @@ Actions.propTypes = { children: PropTypes.node.isRequired };
  * @returns {JSX.Element} The element.
  */
 export const CloseButton = ( { onClose } ) => (
-	<Button variant="secondary" onClick={ onClose } className="yst-w-full sm:yst-w-auto">
+	<Button variant="secondary" onClick={ onClose }>
 		{ __( "Close", "wordpress-seo" ) }
 	</Button>
 );
@@ -57,12 +57,12 @@ CloseButton.propTypes = { onClose: PropTypes.func.isRequired };
  */
 export const RetryableActions = ( { showActions = false, onRetry, onClose } ) => (
 	<Actions>
+		<CloseButton onClose={ onClose } />
 		{ showActions && (
-			<Button variant="primary" onClick={ onRetry } className="yst-w-full sm:yst-w-auto">
+			<Button variant="primary" onClick={ onRetry }>
 				{ __( "Try again", "wordpress-seo" ) }
 			</Button>
 		) }
-		<CloseButton onClose={ onClose } />
 	</Actions>
 );
 RetryableActions.propTypes = {
@@ -87,11 +87,18 @@ export const DangerModal = ( { isOpen, title, onClose = noop, children } ) => {
 	return (
 		<Modal isOpen={ isOpen } onClose={ onClose }>
 			<Modal.Panel className="yst-max-w-lg" closeButtonScreenReaderText={ __( "Dismiss", "wordpress-seo" ) }>
-				<div className="yst-flex yst-flex-col yst-items-center sm:yst-flex-row sm:yst-items-start yst-gap-4">
-					<div className="yst-mx-auto yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100 sm:yst-mx-0">
-						<ExclamationIcon className="yst-h-4 yst-w-4 yst-text-red-600" { ...svgAriaProps } />
+				{ /*
+					* An unconditional row (icon | title + body), not the `sm:`-gated
+					* stack-then-row other danger modals use. This modal is portaled inside
+					* the block editor, where the viewport `sm` breakpoint does not match
+					* reliably; gating the layout on it leaves the modal stuck stacked and
+					* centered. Mirrors `ReplaceContentModal`, which renders in the same context.
+					*/ }
+				<div className="yst-flex yst-items-start yst-gap-4">
+					<div className="yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100">
+						<ExclamationIcon className="yst-h-6 yst-w-6 yst-text-red-600" { ...svgAriaProps } />
 					</div>
-					<div className="yst-text-center sm:yst-text-left yst-flex-1 yst-min-w-0">
+					<div className="yst-text-start yst-flex-1 yst-min-w-0">
 						<Modal.Title className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
 							{ title }
 						</Modal.Title>

--- a/packages/js/src/ai-generator/components/errors/modal-parts.js
+++ b/packages/js/src/ai-generator/components/errors/modal-parts.js
@@ -1,0 +1,110 @@
+import ExclamationIcon from "@heroicons/react/outline/ExclamationIcon";
+import { __ } from "@wordpress/i18n";
+import { Button, Modal, useSvgAria } from "@yoast/ui-library";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+
+/**
+ * Wraps the error copy below the title, applying the muted modal-description tone.
+ * The message `Paragraph`s add their own top margin, so the first paragraph sits
+ * just under the title.
+ *
+ * @param {JSX.node} children The copy (message `Body`).
+ * @returns {JSX.Element} The element.
+ */
+export const ModalDescription = ( { children } ) => (
+	<div className="yst-mt-1 yst-text-sm yst-text-slate-500">
+		{ children }
+	</div>
+);
+ModalDescription.propTypes = { children: PropTypes.node.isRequired };
+
+/**
+ * The button row shown at the bottom of an error modal.
+ *
+ * @param {JSX.node} children The buttons.
+ * @returns {JSX.Element} The element.
+ */
+export const Actions = ( { children } ) => (
+	<div className="yst-mt-6 yst-flex yst-flex-col sm:yst-flex-row-reverse yst-gap-3 yst-place-content-start">
+		{ children }
+	</div>
+);
+Actions.propTypes = { children: PropTypes.node.isRequired };
+
+/**
+ * A "Close" button that dismisses the modal.
+ *
+ * @param {function} onClose Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const CloseButton = ( { onClose } ) => (
+	<Button variant="secondary" onClick={ onClose } className="yst-w-full sm:yst-w-auto">
+		{ __( "Close", "wordpress-seo" ) }
+	</Button>
+);
+CloseButton.propTypes = { onClose: PropTypes.func.isRequired };
+
+/**
+ * The action row for retryable errors: always a Close button, plus a Try again
+ * when `showActions` is set (a retryable context such as a timeout or a failed
+ * request). The Close mirrors the always-available top-right dismiss.
+ *
+ * @param {boolean} [showActions=false] Whether to add the Try again button.
+ * @param {function} onRetry Retries the request.
+ * @param {function} onClose Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const RetryableActions = ( { showActions = false, onRetry, onClose } ) => (
+	<Actions>
+		{ showActions && (
+			<Button variant="primary" onClick={ onRetry } className="yst-w-full sm:yst-w-auto">
+				{ __( "Try again", "wordpress-seo" ) }
+			</Button>
+		) }
+		<CloseButton onClose={ onClose } />
+	</Actions>
+);
+RetryableActions.propTypes = {
+	showActions: PropTypes.bool,
+	onRetry: PropTypes.func.isRequired,
+	onClose: PropTypes.func.isRequired,
+};
+
+/**
+ * The "Danger modal" shell every AI error shares: a centered modal panel with the
+ * rose-circle outline exclamation icon, the resolved title, and a dismiss control.
+ *
+ * @param {boolean} isOpen Whether the modal is open.
+ * @param {string} title The modal title.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @param {JSX.node} children The modal body (copy + actions).
+ * @returns {JSX.Element} The element.
+ */
+export const DangerModal = ( { isOpen, title, onClose = noop, children } ) => {
+	const svgAriaProps = useSvgAria();
+
+	return (
+		<Modal isOpen={ isOpen } onClose={ onClose }>
+			<Modal.Panel className="yst-max-w-lg" closeButtonScreenReaderText={ __( "Dismiss", "wordpress-seo" ) }>
+				<div className="yst-flex yst-flex-col yst-items-center sm:yst-flex-row sm:yst-items-start yst-gap-4">
+					<div className="yst-mx-auto yst-flex-shrink-0 yst-flex yst-items-center yst-justify-center yst-h-10 yst-w-10 yst-rounded-full yst-bg-red-100 sm:yst-mx-0">
+						<ExclamationIcon className="yst-h-4 yst-w-4 yst-text-red-600" { ...svgAriaProps } />
+					</div>
+					<div className="yst-text-center sm:yst-text-left yst-flex-1 yst-min-w-0">
+						<Modal.Title className="yst-text-lg yst-leading-6 yst-font-medium yst-text-slate-900">
+							{ title }
+						</Modal.Title>
+						{ children }
+					</div>
+				</div>
+			</Modal.Panel>
+		</Modal>
+	);
+};
+DangerModal.propTypes = {
+	isOpen: PropTypes.bool.isRequired,
+	title: PropTypes.string.isRequired,
+	onClose: PropTypes.func,
+	children: PropTypes.node.isRequired,
+};

--- a/packages/js/src/ai-generator/components/errors/not-enough-content-alert.js
+++ b/packages/js/src/ai-generator/components/errors/not-enough-content-alert.js
@@ -1,39 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/not-enough-content";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const NotEnoughContentAlert = () => {
-	const commonErrorsLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-common-errors" ), [] );
-	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Not enough content", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
-						__(
-							"Please add more content to ensure a valuable AI suggestion. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
-							"wordpress-seo"
-						),
-						"<a1>",
-						"</a1>",
-						"<a2>",
-						"</a2>"
-					),
-					{
-						a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
-						a2: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const NotEnoughContentAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/not-enough-content-modal.js
+++ b/packages/js/src/ai-generator/components/errors/not-enough-content-modal.js
@@ -1,0 +1,24 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/not-enough-content";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The not-enough-content error (400 / NOT_ENOUGH_CONTENT) as a danger modal.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const NotEnoughContentModal = ( { isOpen = true, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<Actions>
+			<CloseButton onClose={ onClose } />
+		</Actions>
+	</DangerModal>
+);
+NotEnoughContentModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/rate-limit-alert.js
+++ b/packages/js/src/ai-generator/components/errors/rate-limit-alert.js
@@ -1,34 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/rate-limit";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const RateLimitAlert = () => {
-	const ratelimitLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-generator-rate-limit-help" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "You've reached the Yoast AI rate limit", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
-						__(
-							"You might have reached your Yoast AI rate limit for a specific time frame or your sparks limit for this month. If you have reached your rate limit, please reduce the frequency of your requests to continue using Yoast AI features. Our %1$shelp article%2$s provides guidance on effectively planning and pacing your requests for an optimized workflow.",
-							"wordpress-seo"
-						),
-						"<a>",
-						"</a>"
-					), {
-						a: <OutboundLink variant="error" href={ ratelimitLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const RateLimitAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/rate-limit-modal.js
+++ b/packages/js/src/ai-generator/components/errors/rate-limit-modal.js
@@ -1,0 +1,25 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/rate-limit";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The rate-limit error (429, without USAGE_LIMIT_REACHED) as a danger modal.
+ * It offers no retry: the user must pace their requests.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const RateLimitModal = ( { isOpen = true, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<Actions>
+			<CloseButton onClose={ onClose } />
+		</Actions>
+	</DangerModal>
+);
+RateLimitModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-error.js
+++ b/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-error.js
@@ -1,18 +1,12 @@
-import { useSelect } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { Alert, Button, useModalContext } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/seo-analysis-inactive";
 
 /**
  * @returns {JSX.Element} The element.
  */
 export const SeoAnalysisInactiveError = () => {
-	const seoAnalysisFeatureToggleLink = useSelect( select => select( STORE_NAME_EDITOR )
-		.selectAdminLink( "?page=wpseo_page_settings#/site-features#card-wpseo-keyword_analysis_active" ), [] );
-
 	const handleRefresh = useCallback( () => {
 		window.location.reload();
 	}, [] );
@@ -22,30 +16,8 @@ export const SeoAnalysisInactiveError = () => {
 	return (
 		<>
 			<Alert variant="error">
-				<span className="yst-block yst-font-medium">{ __( "SEO analysis required", "wordpress-seo" ) }</span>
-				<p className="yst-mt-2">
-					{ safeCreateInterpolateElement(
-						sprintf(
-							/**
-							 * translators:
-							 * %1$s expands to Yoast SEO.
-							 * %2$s and %3$s expand to an opening and closing anchor tag, respectively, that links to the settings page.
-							 * %4$s expands to Yoast AI.
-							 */
-							__(
-								"%4$s requires the SEO analysis to be enabled. To enable it, please navigate to %2$sSite features%3$s in %1$s, turn on the SEO analysis, and click 'Save changes'. If it's disabled in your WordPress user profile, access your profile and enable it there. Please contact your administrator if you don't have access to these settings.",
-								"wordpress-seo"
-							),
-							"Yoast SEO",
-							"<a>",
-							"</a>",
-							"Yoast AI"
-						),
-						{
-							a: <OutboundLink variant="error" href={ seoAnalysisFeatureToggleLink } />,
-						}
-					) }
-				</p>
+				<span className="yst-block yst-font-medium">{ title }</span>
+				<Body />
 			</Alert>
 			<div className="yst-mt-6 yst-mb-1 yst-flex yst-space-x-3 rtl:yst-space-x-reverse yst-place-content-end">
 				<Button variant="secondary" onClick={ onClose }>

--- a/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-modal.js
+++ b/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-modal.js
@@ -21,10 +21,10 @@ export const SeoAnalysisInactiveModal = ( { isOpen = true, onClose = noop } ) =>
 		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
 			<ModalDescription><Body /></ModalDescription>
 			<Actions>
-				<Button variant="primary" onClick={ handleRefresh } className="yst-w-full sm:yst-w-auto">
+				<CloseButton onClose={ onClose } />
+				<Button variant="primary" onClick={ handleRefresh }>
 					{ __( "Refresh page", "wordpress-seo" ) }
 				</Button>
-				<CloseButton onClose={ onClose } />
 			</Actions>
 		</DangerModal>
 	);

--- a/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-modal.js
+++ b/packages/js/src/ai-generator/components/errors/seo-analysis-inactive-modal.js
@@ -1,0 +1,35 @@
+import { useCallback } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { Button } from "@yoast/ui-library";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/seo-analysis-inactive";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The SEO-analysis-inactive error (SEO_ANALYSIS_INACTIVE) as a danger modal.
+ * Its "Refresh page" action reloads once the user has enabled the analysis.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const SeoAnalysisInactiveModal = ( { isOpen = true, onClose = noop } ) => {
+	const handleRefresh = useCallback( () => window.location.reload(), [] );
+
+	return (
+		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+			<ModalDescription><Body /></ModalDescription>
+			<Actions>
+				<Button variant="primary" onClick={ handleRefresh } className="yst-w-full sm:yst-w-auto">
+					{ __( "Refresh page", "wordpress-seo" ) }
+				</Button>
+				<CloseButton onClose={ onClose } />
+			</Actions>
+		</DangerModal>
+	);
+};
+SeoAnalysisInactiveModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/site-unreachable-alert.js
+++ b/packages/js/src/ai-generator/components/errors/site-unreachable-alert.js
@@ -1,39 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/site-unreachable";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const SiteUnreachableAlert = () => {
-	const commonErrorsLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-common-errors" ), [] );
-	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Yoast AI cannot reach your site", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
-						__(
-							"To use this feature, your site must be publicly accessible. This applies to both test sites and instances where your REST API is password-protected. Please ensure your site is accessible to the public and try again. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
-							"wordpress-seo"
-						),
-						"<a1>",
-						"</a1>",
-						"<a2>",
-						"</a2>"
-					),
-					{
-						a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
-						a2: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const SiteUnreachableAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
+++ b/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
@@ -1,7 +1,8 @@
 import { useSelect } from "@wordpress/data";
 import { __, sprintf } from "@wordpress/i18n";
 import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
-import { Button } from "@yoast/ui-library";
+import ExternalLinkIcon from "@heroicons/react/outline/ExternalLinkIcon";
+import { Button, useSvgAria } from "@yoast/ui-library";
 import { noop } from "lodash";
 import PropTypes from "prop-types";
 import { safeCreateInterpolateElement } from "../../../helpers/i18n";
@@ -40,6 +41,7 @@ LearnMoreAboutConnecting.propTypes = { learnMoreUrl: PropTypes.string };
  * @returns {JSX.Element} The element.
  */
 const UnavailableBody = () => {
+	const svgAriaProps = useSvgAria();
 	const { commonErrorsLink, supportLink } = useSelect( ( select ) => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
@@ -56,12 +58,17 @@ const UnavailableBody = () => {
 				</Paragraph>
 			</ModalDescription>
 			<Actions>
-				<Button as="a" href={ commonErrorsLink } target="_blank" rel="noopener noreferrer" variant="primary" className="yst-w-full sm:yst-w-auto">
-					{ __( "Learn more", "wordpress-seo" ) }
-					<ArrowNarrowRightIcon className="yst-ms-1 yst-h-4 yst-w-4 rtl:yst-rotate-180" />
-				</Button>
-				<Button as="a" href={ supportLink } target="_blank" rel="noopener noreferrer" variant="secondary" className="yst-w-full sm:yst-w-auto">
+				<Button as="a" href={ supportLink } target="_blank" rel="noopener noreferrer" variant="secondary">
 					{ __( "Still need help?", "wordpress-seo" ) }
+					<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-4 yst-w-4 yst-text-slate-400 rtl:yst-rotate-[270deg]" { ...svgAriaProps } />
+					<span className="yst-sr-only">
+						{ /* translators: Hidden accessibility text. */ }
+						{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+					</span>
+				</Button>
+				<Button as="a" href={ commonErrorsLink } target="_blank" rel="noopener noreferrer" variant="primary">
+					{ __( "Learn more", "wordpress-seo" ) }
+					<ArrowNarrowRightIcon className="yst--me-1 yst-ms-1 yst-h-4 yst-w-4 rtl:yst-rotate-180" { ...svgAriaProps } />
 				</Button>
 			</Actions>
 		</>
@@ -74,9 +81,10 @@ const UnavailableBody = () => {
  *
  * @param {Object} connection The MyYoast connection slice.
  * @param {function} onClose Dismisses the modal.
+ * @param {Object} svgAriaProps The aria props for decorative SVGs.
  * @returns {JSX.Element} The body.
  */
-const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onClose ) => {
+const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onClose, svgAriaProps ) => {
 	// Variant 2: the site can be connected and the current user may do so.
 	if ( isAvailable && canConnect && connectUrl ) {
 		return (
@@ -88,14 +96,19 @@ const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onC
 					<LearnMoreAboutConnecting learnMoreUrl={ learnMoreUrl } />
 				</ModalDescription>
 				<Actions>
+					<CloseButton onClose={ onClose } />
 					{ /*
 						* A plain link in a new tab: the Integrations page auto-starts the connection
 						* there, so unsaved editor content is never lost to the OAuth redirect.
 						*/ }
-					<Button as="a" href={ connectUrl } target="_blank" rel="noopener noreferrer" variant="primary" className="yst-w-full sm:yst-w-auto">
+					<Button as="a" href={ connectUrl } target="_blank" rel="noopener noreferrer" variant="primary">
 						{ __( "Connect to MyYoast", "wordpress-seo" ) }
+						<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-4 yst-w-4 rtl:yst-rotate-[270deg]" { ...svgAriaProps } />
+						<span className="yst-sr-only">
+							{ /* translators: Hidden accessibility text. */ }
+							{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+						</span>
 					</Button>
-					<CloseButton onClose={ onClose } />
 				</Actions>
 			</>
 		);
@@ -135,11 +148,12 @@ const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onC
  * @returns {JSX.Element} The element.
  */
 export const SiteUnreachableModal = ( { isOpen = true, onClose = noop } ) => {
+	const svgAriaProps = useSvgAria();
 	const connection = useSelect( select => select( STORE_NAME_AI ).selectMyyoastConnection(), [] );
 
 	return (
 		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
-			{ resolveBody( connection, onClose ) }
+			{ resolveBody( connection, onClose, svgAriaProps ) }
 		</DangerModal>
 	);
 };

--- a/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
+++ b/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
@@ -1,0 +1,149 @@
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import ArrowNarrowRightIcon from "@heroicons/react/solid/ArrowNarrowRightIcon";
+import { Button } from "@yoast/ui-library";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { safeCreateInterpolateElement } from "../../../helpers/i18n";
+import { OutboundLink } from "../../../shared-admin/components";
+import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../constants";
+import { title } from "./messages/site-unreachable";
+import { Paragraph } from "./messages/parts";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The "Learn more about connecting" paragraph shown by the two connect-aware
+ * variants.
+ *
+ * @param {string} learnMoreUrl The MyYoast connection help URL.
+ * @returns {JSX.Element} The element.
+ */
+const LearnMoreAboutConnecting = ( { learnMoreUrl = "" } ) => (
+	<Paragraph>
+		{ safeCreateInterpolateElement(
+			sprintf(
+				/* translators: %1$s expands to an opening tag. %2$s expands to a closing tag. */
+				__( "%1$sLearn more about connecting with MyYoast.%2$s", "wordpress-seo" ),
+				"<a>",
+				"</a>"
+			),
+			{ a: <OutboundLink variant="error" href={ learnMoreUrl } /> }
+		) }
+	</Paragraph>
+);
+LearnMoreAboutConnecting.propTypes = { learnMoreUrl: PropTypes.string };
+
+/**
+ * Variant 1: MyYoast connection unavailable (flag off / not provisioned).
+ * Informational only, nudging the user toward help rather than a connection.
+ *
+ * @returns {JSX.Element} The element.
+ */
+const UnavailableBody = () => {
+	const { commonErrorsLink, supportLink } = useSelect( ( select ) => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			commonErrorsLink: editorSelect.selectLink( "https://yoa.st/ai-common-errors" ),
+			supportLink: editorSelect.selectAdminLink( "?page=wpseo_page_support" ),
+		};
+	}, [] );
+
+	return (
+		<>
+			<ModalDescription>
+				<Paragraph>
+					{ __( "This feature requires a publicly accessible site. Check that your site (including any password-protected REST APIs or test environments) is visible to the public, then try again.", "wordpress-seo" ) }
+				</Paragraph>
+			</ModalDescription>
+			<Actions>
+				<Button as="a" href={ commonErrorsLink } target="_blank" rel="noopener noreferrer" variant="primary" className="yst-w-full sm:yst-w-auto">
+					{ __( "Learn more", "wordpress-seo" ) }
+					<ArrowNarrowRightIcon className="yst-ms-1 yst-h-4 yst-w-4 rtl:yst-rotate-180" />
+				</Button>
+				<Button as="a" href={ supportLink } target="_blank" rel="noopener noreferrer" variant="secondary" className="yst-w-full sm:yst-w-auto">
+					{ __( "Still need help?", "wordpress-seo" ) }
+				</Button>
+			</Actions>
+		</>
+	);
+};
+
+/**
+ * Picks the body for the site-unreachable modal based on the MyYoast connection
+ * state.
+ *
+ * @param {Object} connection The MyYoast connection slice.
+ * @param {function} onClose Dismisses the modal.
+ * @returns {JSX.Element} The body.
+ */
+const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onClose ) => {
+	// Variant 2: the site can be connected and the current user may do so.
+	if ( isAvailable && canConnect && connectUrl ) {
+		return (
+			<>
+				<ModalDescription>
+					<Paragraph>
+						{ __( "This feature requires a publicly accessible site. Connect to MyYoast to use Yoast AI even when your site is offline, behind a firewall, or with the REST API disabled.", "wordpress-seo" ) }
+					</Paragraph>
+					<LearnMoreAboutConnecting learnMoreUrl={ learnMoreUrl } />
+				</ModalDescription>
+				<Actions>
+					{ /*
+						* A plain link in a new tab: the Integrations page auto-starts the connection
+						* there, so unsaved editor content is never lost to the OAuth redirect.
+						*/ }
+					<Button as="a" href={ connectUrl } target="_blank" rel="noopener noreferrer" variant="primary" className="yst-w-full sm:yst-w-auto">
+						{ __( "Connect to MyYoast", "wordpress-seo" ) }
+					</Button>
+					<CloseButton onClose={ onClose } />
+				</Actions>
+			</>
+		);
+	}
+
+	// Variant 3: the site can be connected, but not by this user.
+	if ( isAvailable && ! canConnect ) {
+		return (
+			<>
+				<ModalDescription>
+					<Paragraph>
+						{ __( "Your site isn't publicly accessible. Ask your site administrator to connect to MyYoast. They can find it on the Integrations page in Yoast SEO. This allows Yoast AI to work even when your site is offline, behind a firewall, or with the REST API disabled.", "wordpress-seo" ) }
+					</Paragraph>
+					<LearnMoreAboutConnecting learnMoreUrl={ learnMoreUrl } />
+				</ModalDescription>
+				<Actions>
+					<CloseButton onClose={ onClose } />
+				</Actions>
+			</>
+		);
+	}
+
+	// Variant 1: MyYoast connection unavailable (flag off / not provisioned).
+	return <UnavailableBody />;
+};
+
+/**
+ * The site-unreachable error (400 / SITE_UNREACHABLE) as a danger modal.
+ *
+ * Renders one of three variants based on the site's MyYoast connection state,
+ * nudging the user to connect when it makes sense. Reads the connection data the
+ * editor localizes; when it is unavailable (feature flag off or not provisioned)
+ * it falls back to the informational-only variant.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const SiteUnreachableModal = ( { isOpen = true, onClose = noop } ) => {
+	const connection = useSelect( select => select( STORE_NAME_AI ).selectMyyoastConnection(), [] );
+
+	return (
+		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+			{ resolveBody( connection, onClose ) }
+		</DangerModal>
+	);
+};
+SiteUnreachableModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/subscription-error.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-error.js
@@ -1,28 +1,18 @@
 import apiFetch from "@wordpress/api-fetch";
 import { useSelect } from "@wordpress/data";
 import { Fragment, useCallback } from "@wordpress/element";
-import { __, sprintf } from "@wordpress/i18n";
+import { __ } from "@wordpress/i18n";
 import { Alert, Button, useModalContext } from "@yoast/ui-library";
 import PropTypes from "prop-types";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../../constants";
+import { STORE_NAME_AI } from "../../constants";
+import { Body, title } from "./messages/subscription";
 
 /**
  * @param {string[]} [invalidSubscriptions=[]] The array with the names of products with invalid subscription.
  * @returns {JSX.Element} The element.
  */
 export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
-	const { newYoastWooLink, activateYoastWooLink, newPremiumLink, activatePremiumLink, bustSubscriptionCacheEndpoint } = useSelect( ( select ) => {
-		const editorSelect = select( STORE_NAME_EDITOR );
-		return {
-			newYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-yoast-woocommerce" ),
-			activateYoastWooLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-yoast-woocommerce" ),
-			newPremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-new-premium" ),
-			activatePremiumLink: editorSelect.selectLink( "https://yoa.st/ai-generator-activate-premium" ),
-			bustSubscriptionCacheEndpoint: select( STORE_NAME_AI ).selectBustSubscriptionCacheEndpoint(),
-		};
-	}, [] );
+	const bustSubscriptionCacheEndpoint = useSelect( select => select( STORE_NAME_AI ).selectBustSubscriptionCacheEndpoint(), [] );
 
 	const { onClose } = useModalContext();
 
@@ -39,50 +29,11 @@ export const SubscriptionError = ( { invalidSubscriptions = [] } ) => {
 		window.location.reload();
 	}, [] );
 
-	let addonProduct;
-	let activateSubscriptionLink;
-	let newSubscriptionLink;
-	if ( invalidSubscriptions.includes( "Yoast WooCommerce SEO" ) ) {
-		addonProduct = "Yoast WooCommerce SEO";
-		activateSubscriptionLink = activateYoastWooLink;
-		newSubscriptionLink = newYoastWooLink;
-	} else if ( invalidSubscriptions.includes( "Yoast SEO Premium" ) ) {
-		addonProduct = "Yoast SEO Premium";
-		activateSubscriptionLink = activatePremiumLink;
-		newSubscriptionLink = newPremiumLink;
-	}
-
 	return (
 		<Fragment>
 			<Alert variant="error">
-				<span className="yst-block yst-font-medium">{ __( "Subscription required", "wordpress-seo" ) }</span>
-				<p className="yst-mt-2">
-					{ safeCreateInterpolateElement(
-						sprintf(
-							/**
-							 * translators:
-							 * %1$s expands to Yoast SEO Premium or Yoast WooCommerce SEO.
-							 * %2$s expands to MyYoast.
-							 * %3$s and %4$s expand to an opening and closing anchor tag, respectively, to activate your subscription.
-							 * %5$s and %6$s expand to an opening and closing anchor tag, respectively, to get a new subscription.
-							 **/
-							__(
-								"To access this feature, you need an active %1$s subscription. Please %3$sactivate your subscription in %2$s%4$s or %5$sget a new %1$s subscription%6$s. Afterward, refresh this page. It may take up to 30 seconds for the feature to function correctly.",
-								"wordpress-seo"
-							),
-							addonProduct,
-							"MyYoast",
-							"<Activate>",
-							"</Activate>",
-							"<New>",
-							"</New>"
-						),
-						{
-							Activate: <OutboundLink variant="error" href={ activateSubscriptionLink } />,
-							New: <OutboundLink variant="error" href={ newSubscriptionLink } />,
-						}
-					) }
-				</p>
+				<span className="yst-block yst-font-medium">{ title }</span>
+				<Body invalidSubscriptions={ invalidSubscriptions } />
 			</Alert>
 			<div className="yst-mt-6 yst-mb-1 yst-flex yst-space-x-3 rtl:yst-space-x-reverse yst-place-content-end">
 				<Button variant="secondary" onClick={ onClose }>

--- a/packages/js/src/ai-generator/components/errors/subscription-modal.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-modal.js
@@ -1,0 +1,50 @@
+import apiFetch from "@wordpress/api-fetch";
+import { useSelect } from "@wordpress/data";
+import { useCallback } from "@wordpress/element";
+import { __ } from "@wordpress/i18n";
+import { Button } from "@yoast/ui-library";
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { STORE_NAME_AI } from "../../constants";
+import { Body, title } from "./messages/subscription";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The subscription-required error (402, and 429 / USAGE_LIMIT_REACHED) as a danger
+ * modal. Its "Refresh page" action busts the subscription cache before reloading,
+ * mirroring the inline `SubscriptionError`.
+ *
+ * @param {string[]} [invalidSubscriptions=[]] The products with an invalid subscription.
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const SubscriptionModal = ( { invalidSubscriptions = [], isOpen = true, onClose = noop } ) => {
+	const bustSubscriptionCacheEndpoint = useSelect( select => select( STORE_NAME_AI ).selectBustSubscriptionCacheEndpoint(), [] );
+
+	const handleRefresh = useCallback( async() => {
+		try {
+			await apiFetch( { path: bustSubscriptionCacheEndpoint, method: "POST", parse: false } );
+		} catch ( e ) {
+			console.error( e );
+		}
+		window.location.reload();
+	}, [ bustSubscriptionCacheEndpoint ] );
+
+	return (
+		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+			<ModalDescription><Body invalidSubscriptions={ invalidSubscriptions } /></ModalDescription>
+			<Actions>
+				<Button variant="primary" onClick={ handleRefresh } className="yst-w-full sm:yst-w-auto">
+					{ __( "Refresh page", "wordpress-seo" ) }
+				</Button>
+				<CloseButton onClose={ onClose } />
+			</Actions>
+		</DangerModal>
+	);
+};
+SubscriptionModal.propTypes = {
+	invalidSubscriptions: PropTypes.arrayOf( PropTypes.string ),
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/subscription-modal.js
+++ b/packages/js/src/ai-generator/components/errors/subscription-modal.js
@@ -35,10 +35,10 @@ export const SubscriptionModal = ( { invalidSubscriptions = [], isOpen = true, o
 		<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
 			<ModalDescription><Body invalidSubscriptions={ invalidSubscriptions } /></ModalDescription>
 			<Actions>
-				<Button variant="primary" onClick={ handleRefresh } className="yst-w-full sm:yst-w-auto">
+				<CloseButton onClose={ onClose } />
+				<Button variant="primary" onClick={ handleRefresh }>
 					{ __( "Refresh page", "wordpress-seo" ) }
 				</Button>
-				<CloseButton onClose={ onClose } />
 			</Actions>
 		</DangerModal>
 	);

--- a/packages/js/src/ai-generator/components/errors/timeout-alert.js
+++ b/packages/js/src/ai-generator/components/errors/timeout-alert.js
@@ -1,39 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/timeout";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const TimeoutAlert = () => {
-	const commonErrorsLink = useSelect( select => select( STORE_NAME_EDITOR ).selectLink( "https://yoa.st/ai-common-errors" ), [] );
-	const supportLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "?page=wpseo_page_support" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Connection timeout", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s and %3$s expand to an opening tag. %2$s and %4$s expand to a closing tag. */
-						__(
-							"It seems that a connection timeout has occurred. Please check your internet connection and try again later. Learn more on our page about %1$scommon AI feature problems and errors%2$s. In case you need further help, please %3$scontact our support team%4$s.",
-							"wordpress-seo"
-						),
-						"<a1>",
-						"</a1>",
-						"<a2>",
-						"</a2>"
-					),
-					{
-						a1: <OutboundLink variant="error" href={ commonErrorsLink } />,
-						a2: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const TimeoutAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/timeout-modal.js
+++ b/packages/js/src/ai-generator/components/errors/timeout-modal.js
@@ -1,0 +1,26 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/timeout";
+import { DangerModal, ModalDescription, RetryableActions } from "./modal-parts";
+
+/**
+ * The connection-timeout error (408) as a danger modal.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {boolean} [showActions=false] Whether to show the Try again / Close actions.
+ * @param {function} [onRetry=noop] Retries the request.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const TimeoutModal = ( { isOpen = true, showActions = false, onRetry = noop, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<RetryableActions showActions={ showActions } onRetry={ onRetry } onClose={ onClose } />
+	</DangerModal>
+);
+TimeoutModal.propTypes = {
+	isOpen: PropTypes.bool,
+	showActions: PropTypes.bool,
+	onRetry: PropTypes.func,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/unethical-request-alert.js
+++ b/packages/js/src/ai-generator/components/errors/unethical-request-alert.js
@@ -1,42 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/unethical-request";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const UnethicalRequestAlert = () => {
-	const supportLink = useSelect( select => select( STORE_NAME_EDITOR )
-		.selectAdminLink( "?page=wpseo_page_support" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Usage policy violation", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s, %2$s, %3$s, %4$s are anchor tags.
-						 * %5$s expands to OpenAI.
-						 */
-						__(
-							"Due to %5$s's strict ethical guidelines and %1$susage policies%2$s, we cannot generate suggestions for the content on this page. If you intend to use AI, kindly avoid the use of explicit, violent, copyrighted, or sexually explicit content. In case you need further help, please %3$scontact our support team%4$s.",
-							"wordpress-seo"
-						),
-						"<a1>",
-						"</a1>",
-						"<a2>",
-						"</a2>",
-						"OpenAI"
-					),
-					{
-						a1: <OutboundLink variant="error" href={ "https://openai.com/policies/usage-policies" } />,
-						a2: <OutboundLink variant="error" href={ supportLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const UnethicalRequestAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/unethical-request-modal.js
+++ b/packages/js/src/ai-generator/components/errors/unethical-request-modal.js
@@ -1,0 +1,25 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/unethical-request";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The content-filter error (400 / AI_CONTENT_FILTER) as a danger modal.
+ * It offers no retry: the request itself is the problem.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const UnethicalRequestModal = ( { isOpen = true, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<Actions>
+			<CloseButton onClose={ onClose } />
+		</Actions>
+	</DangerModal>
+);
+UnethicalRequestModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/errors/upgrade-alert.js
+++ b/packages/js/src/ai-generator/components/errors/upgrade-alert.js
@@ -1,33 +1,12 @@
-import { useSelect } from "@wordpress/data";
-import { __, sprintf } from "@wordpress/i18n";
 import { Alert } from "@yoast/ui-library";
-import { safeCreateInterpolateElement } from "../../../helpers/i18n";
-import { OutboundLink } from "../../../shared-admin/components";
-import { STORE_NAME_EDITOR } from "../../constants";
+import { Body, title } from "./messages/upgrade";
 
 /**
  * @returns {JSX.Element} The element.
  */
-export const UpgradeAlert = () => {
-	const pluginsLink = useSelect( select => select( STORE_NAME_EDITOR ).selectAdminLink( "plugins.php" ), [] );
-
-	return (
-		<Alert variant="error">
-			<span className="yst-block yst-font-medium">{ __( "Something went wrong", "wordpress-seo" ) }</span>
-			<p className="yst-mt-2">
-				{ safeCreateInterpolateElement(
-					sprintf(
-						/* translators: %1$s expands to Yoast SEO Premium. %2$s expands to an opening link tag. %3$s expands to a closing link tag. */
-						__( "The version of %1$s is outdated. Please upgrade %1$s %2$shere%3$s!", "wordpress-seo" ),
-						"Yoast SEO Premium",
-						"<a>",
-						"</a>"
-					),
-					{
-						a: <OutboundLink variant="error" href={ pluginsLink } />,
-					}
-				) }
-			</p>
-		</Alert>
-	);
-};
+export const UpgradeAlert = () => (
+	<Alert variant="error">
+		<span className="yst-block yst-font-medium">{ title }</span>
+		<Body />
+	</Alert>
+);

--- a/packages/js/src/ai-generator/components/errors/upgrade-modal.js
+++ b/packages/js/src/ai-generator/components/errors/upgrade-modal.js
@@ -1,0 +1,25 @@
+import { noop } from "lodash";
+import PropTypes from "prop-types";
+import { Body, title } from "./messages/upgrade";
+import { Actions, CloseButton, DangerModal, ModalDescription } from "./modal-parts";
+
+/**
+ * The outdated-version error (410) as a danger modal. It offers no retry:
+ * the user must upgrade the plugin first.
+ *
+ * @param {boolean} [isOpen=true] Whether the modal is open.
+ * @param {function} [onClose=noop] Dismisses the modal.
+ * @returns {JSX.Element} The element.
+ */
+export const UpgradeModal = ( { isOpen = true, onClose = noop } ) => (
+	<DangerModal isOpen={ isOpen } title={ title } onClose={ onClose }>
+		<ModalDescription><Body /></ModalDescription>
+		<Actions>
+			<CloseButton onClose={ onClose } />
+		</Actions>
+	</DangerModal>
+);
+UpgradeModal.propTypes = {
+	isOpen: PropTypes.bool,
+	onClose: PropTypes.func,
+};

--- a/packages/js/src/ai-generator/components/index.js
+++ b/packages/js/src/ai-generator/components/index.js
@@ -1,3 +1,4 @@
+export { AIErrorModal } from "./ai-error-modal";
 export { App } from "./app";
 export { GoogleContent } from "./google-content";
 export { GooglePreview } from "./google-preview";

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -349,6 +349,29 @@ export const ModalContent = ( { height, onFatalError } ) => {
 						</> }
 					</>
 				) }
+				{ /*
+					* A non-fatal "generate 5 more" failure: keep the modal open and surface
+					* the error inline at the bottom of the content. No action row — the
+					* "Generate 5 more" button above is the retry; the modal's own Close
+					* dismisses it. Clears on the next fetch.
+					*/ }
+				{ showError && (
+					<>
+						<div className="yst-mt-8" />
+						<SuggestionError
+							errorCode={ suggestions.error.code }
+							errorIdentifier={ suggestions.error.errorIdentifier }
+							invalidSubscriptions={ suggestions.error.missingLicenses }
+							errorMessage={ suggestions.error.message }
+						/>
+						<SuggestionsFooter
+							current={ currentPage }
+							total={ totalPages }
+							onNavigate={ setCurrentPage }
+							disabled={ suggestions.status === ASYNC_ACTION_STATUS.loading }
+						/>
+					</>
+				) }
 			</Modal.Container.Content>
 			<Modal.Container.Footer>
 				{ contentIsScrolling && (
@@ -406,17 +429,6 @@ export const ModalContent = ( { height, onFatalError } ) => {
 				) }
 				{ ( suggestions.status === ASYNC_ACTION_STATUS.success || suggestions.status === ASYNC_ACTION_STATUS.loading ) && (
 					<TipNotification />
-				) }
-				{ /* A non-fatal "generate 5 more" failure: keep the modal open and offer a retry inline. */ }
-				{ showError && (
-					<SuggestionError
-						errorCode={ suggestions.error.code }
-						errorIdentifier={ suggestions.error.errorIdentifier }
-						invalidSubscriptions={ suggestions.error.missingLicenses }
-						errorMessage={ suggestions.error.message }
-						showActions={ true }
-						onRetry={ handleGenerateMore }
-					/>
 				) }
 			</Notifications>
 		</Fragment>

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -280,11 +280,13 @@ export const ModalContent = ( { height, onFatalError } ) => {
 		( suggestions.status === ASYNC_ACTION_STATUS.error && suggestions.error.code === 402 );
 	useEffect( () => {
 		if ( isFatalError ) {
+			// suggestions.error is null when the initial fetch itself failed before any
+			// suggestion request ran, so read it defensively.
 			onFatalError( {
-				errorCode: suggestions.error.code,
-				errorIdentifier: suggestions.error.errorIdentifier ?? "",
-				invalidSubscriptions: suggestions.error.missingLicenses ?? [],
-				errorMessage: suggestions.error.message ?? "",
+				errorCode: suggestions.error?.code ?? 0,
+				errorIdentifier: suggestions.error?.errorIdentifier ?? "",
+				invalidSubscriptions: suggestions.error?.missingLicenses ?? [],
+				errorMessage: suggestions.error?.message ?? "",
 			} );
 		}
 	}, [ isFatalError, suggestions.error, onFatalError ] );

--- a/packages/js/src/ai-generator/components/modal-content.js
+++ b/packages/js/src/ai-generator/components/modal-content.js
@@ -1,7 +1,7 @@
 /* eslint-disable complexity, max-statements */
 import CheckIcon from "@heroicons/react/outline/CheckIcon";
 import { useDispatch, useSelect } from "@wordpress/data";
-import { Fragment, useCallback, useMemo, useState } from "@wordpress/element";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Badge, Button, Label, Modal, Notifications, Pagination, useModalContext, usePrevious } from "@yoast/ui-library";
 import { map, noop } from "lodash";
@@ -86,9 +86,12 @@ const SuggestionsFooter = ( { total, current, onNavigate, disabled = false, ...p
 
 /**
  * @param {number} height The height of the scrolling container above.
+ * @param {function} onFatalError Called with an error descriptor when the initial
+ *                                fetch fails (or a subscription error occurs), so
+ *                                the parent can close the modal and show a danger modal.
  * @returns {JSX.Element} The element.
  */
-export const ModalContent = ( { height } ) => {
+export const ModalContent = ( { height, onFatalError } ) => {
 	const [ initialFetch, setInitialFetch ] = useState( "" );
 	const { onClose } = useModalContext();
 	const { editType, previewType, contentType } = useTypeContext();
@@ -210,8 +213,12 @@ export const ModalContent = ( { height } ) => {
 		( suggestions.status === ASYNC_ACTION_STATUS.error && ! isOnLastPage )
 	), [ suggestions.status, isOnLastPage ] );
 	const showLoading = useMemo( () => suggestions.status === ASYNC_ACTION_STATUS.loading && isOnLastPage, [ suggestions.status, isOnLastPage ] );
-	const showError = useMemo( () => suggestions.status === ASYNC_ACTION_STATUS.error && isOnLastPage, [ suggestions.status, isOnLastPage ] );
-
+	// A "generate 5 more" failure on the last page surfaces as an inline alert with
+	// a retry, and clears on the next fetch.
+	const showError = useMemo(
+		() => suggestions.status === ASYNC_ACTION_STATUS.error && isOnLastPage,
+		[ suggestions.status, isOnLastPage ]
+	);
 	const handleGenerateMore = useCallback( () => {
 		if ( disableGenerateMore ) {
 			return;
@@ -229,7 +236,6 @@ export const ModalContent = ( { height } ) => {
 			}
 		} );
 	}, [ fetchSuggestions, suggestions.status, totalPages, setCurrentPage, setSelectedSuggestion, isUsageCountLimitReached ] );
-	const handleRetryInitialFetch = useCallback( () => setInitialFetch( "" ), [ setInitialFetch ] );
 	const setTitleOrDescription = useSetTitleOrDescription();
 	const openYoastSidebarWhenPublishing = useOpenYoastSidebarWhenPublishing( true );
 	const handleApplySuggestion = useCallback( () => {
@@ -267,20 +273,24 @@ export const ModalContent = ( { height } ) => {
 		return Promise.resolve();
 	}, [ initialFetch, addUsageCount, fetchSuggestions ] );
 
-	// Initial fetch gone wrong OR subscription error on any request.
-	if ( initialFetch === FETCH_RESPONSE_STATUS.error || ( suggestions.status === ASYNC_ACTION_STATUS.error && suggestions.error.code === 402 ) ) {
-		return (
-			<div className="yst-flex yst-flex-col yst-space-y-6 yst-mt-6">
-				<SuggestionError
-					errorCode={ suggestions.error.code }
-					errorIdentifier={ suggestions.error.errorIdentifier }
-					invalidSubscriptions={ suggestions.error.missingLicenses }
-					showActions={ true }
-					onRetry={ handleRetryInitialFetch }
-					errorMessage={ suggestions.error.message }
-				/>
-			</div>
-		);
+	// Initial fetch gone wrong OR subscription error on any request: this is fatal
+	// for the modal — hand the error to the parent, which closes the AI modal and
+	// surfaces it as a danger modal (the design shows these errors outside the AI modal).
+	const isFatalError = initialFetch === FETCH_RESPONSE_STATUS.error ||
+		( suggestions.status === ASYNC_ACTION_STATUS.error && suggestions.error.code === 402 );
+	useEffect( () => {
+		if ( isFatalError ) {
+			onFatalError( {
+				errorCode: suggestions.error.code,
+				errorIdentifier: suggestions.error.errorIdentifier ?? "",
+				invalidSubscriptions: suggestions.error.missingLicenses ?? [],
+				errorMessage: suggestions.error.message ?? "",
+			} );
+		}
+	}, [ isFatalError, suggestions.error, onFatalError ] );
+	if ( isFatalError ) {
+		// Render nothing while the parent closes the modal.
+		return null;
 	}
 
 	const suggestionClassNames = [
@@ -337,23 +347,6 @@ export const ModalContent = ( { height } ) => {
 								disabled={ suggestions.status === ASYNC_ACTION_STATUS.loading || showError }
 							/>
 						</> }
-					</>
-				) }
-				{ ( suggestions.status === ASYNC_ACTION_STATUS.error && isOnLastPage ) && (
-					<>
-						<div className="yst-mt-8" />
-						<SuggestionError
-							errorCode={ suggestions.error.code }
-							errorIdentifier={ suggestions.error.errorIdentifier }
-							invalidSubscriptions={ suggestions.error.missingLicenses }
-							errorMessage={ suggestions.error.message }
-						/>
-						<SuggestionsFooter
-							current={ currentPage }
-							total={ totalPages }
-							onNavigate={ setCurrentPage }
-							disabled={ suggestions.status === ASYNC_ACTION_STATUS.loading }
-						/>
 					</>
 				) }
 			</Modal.Container.Content>
@@ -414,10 +407,22 @@ export const ModalContent = ( { height } ) => {
 				{ ( suggestions.status === ASYNC_ACTION_STATUS.success || suggestions.status === ASYNC_ACTION_STATUS.loading ) && (
 					<TipNotification />
 				) }
+				{ /* A non-fatal "generate 5 more" failure: keep the modal open and offer a retry inline. */ }
+				{ showError && (
+					<SuggestionError
+						errorCode={ suggestions.error.code }
+						errorIdentifier={ suggestions.error.errorIdentifier }
+						invalidSubscriptions={ suggestions.error.missingLicenses }
+						errorMessage={ suggestions.error.message }
+						showActions={ true }
+						onRetry={ handleGenerateMore }
+					/>
+				) }
 			</Notifications>
 		</Fragment>
 	);
 };
 ModalContent.propTypes = {
 	height: PropTypes.number.isRequired,
+	onFatalError: PropTypes.func.isRequired,
 };

--- a/packages/js/src/ai-generator/hooks/index.js
+++ b/packages/js/src/ai-generator/hooks/index.js
@@ -1,5 +1,6 @@
 export { useApplyReplacementVariables } from "./use-apply-replacement-variables";
 export { useDescriptionTemplate } from "./use-description-template";
+export { useFeatureErrorDescriptor } from "./use-feature-error-descriptor";
 export { useEffectOneAtATime } from "./use-effect-one-at-a-time";
 export { useGetDescriptionTemplate } from "./use-get-description-template";
 export { useGetTitleTemplate } from "./use-get-title-template";

--- a/packages/js/src/ai-generator/hooks/use-feature-error-descriptor.js
+++ b/packages/js/src/ai-generator/hooks/use-feature-error-descriptor.js
@@ -4,6 +4,30 @@ import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
 import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
 
 /**
+ * Whether a valid Premium subscription is required but missing for this entity.
+ *
+ * @param {Object} editorSelect The editor store selectors.
+ * @param {Object} currentSubscriptions The premium/woo subscription validity.
+ * @returns {boolean} Whether Premium is needed but not active.
+ */
+const needsPremiumSubscription = ( editorSelect, currentSubscriptions ) => {
+	const requiresPremium = editorSelect.getIsPremium() || editorSelect.getIsWooProductEntity();
+	return requiresPremium && ! currentSubscriptions.premiumSubscription;
+};
+
+/**
+ * Whether a valid WooCommerce SEO subscription is required but missing for this entity.
+ *
+ * @param {Object} editorSelect The editor store selectors.
+ * @param {Object} currentSubscriptions The premium/woo subscription validity.
+ * @returns {boolean} Whether WooCommerce SEO is needed but not active.
+ */
+const needsWooSeoSubscription = ( editorSelect, currentSubscriptions ) => {
+	const requiresWooSeo = editorSelect.getIsWooProductEntity() && editorSelect.getIsWooSeoActive();
+	return requiresWooSeo && ! currentSubscriptions.wooCommerceSubscription;
+};
+
+/**
  * Collects the products whose subscription is invalid for the current entity.
  *
  * @param {Object} currentSubscriptions The premium/woo subscription validity.
@@ -11,18 +35,12 @@ import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
  */
 const collectInvalidSubscriptions = ( currentSubscriptions ) => {
 	const editorSelect = select( STORE_NAME_EDITOR );
-	const isPremium = editorSelect.getIsPremium();
-	const isWooProductEntity = editorSelect.getIsWooProductEntity();
-	const isWooSeoActive = editorSelect.getIsWooSeoActive();
-
-	const needsPremium = ( isPremium || isWooProductEntity ) && ! currentSubscriptions.premiumSubscription;
-	const needsWooSeo = isWooProductEntity && isWooSeoActive && ! currentSubscriptions.wooCommerceSubscription;
 
 	const invalidSubscriptions = [];
-	if ( needsPremium ) {
+	if ( needsPremiumSubscription( editorSelect, currentSubscriptions ) ) {
 		invalidSubscriptions.push( "Yoast SEO Premium" );
 	}
-	if ( needsWooSeo ) {
+	if ( needsWooSeoSubscription( editorSelect, currentSubscriptions ) ) {
 		invalidSubscriptions.push( "Yoast WooCommerce SEO" );
 	}
 	return invalidSubscriptions;

--- a/packages/js/src/ai-generator/hooks/use-feature-error-descriptor.js
+++ b/packages/js/src/ai-generator/hooks/use-feature-error-descriptor.js
@@ -1,0 +1,79 @@
+import { select } from "@wordpress/data";
+import { useCallback } from "@wordpress/element";
+import { ASYNC_ACTION_STATUS } from "../../shared-admin/constants";
+import { STORE_NAME_AI, STORE_NAME_EDITOR } from "../constants";
+
+/**
+ * Collects the products whose subscription is invalid for the current entity.
+ *
+ * @param {Object} currentSubscriptions The premium/woo subscription validity.
+ * @returns {string[]} The product names with an invalid subscription.
+ */
+const collectInvalidSubscriptions = ( currentSubscriptions ) => {
+	const editorSelect = select( STORE_NAME_EDITOR );
+	const isPremium = editorSelect.getIsPremium();
+	const isWooProductEntity = editorSelect.getIsWooProductEntity();
+	const isWooSeoActive = editorSelect.getIsWooSeoActive();
+
+	const needsPremium = ( isPremium || isWooProductEntity ) && ! currentSubscriptions.premiumSubscription;
+	const needsWooSeo = isWooProductEntity && isWooSeoActive && ! currentSubscriptions.wooCommerceSubscription;
+
+	const invalidSubscriptions = [];
+	if ( needsPremium ) {
+		invalidSubscriptions.push( "Yoast SEO Premium" );
+	}
+	if ( needsWooSeo ) {
+		invalidSubscriptions.push( "Yoast WooCommerce SEO" );
+	}
+	return invalidSubscriptions;
+};
+
+/**
+ * Reads the usage-count error from the store as an error descriptor, or null when
+ * the usage-count fetch did not fail.
+ *
+ * @returns {Object|null} The descriptor or null.
+ */
+const usageCountErrorDescriptor = () => {
+	const aiSelect = select( STORE_NAME_AI );
+	if ( aiSelect.selectUsageCountStatus() !== ASYNC_ACTION_STATUS.error ) {
+		return null;
+	}
+	const usageCountError = aiSelect.selectUsageCountError();
+	return {
+		errorCode: usageCountError.errorCode,
+		errorIdentifier: usageCountError.errorIdentifier ?? "",
+		invalidSubscriptions: [],
+		errorMessage: usageCountError.errorMessage ?? "",
+	};
+};
+
+/**
+ * Returns a resolver that turns the current feature-precondition state into an
+ * error descriptor for the AI error modal, or `null` when there's nothing to show.
+ *
+ * Mirrors the decision the inline `FeatureError` component makes (invalid
+ * subscription → SEO analysis inactive → usage-count fetch error), but yields a
+ * plain descriptor the modal can render instead of JSX. Kept editor-only so the
+ * shared `FeatureError`/`SuggestionError` contract used by Premium stays untouched.
+ *
+ * The resolver reads the store imperatively (via `select`) at call time rather
+ * than from a render snapshot, because callers invoke it right after awaiting a
+ * usage-count fetch — the fresh error state must be observed, not a stale one.
+ *
+ * @returns {function(Object): (Object|null)} Resolver taking
+ *   `{ currentSubscriptions, isSeoAnalysisActive }` and returning a descriptor
+ *   `{ errorCode, errorIdentifier, invalidSubscriptions, errorMessage }` or null.
+ */
+export const useFeatureErrorDescriptor = () => useCallback( ( { currentSubscriptions, isSeoAnalysisActive } ) => {
+	const invalidSubscriptions = collectInvalidSubscriptions( currentSubscriptions );
+	if ( invalidSubscriptions.length > 0 ) {
+		return { errorCode: 402, errorIdentifier: "", invalidSubscriptions, errorMessage: "" };
+	}
+
+	if ( ! isSeoAnalysisActive ) {
+		return { errorCode: 0, errorIdentifier: "SEO_ANALYSIS_INACTIVE", invalidSubscriptions: [], errorMessage: "" };
+	}
+
+	return usageCountErrorDescriptor();
+}, [] );

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -99,7 +99,7 @@ const initializeAiGenerator = () => {
 		},
 		[ MYYOAST_CONNECTION_NAME ]: {
 			// Absent payload means the feature is unavailable; the editor then shows the informational variant.
-			isAvailable: Boolean( myyoastConnection ),
+			isAvailable: Boolean( myyoastConnection ) && get( myyoastConnection, "isProvisioned", false ),
 			canConnect: get( myyoastConnection, "canConnect", false ),
 			connectUrl: get( myyoastConnection, "connectUrl", null ),
 			learnMoreUrl: get( myyoastConnection, "learnMoreUrl", "" ),

--- a/packages/js/src/ai-generator/initialize.js
+++ b/packages/js/src/ai-generator/initialize.js
@@ -12,6 +12,7 @@ import { PRODUCT_SUBSCRIPTIONS_NAME } from "./store/product-subscriptions";
 import { ENDPOINTS_NAME } from "./store/endpoints";
 import { USAGE_COUNT_NAME } from "./store/usage-count";
 import { FREE_SPARKS_NAME } from "./store/free-sparks";
+import { MYYOAST_CONNECTION_NAME } from "./store/myyoast-connection";
 import domReady from "@wordpress/dom-ready";
 
 /**
@@ -77,6 +78,8 @@ const filterReplacementVariableEditorButtons = ( buttons, { fieldId, type: editT
  * @returns {void}
  */
 const initializeAiGenerator = () => {
+	// Null when the MyYoast connection feature is unavailable (flag off / not provisioned).
+	const myyoastConnection = get( window, "wpseoAiGenerator.myyoastConnection", null );
 	registerStore( {
 		[ HAS_AI_GENERATOR_CONSENT_NAME ]: {
 			hasConsent: get( window, "wpseoAiGenerator.hasConsent", false ) === "1",
@@ -93,6 +96,13 @@ const initializeAiGenerator = () => {
 		[ ENDPOINTS_NAME ]: {
 			getSuggestions: get( window, "wpseoAiGenerator.endpoints.getSuggestions", "" ),
 			bustSubscriptionCache: get( window, "wpseoAiGenerator.endpoints.bustSubscriptionCache", "" ),
+		},
+		[ MYYOAST_CONNECTION_NAME ]: {
+			// Absent payload means the feature is unavailable; the editor then shows the informational variant.
+			isAvailable: Boolean( myyoastConnection ),
+			canConnect: get( myyoastConnection, "canConnect", false ),
+			connectUrl: get( myyoastConnection, "connectUrl", null ),
+			learnMoreUrl: get( myyoastConnection, "learnMoreUrl", "" ),
 		},
 	} );
 

--- a/packages/js/src/ai-generator/store/index.js
+++ b/packages/js/src/ai-generator/store/index.js
@@ -53,6 +53,13 @@ import {
 	freeSparksReducer,
 	freeSparksControls,
 } from "./free-sparks";
+import {
+	getInitialMyyoastConnectionState,
+	MYYOAST_CONNECTION_NAME,
+	myyoastConnectionActions,
+	myyoastConnectionReducer,
+	myyoastConnectionSelectors,
+} from "./myyoast-connection";
 
 /** @typedef {import("@wordpress/data/src/types").WPDataStore} WPDataStore */
 
@@ -70,6 +77,7 @@ const createStore = ( initialState ) => {
 			...usageCountActions,
 			...freeSparksActions,
 			...endpointsActions,
+			...myyoastConnectionActions,
 		},
 		selectors: {
 			...hasAiGeneratorConsentSelectors,
@@ -79,6 +87,7 @@ const createStore = ( initialState ) => {
 			...usageCountSelectors,
 			...freeSparksSelectors,
 			...endpointsSelectors,
+			...myyoastConnectionSelectors,
 		},
 		initialState: merge(
 			{},
@@ -90,6 +99,7 @@ const createStore = ( initialState ) => {
 				[ USAGE_COUNT_NAME ]: getInitialUsageCount(),
 				[ FREE_SPARKS_NAME ]: getInitialFreeSparks(),
 				[ ENDPOINTS_NAME ]: getInitialEndpointsState(),
+				[ MYYOAST_CONNECTION_NAME ]: getInitialMyyoastConnectionState(),
 			},
 			initialState
 		),
@@ -101,6 +111,7 @@ const createStore = ( initialState ) => {
 			[ USAGE_COUNT_NAME ]: usageCountReducer,
 			[ FREE_SPARKS_NAME ]: freeSparksReducer,
 			[ ENDPOINTS_NAME ]: endpointsReducer,
+			[ MYYOAST_CONNECTION_NAME ]: myyoastConnectionReducer,
 		} ),
 		controls: {
 			...hasAiGeneratorConsentControls,

--- a/packages/js/src/ai-generator/store/myyoast-connection.js
+++ b/packages/js/src/ai-generator/store/myyoast-connection.js
@@ -1,0 +1,32 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+export const MYYOAST_CONNECTION_NAME = "myyoastConnection";
+
+const slice = createSlice( {
+	name: MYYOAST_CONNECTION_NAME,
+	initialState: {
+		// Whether the MyYoast connection is available on this build. When false
+		// (feature flag off or not provisioned), the editor shows the
+		// informational-only "cannot reach your site" notification.
+		isAvailable: false,
+		// Whether the current user may register/connect this site to MyYoast.
+		canConnect: false,
+		// The nonce-protected Integrations-page URL that auto-starts the connection
+		// flow, or null when the user can't connect.
+		connectUrl: null,
+		// The "learn more about connecting with MyYoast" outbound link.
+		learnMoreUrl: "",
+	},
+	reducers: {},
+} );
+
+export const getInitialMyyoastConnectionState = slice.getInitialState;
+
+export const myyoastConnectionSelectors = {
+	selectMyyoastConnection: state => get( state, MYYOAST_CONNECTION_NAME, getInitialMyyoastConnectionState() ),
+};
+
+export const myyoastConnectionActions = slice.actions;
+
+export const myyoastConnectionReducer = slice.reducer;

--- a/packages/js/src/editor-modules.js
+++ b/packages/js/src/editor-modules.js
@@ -36,7 +36,7 @@ import {
 	SidebarLayout,
 	ErrorFallback,
 } from "./shared-admin/components";
-import { Introduction, SuggestionError, SparksLimitNotification, FeatureError } from "./ai-generator/components";
+import { AIErrorModal, Introduction, SuggestionError, SparksLimitNotification, FeatureError } from "./ai-generator/components";
 import { removesLocaleVariantSuffixes, fetchSuggestions } from "./ai-generator/helpers";
 import SynonymsInputField from "./components/contentAnalysis/SynonymsInput";
 
@@ -51,6 +51,7 @@ window.yoast.editorModules = {
 	},
 	aiGenerator: {
 		components: {
+			AIErrorModal,
 			Introduction,
 			SuggestionError,
 			SparksLimitNotification,

--- a/packages/js/src/integrations-page/myyoast-connection/myyoast-integration.js
+++ b/packages/js/src/integrations-page/myyoast-connection/myyoast-integration.js
@@ -7,9 +7,11 @@ import { useCallback, useEffect, useId, useRef, useState } from "@wordpress/elem
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { addQueryArgs } from "@wordpress/url";
 import { Alert, Button, Link, Notifications, TooltipContainer, TooltipTrigger, TooltipWithContext, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { get } from "lodash";
 import PropTypes from "prop-types";
 import { ReactComponent as MyYoastLogo } from "../../../images/myyoast-logo.svg";
 import { safeCreateInterpolateElement } from "../../helpers/i18n";
+import { addHistoryState, removeSearchParam } from "../../helpers/urlHelpers";
 import { MyyoastConnectionDisconnectModal } from "./myyoast-disconnect-modal";
 import { MYYOAST_STORE_NAME } from "./constants";
 import { Card } from "../tailwind-components/card";
@@ -339,6 +341,22 @@ export const MyyoastIntegration = () => {
 			setIsConnecting( false );
 		}
 	}, [ showFeedback ] );
+	// Auto-start the connection flow when the page was opened from the editor's
+	// "Connect to MyYoast" nudge. The `startConnection` flag is set server-side
+	// only after the one-time nonce and the connect capability are verified, so
+	// it's safe to act on. We strip the query args first so a refresh or back
+	// navigation doesn't re-trigger, and skip when the site is already registered.
+	const autoStartFired = useRef( false );
+	useEffect( () => {
+		const shouldStart = get( window, "wpseoIntegrationsData.myyoast_connection.startConnection", false ) === true;
+		if ( ! shouldStart || autoStartFired.current || status.isRegistered ) {
+			return;
+		}
+		autoStartFired.current = true;
+		addHistoryState( null, document.title, removeSearchParam( removeSearchParam( window.location.href, "start-myyoast-connection" ), "_wpnonce" ) );
+		handleConnect();
+	}, [ handleConnect, status.isRegistered ] );
+
 	const handleReconnect = useCallback( () => runAction( "update", null, { onFeedback: showFeedback } ), [ showFeedback ] );
 	const handleDisconnectConfirm = useCallback( () => {
 		closeDisconnect();

--- a/packages/js/tests/ai-generator/components/ai-error-modal.test.js
+++ b/packages/js/tests/ai-generator/components/ai-error-modal.test.js
@@ -110,7 +110,7 @@ describe( "AIErrorModal", () => {
 			expect( screen.getByText( "Yoast AI cannot reach your site" ) ).toBeInTheDocument();
 			expect( screen.getByRole( "link", { name: /Still need help\?/ } ) ).toBeInTheDocument();
 			expect( screen.getByRole( "link", { name: /Learn more/ } ) ).toBeInTheDocument();
-			expect( screen.queryByRole( "link", { name: "Connect to MyYoast" } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( "link", { name: /Connect to MyYoast/ } ) ).not.toBeInTheDocument();
 		} );
 
 		it( "shows variant 2 (Connect to MyYoast) when the user can connect", () => {
@@ -120,7 +120,7 @@ describe( "AIErrorModal", () => {
 				connectUrl: "https://example.test/connect",
 			} ) );
 			renderModal( props );
-			const connect = screen.getByRole( "link", { name: "Connect to MyYoast" } );
+			const connect = screen.getByRole( "link", { name: /Connect to MyYoast/ } );
 			expect( connect ).toBeInTheDocument();
 			// The CTA is a plain link to the nonce-protected URL, opening in a new tab.
 			expect( connect ).toHaveAttribute( "href", "https://example.test/connect" );
@@ -131,7 +131,7 @@ describe( "AIErrorModal", () => {
 			useSelect.mockImplementation( selectImplementation( { isAvailable: true, canConnect: false } ) );
 			renderModal( props );
 			expect( screen.getByText( /Ask your site administrator to connect to MyYoast/ ) ).toBeInTheDocument();
-			expect( screen.queryByRole( "link", { name: "Connect to MyYoast" } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( "link", { name: /Connect to MyYoast/ } ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/js/tests/ai-generator/components/ai-error-modal.test.js
+++ b/packages/js/tests/ai-generator/components/ai-error-modal.test.js
@@ -1,0 +1,190 @@
+import { useSelect } from "@wordpress/data";
+import { expect } from "@jest/globals";
+import { fireEvent, render, screen } from "../../test-utils";
+import { AIErrorModal } from "../../../src/ai-generator/components/ai-error-modal";
+import { SuggestionError } from "../../../src/ai-generator/components/suggestion-error";
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+	combineReducers: jest.fn(),
+	registerStore: jest.fn(),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+} ) );
+
+// Note: SuggestionError (used only by the drift-guardrail test) reads
+// useModalContext, which defaults to { onClose: noop } outside a Modal, so no
+// Modal provider is needed here.
+
+/**
+ * Builds the useSelect implementation backing the AI + editor stores.
+ *
+ * @param {Object} myyoastConnection The MyYoast connection slice for the AI store.
+ * @returns {function} A useSelect implementation.
+ */
+const selectImplementation = ( myyoastConnection = {} ) => ( selectFn ) => selectFn( ( storeName ) => {
+	if ( storeName === "yoast-seo/editor" ) {
+		return {
+			selectLink: ( url ) => url,
+			selectAdminLink: ( path ) => path,
+		};
+	}
+	if ( storeName === "yoast-seo/ai-generator" ) {
+		return {
+			selectBustSubscriptionCacheEndpoint: () => "/bust-cache",
+			selectMyyoastConnection: () => ( {
+				isAvailable: false,
+				canConnect: false,
+				connectUrl: null,
+				learnMoreUrl: "https://yoa.st/ai-myyoast-connection",
+				...myyoastConnection,
+			} ),
+		};
+	}
+	return {};
+} );
+
+/**
+ * Renders the error modal in its open state.
+ *
+ * @param {Object} props The component props.
+ * @returns {Object} The render result.
+ */
+const renderModal = ( props ) => render( <AIErrorModal isOpen={ true } { ...props } /> );
+
+describe( "AIErrorModal", () => {
+	beforeEach( () => {
+		useSelect.mockImplementation( selectImplementation() );
+	} );
+
+	it( "renders the generic error for an unmapped code", () => {
+		renderModal( { errorCode: 503 } );
+		expect( screen.getByText( "Something went wrong" ) ).toBeInTheDocument();
+	} );
+
+	it( "renders the timeout error with a Try again action when actions are shown", () => {
+		const onRetry = jest.fn();
+		renderModal( { errorCode: 408, showActions: true, onRetry } );
+		expect( screen.getByText( "Connection timeout" ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( "button", { name: "Try again" } ) );
+		expect( onRetry ).toHaveBeenCalled();
+	} );
+
+	it( "does not show a Try again action for message-only errors", () => {
+		renderModal( { errorCode: 429, showActions: true } );
+		expect( screen.getByText( "You've reached the Yoast AI rate limit" ) ).toBeInTheDocument();
+		expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
+	} );
+
+	it( "renders the content-filter error without actions", () => {
+		renderModal( { errorCode: 400, errorIdentifier: "AI_CONTENT_FILTER", showActions: true } );
+		expect( screen.getByText( "Usage policy violation" ) ).toBeInTheDocument();
+		expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
+	} );
+
+	it( "renders the subscription error with a Refresh page action", () => {
+		renderModal( { errorCode: 402, invalidSubscriptions: [ "Yoast SEO Premium" ] } );
+		expect( screen.getByText( "Subscription required" ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Refresh page" } ) ).toBeInTheDocument();
+	} );
+
+	it( "treats a usage-limit 429 as a subscription error", () => {
+		renderModal( { errorCode: 429, errorIdentifier: "USAGE_LIMIT_REACHED", invalidSubscriptions: [ "Yoast SEO Premium" ] } );
+		expect( screen.getByText( "Subscription required" ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Refresh page" } ) ).toBeInTheDocument();
+	} );
+
+	it( "renders the SEO-analysis-inactive error", () => {
+		renderModal( { errorCode: 0, errorIdentifier: "SEO_ANALYSIS_INACTIVE" } );
+		expect( screen.getByText( "SEO analysis required" ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Refresh page" } ) ).toBeInTheDocument();
+	} );
+
+	describe( "site-unreachable variants", () => {
+		const props = { errorCode: 400, errorIdentifier: "SITE_UNREACHABLE" };
+
+		it( "shows variant 1 (informational, with help actions) when the connection is unavailable", () => {
+			useSelect.mockImplementation( selectImplementation( { isAvailable: false } ) );
+			renderModal( props );
+			expect( screen.getByText( "Yoast AI cannot reach your site" ) ).toBeInTheDocument();
+			expect( screen.getByRole( "link", { name: /Still need help\?/ } ) ).toBeInTheDocument();
+			expect( screen.getByRole( "link", { name: /Learn more/ } ) ).toBeInTheDocument();
+			expect( screen.queryByRole( "link", { name: "Connect to MyYoast" } ) ).not.toBeInTheDocument();
+		} );
+
+		it( "shows variant 2 (Connect to MyYoast) when the user can connect", () => {
+			useSelect.mockImplementation( selectImplementation( {
+				isAvailable: true,
+				canConnect: true,
+				connectUrl: "https://example.test/connect",
+			} ) );
+			renderModal( props );
+			const connect = screen.getByRole( "link", { name: "Connect to MyYoast" } );
+			expect( connect ).toBeInTheDocument();
+			// The CTA is a plain link to the nonce-protected URL, opening in a new tab.
+			expect( connect ).toHaveAttribute( "href", "https://example.test/connect" );
+			expect( connect ).toHaveAttribute( "target", "_blank" );
+		} );
+
+		it( "shows variant 3 (ask your administrator) when the user cannot connect", () => {
+			useSelect.mockImplementation( selectImplementation( { isAvailable: true, canConnect: false } ) );
+			renderModal( props );
+			expect( screen.getByText( /Ask your site administrator to connect to MyYoast/ ) ).toBeInTheDocument();
+			expect( screen.queryByRole( "link", { name: "Connect to MyYoast" } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( "always offers a bottom Close button that calls onClose, even for a message-only error", () => {
+		const onClose = jest.fn();
+		renderModal( { errorCode: 503, onClose } );
+		fireEvent.click( screen.getByRole( "button", { name: "Close" } ) );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( "calls onClose from the top-right dismiss control", () => {
+		const onClose = jest.fn();
+		renderModal( { errorCode: 503, onClose } );
+		fireEvent.click( screen.getByRole( "button", { name: "Dismiss" } ) );
+		expect( onClose ).toHaveBeenCalled();
+	} );
+
+	it( "shows a Close button but no Try again for a retryable error when actions are hidden", () => {
+		renderModal( { errorCode: 408, showActions: false } );
+		expect( screen.getByRole( "button", { name: "Close" } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( "button", { name: "Try again" } ) ).not.toBeInTheDocument();
+	} );
+
+	// Drift guardrail: the modal and the inline SuggestionError keep their own
+	// switches, so this asserts both still produce a rendered error for every
+	// (errorCode, errorIdentifier) pair. If a case is added to one but not the
+	// other, one of these renders comes back empty and the test fails.
+	describe( "stays in lockstep with SuggestionError", () => {
+		const cases = [
+			[ 400, "AI_CONTENT_FILTER" ],
+			[ 400, "NOT_ENOUGH_CONTENT" ],
+			[ 400, "SITE_UNREACHABLE" ],
+			[ 400, "WP_HTTP_REQUEST_ERROR" ],
+			[ 400, "" ],
+			[ 402, "" ],
+			[ 408, "" ],
+			[ 429, "" ],
+			[ 429, "USAGE_LIMIT_REACHED" ],
+			[ 410, "" ],
+			[ 403, "" ],
+			[ 503, "" ],
+		];
+
+		it.each( cases )( "both render for code %s / identifier '%s'", ( errorCode, errorIdentifier ) => {
+			const shared = { errorCode, errorIdentifier, invalidSubscriptions: [ "Yoast SEO Premium" ], errorMessage: "boom" };
+
+			const modal = renderModal( shared );
+			expect( modal.baseElement ).not.toBeEmptyDOMElement();
+			modal.unmount();
+
+			const inline = render( <SuggestionError { ...shared } /> );
+			expect( inline.container ).not.toBeEmptyDOMElement();
+			inline.unmount();
+		} );
+	} );
+} );

--- a/src/ai-generator/user-interface/ai-generator-integration.php
+++ b/src/ai-generator/user-interface/ai-generator-integration.php
@@ -10,13 +10,17 @@ use Yoast\WP\SEO\AI\Generator\Application\Generator_Endpoints_Repository;
 use Yoast\WP\SEO\AI_HTTP_Request\Infrastructure\API_Client;
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
 use Yoast\WP\SEO\Conditionals\AI_Editor_Conditional;
+use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
 use Yoast\WP\SEO\Conditionals\Old_Premium_AI_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Integrations_Page;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 
 /**
  * Ai_Generator_Integration class.
@@ -94,6 +98,27 @@ class Ai_Generator_Integration implements Integration_Interface {
 	private $free_sparks_endpoints_repository;
 
 	/**
+	 * The MyYoast connection feature-flag conditional.
+	 *
+	 * @var MyYoast_Connection_Conditional
+	 */
+	private $myyoast_connection_conditional;
+
+	/**
+	 * The MyYoast connection status presenter.
+	 *
+	 * @var Status_Presenter
+	 */
+	private $status_presenter;
+
+	/**
+	 * The short-link helper.
+	 *
+	 * @var Short_Link_Helper
+	 */
+	private $short_link_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -115,6 +140,9 @@ class Ai_Generator_Integration implements Integration_Interface {
 	 * @param Generator_Endpoints_Repository   $generator_endpoints_repository   The Generator endpoints repository.
 	 * @param Consent_Endpoints_Repository     $consent_endpoints_repository     The Consent endpoints repository.
 	 * @param Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository The Free Sparks endpoints repository.
+	 * @param MyYoast_Connection_Conditional   $myyoast_connection_conditional   The MyYoast connection feature-flag conditional.
+	 * @param Status_Presenter                 $status_presenter                 The MyYoast connection status presenter.
+	 * @param Short_Link_Helper                $short_link_helper                The short-link helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -126,7 +154,10 @@ class Ai_Generator_Integration implements Integration_Interface {
 		Introductions_Seen_Repository $introductions_seen_repository,
 		Generator_Endpoints_Repository $generator_endpoints_repository,
 		Consent_Endpoints_Repository $consent_endpoints_repository,
-		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository
+		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository,
+		MyYoast_Connection_Conditional $myyoast_connection_conditional,
+		Status_Presenter $status_presenter,
+		Short_Link_Helper $short_link_helper
 	) {
 		$this->asset_manager                    = $asset_manager;
 		$this->addon_manager                    = $addon_manager;
@@ -138,6 +169,9 @@ class Ai_Generator_Integration implements Integration_Interface {
 		$this->generator_endpoints_repository   = $generator_endpoints_repository;
 		$this->consent_endpoints_repository     = $consent_endpoints_repository;
 		$this->free_sparks_endpoints_repository = $free_sparks_endpoints_repository;
+		$this->myyoast_connection_conditional   = $myyoast_connection_conditional;
+		$this->status_presenter                 = $status_presenter;
+		$this->short_link_helper                = $short_link_helper;
 	}
 
 	/**
@@ -187,7 +221,61 @@ class Ai_Generator_Integration implements Integration_Interface {
 			'requestTimeout'       => $this->api_client->get_request_timeout(),
 			'isFreeSparks'         => $this->options_helper->get( 'ai_free_sparks_started_on', null ) !== null,
 			'endpoints'            => $endpoints,
+			'myyoastConnection'    => $this->get_myyoast_connection_data(),
 		];
+	}
+
+	/**
+	 * Builds the read-only MyYoast connection payload used to pick the
+	 * "Yoast AI cannot reach your site" notification variant in the editor.
+	 *
+	 * Returns `null` when the feature flag is disabled, so the editor treats the
+	 * connection as unavailable and shows the informational-only variant. The
+	 * payload is deliberately minimal — no store, actions, or tokens reach the
+	 * editor; the connect call-to-action is just a nonce-protected link that
+	 * auto-starts the flow on the Integrations page in a new tab.
+	 *
+	 * @return array{isProvisioned: bool, canConnect: bool, connectUrl: string|null, learnMoreUrl: string}|null
+	 */
+	public function get_myyoast_connection_data() {
+		if ( ! $this->myyoast_connection_conditional->is_met() ) {
+			return null;
+		}
+
+		$status      = $this->status_presenter->present();
+		$can_connect = \current_user_can( 'wpseo_manage_options' );
+
+		return [
+			'isProvisioned' => $status['is_provisioned'],
+			'canConnect'    => $can_connect,
+			// Only users who can manage options can start the flow; for everyone
+			// else the link is omitted and the editor shows the "ask your admin" variant.
+			'connectUrl'    => ( $can_connect ) ? $this->get_connect_url() : null,
+			'learnMoreUrl'  => $this->short_link_helper->get( 'https://yoa.st/ai-myyoast-connection' ),
+		];
+	}
+
+	/**
+	 * Builds the nonce-protected Integrations-page URL that auto-starts the
+	 * MyYoast connection flow when opened.
+	 *
+	 * The nonce keeps the auto-start trigger from being cross-site forgeable; the
+	 * Integrations page verifies it before kicking off the flow.
+	 *
+	 * Built with `add_query_arg()` + `wp_create_nonce()` rather than `wp_nonce_url()`:
+	 * the latter HTML-encodes the `&` separators for markup output, but this URL is
+	 * localized and assigned to a React `href`, where it isn't decoded — the browser
+	 * would then send `amp;start-myyoast-connection` as the query-arg name and the
+	 * flow would never start. This form keeps the separators as plain `&`.
+	 *
+	 * @return string The connect URL.
+	 */
+	private function get_connect_url() {
+		return \add_query_arg(
+			'_wpnonce',
+			\wp_create_nonce( 'wpseo-start-myyoast-connection' ),
+			\self_admin_url( 'admin.php?page=' . Integrations_Page::PAGE . '&start-myyoast-connection=1' ),
+		);
 	}
 
 	/**

--- a/src/ai-generator/user-interface/ai-generator-integration.php
+++ b/src/ai-generator/user-interface/ai-generator-integration.php
@@ -20,6 +20,7 @@ use Yoast\WP\SEO\Integrations\Admin\Integrations_Page;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Connection_Permission;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 
 /**
@@ -119,6 +120,13 @@ class Ai_Generator_Integration implements Integration_Interface {
 	private $short_link_helper;
 
 	/**
+	 * The MyYoast connection-management permission check.
+	 *
+	 * @var Connection_Permission
+	 */
+	private $connection_permission;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -143,6 +151,7 @@ class Ai_Generator_Integration implements Integration_Interface {
 	 * @param MyYoast_Connection_Conditional   $myyoast_connection_conditional   The MyYoast connection feature-flag conditional.
 	 * @param Status_Presenter                 $status_presenter                 The MyYoast connection status presenter.
 	 * @param Short_Link_Helper                $short_link_helper                The short-link helper.
+	 * @param Connection_Permission            $connection_permission            The MyYoast connection-management permission check.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -157,7 +166,8 @@ class Ai_Generator_Integration implements Integration_Interface {
 		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository,
 		MyYoast_Connection_Conditional $myyoast_connection_conditional,
 		Status_Presenter $status_presenter,
-		Short_Link_Helper $short_link_helper
+		Short_Link_Helper $short_link_helper,
+		Connection_Permission $connection_permission
 	) {
 		$this->asset_manager                    = $asset_manager;
 		$this->addon_manager                    = $addon_manager;
@@ -172,6 +182,7 @@ class Ai_Generator_Integration implements Integration_Interface {
 		$this->myyoast_connection_conditional   = $myyoast_connection_conditional;
 		$this->status_presenter                 = $status_presenter;
 		$this->short_link_helper                = $short_link_helper;
+		$this->connection_permission            = $connection_permission;
 	}
 
 	/**
@@ -243,10 +254,10 @@ class Ai_Generator_Integration implements Integration_Interface {
 		}
 
 		$status      = $this->status_presenter->present();
-		$can_connect = \current_user_can( 'wpseo_manage_options' );
+		$can_connect = $this->connection_permission->can_manage();
 
 		return [
-			'isProvisioned' => $status['is_provisioned'],
+			'isProvisioned' => \is_bool( $status['is_provisioned'] ) && $status['is_provisioned'],
 			'canConnect'    => $can_connect,
 			// Only users who can manage options can start the flow; for everyone
 			// else the link is omitted and the editor shows the "ask your admin" variant.

--- a/src/ai/generator/user-interface/ai-generator-integration.php
+++ b/src/ai/generator/user-interface/ai-generator-integration.php
@@ -22,6 +22,7 @@ use Yoast\WP\SEO\Integrations\Admin\Integrations_Page;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Connection_Permission;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 
 /**
@@ -121,6 +122,13 @@ class Ai_Generator_Integration implements Integration_Interface {
 	private $short_link_helper;
 
 	/**
+	 * The MyYoast connection-management permission check.
+	 *
+	 * @var Connection_Permission
+	 */
+	private $connection_permission;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -145,6 +153,7 @@ class Ai_Generator_Integration implements Integration_Interface {
 	 * @param MyYoast_Connection_Conditional   $myyoast_connection_conditional   The MyYoast connection feature-flag conditional.
 	 * @param Status_Presenter                 $status_presenter                 The MyYoast connection status presenter.
 	 * @param Short_Link_Helper                $short_link_helper                The short-link helper.
+	 * @param Connection_Permission            $connection_permission            The MyYoast connection-management permission check.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -159,7 +168,8 @@ class Ai_Generator_Integration implements Integration_Interface {
 		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository,
 		MyYoast_Connection_Conditional $myyoast_connection_conditional,
 		Status_Presenter $status_presenter,
-		Short_Link_Helper $short_link_helper
+		Short_Link_Helper $short_link_helper,
+		Connection_Permission $connection_permission
 	) {
 		$this->asset_manager                    = $asset_manager;
 		$this->addon_manager                    = $addon_manager;
@@ -174,6 +184,7 @@ class Ai_Generator_Integration implements Integration_Interface {
 		$this->myyoast_connection_conditional   = $myyoast_connection_conditional;
 		$this->status_presenter                 = $status_presenter;
 		$this->short_link_helper                = $short_link_helper;
+		$this->connection_permission            = $connection_permission;
 	}
 
 	/**
@@ -244,7 +255,7 @@ class Ai_Generator_Integration implements Integration_Interface {
 		}
 
 		$status      = $this->status_presenter->present();
-		$can_connect = \current_user_can( 'wpseo_manage_options' );
+		$can_connect = $this->connection_permission->can_manage();
 
 		return [
 			'isProvisioned' => \is_bool( $status['is_provisioned'] ) && $status['is_provisioned'],

--- a/src/ai/generator/user-interface/ai-generator-integration.php
+++ b/src/ai/generator/user-interface/ai-generator-integration.php
@@ -12,13 +12,17 @@ use Yoast\WP\SEO\AI\Generator\Application\Generator_Endpoints_Repository;
 use Yoast\WP\SEO\AI\HTTP_Request\Infrastructure\API_Client;
 use Yoast\WP\SEO\Conditionals\AI_Conditional;
 use Yoast\WP\SEO\Conditionals\AI_Editor_Conditional;
+use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
 use Yoast\WP\SEO\Conditionals\New_Premium_Or_Free_AI_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
+use Yoast\WP\SEO\Integrations\Admin\Integrations_Page;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Introductions\Application\Ai_Fix_Assessments_Upsell;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 
 /**
  * Ai_Generator_Integration class.
@@ -96,6 +100,27 @@ class Ai_Generator_Integration implements Integration_Interface {
 	private $free_sparks_endpoints_repository;
 
 	/**
+	 * The MyYoast connection feature-flag conditional.
+	 *
+	 * @var MyYoast_Connection_Conditional
+	 */
+	private $myyoast_connection_conditional;
+
+	/**
+	 * The MyYoast connection status presenter.
+	 *
+	 * @var Status_Presenter
+	 */
+	private $status_presenter;
+
+	/**
+	 * The short-link helper.
+	 *
+	 * @var Short_Link_Helper
+	 */
+	private $short_link_helper;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array<string>
@@ -117,6 +142,9 @@ class Ai_Generator_Integration implements Integration_Interface {
 	 * @param Generator_Endpoints_Repository   $generator_endpoints_repository   The Generator endpoints repository.
 	 * @param Consent_Endpoints_Repository     $consent_endpoints_repository     The Consent endpoints repository.
 	 * @param Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository The Free Sparks endpoints repository.
+	 * @param MyYoast_Connection_Conditional   $myyoast_connection_conditional   The MyYoast connection feature-flag conditional.
+	 * @param Status_Presenter                 $status_presenter                 The MyYoast connection status presenter.
+	 * @param Short_Link_Helper                $short_link_helper                The short-link helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -128,7 +156,10 @@ class Ai_Generator_Integration implements Integration_Interface {
 		Introductions_Seen_Repository $introductions_seen_repository,
 		Generator_Endpoints_Repository $generator_endpoints_repository,
 		Consent_Endpoints_Repository $consent_endpoints_repository,
-		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository
+		Free_Sparks_Endpoints_Repository $free_sparks_endpoints_repository,
+		MyYoast_Connection_Conditional $myyoast_connection_conditional,
+		Status_Presenter $status_presenter,
+		Short_Link_Helper $short_link_helper
 	) {
 		$this->asset_manager                    = $asset_manager;
 		$this->addon_manager                    = $addon_manager;
@@ -140,6 +171,9 @@ class Ai_Generator_Integration implements Integration_Interface {
 		$this->generator_endpoints_repository   = $generator_endpoints_repository;
 		$this->consent_endpoints_repository     = $consent_endpoints_repository;
 		$this->free_sparks_endpoints_repository = $free_sparks_endpoints_repository;
+		$this->myyoast_connection_conditional   = $myyoast_connection_conditional;
+		$this->status_presenter                 = $status_presenter;
+		$this->short_link_helper                = $short_link_helper;
 	}
 
 	/**
@@ -188,7 +222,61 @@ class Ai_Generator_Integration implements Integration_Interface {
 			'requestTimeout'       => $this->api_client->get_request_timeout(),
 			'isFreeSparks'         => $this->options_helper->get( 'ai_free_sparks_started_on', null ) !== null,
 			'endpoints'            => $endpoints,
+			'myyoastConnection'    => $this->get_myyoast_connection_data(),
 		];
+	}
+
+	/**
+	 * Builds the read-only MyYoast connection payload used to pick the
+	 * "Yoast AI cannot reach your site" notification variant in the editor.
+	 *
+	 * Returns `null` when the feature flag is disabled, so the editor treats the
+	 * connection as unavailable and shows the informational-only variant. The
+	 * payload is deliberately minimal — no store, actions, or tokens reach the
+	 * editor; the connect call-to-action is just a nonce-protected link that
+	 * auto-starts the flow on the Integrations page in a new tab.
+	 *
+	 * @return array{isProvisioned: bool, canConnect: bool, connectUrl: string|null, learnMoreUrl: string}|null
+	 */
+	public function get_myyoast_connection_data() {
+		if ( ! $this->myyoast_connection_conditional->is_met() ) {
+			return null;
+		}
+
+		$status      = $this->status_presenter->present();
+		$can_connect = \current_user_can( 'wpseo_manage_options' );
+
+		return [
+			'isProvisioned' => \is_bool( $status['is_provisioned'] ) && $status['is_provisioned'],
+			'canConnect'    => $can_connect,
+			// Only users who can manage options can start the flow; for everyone
+			// else the link is omitted and the editor shows the "ask your admin" variant.
+			'connectUrl'    => ( $can_connect ) ? $this->get_connect_url() : null,
+			'learnMoreUrl'  => $this->short_link_helper->get( 'https://yoa.st/ai-myyoast-connection' ),
+		];
+	}
+
+	/**
+	 * Builds the nonce-protected Integrations-page URL that auto-starts the
+	 * MyYoast connection flow when opened.
+	 *
+	 * The nonce keeps the auto-start trigger from being cross-site forgeable; the
+	 * Integrations page verifies it before kicking off the flow.
+	 *
+	 * Built with `add_query_arg()` + `wp_create_nonce()` rather than `wp_nonce_url()`:
+	 * the latter HTML-encodes the `&` separators for markup output, but this URL is
+	 * localized and assigned to a React `href`, where it isn't decoded — the browser
+	 * would then send `amp;start-myyoast-connection` as the query-arg name and the
+	 * flow would never start. This form keeps the separators as plain `&`.
+	 *
+	 * @return string The connect URL.
+	 */
+	private function get_connect_url() {
+		return \add_query_arg(
+			'_wpnonce',
+			\wp_create_nonce( 'wpseo-start-myyoast-connection' ),
+			\self_admin_url( 'admin.php?page=' . Integrations_Page::PAGE . '&start-myyoast-connection=1' ),
+		);
 	}
 
 	/**

--- a/src/myyoast-client/user-interface/connection-permission.php
+++ b/src/myyoast-client/user-interface/connection-permission.php
@@ -1,0 +1,35 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\MyYoast_Client\User_Interface;
+
+/**
+ * Single source of truth for the HTTP-boundary check that gates managing the
+ * site's MyYoast connection.
+ *
+ * Deliberately a user-interface concern, not an application one: the WP-CLI
+ * entry point (`wp yoast auth`) is trusted by virtue of shell access and runs
+ * with no logged-in user, so the capability check must live at the HTTP
+ * boundary and never leak into `MyYoast_Client` or the application layer.
+ * Pushing it down would break CLI usage or force a `--user=` flag on every
+ * command.
+ */
+class Connection_Permission {
+
+	/**
+	 * The capability required to manage the MyYoast connection over HTTP.
+	 *
+	 * @var string
+	 */
+	private const MANAGE_CAPABILITY = 'wpseo_manage_options';
+
+	/**
+	 * Whether the current HTTP user may manage the MyYoast connection.
+	 *
+	 * @return bool
+	 */
+	public function can_manage(): bool {
+		return \current_user_can( self::MANAGE_CAPABILITY );
+	}
+}

--- a/src/myyoast-client/user-interface/integrations-page-script-data.php
+++ b/src/myyoast-client/user-interface/integrations-page-script-data.php
@@ -74,7 +74,7 @@ class Integrations_Page_Script_Data {
 	 * callback finished for this user since the last time the Integrations page
 	 * was rendered, so the React app can surface a one-shot notification.
 	 *
-	 * @return array{initialStatus: array{is_provisioned: bool, is_registered: bool, registered_at: int|null, registered_at_iso: string|null, redirect_uris: array<int, array{uri: string, origin: string, is_verified: bool}>, redirect_uris_match: bool}, callbackOutcome: array{kind: string, key: string}|null, linkParams: array<string, string>}|null
+	 * @return array{initialStatus: array{is_provisioned: bool, is_registered: bool, registered_at: int|null, registered_at_iso: string|null, redirect_uris: array<int, array{uri: string, origin: string, is_verified: bool}>, redirect_uris_match: bool}, callbackOutcome: array{kind: string, key: string}|null, linkParams: array<string, string>, startConnection: bool}|null
 	 */
 	public function present(): ?array {
 		if ( ! $this->myyoast_connection_conditional->is_met() ) {
@@ -85,7 +85,29 @@ class Integrations_Page_Script_Data {
 			'initialStatus'   => $this->status_presenter->present(),
 			'callbackOutcome' => $this->consume_callback_outcome(),
 			'linkParams'      => $this->short_link_helper->get_query_params(),
+			'startConnection' => $this->should_auto_start_connection(),
 		];
+	}
+
+	/**
+	 * Whether the page was opened by the editor's "Connect to MyYoast" link and
+	 * should auto-start the connection flow.
+	 *
+	 * Verifies the one-time nonce so the auto-start trigger can't be forged from
+	 * another site, and re-checks the connect capability so only users who may
+	 * register a client trigger it. The actual register/authorize REST calls are
+	 * independently nonce-protected; this gate is defense-in-depth on the trigger.
+	 *
+	 * @return bool Whether to auto-start the connection flow.
+	 */
+	private function should_auto_start_connection(): bool {
+		if ( ! isset( $_GET['start-myyoast-connection'] ) || ! \current_user_can( 'wpseo_manage_options' ) ) {
+			return false;
+		}
+
+		$nonce = isset( $_GET['_wpnonce'] ) ? \sanitize_text_field( \wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+		return \wp_verify_nonce( $nonce, 'wpseo-start-myyoast-connection' ) !== false;
 	}
 
 	/**

--- a/src/myyoast-client/user-interface/integrations-page-script-data.php
+++ b/src/myyoast-client/user-interface/integrations-page-script-data.php
@@ -56,6 +56,13 @@ class Integrations_Page_Script_Data {
 	private $endpoints_repository;
 
 	/**
+	 * The MyYoast connection-management permission check.
+	 *
+	 * @var Connection_Permission
+	 */
+	private $connection_permission;
+
+	/**
 	 * Integrations_Page_Script_Data constructor.
 	 *
 	 * @param Status_Presenter                $status_presenter               The status presenter.
@@ -63,19 +70,22 @@ class Integrations_Page_Script_Data {
 	 * @param OAuth_Callback_Handler          $callback_handler               The callback handler.
 	 * @param Short_Link_Helper               $short_link_helper              The short-link helper.
 	 * @param Management_Endpoints_Repository $endpoints_repository           The management endpoints repository.
+	 * @param Connection_Permission           $connection_permission          The MyYoast connection-management permission check.
 	 */
 	public function __construct(
 		Status_Presenter $status_presenter,
 		MyYoast_Connection_Conditional $myyoast_connection_conditional,
 		OAuth_Callback_Handler $callback_handler,
 		Short_Link_Helper $short_link_helper,
-		Management_Endpoints_Repository $endpoints_repository
+		Management_Endpoints_Repository $endpoints_repository,
+		Connection_Permission $connection_permission
 	) {
 		$this->status_presenter               = $status_presenter;
 		$this->myyoast_connection_conditional = $myyoast_connection_conditional;
 		$this->callback_handler               = $callback_handler;
 		$this->short_link_helper              = $short_link_helper;
 		$this->endpoints_repository           = $endpoints_repository;
+		$this->connection_permission          = $connection_permission;
 	}
 
 	/**
@@ -114,7 +124,7 @@ class Integrations_Page_Script_Data {
 	 * @return bool Whether to auto-start the connection flow.
 	 */
 	private function should_auto_start_connection(): bool {
-		if ( ! isset( $_GET['start-myyoast-connection'] ) || ! \current_user_can( 'wpseo_manage_options' ) ) {
+		if ( ! isset( $_GET['start-myyoast-connection'] ) || ! $this->connection_permission->can_manage() ) {
 			return false;
 		}
 

--- a/src/myyoast-client/user-interface/management-route.php
+++ b/src/myyoast-client/user-interface/management-route.php
@@ -93,24 +93,34 @@ class Management_Route implements Route_Interface, LoggerAwareInterface {
 	private $client_registration;
 
 	/**
+	 * The connection-management permission check.
+	 *
+	 * @var Connection_Permission
+	 */
+	private $connection_permission;
+
+	/**
 	 * Management_Route constructor.
 	 *
-	 * @param MyYoast_Client                $myyoast_client      The MyYoast client facade.
-	 * @param Status_Presenter              $status_presenter    The status presenter.
-	 * @param Issuer_Config                 $issuer_config       The issuer configuration.
-	 * @param Client_Registration_Interface $client_registration The client registration port.
+	 * @param MyYoast_Client                $myyoast_client        The MyYoast client facade.
+	 * @param Status_Presenter              $status_presenter      The status presenter.
+	 * @param Issuer_Config                 $issuer_config         The issuer configuration.
+	 * @param Client_Registration_Interface $client_registration   The client registration port.
+	 * @param Connection_Permission         $connection_permission The connection-management permission check.
 	 */
 	public function __construct(
 		MyYoast_Client $myyoast_client,
 		Status_Presenter $status_presenter,
 		Issuer_Config $issuer_config,
-		Client_Registration_Interface $client_registration
+		Client_Registration_Interface $client_registration,
+		Connection_Permission $connection_permission
 	) {
-		$this->myyoast_client      = $myyoast_client;
-		$this->status_presenter    = $status_presenter;
-		$this->issuer_config       = $issuer_config;
-		$this->client_registration = $client_registration;
-		$this->logger              = new NullLogger();
+		$this->myyoast_client        = $myyoast_client;
+		$this->status_presenter      = $status_presenter;
+		$this->issuer_config         = $issuer_config;
+		$this->client_registration   = $client_registration;
+		$this->connection_permission = $connection_permission;
+		$this->logger                = new NullLogger();
 	}
 
 	/**
@@ -202,7 +212,7 @@ class Management_Route implements Route_Interface, LoggerAwareInterface {
 	 * @return bool
 	 */
 	public function can_manage() {
-		return \current_user_can( 'wpseo_manage_options' );
+		return $this->connection_permission->can_manage();
 	}
 
 	/**

--- a/src/myyoast-client/user-interface/management-route.php
+++ b/src/myyoast-client/user-interface/management-route.php
@@ -243,7 +243,7 @@ class Management_Route implements Route_Interface, LoggerAwareInterface {
 
 		try {
 			$this->myyoast_client->refresh_registration_status();
-		} catch ( Registration_Failed_Exception $e ) {
+		} catch ( Throwable $e ) {
 			return $this->handle_exception( $e );
 		}
 
@@ -266,7 +266,7 @@ class Management_Route implements Route_Interface, LoggerAwareInterface {
 
 		try {
 			$this->myyoast_client->ensure_registered();
-		} catch ( Registration_Failed_Exception $e ) {
+		} catch ( Throwable $e ) {
 			return $this->handle_exception( $e );
 		}
 

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Abstract_AI_Generator_Integration_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Abstract_AI_Generator_Integration_Test.php
@@ -18,6 +18,7 @@ use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Connection_Permission;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -127,6 +128,13 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 	protected $short_link_helper;
 
 	/**
+	 * Represents the MyYoast connection-management permission check.
+	 *
+	 * @var Mockery\MockInterface|Connection_Permission
+	 */
+	protected $connection_permission;
+
+	/**
 	 * Sets an instance for test purposes.
 	 *
 	 * @return void
@@ -147,6 +155,7 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 		$this->myyoast_connection_conditional   = Mockery::mock( MyYoast_Connection_Conditional::class );
 		$this->status_presenter                 = Mockery::mock( Status_Presenter::class );
 		$this->short_link_helper                = Mockery::mock( Short_Link_Helper::class );
+		$this->connection_permission            = Mockery::mock( Connection_Permission::class );
 
 		$this->instance = new Ai_Generator_Integration(
 			$this->asset_manager,
@@ -162,6 +171,7 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 			$this->myyoast_connection_conditional,
 			$this->status_presenter,
 			$this->short_link_helper,
+			$this->connection_permission,
 		);
 	}
 }

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Abstract_AI_Generator_Integration_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Abstract_AI_Generator_Integration_Test.php
@@ -12,10 +12,13 @@ use Yoast\WP\SEO\AI\Free_Sparks\Application\Free_Sparks_Endpoints_Repository;
 use Yoast\WP\SEO\AI\Generator\Application\Generator_Endpoints_Repository;
 use Yoast\WP\SEO\AI\Generator\User_Interface\Ai_Generator_Integration;
 use Yoast\WP\SEO\AI\HTTP_Request\Infrastructure\API_Client;
+use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -103,6 +106,27 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 	protected $free_sparks_endpoints_repository;
 
 	/**
+	 * Represents the MyYoast connection feature-flag conditional.
+	 *
+	 * @var Mockery\MockInterface|MyYoast_Connection_Conditional
+	 */
+	protected $myyoast_connection_conditional;
+
+	/**
+	 * Represents the MyYoast connection status presenter.
+	 *
+	 * @var Mockery\MockInterface|Status_Presenter
+	 */
+	protected $status_presenter;
+
+	/**
+	 * Represents the short-link helper.
+	 *
+	 * @var Mockery\MockInterface|Short_Link_Helper
+	 */
+	protected $short_link_helper;
+
+	/**
 	 * Sets an instance for test purposes.
 	 *
 	 * @return void
@@ -120,6 +144,9 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 		$this->generator_endpoints_repository   = Mockery::mock( Generator_Endpoints_Repository::class );
 		$this->consent_endpoints_repository     = Mockery::mock( Consent_Endpoints_Repository::class );
 		$this->free_sparks_endpoints_repository = Mockery::mock( Free_Sparks_Endpoints_Repository::class );
+		$this->myyoast_connection_conditional   = Mockery::mock( MyYoast_Connection_Conditional::class );
+		$this->status_presenter                 = Mockery::mock( Status_Presenter::class );
+		$this->short_link_helper                = Mockery::mock( Short_Link_Helper::class );
 
 		$this->instance = new Ai_Generator_Integration(
 			$this->asset_manager,
@@ -132,6 +159,9 @@ abstract class Abstract_AI_Generator_Integration_Test extends TestCase {
 			$this->generator_endpoints_repository,
 			$this->consent_endpoints_repository,
 			$this->free_sparks_endpoints_repository,
+			$this->myyoast_connection_conditional,
+			$this->status_presenter,
+			$this->short_link_helper,
 		);
 	}
 }

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Constructor_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Constructor_Test.php
@@ -7,10 +7,13 @@ namespace Yoast\WP\SEO\Tests\Unit\AI\Generator\User_Interface\AI_Generator_Integ
 use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\AI\HTTP_Request\Infrastructure\API_Client;
+use Yoast\WP\SEO\Conditionals\MyYoast_Connection_Conditional;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Introductions\Infrastructure\Introductions_Seen_Repository;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 
 /**
  * Tests the AI_Generator_Integration's construct method.
@@ -54,6 +57,18 @@ final class Constructor_Test extends Abstract_AI_Generator_Integration_Test {
 		$this->assertInstanceOf(
 			Introductions_Seen_Repository::class,
 			$this->getPropertyValue( $this->instance, 'introductions_seen_repository' ),
+		);
+		$this->assertInstanceOf(
+			MyYoast_Connection_Conditional::class,
+			$this->getPropertyValue( $this->instance, 'myyoast_connection_conditional' ),
+		);
+		$this->assertInstanceOf(
+			Status_Presenter::class,
+			$this->getPropertyValue( $this->instance, 'status_presenter' ),
+		);
+		$this->assertInstanceOf(
+			Short_Link_Helper::class,
+			$this->getPropertyValue( $this->instance, 'short_link_helper' ),
 		);
 	}
 }

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Enqueue_Assets_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Enqueue_Assets_Test.php
@@ -69,6 +69,9 @@ final class Enqueue_Assets_Test extends Abstract_AI_Generator_Integration_Test {
 		$generator_endpoint_list->expects( 'merge_with' )->once()->with( $free_sparks_endpoint_list )->andReturnSelf();
 		$generator_endpoint_list->expects( 'to_paths_array' )->once()->andReturn( [] );
 
+		// The MyYoast connection feature flag is disabled, so the payload is null.
+		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnFalse();
+
 		// Enqueueing.
 		$this->asset_manager->expects( 'enqueue_script' )->once()->with( 'ai-generator' );
 		$this->asset_manager->expects( 'localize_script' )->once()->with(
@@ -84,6 +87,7 @@ final class Enqueue_Assets_Test extends Abstract_AI_Generator_Integration_Test {
 				'requestTimeout'       => 0,
 				'isFreeSparks'         => true,
 				'endpoints'            => [],
+				'myyoastConnection'    => null,
 			],
 		);
 		$this->asset_manager->expects( 'enqueue_style' )->once()->with( 'ai-generator' );

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Myyoast_Connection_Data_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Myyoast_Connection_Data_Test.php
@@ -1,0 +1,129 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Generator\User_Interface\AI_Generator_Integration;
+
+use Brain\Monkey;
+
+/**
+ * Tests the AI_Generator_Integration's get_myyoast_connection_data method.
+ *
+ * @group ai-generator
+ *
+ * @covers \Yoast\WP\SEO\AI\Generator\User_Interface\AI_Generator_Integration::get_myyoast_connection_data
+ */
+final class Get_Myyoast_Connection_Data_Test extends Abstract_AI_Generator_Integration_Test {
+
+	/**
+	 * The status payload returned by the Status_Presenter.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private const PROVISIONED_STATUS = [
+		'is_provisioned'      => true,
+		'is_registered'       => false,
+		'registered_at'       => null,
+		'registered_at_iso'   => null,
+		'redirect_uris'       => [],
+		'redirect_uris_match' => true,
+	];
+
+	/**
+	 * Tests that the payload is null when the feature flag is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_returns_null_when_feature_flag_disabled() {
+		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnFalse();
+
+		$this->assertNull( $this->instance->get_myyoast_connection_data() );
+	}
+
+	/**
+	 * Tests the payload for a user who can connect: it carries the connect URL,
+	 * built with the nonce appended via `add_query_arg()` so the `&` separators
+	 * stay plain.
+	 *
+	 * The URL is localized and assigned to a React `href`, not printed as HTML, so
+	 * it must not carry the HTML-encoded separators `wp_nonce_url()` would add —
+	 * otherwise the browser sends `amp;start-myyoast-connection` as the query-arg
+	 * name and the auto-start flow never triggers.
+	 *
+	 * @return void
+	 */
+	public function test_returns_connect_url_with_plain_separators_when_user_can_connect() {
+		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnTrue();
+		$this->status_presenter->expects( 'present' )->once()->andReturn( self::PROVISIONED_STATUS );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->once()
+			->andReturnTrue();
+
+		Monkey\Functions\expect( 'self_admin_url' )
+			->once()
+			->andReturnFirstArg();
+		Monkey\Functions\expect( 'wp_create_nonce' )
+			->once()
+			->with( 'wpseo-start-myyoast-connection' )
+			->andReturn( 'abc123' );
+		// add_query_arg keeps plain `&` separators; mirror that so the test proves
+		// the URL is never HTML-encoded.
+		Monkey\Functions\expect( 'add_query_arg' )
+			->once()
+			->with(
+				'_wpnonce',
+				'abc123',
+				'admin.php?page=wpseo_integrations&start-myyoast-connection=1',
+			)
+			->andReturn( 'admin.php?page=wpseo_integrations&start-myyoast-connection=1&_wpnonce=abc123' );
+
+		$this->short_link_helper->expects( 'get' )
+			->once()
+			->with( 'https://yoa.st/ai-myyoast-connection' )
+			->andReturn( 'https://yoa.st/ai-myyoast-connection?utm=1' );
+
+		$expected = [
+			'isProvisioned' => true,
+			'canConnect'    => true,
+			'connectUrl'    => 'admin.php?page=wpseo_integrations&start-myyoast-connection=1&_wpnonce=abc123',
+			'learnMoreUrl'  => 'https://yoa.st/ai-myyoast-connection?utm=1',
+		];
+
+		$this->assertSame( $expected, $this->instance->get_myyoast_connection_data() );
+	}
+
+	/**
+	 * Tests the payload for a user who cannot connect: the connect URL is omitted.
+	 *
+	 * @return void
+	 */
+	public function test_omits_connect_url_when_user_cannot_connect() {
+		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnTrue();
+		$this->status_presenter->expects( 'present' )->once()->andReturn( self::PROVISIONED_STATUS );
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->with( 'wpseo_manage_options' )
+			->once()
+			->andReturnFalse();
+
+		// No connect URL is built for a user who cannot connect.
+		Monkey\Functions\expect( 'wp_create_nonce' )->never();
+		Monkey\Functions\expect( 'add_query_arg' )->never();
+
+		$this->short_link_helper->expects( 'get' )
+			->once()
+			->with( 'https://yoa.st/ai-myyoast-connection' )
+			->andReturn( 'https://yoa.st/ai-myyoast-connection?utm=1' );
+
+		$expected = [
+			'isProvisioned' => true,
+			'canConnect'    => false,
+			'connectUrl'    => null,
+			'learnMoreUrl'  => 'https://yoa.st/ai-myyoast-connection?utm=1',
+		];
+
+		$this->assertSame( $expected, $this->instance->get_myyoast_connection_data() );
+	}
+}

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Myyoast_Connection_Data_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Myyoast_Connection_Data_Test.php
@@ -56,10 +56,7 @@ final class Get_Myyoast_Connection_Data_Test extends Abstract_AI_Generator_Integ
 		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnTrue();
 		$this->status_presenter->expects( 'present' )->once()->andReturn( self::PROVISIONED_STATUS );
 
-		Monkey\Functions\expect( 'current_user_can' )
-			->with( 'wpseo_manage_options' )
-			->once()
-			->andReturnTrue();
+		$this->connection_permission->expects( 'can_manage' )->once()->andReturnTrue();
 
 		Monkey\Functions\expect( 'self_admin_url' )
 			->once()
@@ -103,10 +100,7 @@ final class Get_Myyoast_Connection_Data_Test extends Abstract_AI_Generator_Integ
 		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnTrue();
 		$this->status_presenter->expects( 'present' )->once()->andReturn( self::PROVISIONED_STATUS );
 
-		Monkey\Functions\expect( 'current_user_can' )
-			->with( 'wpseo_manage_options' )
-			->once()
-			->andReturnFalse();
+		$this->connection_permission->expects( 'can_manage' )->once()->andReturnFalse();
 
 		// No connect URL is built for a user who cannot connect.
 		Monkey\Functions\expect( 'wp_create_nonce' )->never();

--- a/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Script_Data_Test.php
+++ b/tests/Unit/AI/Generator/User_Interface/AI_Generator_Integration/Get_Script_Data_Test.php
@@ -69,6 +69,9 @@ final class Get_Script_Data_Test extends Abstract_AI_Generator_Integration_Test 
 		$generator_endpoint_list->expects( 'merge_with' )->once()->with( $free_sparks_endpoint_list )->andReturnSelf();
 		$generator_endpoint_list->expects( 'to_paths_array' )->once()->andReturn( [] );
 
+		// The MyYoast connection feature flag is disabled, so the payload is null.
+		$this->myyoast_connection_conditional->expects( 'is_met' )->once()->andReturnFalse();
+
 		$expected = [
 			'hasConsent'           => true,
 			'productSubscriptions' => [
@@ -79,6 +82,7 @@ final class Get_Script_Data_Test extends Abstract_AI_Generator_Integration_Test 
 			'requestTimeout'       => 0,
 			'isFreeSparks'         => true,
 			'endpoints'            => [],
+			'myyoastConnection'    => null,
 		];
 
 		$this->assertSame( $expected, $this->instance->get_script_data() );

--- a/tests/Unit/MyYoast_Client/User_Interface/Integrations_Page_Script_Data_Test.php
+++ b/tests/Unit/MyYoast_Client/User_Interface/Integrations_Page_Script_Data_Test.php
@@ -241,4 +241,112 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 
 		$this->assertNull( $this->instance->present() );
 	}
+
+	/**
+	 * Tests the auto-start flag is false when the query arg is absent.
+	 *
+	 * @covers ::present
+	 * @covers ::should_auto_start_connection
+	 *
+	 * @return void
+	 */
+	public function test_start_connection_false_without_query_arg() {
+		unset( $_GET['start-myyoast-connection'] );
+		$this->prime_present();
+
+		$this->assertFalse( $this->instance->present()['startConnection'] );
+	}
+
+	/**
+	 * Tests the auto-start flag is true with the query arg, a valid nonce, and the
+	 * connect capability.
+	 *
+	 * @covers ::should_auto_start_connection
+	 *
+	 * @return void
+	 */
+	public function test_start_connection_true_with_valid_nonce_and_capability() {
+		$_GET['start-myyoast-connection'] = '1';
+		$_GET['_wpnonce']                 = 'nonce-value';
+		$this->prime_present();
+
+		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\stubs(
+			[
+				'wp_unslash'          => static function ( $value ) {
+					return $value;
+				},
+				'sanitize_text_field' => static function ( $value ) {
+					return $value;
+				},
+			],
+		);
+		Monkey\Functions\expect( 'wp_verify_nonce' )->with( 'nonce-value', 'wpseo-start-myyoast-connection' )->andReturn( 1 );
+
+		$this->assertTrue( $this->instance->present()['startConnection'] );
+
+		unset( $_GET['start-myyoast-connection'], $_GET['_wpnonce'] );
+	}
+
+	/**
+	 * Tests the auto-start flag is false when the nonce is invalid.
+	 *
+	 * @covers ::should_auto_start_connection
+	 *
+	 * @return void
+	 */
+	public function test_start_connection_false_with_invalid_nonce() {
+		$_GET['start-myyoast-connection'] = '1';
+		$_GET['_wpnonce']                 = 'tampered';
+		$this->prime_present();
+
+		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		Monkey\Functions\stubs(
+			[
+				'wp_unslash'          => static function ( $value ) {
+					return $value;
+				},
+				'sanitize_text_field' => static function ( $value ) {
+					return $value;
+				},
+			],
+		);
+		Monkey\Functions\expect( 'wp_verify_nonce' )->with( 'tampered', 'wpseo-start-myyoast-connection' )->andReturnFalse();
+
+		$this->assertFalse( $this->instance->present()['startConnection'] );
+
+		unset( $_GET['start-myyoast-connection'], $_GET['_wpnonce'] );
+	}
+
+	/**
+	 * Tests the auto-start flag is false when the user lacks the connect capability.
+	 *
+	 * @covers ::should_auto_start_connection
+	 *
+	 * @return void
+	 */
+	public function test_start_connection_false_without_capability() {
+		$_GET['start-myyoast-connection'] = '1';
+		$this->prime_present();
+
+		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnFalse();
+		Monkey\Functions\expect( 'wp_verify_nonce' )->never();
+
+		$this->assertFalse( $this->instance->present()['startConnection'] );
+
+		unset( $_GET['start-myyoast-connection'] );
+	}
+
+	/**
+	 * Primes the present() collaborators that are unrelated to the auto-start flag.
+	 *
+	 * @return void
+	 */
+	private function prime_present(): void {
+		$this->myyoast_connection_conditional->shouldReceive( 'is_met' )->andReturn( true );
+		$this->status_presenter->shouldReceive( 'present' )->andReturn( [] );
+		Monkey\Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		$this->callback_handler->shouldReceive( 'consume_outcome' )->andReturn( null );
+		$this->short_link_helper->shouldReceive( 'get_query_params' )->andReturn( [] );
+	}
 }

--- a/tests/Unit/MyYoast_Client/User_Interface/Integrations_Page_Script_Data_Test.php
+++ b/tests/Unit/MyYoast_Client/User_Interface/Integrations_Page_Script_Data_Test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\MyYoast_Client\Application\Callback_Outcome;
 use Yoast\WP\SEO\MyYoast_Client\Application\Management_Endpoints_Repository;
 use Yoast\WP\SEO\MyYoast_Client\Application\OAuth_Callback_Handler;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Connection_Permission;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Integrations_Page_Script_Data;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 use Yoast\WP\SEO\Routes\Endpoint\Endpoint_List;
@@ -57,6 +58,13 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 	private $endpoints_repository;
 
 	/**
+	 * The connection-management permission mock.
+	 *
+	 * @var Connection_Permission|Mockery\MockInterface
+	 */
+	private $connection_permission;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Integrations_Page_Script_Data
@@ -76,12 +84,14 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 		$this->callback_handler               = Mockery::mock( OAuth_Callback_Handler::class );
 		$this->short_link_helper              = Mockery::mock( Short_Link_Helper::class );
 		$this->endpoints_repository           = Mockery::mock( Management_Endpoints_Repository::class );
+		$this->connection_permission          = Mockery::mock( Connection_Permission::class );
 		$this->instance                       = new Integrations_Page_Script_Data(
 			$this->status_presenter,
 			$this->myyoast_connection_conditional,
 			$this->callback_handler,
 			$this->short_link_helper,
 			$this->endpoints_repository,
+			$this->connection_permission,
 		);
 	}
 
@@ -299,7 +309,7 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 		$_GET['_wpnonce']                 = 'nonce-value';
 		$this->prime_present();
 
-		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		$this->connection_permission->shouldReceive( 'can_manage' )->andReturnTrue();
 		Monkey\Functions\stubs(
 			[
 				'wp_unslash'          => static function ( $value ) {
@@ -329,7 +339,7 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 		$_GET['_wpnonce']                 = 'tampered';
 		$this->prime_present();
 
-		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnTrue();
+		$this->connection_permission->shouldReceive( 'can_manage' )->andReturnTrue();
 		Monkey\Functions\stubs(
 			[
 				'wp_unslash'          => static function ( $value ) {
@@ -358,7 +368,7 @@ final class Integrations_Page_Script_Data_Test extends TestCase {
 		$_GET['start-myyoast-connection'] = '1';
 		$this->prime_present();
 
-		Monkey\Functions\expect( 'current_user_can' )->with( 'wpseo_manage_options' )->andReturnFalse();
+		$this->connection_permission->shouldReceive( 'can_manage' )->andReturnFalse();
 		Monkey\Functions\expect( 'wp_verify_nonce' )->never();
 
 		$this->assertFalse( $this->instance->present()['startConnection'] );

--- a/tests/Unit/MyYoast_Client/User_Interface/Management_Route_Test.php
+++ b/tests/Unit/MyYoast_Client/User_Interface/Management_Route_Test.php
@@ -20,6 +20,7 @@ use Yoast\WP\SEO\MyYoast_Client\Application\MyYoast_Client;
 use Yoast\WP\SEO\MyYoast_Client\Application\Ports\Client_Registration_Interface;
 use Yoast\WP\SEO\MyYoast_Client\Domain\Registered_Client;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\OIDC\Issuer_Config;
+use Yoast\WP\SEO\MyYoast_Client\User_Interface\Connection_Permission;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Management_Route;
 use Yoast\WP\SEO\MyYoast_Client\User_Interface\Status_Presenter;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -65,6 +66,13 @@ final class Management_Route_Test extends TestCase {
 	private $client_registration;
 
 	/**
+	 * The connection-management permission check mock.
+	 *
+	 * @var Connection_Permission|Mockery\MockInterface
+	 */
+	private $connection_permission;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Management_Route
@@ -79,16 +87,18 @@ final class Management_Route_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->myyoast_client      = Mockery::mock( MyYoast_Client::class );
-		$this->status_presenter    = Mockery::mock( Status_Presenter::class );
-		$this->issuer_config       = Mockery::mock( Issuer_Config::class );
-		$this->client_registration = Mockery::mock( Client_Registration_Interface::class );
+		$this->myyoast_client        = Mockery::mock( MyYoast_Client::class );
+		$this->status_presenter      = Mockery::mock( Status_Presenter::class );
+		$this->issuer_config         = Mockery::mock( Issuer_Config::class );
+		$this->client_registration   = Mockery::mock( Client_Registration_Interface::class );
+		$this->connection_permission = Mockery::mock( Connection_Permission::class );
 
 		$this->instance = new Management_Route(
 			$this->myyoast_client,
 			$this->status_presenter,
 			$this->issuer_config,
 			$this->client_registration,
+			$this->connection_permission,
 		);
 
 		// Default throttle stubs: the issuer key is always available and the marker
@@ -185,15 +195,15 @@ final class Management_Route_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that the permission callback checks `wpseo_manage_options`.
+	 * Tests that the permission callback delegates to the connection-permission check.
 	 *
 	 * @covers ::can_manage
 	 *
 	 * @return void
 	 */
 	public function test_can_manage() {
-		Monkey\Functions\expect( 'current_user_can' )
-			->with( 'wpseo_manage_options' )
+		$this->connection_permission
+			->shouldReceive( 'can_manage' )
 			->once()
 			->andReturn( true );
 


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When Yoast AI cannot reach a user's site (the `SITE_UNREACHABLE` error and a handful of related failures), the AI generator showed an inline alert *inside* its modal that essentially said "make your site publicly accessible" — a dead end with no path forward. Now that a site can be connected to MyYoast (RT-1168, on the base branch), that same error is the right moment to nudge the user into connecting: a connected site lets Yoast AI work even when the site is offline, behind a firewall, or with the REST API disabled.

The danger-modal presentation is a UX refresh prompted by @ux-tom.

> **Base branch:** this PR is stacked on top of `DE/rt1168-oauth-client-controls` (PR #23395), which carries the MyYoast OAuth connection it builds on. Review and merge that PR first; this one should be rebased onto `trunk` once it lands.

## Summary

This PR can be summarized in the following changelog entries:

* Adds a MyYoast connection nudge to the Yoast AI error states, so users can connect their site when Yoast AI cannot reach it.
* Presents fatal Yoast AI generator errors as a dedicated danger modal instead of an inline alert.

## Relevant technical choices:

* **Fatal vs non-fatal errors.** A fatal error (failed initial fetch, or a subscription/precondition failure) closes the AI modal and hands over to a full-replacement danger modal (`AIErrorModal`); the error state lives in `App` so it survives the modal closing. The non-fatal "generate 5 more failed" case keeps the modal open and shows an inline notice with a retry, where the user's attention already is.
* **New components, not refactors.** `SuggestionError`/`FeatureError` and the inline `*-alert.js` components are a live cross-repo contract consumed by Premium via `window.yoast.editorModules.aiGenerator`, so they are left untouched. The new presentation lives in new `*-modal.js` components routed by a new `AIErrorModal`. Copy is centralized under `errors/messages/` so alert and modal wording can't drift, and a guardrail test asserts both routers cover the same `(errorCode, errorIdentifier)` set.
* **Three site-unreachable variants**, driven by a read-only `myyoastConnection` payload localized to the editor: (1) informational only — feature flag off or not provisioned; (2) "Connect to MyYoast" — provisioned and the user can connect; (3) "ask your administrator" — provisioned but the user can't connect.
* **New tab + server-side auto-start, not in-editor OAuth.** The OAuth flow ends in a full-page redirect that would discard unsaved post content. The connect CTA opens the Integrations page in a new tab, which auto-starts the `connect → authorize` flow only after a one-time nonce **and** the connect capability are verified server-side, then strips the query args so a refresh can't re-trigger.
* **Capability check at the HTTP boundary.** `Connection_Permission` is the single source of truth for the `wpseo_manage_options` check, kept in the user-interface layer (not the application layer) so the trusted `wp yoast auth` CLI path — which runs with no logged-in user — isn't broken by a `current_user_can` call.
* **No secrets in the editor.** The localized payload carries only provisioning/capability booleans and URLs — never tokens, the software statement, or the initial access token. Outbound links use `target="_blank"` + `rel="noopener noreferrer"`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Preconditions: a site with an active Yoast SEO Premium subscription (so the AI generator is available), logged in as a user, on a post in the block editor.

To force the "Yoast AI cannot reach your site" error, make the site unreachable to the AI backend (e.g. on a local/staging site behind basic auth or a firewall, or temporarily block the REST API), then trigger an AI title/description suggestion.

* **Variant 1 — informational (no connect option).** With the MyYoast connection feature flag **off**, trigger the unreachable error. Expect a danger modal explaining Yoast AI can't reach the site, with "Learn more" and "Still need help?" links and a Close button — **no** connect option.
* **Variant 2 — connect.** With the feature flag **on**, the site **provisioned**, and logged in as an **administrator** (can manage options), trigger the error. Expect a "Connect to MyYoast" button. Clicking it opens the **Integrations page in a new tab** and **auto-starts** the connection flow (redirects to MyYoast to authorize). Confirm the editor tab is untouched and unsaved content is preserved.
* **Variant 3 — ask admin.** With the feature flag **on** and provisioned, but logged in as a user **without** the manage-options capability (e.g. Editor role), trigger the error. Expect "ask your site administrator" copy and a Close button — **no** connect button.
* **Other error modals.** Trigger other fatal errors (e.g. rate limit, subscription/precondition failure) and confirm they now appear as a centered danger modal with the appropriate copy, a Close button, and a "Try again" / "Refresh page" action where applicable.
* **Non-fatal stays inline.** Generate suggestions, then on a "generate 5 more" failure, confirm the already-generated suggestions stay visible and the failure shows as an inline notice with a retry — the modal does **not** close.
* **Auto-start tamper check.** Visit `admin.php?page=wpseo_integrations&start-myyoast-connection=1` **without** a valid nonce (or as a non-admin); confirm the connection does **not** auto-start, while the Integrations page still loads normally and Connect can be used manually.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
Console: watch for React errors when the danger modal mounts/replaces the AI modal. Editors: the AI generator runs in Block/Gutenberg, Classic, and Elementor — confirm the modal renders in each.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast AI generator error states in the editor (both the new/free and old-Premium AI generator integrations).
* The MyYoast connection card on the Integrations page (auto-start on mount).
* The editor script payload (`wpseoAiGenerator`) and the Integrations page script payload now carry additional read-only fields.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

<!--
Premium note: this PR additively exports `AIErrorModal` on editor-modules so Premium *can* adopt the modal/nudge presentation later, but it makes no Premium change and breaks no existing Premium contract. No `[wordpress-seo-premium]` changelog entry is added here — the Premium adoption is a separate, coordinated PR.
-->

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1325
