### PR TITLE
style(bulk-editor): add page styles for Premium AI error notices

### DIFF
--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -66,7 +66,7 @@
 }
 
 /* The AI error alerts in Premium */
-.yst-root .yst-bulk-editor-notice-dismiss {
+.yst-root .yst-bulk-editor-error-dismiss {
 	font-size: 10px;
 }
 

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -64,3 +64,12 @@
 .yst-root .yst-bulk-editor-ai-suggestion textarea.yst-textarea {
 	@apply !yst-bg-primary-50;
 }
+
+/* The AI error alerts in Premium */
+.yst-root .yst-bulk-editor-notice-dismiss {
+	font-size: 10px;
+}
+
+.yst-root .yst-bulk-editor-error-body {
+	max-width: 576px;
+}


### PR DESCRIPTION
## Context

The Premium AI bulk-generation error notices (Yoast/wordpress-seo-premium#5011) render into the Free bulk editor page through slot fills. Two design details — a 10px close glyph and a body width capped at 576px so the message wraps to a couple of lines — cannot be expressed with the prebuilt ui-library utility set the Premium bundle relies on (arbitrary values like `text-[10px]` and `max-w-[576px]` are not compiled there). They therefore need page-level CSS in the Free stylesheet the fills render into. Part of the Bulk editor epic (Yoast/reserved-tasks#1329).

## Summary

This PR can be summarized in the following changelog entry:

* Adds bulk editor page styles for the Premium AI error alerts.

## Relevant technical choices:

* **Page-level CSS, not utilities** — the Premium fills use the prebuilt ui-library CSS, which does not compile arbitrary values, so the two rules live in the Free page stylesheet (`css/src/bulk-editor-page.css`) that the fills render into.
* **Scoped under `.yst-root`** — matches the existing rules in the same file.
* CSS-only change, so no unit tests apply; verified in the browser instead (see test instructions).

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* With Premium branch `bulk-editor/error-handling` (Yoast/wordpress-seo-premium#5011) active, open **SEO → Bulk editor**.
* Trigger a whole-request AI error (or a partial failure with some rows failing).
* Confirm the error banner's close button (×) is small (10px), positioned top-right.
* Confirm the banner body text wraps to a couple of lines (capped at 576px) instead of spanning the full width of the banner.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — the bulk editor feature is unreleased and this is a non-user-facing styling change supporting Premium #5011.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor page stylesheet only; the two classes are consumed exclusively by the Premium AI error notices.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo-premium/pull/5011