### PR TITLE
feat(bulk-editor): indeterminate select-all checkbox on a partial selection

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -1,6 +1,6 @@
 import ChevronDownIcon from "@heroicons/react/outline/ChevronDownIcon";
 import { Slot } from "@wordpress/components";
-import { useMemo } from "@wordpress/element";
+import { useEffect, useMemo, useRef } from "@wordpress/element";
 import { applyFilters } from "@wordpress/hooks";
 import { __, sprintf } from "@wordpress/i18n";
 import { Button, Checkbox, DropdownMenu, useSvgAria, useToggleState } from "@yoast/ui-library";
@@ -55,6 +55,7 @@ const SelectMenu = ( { onSelectAll, onDeselectAll, selectedCount, totalCount } )
  * @param {Object}   props               The props.
  * @param {string}   [props.idSuffix]    A suffix that keeps the checkbox id unique across the two tab tables.
  * @param {boolean}  props.isAllSelected Whether every row is selected.
+ * @param {boolean}  [props.isIndeterminate] Whether only some rows are selected (renders the checkbox as a minus).
  * @param {Function} props.onToggleAll   Toggles between selecting every row and none.
  * @param {Function} props.onSelectAll   Selects every row.
  * @param {Function} props.onDeselectAll Clears the selection.
@@ -64,12 +65,20 @@ const SelectMenu = ( { onSelectAll, onDeselectAll, selectedCount, totalCount } )
  *
  * @returns {JSX.Element} The selection toolbar.
  */
