### PR TITLE
fix(di): run Logger_Aware_Pass before Inject_From_Registry_Pass

### DIFF
--- a/config/dependency-injection/container-compiler.php
+++ b/config/dependency-injection/container-compiler.php
@@ -56,8 +56,8 @@ class Container_Compiler {
 			$container_builder->addCompilerPass( new Loader_Pass() );
 			$container_builder->addCompilerPass( new Interface_Injection_Pass() );
 			$container_builder->addCompilerPass( new AutowireRequiredMethodsPass() );
-			$container_builder->addCompilerPass( new Inject_From_Registry_Pass() );
 			$container_builder->addCompilerPass( new Logger_Aware_Pass() );
+			$container_builder->addCompilerPass( new Inject_From_Registry_Pass() );
 			$loader = new Custom_Loader( $container_builder, $class_map_path );
 			$loader->load( $services_path );
 			$container_builder->compile();


### PR DESCRIPTION

## Context
The `Logger_Aware_Pass` automatically adds a `setLogger()` method call to every service that implements `LoggerAwareInterface`. The `Inject_From_Registry_Pass` is what resolves the type-hinted arguments of those method calls, creating registry-backed definitions for types that live in another plugin's container (e.g. the `Logger` that Premium pulls from the free plugin's container registry). With the passes registered in the previous order, `Inject_From_Registry_Pass` ran first and never saw the `setLogger()` calls that `Logger_Aware_Pass` added afterwards, so Premium could not resolve the logger reference from the registry.

## Summary

This PR can be summarized in the following changelog entry:

* Registers the logger-aware compiler pass before the inject-from-registry pass so logger injection resolves for services provided through the container registry.

## Relevant technical choices:

* Moving `Logger_Aware_Pass` one position up (before `Inject_From_Registry_Pass`) means the `setLogger()` method calls it adds are in place when `Inject_From_Registry_Pass` walks each definition's method calls, so the `Logger` reference can be sourced from the container registry when it isn't already defined locally.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* A good smoke test will do here. There should be no impact at all.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* 

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The compiled dependency injection container. Regenerate it with `composer compile-di` and confirm the container compiles without errors and services implementing `LoggerAwareInterface` still receive their logger.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
