### PR TITLE
feat(bulk-editor): add Save edits / Cancel edits for manual edits

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -141,7 +141,7 @@ const FreeBulkActions = ( { contentType } ) => {
  * @param {number}   props.editCount   The number of rows with unsaved manual edits.
  * @param {Function} props.onApplyAll  Saves every row's open edits.
  * @param {Function} props.onDiscardAll Discards every row's open edits.
- * @param {boolean}  [props.isApplying] Whether an apply-all is in flight; disables both actions.
+ * @param {boolean}  [props.isApplying=false] Whether an apply-all is in flight; disables both actions.
  *
  * @returns {JSX.Element} The manual review actions.
  */

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -1,8 +1,10 @@
+import CheckIcon from "@heroicons/react/outline/CheckIcon";
 import ChevronDownIcon from "@heroicons/react/outline/ChevronDownIcon";
+import XIcon from "@heroicons/react/outline/XIcon";
 import { Slot } from "@wordpress/components";
-import { useEffect, useMemo, useRef } from "@wordpress/element";
+import { useEffect, useId, useMemo, useRef } from "@wordpress/element";
 import { applyFilters } from "@wordpress/hooks";
-import { __, sprintf } from "@wordpress/i18n";
+import { __, _n, sprintf } from "@wordpress/i18n";
 import { Button, Checkbox, DropdownMenu, useSvgAria, useToggleState } from "@yoast/ui-library";
 import { BULK_ACTIONS_SLOT, BULK_NOTICES_SLOT, SELECT_MENU_ITEMS_FILTER } from "../constants";
 import { useAiUpsell } from "../hooks/use-ai-upsell";
@@ -133,6 +135,44 @@ const FreeBulkActions = ( { contentType } ) => {
 };
 
 /**
+ * The Save edits / Cancel edits actions for pending manual edits.
+ *
+ * @param {Object}   props             The props.
+ * @param {number}   props.editCount   The number of rows with unsaved manual edits.
+ * @param {Function} props.onApplyAll  Saves every row's open edits.
+ * @param {Function} props.onDiscardAll Discards every row's open edits.
+ * @param {boolean}  [props.isApplying] Whether an apply-all is in flight; disables both actions.
+ *
+ * @returns {JSX.Element} The manual review actions.
+ */
+export const ManualReviewActions = ( { editCount, onApplyAll, onDiscardAll, isApplying = false } ) => {
+	// Couple the count summary to each action, so screen readers announce it.
+	const summaryId = useId();
+
+	return (
+		<div className="yst-grow yst-flex yst-justify-end yst-items-center yst-gap-4">
+			<span id={ summaryId } className="yst-text-sm yst-font-medium yst-text-slate-800">
+				{ sprintf(
+					/* translators: %d expands to the number of rows with unsaved changes. */
+					_n( "%d row with unsaved changes", "%d rows with unsaved changes", editCount, "wordpress-seo" ),
+					editCount
+				) }
+			</span>
+			<div className="yst-flex yst-gap-2">
+				<Button variant="secondary" size="small" className="yst-gap-1.5" onClick={ onApplyAll } disabled={ isApplying } aria-describedby={ summaryId }>
+					<CheckIcon className="yst-h-4 yst-w-4 yst-text-green-500" aria-hidden="true" />
+					{ __( "Save edits", "wordpress-seo" ) }
+				</Button>
+				<Button variant="secondary" size="small" className="yst-gap-1.5" onClick={ onDiscardAll } disabled={ isApplying } aria-describedby={ summaryId }>
+					<XIcon className="yst-h-4 yst-w-4 yst-text-red-500" aria-hidden="true" />
+					{ __( "Cancel edits", "wordpress-seo" ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+/**
  * The AI generate buttons toolbar row, shown when rows are selected. In Premium the active tab's slot is filled
  * with the AI buttons (the fill receives `fillProps`); in Free they open the upsell modal. The notices slot above
  * it is full-bleed (outside the padded band), so Premium can fill it with a full-width row (e.g. an alert).
@@ -147,12 +187,18 @@ const FreeBulkActions = ( { contentType } ) => {
  * @param {string}   [props.contentTypeLabel] The active content type label (plural), passed to the notices fill for its copy.
  * @param {string}   [props.contentTypeSingularLabel] The active content type singular label, passed to the notices fill.
  * @param {boolean}  [props.hasUnsavedEdits]  Whether a row has unsaved manual edits, passed to the actions fill so Premium
- *                                             can disable the AI buttons while edits are in progress.
+ *                                             can disable the AI buttons while edits are in progress. While true, the bar
+ *                                             also shows the Apply all / Discard all review actions alongside the generate ones.
+ * @param {number}   [props.editCount]        The number of rows with unsaved manual edits, shown in the review summary.
+ * @param {Function} [props.onApplyAll]       Saves every row's open edits.
+ * @param {Function} [props.onDiscardAll]     Discards every row's open edits.
+ * @param {boolean}  [props.isApplyingAll]    Whether an apply-all is in flight; disables the review actions.
  *
  * @returns {JSX.Element} The bulk actions row content.
  */
 export const BulkActions = ( {
-	isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
+	isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel,
+	hasUnsavedEdits, editCount, onApplyAll, onDiscardAll, isApplyingAll,
 } ) => (
 	<div className="yst-flex yst-flex-col">
 		{ isActive && (
@@ -163,7 +209,12 @@ export const BulkActions = ( {
 		) }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
 			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
-			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType, hasUnsavedEdits } } /> }
+			{ isActive && (
+				<Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType, hasUnsavedEdits } } />
+			) }
+			{ isActive && hasUnsavedEdits && (
+				<ManualReviewActions editCount={ editCount } onApplyAll={ onApplyAll } onDiscardAll={ onDiscardAll } isApplying={ isApplyingAll } />
+			) }
 		</div>
 	</div>
 );

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -5,7 +5,7 @@ import { Slot } from "@wordpress/components";
 import { useEffect, useId, useMemo, useRef } from "@wordpress/element";
 import { applyFilters } from "@wordpress/hooks";
 import { __, _n, sprintf } from "@wordpress/i18n";
-import { Button, Checkbox, DropdownMenu, useSvgAria, useToggleState } from "@yoast/ui-library";
+import { Alert, Button, Checkbox, DropdownMenu, useSvgAria, useToggleState } from "@yoast/ui-library";
 import { BULK_ACTIONS_SLOT, BULK_NOTICES_SLOT, SELECT_MENU_ITEMS_FILTER } from "../constants";
 import { useAiUpsell } from "../hooks/use-ai-upsell";
 import { UpsellModal } from "./upsell-modal";
@@ -173,6 +173,58 @@ export const ManualReviewActions = ( { editCount, onApplyAll, onDiscardAll, isAp
 };
 
 /**
+ * The inline error shown when a batch "Save edits" had one or more rows fail to save.
+ *
+ * @param {Object}   props           The props.
+ * @param {Function} props.onDismiss Dismisses the notice.
+ *
+ * @returns {JSX.Element} The save-error notice.
+ */
+export const ManualSaveErrorNotice = ( { onDismiss } ) => (
+	<Alert variant="error" as="div" role="alert" className="yst-rounded-none yst-relative">
+		<div className="yst-flex yst-flex-col yst-gap-1">
+			<span className="yst-block yst-font-medium">{ __( "Couldn't save your edits.", "wordpress-seo" ) }</span>
+			<span className="yst-font-normal">{ __( "Something went wrong. Please try again.", "wordpress-seo" ) }</span>
+		</div>
+		<button
+			type="button"
+			className="yst-absolute yst-end-4 yst-top-4 yst-leading-none yst-text-current hover:yst-opacity-75 yst-cursor-pointer"
+			onClick={ onDismiss }
+			aria-label={ __( "Dismiss", "wordpress-seo" ) }
+		>
+			&times;
+		</button>
+	</Alert>
+);
+
+/**
+ * The Free save-error notice, and the alerts slot Premium fills (e.g. its AI alerts).
+ * Only rendered on the active tab, so each tab has a single slot to target.
+ *
+ * @param {Object}   props                      The props.
+ * @param {boolean}  [props.hasSaveError]       Whether the last apply-all failed; shows the save-error notice.
+ * @param {Function} [props.onDismissSaveError] Dismisses the save-error notice.
+ * @param {number[]} props.selectedIds          The ids of the selected rows, passed to the notices fill.
+ * @param {string}   props.activeFieldSet       The active field set, passed to the notices fill.
+ * @param {string}   props.contentType          The active content type, passed to the notices fill.
+ * @param {string}   [props.contentTypeLabel]   The active content type label (plural), passed to the notices fill.
+ * @param {string}   [props.contentTypeSingularLabel] The active content type singular label, passed to the notices fill.
+ *
+ * @returns {JSX.Element} The notices region.
+ */
+const BulkActionsNotices = ( {
+	hasSaveError, onDismissSaveError, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel,
+} ) => (
+	<>
+		{ hasSaveError && <ManualSaveErrorNotice onDismiss={ onDismissSaveError } /> }
+		<Slot
+			name={ BULK_NOTICES_SLOT }
+			fillProps={ { selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } }
+		/>
+	</>
+);
+
+/**
  * The AI generate buttons toolbar row, shown when rows are selected. In Premium the active tab's slot is filled
  * with the AI buttons (the fill receives `fillProps`); in Free they open the upsell modal. The notices slot above
  * it is full-bleed (outside the padded band), so Premium can fill it with a full-width row (e.g. an alert).
@@ -192,18 +244,25 @@ export const ManualReviewActions = ( { editCount, onApplyAll, onDiscardAll, isAp
  * @param {Function} [props.onApplyAll]       Saves every row's open edits.
  * @param {Function} [props.onDiscardAll]     Discards every row's open edits.
  * @param {boolean}  [props.isApplyingAll]    Whether an apply-all is in flight; disables the review actions.
+ * @param {boolean}  [props.hasSaveError]     Whether the last apply-all failed; shows the inline save-error notice.
+ * @param {Function} [props.onDismissSaveError] Dismisses the save-error notice.
  *
  * @returns {JSX.Element} The bulk actions row content.
  */
 export const BulkActions = ( {
 	isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel,
-	hasUnsavedEdits, editCount, onApplyAll, onDiscardAll, isApplyingAll,
+	hasUnsavedEdits, editCount, onApplyAll, onDiscardAll, isApplyingAll, hasSaveError, onDismissSaveError,
 } ) => (
 	<div className="yst-flex yst-flex-col">
 		{ isActive && (
-			<Slot
-				name={ BULK_NOTICES_SLOT }
-				fillProps={ { selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel } }
+			<BulkActionsNotices
+				hasSaveError={ hasSaveError }
+				onDismissSaveError={ onDismissSaveError }
+				selectedIds={ selectedIds }
+				activeFieldSet={ activeFieldSet }
+				contentType={ contentType }
+				contentTypeLabel={ contentTypeLabel }
+				contentTypeSingularLabel={ contentTypeSingularLabel }
 			/>
 		) }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -187,8 +187,7 @@ export const ManualReviewActions = ( { editCount, onApplyAll, onDiscardAll, isAp
  * @param {string}   [props.contentTypeLabel] The active content type label (plural), passed to the notices fill for its copy.
  * @param {string}   [props.contentTypeSingularLabel] The active content type singular label, passed to the notices fill.
  * @param {boolean}  [props.hasUnsavedEdits]  Whether a row has unsaved manual edits, passed to the actions fill so Premium
- *                                             can disable the AI buttons while edits are in progress. While true, the bar
- *                                             also shows the Apply all / Discard all review actions alongside the generate ones.
+ *                                             can disable the AI buttons while edits are in progress.
  * @param {number}   [props.editCount]        The number of rows with unsaved manual edits, shown in the review summary.
  * @param {Function} [props.onApplyAll]       Saves every row's open edits.
  * @param {Function} [props.onDiscardAll]     Discards every row's open edits.

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -94,15 +94,10 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 	}, [ activeFieldSet, hasUnsavedEdits, hasExternalPendingChanges, setActiveFieldSet ] );
 
 	const onSaveAndSwitch = useCallback( () => {
-		// Fire the save for every open field; each reads its draft synchronously, so clearing the edit state
-		// right after still posts the captured values while leaving the new tab clean. Clearing the edits flips
-		// hasUnsavedEdits to false, after which the switch completes via the self-heal effect (nothing external
-		// pending) or the slot modal (an external plugin still has pending changes) — never both at once.
-		Object.entries( editing.editingRows ).forEach( ( [ id, row ] ) =>
-			row.openFields.forEach( ( key ) => editing.onApplyField( { id: Number( id ), key } ) )
-		);
-		stopEditing();
-	}, [ editing, stopEditing ] );
+		// Save every open edit as one batch. On failure the drafts stay open, so the switch is not committed
+		// and no edits are silently lost.
+		editing.onApplyAll();
+	}, [ editing ] );
 
 	const onDiscardAndSwitch = useCallback( () => {
 		// Clearing the edits flips hasUnsavedEdits to false; the self-heal effect or the slot modal then completes

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -76,7 +76,8 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 	// The tab the user wants to switch to while a switch is guarded (unsaved manual edits, or an external plugin
 	// reporting pending changes); drives the confirmation modal.
 	const [ pendingTab, setPendingTab ] = useState( null );
-	const hasUnsavedEdits = Object.keys( editing.editingRows ).length > 0;
+	const editCount = Object.keys( editing.editingRows ).length;
+	const hasUnsavedEdits = editCount > 0;
 
 
 	const onChangeTab = useCallback( ( id ) => {
@@ -182,11 +183,16 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								contentTypeLabel={ contentTypeLabel }
 								contentTypeSingularLabel={ contentTypeSingularLabel }
 								hasUnsavedEdits={ hasUnsavedEdits }
+								editCount={ editCount }
+								onApplyAll={ editing.onApplyAll }
+								onDiscardAll={ editing.onDiscardAll }
+								isApplyingAll={ editing.isApplyingAll }
 							/>
 						}
-						showBulkActions={ hasSelection }
+						showBulkActions={ hasSelection || hasUnsavedEdits }
 						filters={ <BulkEditorFilters /> }
 						isLoading={ isPending }
+						hasExternalPendingChanges={ hasExternalPendingChanges }
 						footer={ total > 0
 							? <BulkEditorFooter total={ total } totalPages={ totalPages } isPending={ isPending } />
 							: null }

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -182,6 +182,8 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								onApplyAll={ editing.onApplyAll }
 								onDiscardAll={ editing.onDiscardAll }
 								isApplyingAll={ editing.isApplyingAll }
+								hasSaveError={ editing.hasSaveError }
+								onDismissSaveError={ editing.dismissSaveError }
 							/>
 						}
 						showBulkActions={ hasSelection || hasUnsavedEdits }

--- a/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
+++ b/packages/js/src/bulk-editor/components/table/bulk-editor-table.js
@@ -70,6 +70,7 @@ const TableFooter = ( { columnCount, children } ) => {
  * @param {boolean}             [props.showBulkActions]  Whether the bulk-actions row is expanded (a selection is active).
  * @param {JSX.Element}         [props.filters]          The filters control, rendered in the toolbar row.
  * @param {JSX.Element}         [props.footer]           The results footer, rendered as the table's bottom row.
+ * @param {boolean}             [props.hasExternalPendingChanges] Whether Premium AI suggestions are pending review; disables row editing.
  *
  * @returns {JSX.Element} The table.
  */
@@ -84,6 +85,7 @@ export const BulkEditorTable = ( {
 	showBulkActions = false,
 	filters,
 	footer,
+	hasExternalPendingChanges,
 } ) => {
 	const columnCount = getColumnCount( fieldSet.fields );
 	const selectionState = { selectedIds: [], isAllSelected: false, onToggleRow: noop, onToggleAll: noop, ...selection };
@@ -127,6 +129,7 @@ export const BulkEditorTable = ( {
 						selection={ selectionState }
 						editing={ editingState }
 						isLoading={ isLoading }
+						hasExternalPendingChanges={ hasExternalPendingChanges }
 					/>
 				</Table.Body>
 				<TableFooter columnCount={ columnCount }>{ footer }</TableFooter>

--- a/packages/js/src/bulk-editor/components/table/table-body.js
+++ b/packages/js/src/bulk-editor/components/table/table-body.js
@@ -38,7 +38,7 @@ const SkeletonRows = ( { columnCount } ) => (
  * @param {BulkEditorSelection} props.selection   The selection props.
  * @param {BulkEditorEditing}   props.editing     The inline-edit props.
  * @param {boolean}             props.isLoading   Whether to render skeleton rows.
- * @param {boolean}             [props.hasExternalPendingChanges] Whether Premium AI suggestions are pending review; disables editing.
+ * @param {boolean}             [props.hasExternalPendingChanges=false] Whether Premium AI suggestions are pending review; disables editing.
  *
  * @returns {JSX.Element} The body rows.
  */

--- a/packages/js/src/bulk-editor/components/table/table-body.js
+++ b/packages/js/src/bulk-editor/components/table/table-body.js
@@ -38,10 +38,11 @@ const SkeletonRows = ( { columnCount } ) => (
  * @param {BulkEditorSelection} props.selection   The selection props.
  * @param {BulkEditorEditing}   props.editing     The inline-edit props.
  * @param {boolean}             props.isLoading   Whether to render skeleton rows.
+ * @param {boolean}             [props.hasExternalPendingChanges] Whether Premium AI suggestions are pending review; disables editing.
  *
  * @returns {JSX.Element} The body rows.
  */
-export const BulkEditorBody = ( { items, fields, fieldSetId, columnCount, selection, editing, isLoading } ) => {
+export const BulkEditorBody = ( { items, fields, fieldSetId, columnCount, selection, editing, isLoading, hasExternalPendingChanges = false } ) => {
 	const { selectedIds, onToggleRow } = selection;
 
 	if ( isLoading && items.length === 0 ) {
@@ -68,6 +69,7 @@ export const BulkEditorBody = ( { items, fields, fieldSetId, columnCount, select
 			onToggleRow={ onToggleRow }
 			edit={ editing.editingRows[ item.id ] }
 			editing={ editing }
+			hasExternalPendingChanges={ hasExternalPendingChanges }
 		/>
 	) );
 };

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -18,7 +18,7 @@ import { getFieldTextClasses, getRowEditState } from "./table-helpers";
  * @param {Function}          props.onToggleRow Called with the item id when its checkbox is toggled.
  * @param {Object}            [props.edit]      This row's edit state ({ openFields, draft, savingFields }), or undefined when not editing.
  * @param {BulkEditorEditing} props.editing     The inline-edit props (its handlers).
- * @param {boolean}           [props.hasExternalPendingChanges] Whether Premium AI has suggestions pending review; while true,
+ * @param {boolean}           [props.hasExternalPendingChanges=false] Whether Premium AI has suggestions pending review; while true,
  *                                                              editing is disabled so manual edits and AI generation stay mutually exclusive.
  *
  * @returns {JSX.Element} The row.

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -25,8 +25,9 @@ import { getFieldTextClasses, getRowEditState } from "./table-helpers";
  */
 export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleRow, edit, editing, hasExternalPendingChanges = false } ) => {
 	const { isEditing, openFields, draft, savingFields } = getRowEditState( edit );
-	const { onStartEdit, onChangeField, onApplyField, onCancelEdit, onDiscardField, onFieldApplied } = editing;
-	const isSaving = Object.keys( savingFields ).length > 0;
+	const { onStartEdit, onChangeField, onApplyField, onCancelEdit, onDiscardField, onFieldApplied, isApplyingAll } = editing;
+	// Treat a batch "Save edits" as saving this row too, so its inputs and Save/Cancel lock and a per-field save can't race the batch.
+	const isSaving = Object.keys( savingFields ).length > 0 || isApplyingAll;
 	const fillsSeoTitles = useSlotFills( `${ TABLE_CELL_FIELD_SLOT }/seoTitle/${item.id}` );
 	const fillsMetaDescription = useSlotFills( `${ TABLE_CELL_FIELD_SLOT }/metaDescription/${item.id}` );
 	const fillsSocialTitle = useSlotFills( `${ TABLE_CELL_FIELD_SLOT }/socialTitle/${item.id}` );

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -18,10 +18,12 @@ import { getFieldTextClasses, getRowEditState } from "./table-helpers";
  * @param {Function}          props.onToggleRow Called with the item id when its checkbox is toggled.
  * @param {Object}            [props.edit]      This row's edit state ({ openFields, draft, savingFields }), or undefined when not editing.
  * @param {BulkEditorEditing} props.editing     The inline-edit props (its handlers).
+ * @param {boolean}           [props.hasExternalPendingChanges] Whether Premium AI has suggestions pending review; while true,
+ *                                                              editing is disabled so manual edits and AI generation stay mutually exclusive.
  *
  * @returns {JSX.Element} The row.
  */
-export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleRow, edit, editing } ) => {
+export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleRow, edit, editing, hasExternalPendingChanges = false } ) => {
 	const { isEditing, openFields, draft, savingFields } = getRowEditState( edit );
 	const { onStartEdit, onChangeField, onApplyField, onCancelEdit, onDiscardField, onFieldApplied } = editing;
 	const isSaving = Object.keys( savingFields ).length > 0;
@@ -139,7 +141,7 @@ export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleR
 								className="yst--me-2.5"
 								onClick={ handleEdit }
 								aria-label={ editLabel }
-								disabled={ isSlotFilled }
+								disabled={ isSlotFilled || hasExternalPendingChanges }
 							>
 								{ __( "Edit", "wordpress-seo" ) }
 							</Button>

--- a/packages/js/src/bulk-editor/constants.js
+++ b/packages/js/src/bulk-editor/constants.js
@@ -10,6 +10,9 @@ export const ROOT_ID = "yoast-seo-bulk-editor";
 // How many rows the bulk editor shows per page; also sizes the loading skeleton.
 export const PAGE_SIZE = 20;
 
+// The most items a single bulk-update request may carry; mirrors the server's Batch_Limit::MAX_ITEMS.
+export const BULK_UPDATE_BATCH_SIZE = 20;
+
 // The minimum term length before the debounced as-you-type search runs; the Search button has no minimum.
 export const MIN_SEARCH_LENGTH = 3;
 

--- a/packages/js/src/bulk-editor/hooks/use-inline-edit.js
+++ b/packages/js/src/bulk-editor/hooks/use-inline-edit.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useCallback, useMemo, useState } from "@wordpress/element";
+import { useCallback, useMemo, useRef, useState } from "@wordpress/element";
 import { BULK_UPDATE_BATCH_SIZE, STORE_NAME } from "../constants";
 
 /**
@@ -30,6 +30,13 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 	const { startEdit, updateDraftField, setSavingField, closeField, discardEdit, stopEdit } = useDispatch( STORE_NAME );
 
 	const [ isApplyingAll, setIsApplyingAll ] = useState( false );
+	// Whether the last apply-all had one or more requests fail; drives the inline "couldn't save" notice.
+	const [ hasSaveError, setHasSaveError ] = useState( false );
+	// Guards onApplyAll against re-entry, so a batch in flight can't fire a second,
+	// overlapping set of requests. A ref, so the check is synchronous within a tick.
+	const isApplyingAllRef = useRef( false );
+
+	const dismissSaveError = useCallback( () => setHasSaveError( false ), [] );
 
 	const onDiscardField = useCallback( ( { id, key } ) => closeField( { id, key } ), [ closeField ] );
 
@@ -74,11 +81,12 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 
 	const onApplyAll = useCallback( async() => {
 		const fieldSet = fieldSets[ activeFieldSet ];
-		if ( ! remoteDataProvider || Object.keys( editingRows ).length === 0 ) {
+		if ( isApplyingAllRef.current || ! remoteDataProvider || Object.keys( editingRows ).length === 0 ) {
 			return;
 		}
 
-		// Group every row's open drafts by endpoint into one batched item per row.
+		// Group every row's open drafts by endpoint: each row carries both its request payload (`item`) and the
+		// `applied` entries to reflect locally once it saves.
 		const batches = {};
 		Object.entries( editingRows ).forEach( ( [ rowId, row ] ) => {
 			const id = Number( rowId );
@@ -93,13 +101,13 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 					return;
 				}
 				if ( ! batches[ endpointKey ] ) {
-					batches[ endpointKey ] = { endpoint, items: {}, applied: [] };
+					batches[ endpointKey ] = { endpoint, rows: {} };
 				}
-				if ( ! batches[ endpointKey ].items[ id ] ) {
-					batches[ endpointKey ].items[ id ] = { id };
+				if ( ! batches[ endpointKey ].rows[ id ] ) {
+					batches[ endpointKey ].rows[ id ] = { item: { id }, applied: [] };
 				}
-				batches[ endpointKey ].items[ id ][ field.param ] = row.draft[ key ];
-				batches[ endpointKey ].applied.push( { id, key, value: row.draft[ key ] } );
+				batches[ endpointKey ].rows[ id ].item[ field.param ] = row.draft[ key ];
+				batches[ endpointKey ].rows[ id ].applied.push( { id, key, value: row.draft[ key ] } );
 			} );
 		} );
 
@@ -108,36 +116,53 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 			return;
 		}
 
-		// One POST per endpoint, chunked to the server's batch limit: editing rows accumulate across pages, so the
-		// total can exceed a single batch — chunking keeps every request within the limit rather than being rejected.
+		// One POST per endpoint, chunked to the server's batch limit. Each request keeps the `applied` entries for its own rows,
+		// so a failed chunk only holds back its own rows.
 		const requests = groups.flatMap( ( group ) => {
-			const endpointItems = Object.values( group.items );
+			const rows = Object.values( group.rows );
 			const chunks = [];
-			for ( let start = 0; start < endpointItems.length; start += BULK_UPDATE_BATCH_SIZE ) {
-				chunks.push( endpointItems.slice( start, start + BULK_UPDATE_BATCH_SIZE ) );
+			for ( let start = 0; start < rows.length; start += BULK_UPDATE_BATCH_SIZE ) {
+				chunks.push( rows.slice( start, start + BULK_UPDATE_BATCH_SIZE ) );
 			}
-			return chunks.map( ( chunk ) => remoteDataProvider.fetchJson( group.endpoint, {}, {
-				method: "POST",
-				body: JSON.stringify( { items: chunk } ),
+			return chunks.map( ( chunkRows ) => ( {
+				applied: chunkRows.flatMap( ( row ) => row.applied ),
+				promise: remoteDataProvider.fetchJson( group.endpoint, {}, {
+					method: "POST",
+					body: JSON.stringify( { items: chunkRows.map( ( row ) => row.item ) } ),
+				} ),
 			} ) );
 		} );
 
+		isApplyingAllRef.current = true;
 		setIsApplyingAll( true );
+		setHasSaveError( false );
 		try {
-			await Promise.all( requests );
-			// Reflect every saved field on its row, then leave edit mode for all rows at once.
-			groups.forEach( ( group ) => group.applied.forEach( ( { id, key, value } ) => updateItem( id, key, value ) ) );
-			stopEdit();
-		} catch ( error ) {
-			// A request failed: keep the drafts and stay in edit mode so the user can retry.
+			// A partial failure reflects the rows that did save, while the
+			// failed rows stay open for a retry. On full success every field closes, so all rows leave edit mode.
+			const results = await Promise.allSettled( requests.map( ( request ) => request.promise ) );
+			results.forEach( ( result, index ) => {
+				if ( result.status !== "fulfilled" ) {
+					return;
+				}
+				requests[ index ].applied.forEach( ( { id, key, value } ) => {
+					updateItem( id, key, value );
+					closeField( { id, key } );
+				} );
+			} );
+			if ( results.some( ( result ) => result.status === "rejected" ) ) {
+				setHasSaveError( true );
+			}
 		} finally {
+			isApplyingAllRef.current = false;
 			setIsApplyingAll( false );
 		}
-	}, [ fieldSets, activeFieldSet, dataProvider, remoteDataProvider, editingRows, updateItem, stopEdit ] );
+	}, [ fieldSets, activeFieldSet, dataProvider, remoteDataProvider, editingRows, updateItem, closeField ] );
 
 	const editing = useMemo( () => ( {
 		editingRows,
 		isApplyingAll,
+		hasSaveError,
+		dismissSaveError,
 		onStartEdit,
 		onChangeField: updateDraftField,
 		onApplyField,
@@ -147,8 +172,8 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 		onDiscardField,
 		onFieldApplied: updateItem,
 	} ), [
-		editingRows, isApplyingAll, onStartEdit, updateDraftField, onApplyField,
-		onApplyAll, stopEdit, onCancelEdit, onDiscardField, updateItem,
+		editingRows, isApplyingAll, hasSaveError, dismissSaveError, onStartEdit, updateDraftField,
+		onApplyField, onApplyAll, stopEdit, onCancelEdit, onDiscardField, updateItem,
 	] );
 
 	return { editing, stopEditing: stopEdit };

--- a/packages/js/src/bulk-editor/hooks/use-inline-edit.js
+++ b/packages/js/src/bulk-editor/hooks/use-inline-edit.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useCallback, useMemo } from "@wordpress/element";
+import { useCallback, useMemo, useState } from "@wordpress/element";
 import { STORE_NAME } from "../constants";
 
 /**
@@ -28,6 +28,8 @@ const fieldEndpointKey = ( field, fieldSet ) => field.endpoint ?? fieldSet.endpo
 export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, activeFieldSet, items, updateItem } ) => {
 	const editingRows = useSelect( ( select ) => select( STORE_NAME ).selectEditingRows(), [] );
 	const { startEdit, updateDraftField, setSavingField, closeField, discardEdit, stopEdit } = useDispatch( STORE_NAME );
+
+	const [ isApplyingAll, setIsApplyingAll ] = useState( false );
 
 	const onDiscardField = useCallback( ( { id, key } ) => closeField( { id, key } ), [ closeField ] );
 
@@ -70,15 +72,73 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 		}
 	}, [ fieldSets, activeFieldSet, dataProvider, remoteDataProvider, editingRows, setSavingField, closeField, updateItem ] );
 
+	const onApplyAll = useCallback( async() => {
+		const fieldSet = fieldSets[ activeFieldSet ];
+		if ( ! remoteDataProvider || Object.keys( editingRows ).length === 0 ) {
+			return;
+		}
+
+		// Group every row's open drafts by endpoint into one batched item per row.
+		const batches = {};
+		Object.entries( editingRows ).forEach( ( [ rowId, row ] ) => {
+			const id = Number( rowId );
+			row.openFields.forEach( ( key ) => {
+				const field = fieldSet.fields.find( ( candidate ) => candidate.key === key );
+				if ( ! field ) {
+					return;
+				}
+				const endpointKey = fieldEndpointKey( field, fieldSet );
+				const endpoint = dataProvider.getEndpoint( endpointKey );
+				if ( ! endpoint ) {
+					return;
+				}
+				if ( ! batches[ endpointKey ] ) {
+					batches[ endpointKey ] = { endpoint, items: {}, applied: [] };
+				}
+				if ( ! batches[ endpointKey ].items[ id ] ) {
+					batches[ endpointKey ].items[ id ] = { id };
+				}
+				batches[ endpointKey ].items[ id ][ field.param ] = row.draft[ key ];
+				batches[ endpointKey ].applied.push( { id, key, value: row.draft[ key ] } );
+			} );
+		} );
+
+		const groups = Object.values( batches );
+		if ( groups.length === 0 ) {
+			return;
+		}
+
+		setIsApplyingAll( true );
+		try {
+			await Promise.all( groups.map( ( group ) => remoteDataProvider.fetchJson( group.endpoint, {}, {
+				method: "POST",
+				body: JSON.stringify( { items: Object.values( group.items ) } ),
+			} ) ) );
+			// Reflect every saved field on its row, then leave edit mode for all rows at once.
+			groups.forEach( ( group ) => group.applied.forEach( ( { id, key, value } ) => updateItem( id, key, value ) ) );
+			stopEdit();
+		} catch ( error ) {
+			// Keep the drafts so the user can retry; the fields stay in edit mode.
+		} finally {
+			setIsApplyingAll( false );
+		}
+	}, [ fieldSets, activeFieldSet, dataProvider, remoteDataProvider, editingRows, updateItem, stopEdit ] );
+
 	const editing = useMemo( () => ( {
 		editingRows,
+		isApplyingAll,
 		onStartEdit,
 		onChangeField: updateDraftField,
 		onApplyField,
+		onApplyAll,
+		onDiscardAll: stopEdit,
 		onCancelEdit,
 		onDiscardField,
 		onFieldApplied: updateItem,
-	} ), [ editingRows, onStartEdit, updateDraftField, onApplyField, onCancelEdit, onDiscardField, updateItem ] );
+	} ), [
+		editingRows, isApplyingAll, onStartEdit, updateDraftField, onApplyField,
+		onApplyAll, stopEdit, onCancelEdit, onDiscardField, updateItem,
+	] );
 
 	return { editing, stopEditing: stopEdit };
 };

--- a/packages/js/src/bulk-editor/hooks/use-inline-edit.js
+++ b/packages/js/src/bulk-editor/hooks/use-inline-edit.js
@@ -1,6 +1,6 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback, useMemo, useState } from "@wordpress/element";
-import { STORE_NAME } from "../constants";
+import { BULK_UPDATE_BATCH_SIZE, STORE_NAME } from "../constants";
 
 /**
  * The endpoint key a field saves through: a field-level override when set, otherwise the field set's default.
@@ -108,17 +108,28 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 			return;
 		}
 
+		// One POST per endpoint, chunked to the server's batch limit: editing rows accumulate across pages, so the
+		// total can exceed a single batch — chunking keeps every request within the limit rather than being rejected.
+		const requests = groups.flatMap( ( group ) => {
+			const endpointItems = Object.values( group.items );
+			const chunks = [];
+			for ( let start = 0; start < endpointItems.length; start += BULK_UPDATE_BATCH_SIZE ) {
+				chunks.push( endpointItems.slice( start, start + BULK_UPDATE_BATCH_SIZE ) );
+			}
+			return chunks.map( ( chunk ) => remoteDataProvider.fetchJson( group.endpoint, {}, {
+				method: "POST",
+				body: JSON.stringify( { items: chunk } ),
+			} ) );
+		} );
+
 		setIsApplyingAll( true );
 		try {
-			await Promise.all( groups.map( ( group ) => remoteDataProvider.fetchJson( group.endpoint, {}, {
-				method: "POST",
-				body: JSON.stringify( { items: Object.values( group.items ) } ),
-			} ) ) );
+			await Promise.all( requests );
 			// Reflect every saved field on its row, then leave edit mode for all rows at once.
 			groups.forEach( ( group ) => group.applied.forEach( ( { id, key, value } ) => updateItem( id, key, value ) ) );
 			stopEdit();
 		} catch ( error ) {
-			// Keep the drafts so the user can retry; the fields stay in edit mode.
+			// A request failed: keep the drafts and stay in edit mode so the user can retry.
 		} finally {
 			setIsApplyingAll( false );
 		}

--- a/packages/js/src/bulk-editor/hooks/use-inline-edit.js
+++ b/packages/js/src/bulk-editor/hooks/use-inline-edit.js
@@ -38,6 +38,12 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 
 	const dismissSaveError = useCallback( () => setHasSaveError( false ), [] );
 
+	// Discarding all edits also clears any lasting save error.
+	const onDiscardAll = useCallback( () => {
+		setHasSaveError( false );
+		stopEdit();
+	}, [ stopEdit ] );
+
 	const onDiscardField = useCallback( ( { id, key } ) => closeField( { id, key } ), [ closeField ] );
 
 	const onStartEdit = useCallback( ( id ) => {
@@ -167,13 +173,13 @@ export const useInlineEdit = ( { dataProvider, remoteDataProvider, fieldSets, ac
 		onChangeField: updateDraftField,
 		onApplyField,
 		onApplyAll,
-		onDiscardAll: stopEdit,
+		onDiscardAll,
 		onCancelEdit,
 		onDiscardField,
 		onFieldApplied: updateItem,
 	} ), [
 		editingRows, isApplyingAll, hasSaveError, dismissSaveError, onStartEdit, updateDraftField,
-		onApplyField, onApplyAll, stopEdit, onCancelEdit, onDiscardField, updateItem,
+		onApplyField, onApplyAll, onDiscardAll, onCancelEdit, onDiscardField, updateItem,
 	] );
 
 	return { editing, stopEditing: stopEdit };

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -174,8 +174,8 @@ describe( "App", () => {
 				{},
 				expect.objectContaining( { method: "POST" } )
 			);
-			expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument();
-			// Await the switch so the saves settle (updateItem/closeField) within act().
+			// The batch save is async, so the modal closes once the request settles rather than synchronously.
+			await waitFor( () => expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument() );
 			await waitFor( () => expect( screen.getByRole( "tab", { name: "Social appearance" } ) ).toHaveAttribute( "aria-selected", "true" ) );
 		} );
 	} );

--- a/packages/js/tests/bulk-editor/bulk-action-bar.test.js
+++ b/packages/js/tests/bulk-editor/bulk-action-bar.test.js
@@ -1,7 +1,7 @@
 import { Fill, SlotFillProvider } from "@wordpress/components";
 import { addFilter, removeFilter } from "@wordpress/hooks";
 import { fireEvent, render, screen } from "../test-utils";
-import { BulkActions, ManualReviewActions, SelectionToolbar } from "../../src/bulk-editor/components/bulk-action-bar";
+import { BulkActions, ManualReviewActions, ManualSaveErrorNotice, SelectionToolbar } from "../../src/bulk-editor/components/bulk-action-bar";
 import { BULK_ACTIONS_SLOT, SELECT_MENU_ITEMS_FILTER } from "../../src/bulk-editor/constants";
 
 // The hook is covered by use-ai-upsell.test.js; here it just feeds the modal a static upsell.
@@ -123,6 +123,23 @@ describe( "ManualReviewActions", () => {
 	} );
 } );
 
+describe( "ManualSaveErrorNotice", () => {
+	it( "shows the heading and the alert copy", () => {
+		render( <ManualSaveErrorNotice onDismiss={ jest.fn() } /> );
+
+		expect( screen.getByText( "Couldn't save your edits." ) ).toBeInTheDocument();
+		expect( screen.getByRole( "alert" ) ).toHaveTextContent( "Something went wrong. Please try again." );
+	} );
+
+	it( "dismisses from the close button", () => {
+		const onDismiss = jest.fn();
+		render( <ManualSaveErrorNotice onDismiss={ onDismiss } /> );
+
+		fireEvent.click( screen.getByRole( "button", { name: "Dismiss" } ) );
+		expect( onDismiss ).toHaveBeenCalled();
+	} );
+} );
+
 describe( "BulkActions", () => {
 	it( "shows the Free AI generate affordances when not Premium", () => {
 		render( <BulkActions isPremium={ false } /> );
@@ -180,5 +197,20 @@ describe( "BulkActions", () => {
 
 		expect( screen.getByRole( "heading", { name: "Generate Metadata in Bulk" } ) ).toBeInTheDocument();
 		expect( screen.getByRole( "link", { name: /Unlock with Yoast SEO Premium/ } ) ).toHaveAttribute( "href", "https://yoa.st/bulk-editor-ai-upsell" );
+	} );
+
+	it( "shows the save-error notice on the active tab when a save failed", () => {
+		const onDismissSaveError = jest.fn();
+		render( <BulkActions isPremium={ false } isActive={ true } hasSaveError={ true } onDismissSaveError={ onDismissSaveError } /> );
+
+		expect( screen.getByText( "Couldn't save your edits." ) ).toBeInTheDocument();
+		fireEvent.click( screen.getByRole( "button", { name: "Dismiss" } ) );
+		expect( onDismissSaveError ).toHaveBeenCalled();
+	} );
+
+	it( "does not show the save-error notice when there is no error", () => {
+		render( <BulkActions isPremium={ false } isActive={ true } hasSaveError={ false } /> );
+
+		expect( screen.queryByText( "Couldn't save your edits." ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/bulk-editor/bulk-action-bar.test.js
+++ b/packages/js/tests/bulk-editor/bulk-action-bar.test.js
@@ -1,7 +1,7 @@
 import { Fill, SlotFillProvider } from "@wordpress/components";
 import { addFilter, removeFilter } from "@wordpress/hooks";
 import { fireEvent, render, screen } from "../test-utils";
-import { BulkActions, SelectionToolbar } from "../../src/bulk-editor/components/bulk-action-bar";
+import { BulkActions, ManualReviewActions, SelectionToolbar } from "../../src/bulk-editor/components/bulk-action-bar";
 import { BULK_ACTIONS_SLOT, SELECT_MENU_ITEMS_FILTER } from "../../src/bulk-editor/constants";
 
 // The hook is covered by use-ai-upsell.test.js; here it just feeds the modal a static upsell.
@@ -88,12 +88,62 @@ describe( "SelectionToolbar", () => {
 	} );
 } );
 
+describe( "ManualReviewActions", () => {
+	const reviewProps = { editCount: 2, onApplyAll: jest.fn(), onDiscardAll: jest.fn() };
+
+	it( "shows a singular summary for a single edited row", () => {
+		render( <ManualReviewActions { ...reviewProps } editCount={ 1 } /> );
+
+		expect( screen.getByText( "1 row with unsaved changes" ) ).toBeInTheDocument();
+	} );
+
+	it( "shows a plural summary for multiple edited rows", () => {
+		render( <ManualReviewActions { ...reviewProps } editCount={ 3 } /> );
+
+		expect( screen.getByText( "3 rows with unsaved changes" ) ).toBeInTheDocument();
+	} );
+
+	it( "applies and discards all from the actions", () => {
+		const onApplyAll = jest.fn();
+		const onDiscardAll = jest.fn();
+		render( <ManualReviewActions { ...reviewProps } onApplyAll={ onApplyAll } onDiscardAll={ onDiscardAll } /> );
+
+		fireEvent.click( screen.getByRole( "button", { name: "Save edits" } ) );
+		expect( onApplyAll ).toHaveBeenCalled();
+
+		fireEvent.click( screen.getByRole( "button", { name: "Cancel edits" } ) );
+		expect( onDiscardAll ).toHaveBeenCalled();
+	} );
+
+	it( "disables both actions while an apply-all is in flight", () => {
+		render( <ManualReviewActions { ...reviewProps } isApplying={ true } /> );
+
+		expect( screen.getByRole( "button", { name: "Save edits" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Cancel edits" } ) ).toBeDisabled();
+	} );
+} );
+
 describe( "BulkActions", () => {
 	it( "shows the Free AI generate affordances when not Premium", () => {
 		render( <BulkActions isPremium={ false } /> );
 
 		expect( screen.getByRole( "button", { name: "Generate SEO titles" } ) ).toBeInTheDocument();
 		expect( screen.getByRole( "button", { name: "Generate meta descriptions" } ) ).toBeInTheDocument();
+	} );
+
+	it( "shows the review actions alongside the still-enabled Free generate affordances while editing", () => {
+		render(
+			<BulkActions
+				isPremium={ false } isActive={ true } hasUnsavedEdits={ true }
+				editCount={ 2 } onApplyAll={ jest.fn() } onDiscardAll={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( "button", { name: "Save edits" } ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Cancel edits" } ) ).toBeInTheDocument();
+		// Free's generate buttons stay put and enabled so the upsell can still be triggered while editing.
+		expect( screen.getByRole( "button", { name: "Generate SEO titles" } ) ).toBeEnabled();
+		expect( screen.getByRole( "button", { name: "Generate meta descriptions" } ) ).toBeEnabled();
 	} );
 
 	it( "does not render the Free affordances for Premium", () => {

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -120,6 +120,23 @@ describe( "BulkEditorTable", () => {
 		expect( screen.getByRole( "button", { name: "Edit On-Page SEO Checklist" } ) ).toBeDisabled();
 	} );
 
+	it( "locks a row's Save and Cancel while a batch Save edits is in flight", () => {
+		render(
+			<BulkEditorTable
+				items={ items }
+				fieldSet={ searchFieldSet }
+				editing={ {
+					editingRows: { 1: { openFields: [ "seoTitle" ], draft: { seoTitle: "New title" }, savingFields: {} } },
+					isApplyingAll: true,
+				} }
+			/>
+		);
+
+		// A per-field save must not race the in-flight batch, so the row's own Save/Cancel lock too.
+		expect( screen.getByRole( "button", { name: "Save What Is SEO" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Cancel editing What Is SEO" } ) ).toBeDisabled();
+	} );
+
 	it( "marks column and row headers with scope", () => {
 		render( <BulkEditorTable items={ items } fieldSet={ searchFieldSet } /> );
 

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -112,6 +112,14 @@ describe( "BulkEditorTable", () => {
 		expect( onStartEdit ).toHaveBeenCalledWith( 2 );
 	} );
 
+	it( "disables every row's Edit button while Premium AI suggestions are pending review", () => {
+		render( <BulkEditorTable items={ items } fieldSet={ searchFieldSet } hasExternalPendingChanges={ true } /> );
+
+		// Manual editing and AI generation are mutually exclusive: no row can start editing while suggestions are pending.
+		expect( screen.getByRole( "button", { name: "Edit What Is SEO" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Edit On-Page SEO Checklist" } ) ).toBeDisabled();
+	} );
+
 	it( "marks column and row headers with scope", () => {
 		render( <BulkEditorTable items={ items } fieldSet={ searchFieldSet } /> );
 

--- a/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
+++ b/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
@@ -162,4 +162,19 @@ describe( "useInlineEdit batch actions", () => {
 		expect( dispatch.stopEdit ).toHaveBeenCalledTimes( 1 );
 		expect( remoteDataProvider.fetchJson ).not.toHaveBeenCalled();
 	} );
+
+	it( "clears a lingering save error when discarding all edits", async() => {
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.reject( new Error( "boom" ) ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+		expect( result.current.editing.hasSaveError ).toBe( true );
+
+		act( () => result.current.editing.onDiscardAll() );
+
+		expect( result.current.editing.hasSaveError ).toBe( false );
+		expect( dispatch.stopEdit ).toHaveBeenCalled();
+	} );
 } );

--- a/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
+++ b/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
@@ -1,0 +1,103 @@
+import { act, renderHook } from "@testing-library/react";
+import { useDispatch, useSelect } from "@wordpress/data";
+import { useInlineEdit } from "../../../src/bulk-editor/hooks/use-inline-edit";
+import { getFieldSets } from "../../../src/bulk-editor/field-sets";
+import { FIELD_SET_SEARCH } from "../../../src/bulk-editor/constants";
+
+jest.mock( "@wordpress/data", () => ( { useSelect: jest.fn(), useDispatch: jest.fn() } ) );
+
+describe( "useInlineEdit batch actions", () => {
+	const fieldSets = getFieldSets();
+	let editingRows;
+	let dispatch;
+	let dataProvider;
+	let updateItem;
+
+	beforeEach( () => {
+		// Two rows editing search-appearance fields: row 7 has two open fields, row 9 has one.
+		editingRows = {
+			7: { openFields: [ "seoTitle", "metaDescription" ], draft: { seoTitle: "Title 7", metaDescription: "Desc 7" }, savingFields: {} },
+			9: { openFields: [ "seoTitle" ], draft: { seoTitle: "Title 9" }, savingFields: {} },
+		};
+		dispatch = {
+			startEdit: jest.fn(),
+			updateDraftField: jest.fn(),
+			setSavingField: jest.fn(),
+			closeField: jest.fn(),
+			discardEdit: jest.fn(),
+			stopEdit: jest.fn(),
+		};
+		dataProvider = { getEndpoint: jest.fn( ( key ) => `https://example.com/${ key }` ) };
+		updateItem = jest.fn();
+
+		useSelect.mockImplementation( ( mapSelect ) => mapSelect( () => ( { selectEditingRows: () => editingRows } ) ) );
+		useDispatch.mockReturnValue( dispatch );
+	} );
+
+	const renderEdit = ( remoteDataProvider ) => renderHook( () => useInlineEdit( {
+		dataProvider,
+		remoteDataProvider,
+		fieldSets,
+		activeFieldSet: FIELD_SET_SEARCH,
+		items: [],
+		updateItem,
+	} ) );
+
+	it( "batches every row's open drafts into one request per endpoint", async() => {
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.resolve( {} ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+
+		// One request to the search endpoint, carrying one combined item per row.
+		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledTimes( 1 );
+		const [ endpoint, , options ] = remoteDataProvider.fetchJson.mock.calls[ 0 ];
+		expect( endpoint ).toBe( "https://example.com/update_search" );
+		expect( JSON.parse( options.body ) ).toEqual( {
+			/* eslint-disable camelcase -- The REST endpoint expects snake_case parameters. */
+			items: [
+				{ id: 7, seo_title: "Title 7", meta_description: "Desc 7" },
+				{ id: 9, seo_title: "Title 9" },
+			],
+			/* eslint-enable camelcase -- The REST endpoint expects snake_case parameters. */
+		} );
+	} );
+
+	it( "reflects every saved field and leaves edit mode after applying all", async() => {
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.resolve( {} ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+
+		expect( updateItem ).toHaveBeenCalledWith( 7, "seoTitle", "Title 7" );
+		expect( updateItem ).toHaveBeenCalledWith( 7, "metaDescription", "Desc 7" );
+		expect( updateItem ).toHaveBeenCalledWith( 9, "seoTitle", "Title 9" );
+		expect( dispatch.stopEdit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "keeps the drafts and stays in edit mode when the batch save fails", async() => {
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.reject( new Error( "boom" ) ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+
+		expect( updateItem ).not.toHaveBeenCalled();
+		expect( dispatch.stopEdit ).not.toHaveBeenCalled();
+	} );
+
+	it( "discards all edits by leaving edit mode without saving", () => {
+		const remoteDataProvider = { fetchJson: jest.fn() };
+		const { result } = renderEdit( remoteDataProvider );
+
+		result.current.editing.onDiscardAll();
+
+		expect( dispatch.stopEdit ).toHaveBeenCalledTimes( 1 );
+		expect( remoteDataProvider.fetchJson ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
+++ b/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
@@ -65,6 +65,25 @@ describe( "useInlineEdit batch actions", () => {
 		} );
 	} );
 
+	it( "chunks a large batch to the server's item limit, one request per 20 rows", async() => {
+		// Editing rows accumulate across pages, so a batch can exceed the 20-item server limit; 21 rows on one
+		// endpoint must go out as two requests (20 + 1) rather than one oversized POST that would be rejected.
+		editingRows = Object.fromEntries( Array.from( { length: 21 }, ( _row, index ) => {
+			const id = index + 1;
+			return [ id, { openFields: [ "seoTitle" ], draft: { seoTitle: `Title ${ id }` }, savingFields: {} } ];
+		} ) );
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.resolve( {} ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+
+		expect( remoteDataProvider.fetchJson ).toHaveBeenCalledTimes( 2 );
+		const itemCounts = remoteDataProvider.fetchJson.mock.calls.map( ( call ) => JSON.parse( call[ 2 ].body ).items.length );
+		expect( itemCounts ).toEqual( [ 20, 1 ] );
+	} );
+
 	it( "reflects every saved field and leaves edit mode after applying all", async() => {
 		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.resolve( {} ) ) };
 		const { result } = renderEdit( remoteDataProvider );

--- a/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
+++ b/packages/js/tests/bulk-editor/hooks/use-inline-edit.test.js
@@ -84,7 +84,7 @@ describe( "useInlineEdit batch actions", () => {
 		expect( itemCounts ).toEqual( [ 20, 1 ] );
 	} );
 
-	it( "reflects every saved field and leaves edit mode after applying all", async() => {
+	it( "reflects every saved field and closes it after applying all", async() => {
 		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.resolve( {} ) ) };
 		const { result } = renderEdit( remoteDataProvider );
 
@@ -92,13 +92,17 @@ describe( "useInlineEdit batch actions", () => {
 			await result.current.editing.onApplyAll();
 		} );
 
+		// Each saved field is reflected on its row and then closed; a row leaves edit mode once its fields all close.
 		expect( updateItem ).toHaveBeenCalledWith( 7, "seoTitle", "Title 7" );
 		expect( updateItem ).toHaveBeenCalledWith( 7, "metaDescription", "Desc 7" );
 		expect( updateItem ).toHaveBeenCalledWith( 9, "seoTitle", "Title 9" );
-		expect( dispatch.stopEdit ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.closeField ).toHaveBeenCalledWith( { id: 7, key: "seoTitle" } );
+		expect( dispatch.closeField ).toHaveBeenCalledWith( { id: 7, key: "metaDescription" } );
+		expect( dispatch.closeField ).toHaveBeenCalledWith( { id: 9, key: "seoTitle" } );
+		expect( result.current.editing.hasSaveError ).toBe( false );
 	} );
 
-	it( "keeps the drafts and stays in edit mode when the batch save fails", async() => {
+	it( "keeps the drafts and flags an error when the whole batch fails", async() => {
 		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.reject( new Error( "boom" ) ) ) };
 		const { result } = renderEdit( remoteDataProvider );
 
@@ -106,8 +110,47 @@ describe( "useInlineEdit batch actions", () => {
 			await result.current.editing.onApplyAll();
 		} );
 
+		// Nothing reflected or closed, drafts stay open, and the save-error flag is raised for the inline notice.
 		expect( updateItem ).not.toHaveBeenCalled();
-		expect( dispatch.stopEdit ).not.toHaveBeenCalled();
+		expect( dispatch.closeField ).not.toHaveBeenCalled();
+		expect( result.current.editing.hasSaveError ).toBe( true );
+	} );
+
+	it( "reflects the succeeded chunk and keeps the failed one open on a partial failure", async() => {
+		// 21 rows on one endpoint → two chunks (20 + 1). The first chunk resolves, the second rejects.
+		editingRows = Object.fromEntries( Array.from( { length: 21 }, ( _row, index ) => {
+			const id = index + 1;
+			return [ id, { openFields: [ "seoTitle" ], draft: { seoTitle: `Title ${ id }` }, savingFields: {} } ];
+		} ) );
+		const remoteDataProvider = {
+			fetchJson: jest.fn()
+				.mockImplementationOnce( () => Promise.resolve( {} ) )
+				.mockImplementationOnce( () => Promise.reject( new Error( "boom" ) ) ),
+		};
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+
+		// The 20 rows in the succeeded chunk are reflected and closed; the 21st (failed chunk) is not.
+		expect( dispatch.closeField ).toHaveBeenCalledTimes( 20 );
+		expect( dispatch.closeField ).toHaveBeenCalledWith( { id: 1, key: "seoTitle" } );
+		expect( dispatch.closeField ).not.toHaveBeenCalledWith( { id: 21, key: "seoTitle" } );
+		expect( result.current.editing.hasSaveError ).toBe( true );
+	} );
+
+	it( "dismisses the save error", async() => {
+		const remoteDataProvider = { fetchJson: jest.fn( () => Promise.reject( new Error( "boom" ) ) ) };
+		const { result } = renderEdit( remoteDataProvider );
+
+		await act( async() => {
+			await result.current.editing.onApplyAll();
+		} );
+		expect( result.current.editing.hasSaveError ).toBe( true );
+
+		act( () => result.current.editing.dismissSaveError() );
+		expect( result.current.editing.hasSaveError ).toBe( false );
 	} );
 
 	it( "discards all edits by leaving edit mode without saving", () => {


### PR DESCRIPTION
## Context

Free users should be albe to make several manual edits across rows and save them in one action, instead of applying each field one by one. This adds batch **Save edits / Cancel edits** actions for manual edits. Per a product decision, manual editing and AI generation [are mutually exclusive](https://yoast.slack.com/archives/C027BFR5L/p1783518801911839?thread_ts=1783427289.368999&cid=C027BFR5L).

## Summary

This PR can be summarized in the following changelog entry:

* Adds Save edits and Cancel edits actions to the bulk editor to save or discard multiple manual edits at once.

## Relevant technical choices:

* **Batch save:** a new `onApplyAll` groups every editing row's open drafts into one request per endpoint (`update_search` / `update_social`), reusing the existing bulk-update routes; `onDiscardAll` clears all drafts, reverting to the last-saved values.
* **Mutual exclusion:** each row's Edit button is disabled while Premium reports AI suggestions pending review (`hasExternalPendingChanges`), and AI generation is already disabled while manual edits are unsaved — so only one review bar shows at a time.
* **Free-owned:** the manual actions live in Free (`ManualReviewActions`, gated on the active tab); Premium needs no change, as its AI-disable-while-editing behaviour already exists.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Free — manual editing (Save edits / Cancel edits)**

Run on a site with only Yoast SEO Free active.

1. Go to **Yoast SEO → Tools → Bulk editor** and open the **Search appearance** tab.
2. Click **Edit** on a row and change its SEO title, meta description, and/or focus keyphrase.
3. Click **Edit** on one or two more rows and change their fields too.
4. Confirm a bar appears above the table reading "***N* rows with unsaved changes**" with **Save edits** and **Cancel edits** buttons.
5. Click **Save edits**: confirm all edited rows save in a single action, leave edit mode, and show the new values in the table. Reload the page and confirm the values persisted.
6. Edit a few rows again, then click **Cancel edits**: confirm every row exits edit mode and reverts to its previously-saved values, and that no save request is sent (nothing persists after a reload).
7. Repeat steps 2–6 on the **Social appearance** tab (social title / social description).
8. Confirm the **Generate SEO titles** / **Generate meta descriptions** upsell buttons stay visible and clickable while editing (clicking one opens the upsell modal).
9. *Save error:* make a **Save edits** fail (e.g. go offline, or block the `bulk_editor/update_search` request in the browser devtools). Confirm a full-width error notice appears above the toolbar (see 🧵 [thread](https://yoast.slack.com/archives/C03KU0EHCNQ/p1783591599845199))—  **"Couldn't save your edits."** with **"Something went wrong. Please try again."** below and a dismiss **×** — the failed rows stay in edit mode, and retrying **Save edits** (back online) saves them and clears the notice.

**Premium — manual + AI (mutual exclusion)**

Run on a site with Yoast SEO Premium active and a valid subscription.

1. Go to **Yoast SEO → Tools → Bulk editor**.
2. *Manual disables AI:* click **Edit** on a row and change a field. Confirm the **Generate SEO titles** / **Generate meta descriptions** buttons become **disabled** (with a "Save your manual edits to use AI generation" hint) while the **Save edits / Cancel edits** bar is shown. Save or cancel and confirm the Generate buttons re-enable.
3. *AI disables manual:* select one or more rows and click **Generate SEO titles** (or meta descriptions) to produce AI suggestions. While suggestions are pending review, confirm **every row's Edit button is disabled** and the AI **Apply all / Discard all** bar is shown.
4. Apply or discard the AI suggestions and confirm the Edit buttons re-enable once nothing is pending.
5. Confirm the two bars **never appear at the same time**: you see one or the other, never both.
6. *Different labels per mode:* confirm the action labels differ by source so it's always clear what you are acting on:
   * **Manual edits** → **Save edits** / **Cancel edits** (Free's see 🧵 [thread](https://yoast.slack.com/archives/C027BFR5L/p1783520799731699?thread_ts=1783427289.368999&cid=C027BFR5L)).
   * **AI suggestions** → **Apply all** / **Discard all** (Premium's `BulkReviewActions`).
   You should never see the same label set for both, and the summary text differs too ("*N* rows with unsaved changes" for manual vs the AI suggestion count).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — the bulk editor feature is unreleased; this is a non-user-facing enhancement within it.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor's manual inline editing and its interaction with Premium's AI generation (the mutual-exclusion guards).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.

Fixes Yoast/plugins-automated-testing#3063