-export const SelectionToolbar = ( { idSuffix = "", isAllSelected, onToggleAll, onSelectAll, onDeselectAll, selectedCount, totalCount, contentTypeLabel } ) => {
+export const SelectionToolbar = ( { idSuffix = "", isAllSelected, isIndeterminate = false, onToggleAll, onSelectAll, onDeselectAll, selectedCount, totalCount, contentTypeLabel } ) => {
 	const noun = contentTypeLabel ? contentTypeLabel.toLowerCase() : __( "items", "wordpress-seo" );
+
+	const checkboxRef = useRef( null );
+	useEffect( () => {
+		if ( checkboxRef.current ) {
+			checkboxRef.current.indeterminate = isIndeterminate;
+		}
+	}, [ isIndeterminate ] );
 
 	return (
 		<div className="yst-flex yst-items-center yst-gap-4">
 			<Checkbox
+				ref={ checkboxRef }
 				id={ `bulk-editor-select-all${ idSuffix }` }
 				name={ `bulk-editor-select-all${ idSuffix }` }
 				value="all"

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -25,7 +25,7 @@ import { SearchBox } from "./search-box";
  *
  * @returns {{isAllSelected: boolean, isIndeterminate: boolean, selectedCount: number, totalCount: number, hasSelection: boolean}} The selection view.
  */
-const getSelectionView = ( isLoading, selectedIds, items, total ) => {
+export const getSelectionView = ( isLoading, selectedIds, items, total ) => {
 	if ( isLoading ) {
 		return { isAllSelected: false, isIndeterminate: false, selectedCount: 0, totalCount: 0, hasSelection: false };
 	}

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -23,17 +23,20 @@ import { SearchBox } from "./search-box";
  * @param {Object[]} items       The loaded items (per page).
  * @param {number}   total       The total number of items across all pages.
  *
- * @returns {{isAllSelected: boolean, selectedCount: number, totalCount: number, hasSelection: boolean}} The selection view.
+ * @returns {{isAllSelected: boolean, isIndeterminate: boolean, selectedCount: number, totalCount: number, hasSelection: boolean}} The selection view.
  */
 const getSelectionView = ( isLoading, selectedIds, items, total ) => {
 	if ( isLoading ) {
-		return { isAllSelected: false, selectedCount: 0, totalCount: 0, hasSelection: false };
+		return { isAllSelected: false, isIndeterminate: false, selectedCount: 0, totalCount: 0, hasSelection: false };
 	}
+	const selectedCount = selectedIds.length;
+	const isAllSelected = items.length > 0 && selectedCount === items.length;
 	return {
-		isAllSelected: items.length > 0 && selectedIds.length === items.length,
-		selectedCount: selectedIds.length,
+		isAllSelected,
+		isIndeterminate: selectedCount > 0 && ! isAllSelected,
+		selectedCount,
 		totalCount: total,
-		hasSelection: selectedIds.length > 0,
+		hasSelection: selectedCount > 0,
 	};
 };
 
@@ -124,13 +127,14 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 		}
 	}, [ pendingTab, hasUnsavedEdits, hasExternalPendingChanges, onCommitSwitch ] );
 
-	const { isAllSelected, selectedCount, totalCount, hasSelection } = getSelectionView( isPending, selectedIds, items, total );
+	const { isAllSelected, isIndeterminate, selectedCount, totalCount, hasSelection } = getSelectionView( isPending, selectedIds, items, total );
 	const onSelectAll = useCallback( () => {
 		if ( ! isPending ) {
 			selectAll( items.map( ( item ) => item.id ) );
 		}
 	}, [ isPending, selectAll, items ] );
-	const onToggleAll = useCallback( () => ( isAllSelected ? deselectAll() : onSelectAll() ), [ isAllSelected, deselectAll, onSelectAll ] );
+	// Clicking the master checkbox clears the selection whenever anything is selected (all or a partial).
+	const onToggleAll = useCallback( () => ( hasSelection ? deselectAll() : onSelectAll() ), [ hasSelection, deselectAll, onSelectAll ] );
 
 	const selection = useMemo( () => ( {
 		selectedIds,
@@ -159,6 +163,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 							<SelectionToolbar
 								idSuffix={ `-${ tab.id }` }
 								isAllSelected={ isAllSelected }
+								isIndeterminate={ isIndeterminate }
 								onToggleAll={ onToggleAll }
 								onSelectAll={ onSelectAll }
 								onDeselectAll={ deselectAll }

--- a/packages/js/src/bulk-editor/store/selection.js
+++ b/packages/js/src/bulk-editor/store/selection.js
@@ -30,6 +30,7 @@ const slice = createSlice( {
 		// Any change to the shown result set resets the selection: the new set may no longer contain the selected rows.
 		builder.addCase( queryActions.setStatuses, () => createInitialSelectionState() );
 		builder.addCase( queryActions.setSearch, () => createInitialSelectionState() );
+		builder.addCase( queryActions.setPage, () => createInitialSelectionState() );
 		builder.addCase( activeContentTypeActions.setActiveContentType, () => createInitialSelectionState() );
 	},
 } );

--- a/packages/js/tests/bulk-editor/bulk-action-bar.test.js
+++ b/packages/js/tests/bulk-editor/bulk-action-bar.test.js
@@ -43,6 +43,22 @@ describe( "SelectionToolbar", () => {
 		expect( onToggleAll ).toHaveBeenCalled();
 	} );
 
+	it( "renders the master checkbox as indeterminate on a partial selection", () => {
+		render( <SelectionToolbar { ...toolbarProps } isIndeterminate={ true } selectedCount={ 3 } /> );
+
+		const checkbox = screen.getByRole( "checkbox", { name: "Select all" } );
+		expect( checkbox.indeterminate ).toBe( true );
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	it( "renders the master checkbox as checked (not indeterminate) when all rows are selected", () => {
+		render( <SelectionToolbar { ...toolbarProps } isAllSelected={ true } isIndeterminate={ false } selectedCount={ 20 } /> );
+
+		const checkbox = screen.getByRole( "checkbox", { name: "Select all" } );
+		expect( checkbox.indeterminate ).toBe( false );
+		expect( checkbox ).toBeChecked();
+	} );
+
 	it( "selects and deselects all from the Select menu", () => {
 		const onSelectAll = jest.fn();
 		const onDeselectAll = jest.fn();

--- a/packages/js/tests/bulk-editor/bulk-editor-content.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-content.test.js
@@ -1,7 +1,7 @@
 import { Fill, SlotFillProvider } from "@wordpress/components";
 import { dispatch } from "@wordpress/data";
 import { act, fireEvent, render, screen, waitFor } from "../test-utils";
-import { BulkEditorContent } from "../../src/bulk-editor/components/bulk-editor-content";
+import { BulkEditorContent, getSelectionView } from "../../src/bulk-editor/components/bulk-editor-content";
 import { FIELD_SET_SEARCH, PENDING_CHANGES_MODAL_SLOT, STORE_NAME } from "../../src/bulk-editor/constants";
 import { DataProvider } from "../../src/bulk-editor/services";
 import registerStore from "../../src/bulk-editor/store";
@@ -44,6 +44,51 @@ const renderContent = () => render(
 		<SlotProbe />
 	</SlotFillProvider>
 );
+
+describe( "getSelectionView", () => {
+	const items = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+
+	it( "presents a neutral selection while loading", () => {
+		expect( getSelectionView( true, [ 1, 2 ], items, 3 ) ).toEqual( {
+			isAllSelected: false,
+			isIndeterminate: false,
+			selectedCount: 0,
+			totalCount: 0,
+			hasSelection: false,
+		} );
+	} );
+
+	it( "marks the checkbox as checked when every row is selected", () => {
+		const view = getSelectionView( false, [ 1, 2, 3 ], items, 3 );
+
+		expect( view.isAllSelected ).toBe( true );
+		expect( view.isIndeterminate ).toBe( false );
+		expect( view.hasSelection ).toBe( true );
+	} );
+
+	it( "marks the checkbox as indeterminate on a partial selection", () => {
+		const view = getSelectionView( false, [ 1, 2 ], items, 3 );
+
+		expect( view.isAllSelected ).toBe( false );
+		expect( view.isIndeterminate ).toBe( true );
+		expect( view.hasSelection ).toBe( true );
+	} );
+
+	it( "leaves the checkbox neutral when nothing is selected", () => {
+		const view = getSelectionView( false, [], items, 3 );
+
+		expect( view.isAllSelected ).toBe( false );
+		expect( view.isIndeterminate ).toBe( false );
+		expect( view.hasSelection ).toBe( false );
+	} );
+
+	it( "reports the selected and total counts", () => {
+		const view = getSelectionView( false, [ 1, 2 ], items, 42 );
+
+		expect( view.selectedCount ).toBe( 2 );
+		expect( view.totalCount ).toBe( 42 );
+	} );
+} );
 
 describe( "BulkEditorContent tab-switch guard", () => {
 	beforeAll( () => {

--- a/packages/js/tests/bulk-editor/store/selection.test.js
+++ b/packages/js/tests/bulk-editor/store/selection.test.js
@@ -50,6 +50,12 @@ describe( "selection slice", () => {
 		expect( state.selectedIds ).toEqual( [] );
 	} );
 
+	it( "clears the selection when the page changes", () => {
+		const state = reducer( { selectedIds: [ 7, 9 ] }, queryActions.setPage( 2 ) );
+
+		expect( state.selectedIds ).toEqual( [] );
+	} );
+
 	it( "clears the selection when the content type changes", () => {
 		const state = reducer( { selectedIds: [ 7, 9 ] }, activeContentTypeActions.setActiveContentType( "page" ) );
 


### PR DESCRIPTION
## Context

In the bulk editor, selecting some but not all rows left the master select-all checkbox **unchecked**. It now shows the **indeterminate** state (a minus), per [Figma 10-1698](https://www.figma.com/design/hbzvViD3uZMAZN2fuRZokJ/Bulk-editor?node-id=10-1698), and clicking it in that state clears the selection.

## Summary

This PR can be summarized in the following changelog entry:

* Shows the bulk editor's select-all checkbox as indeterminate when only some rows are selected.

## Relevant technical choices:

* **Native `indeterminate` via a ref** — `indeterminate` is a DOM property, not an attribute, so `SelectionToolbar` sets it on the checkbox input through a ref + effect. The minus glyph comes free from `@tailwindcss/forms`' `:indeterminate` styling, so no ui-library or CSS change was needed.
* **Selection math in `getSelectionView`** — `isIndeterminate` (`0 < selected < rowsOnPage`) is computed in the existing helper rather than the component body, keeping `BulkEditorContent` within the complexity limit.
* **Click-to-clear** — `onToggleAll` now clears the selection whenever anything is selected (all or a partial subset), and selects all only from an empty state.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to **Yoast SEO → Tools → Bulk editor** and select **some but not all** rows on the page.
* Confirm the master (select-all) checkbox shows a **minus** (indeterminate), not empty.
<img width="1376" height="481" alt="image" src="https://github.com/user-attachments/assets/a2989c06-02b7-478d-acc0-8575de913d93" />

* Click the master checkbox: confirm it **clears the whole selection**.
* Click it again (empty): confirm it selects all rows (checked); clicking it when all are selected clears them.
<img width="1375" height="622" alt="image" src="https://github.com/user-attachments/assets/8d0738ed-bcea-4250-ad93-f6aa28124b88" />

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

<!-- Cross-content-type: the select-all lives per tab table. Cross-browser: indeterminate relies on the native DOM property + forms-plugin styling. -->

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor selection toolbar only (the master checkbox state and its click behaviour). No change to what selecting rows does downstream.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. (Code comments.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1344