### PR TITLE
feat(bulk-editor): update AI upsell copy and expose modal for Premium

### DIFF
--- a/packages/js/src/bulk-editor/components/upsell-modal.js
+++ b/packages/js/src/bulk-editor/components/upsell-modal.js
@@ -36,7 +36,7 @@ export const UpsellModal = ( { isOpen, onClose, upsellLabel, upsellLink, ctbId, 
 								{ __( "Generate Metadata in Bulk", "wordpress-seo" ) }
 							</Modal.Title>
 							<Modal.Description as="p" className="yst-text-sm yst-text-slate-600">
-								{ __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ) }
+								{ __( "Instantly create SEO titles, meta descriptions, and social metadata for all your products, posts, pages and more. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ) }
 							</Modal.Description>
 						</div>
 					</div>

--- a/packages/js/src/bulk-editor/components/upsell-modal.js
+++ b/packages/js/src/bulk-editor/components/upsell-modal.js
@@ -15,10 +15,19 @@ import { OutboundLink } from "../../shared-admin/components";
  * @param {string}   props.upsellLink      The CTA URL.
  * @param {string}   [props.ctbId]         The click-to-buy id.
  * @param {string}   [props.learnMoreLink] The "Learn more" link URL.
+ * @param {string}   [props.description]   The body copy; defaults to the generic (non-product) copy.
  *
  * @returns {JSX.Element} The upsell modal.
  */
-export const UpsellModal = ( { isOpen, onClose, upsellLabel, upsellLink, ctbId, learnMoreLink } ) => {
+export const UpsellModal = ( {
+	isOpen,
+	onClose,
+	upsellLabel,
+	upsellLink,
+	ctbId,
+	learnMoreLink,
+	description = __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ),
+} ) => {
 	const upsellRef = useRef( null );
 	const svgAriaProps = useSvgAria();
 	const ctbProps = ctbId ? { "data-action": "load-nfd-ctb", "data-ctb-id": ctbId } : {};
@@ -36,7 +45,7 @@ export const UpsellModal = ( { isOpen, onClose, upsellLabel, upsellLink, ctbId, 
 								{ __( "Generate Metadata in Bulk", "wordpress-seo" ) }
 							</Modal.Title>
 							<Modal.Description as="p" className="yst-text-sm yst-text-slate-600">
-								{ __( "Instantly create SEO titles, meta descriptions, and social metadata for all your products, posts, pages and more. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ) }
+								{ description }
 							</Modal.Description>
 						</div>
 					</div>

--- a/packages/js/src/bulk-editor/components/upsell-modal.js
+++ b/packages/js/src/bulk-editor/components/upsell-modal.js
@@ -4,6 +4,7 @@ import { useRef } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Button, GradientSparklesIcon, Modal, useSvgAria } from "@yoast/ui-library";
 import { OutboundLink } from "../../shared-admin/components";
+import { AI_UPSELL_DESCRIPTION } from "../constants";
 
 /**
  * The upsell modal shown when a Free user triggers a bulk AI generate action.
@@ -26,7 +27,7 @@ export const UpsellModal = ( {
 	upsellLink,
 	ctbId,
 	learnMoreLink,
-	description = __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ),
+	description = AI_UPSELL_DESCRIPTION,
 } ) => {
 	const upsellRef = useRef( null );
 	const svgAriaProps = useSvgAria();

--- a/packages/js/src/bulk-editor/constants.js
+++ b/packages/js/src/bulk-editor/constants.js
@@ -1,3 +1,5 @@
+import { __ } from "@wordpress/i18n";
+
 /**
  * Keep constants centralized to avoid circular dependency problems.
  */
@@ -56,3 +58,6 @@ export const AI_UPSELL = {
 
 // The "Learn more" shortlink for the bulk editor upsell modal.
 export const LEARN_MORE_LINK = "https://yoa.st/bulk-editor-learn-more";
+
+// The generic (non-product) body copy for the bulk AI upsell modal; also the modal's default description.
+export const AI_UPSELL_DESCRIPTION = __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" );

--- a/packages/js/src/bulk-editor/hooks/use-ai-upsell.js
+++ b/packages/js/src/bulk-editor/hooks/use-ai-upsell.js
@@ -1,7 +1,7 @@
 import { useSelect } from "@wordpress/data";
 import { useMemo } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { AI_UPSELL, LEARN_MORE_LINK, PRODUCT_CONTENT_TYPE, STORE_NAME } from "../constants";
+import { AI_UPSELL, AI_UPSELL_DESCRIPTION, LEARN_MORE_LINK, PRODUCT_CONTENT_TYPE, STORE_NAME } from "../constants";
 
 /**
  * The bulk AI upsell props for the active content type: WooCommerce SEO on products, Yoast SEO Premium otherwise.
@@ -27,6 +27,6 @@ export const useAiUpsell = ( contentType ) => {
 		learnMoreLink,
 		description: isProduct
 			? __( "Instantly create SEO titles, meta descriptions, and social metadata for all your products, posts, pages and more. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" )
-			: __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ),
+			: AI_UPSELL_DESCRIPTION,
 	} ), [ upsellLink, target.ctbId, isProduct, learnMoreLink ] );
 };

--- a/packages/js/src/bulk-editor/hooks/use-ai-upsell.js
+++ b/packages/js/src/bulk-editor/hooks/use-ai-upsell.js
@@ -8,7 +8,7 @@ import { AI_UPSELL, LEARN_MORE_LINK, PRODUCT_CONTENT_TYPE, STORE_NAME } from "..
  *
  * @param {string} contentType The active content type.
  *
- * @returns {{upsellLabel: string, upsellLink: string, ctbId: string, learnMoreLink: string}} The upsell props for the modal CTA.
+ * @returns {{upsellLabel: string, upsellLink: string, ctbId: string, learnMoreLink: string, description: string}} The upsell props for the modal.
  */
 export const useAiUpsell = ( contentType ) => {
 	const isProduct = contentType === PRODUCT_CONTENT_TYPE;
@@ -25,5 +25,8 @@ export const useAiUpsell = ( contentType ) => {
 			isProduct ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 		),
 		learnMoreLink,
+		description: isProduct
+			? __( "Instantly create SEO titles, meta descriptions, and social metadata for all your products, posts, pages and more. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" )
+			: __( "Instantly create SEO titles, meta descriptions, and social metadata for all your content. Upgrade to unlock bulk AI generation and streamline your workflow.", "wordpress-seo" ),
 	} ), [ upsellLink, target.ctbId, isProduct, learnMoreLink ] );
 };

--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -9,9 +9,18 @@ import { createHashRouter, createRoutesFromElements, Route, RouterProvider } fro
 import { fixWordPressMenuScrolling } from "../shared-admin/helpers";
 import { LINK_PARAMS_NAME } from "../shared-admin/store";
 import App from "./app";
+import { UpsellModal } from "./components/upsell-modal";
 import { PLUGIN_SCOPE, ROOT_ID, STORE_NAME } from "./constants";
+import { useAiUpsell } from "./hooks/use-ai-upsell";
 import { DataProvider } from "./services";
 import registerStore from "./store";
+
+// Expose the bulk AI upsell so Premium can reuse the same modal instead of duplicating it. Premium's bulk-editor
+// bundle depends on this script, so the global is set before Premium reads it.
+window.yoast = window.yoast || {};
+window.yoast.bulkEditor = window.yoast.bulkEditor || {};
+window.yoast.bulkEditor.components = { ...window.yoast.bulkEditor.components, UpsellModal };
+window.yoast.bulkEditor.hooks = { ...window.yoast.bulkEditor.hooks, useAiUpsell };
 
 domReady( () => {
 	const root = document.getElementById( ROOT_ID );


### PR DESCRIPTION
## Context

Part of the bulk editor AI generation work (Yoast/reserved-tasks#1336). Two small Free-side changes:

1. The bulk AI upsell modal body copy is updated to mention products, posts and pages explicitly.
2. The `UpsellModal` and `useAiUpsell` are exposed on `window.yoast.bulkEditor` so Premium can reuse the exact same upsell modal for its WooCommerce SEO subscription upsell, instead of duplicating the component. (Premium side: [wordpress-seo-premium] PR.)

## Summary

This PR can be summarized in the following changelog entry:

* [wordpress-seo-premium] Adds a WooCommerce SEO subscription upsell to the bulk editor when a user without a valid Yoast WooCommerce SEO subscription generates AI metadata for products.

## Relevant technical choices:

* The Free bulk-editor package is not a shared dependency of Premium, so the modal is exposed on a `window.yoast.bulkEditor` global (mirroring the `editorModules` pattern) and Premium's bundle declares the Free `bulk-editor-page` script as a dependency so the global is set first.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Preconditions: Free Yoast SEO only (no Premium active).
* Go to **Yoast SEO → Bulk editor**, select rows, and click **Generate SEO titles**.
* Expected: the upsell modal for non-product post types shows the body 
<img width="402" height="320" alt="image" src="https://github.com/user-attachments/assets/7775d653-29fb-4cfa-b47e-167ef3752dd5" />

The CTA reads **Unlock with Yoast SEO Premium** 

The product upsell shows the body "Instantly create SEO titles, meta descriptions, and social metadata for all your products, posts, pages and more…". 
<img width="407" height="345" alt="image" src="https://github.com/user-attachments/assets/49a87371-4178-4742-a530-c91322494304" />

The CTA reads **Unlock with Yoast WooCommerce SEO** on Products 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The Free bulk editor upsell modal. Low risk — a copy change plus a window-global export consumed only by Premium.

## Documentation

* [x] I have written documentation for this change. (Code comments.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes Yoast/reserved-tasks#1336
