### PR TITLE
fix: prevent the MyYoast connection toast from overlapping the admin menu

### DIFF
--- a/admin/class-admin-asset-manager.php
+++ b/admin/class-admin-asset-manager.php
@@ -704,6 +704,11 @@ class WPSEO_Admin_Asset_Manager {
 				'deps' => [ self::PREFIX . 'tailwind' ],
 			],
 			[
+				'name' => 'integrations-page',
+				'src'  => 'integrations-page-' . $flat_version,
+				'deps' => [ self::PREFIX . 'tailwind' ],
+			],
+			[
 				'name' => 'installation-success',
 				'src'  => 'installation-success-' . $flat_version,
 				'deps' => [ self::PREFIX . 'tailwind' ],

--- a/css/src/integrations-page.css
+++ b/css/src/integrations-page.css
@@ -1,0 +1,43 @@
+body.seo_page_wpseo_integrations {
+	&.sticky-menu {
+		.yst-root .yst-notifications--bottom-left {
+			@media (min-width: 783px) and (max-width: 962px) {
+				left: calc(160px + 2rem); /* Next to admin menu. 160px is the admin menu width. */
+			}
+		}
+
+		&.folded, &.auto-fold {
+			.yst-root .yst-notifications--bottom-left {
+				@media (min-width: 783px) and (max-width: 963px) {
+					left: calc(32px + 2rem); /* Next to admin menu. 32px is the collapsed admin menu width. */
+				}
+			}
+		}
+
+		&.folded {
+			.yst-root .yst-notifications--bottom-left {
+				@media (min-width: 962px) {
+					left: calc(32px + 2rem); /* Next to admin menu. 32px is the collapsed admin menu width. */
+				}
+			}
+		}
+	}
+
+	&:not(.sticky-menu) .wp-responsive-open .yst-root {
+		.yst-notifications--bottom-left {
+			@media (max-width: 783px) {
+				left: calc(190px + 2rem); /* Next to admin menu. 190px is the responsive admin menu width. */
+			}
+		}
+	}
+
+	.yst-root {
+		.yst-notifications--bottom-left {
+			z-index: 9991; /* 1 above admin menu */
+
+			@media (min-width: 783px) {
+				left: calc(160px + 2rem); /* Next to admin menu. 160px is the admin menu width. */
+			}
+		}
+	}
+}

--- a/src/integrations/admin/integrations-page.php
+++ b/src/integrations/admin/integrations-page.php
@@ -167,6 +167,7 @@ class Integrations_Page implements Integration_Interface {
 		$this->admin_asset_manager->enqueue_style( 'admin-css' );
 		$this->admin_asset_manager->enqueue_style( 'tailwind' );
 		$this->admin_asset_manager->enqueue_style( 'monorepo' );
+		$this->admin_asset_manager->enqueue_style( 'integrations-page' );
 
 		$this->admin_asset_manager->enqueue_script( 'integrations-page' );
 

--- a/tests/Unit/Integrations/Admin/Integrations_Page_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Integrations_Page_Integration_Test.php
@@ -164,6 +164,7 @@ final class Integrations_Page_Integration_Test extends TestCase {
 		$this->admin_asset_manager->expects()->enqueue_style( 'admin-css' );
 		$this->admin_asset_manager->expects()->enqueue_style( 'tailwind' );
 		$this->admin_asset_manager->expects()->enqueue_style( 'monorepo' );
+		$this->admin_asset_manager->expects()->enqueue_style( 'integrations-page' );
 		$this->admin_asset_manager->expects()->enqueue_script( 'integrations-page' );
 
 		$schema_api_integrations = [


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The MyYoast connection toast on the Integrations settings page rendered partly underneath the WordPress admin sidebar, so its left edge (and part of its text) sat behind the menu instead of starting at the left edge of the page content.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the MyYoast connection toast overlapped the admin menu on the Integrations page.

## Relevant technical choices:

* The `.yst-notifications--bottom-left` toast from the UI library is `position: fixed` and anchored `2rem` from the viewport's left edge, which ignores the WordPress admin sidebar width.
* The Dashboard, Settings and Redirects pages already correct this with a page-scoped stylesheet that offsets the toast by the admin-menu width; the Integrations page loaded no dedicated stylesheet, so it lacked the override.
* Reused that existing pattern: added `css/src/integrations-page.css` scoped to `body.seo_page_wpseo_integrations` (mirroring `new-settings.css`), registered the `integrations-page` style handle, and enqueued it on the page.
* No JS or PHP behaviour changed — this is a styling-only fix that reuses established width constants (160px expanded / 32px folded / 190px responsive).

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to **Yoast SEO → Integrations** in the WP admin.
* Connect or disconnect the site from MyYoast so the toast notification appears in the bottom-left.
* Verify the toast starts at the left edge of the page content, next to the admin menu, and does not overlap or sit behind the sidebar.
* Collapse the admin menu (Collapse menu) and repeat — the toast should still sit next to the (now narrower) menu.
* Resize the browser to a narrow/mobile width and open the responsive admin menu — the toast should not overlap it.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
Test across browsers because this is a CSS positioning fix that depends on media queries and fixed positioning.
-->

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Only the Integrations settings page (`body.seo_page_wpseo_integrations`); a new page-scoped stylesheet is enqueued there. No other page's styling changes.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #