### PR TITLE
Don't show AI buttons when AI feature is disabled

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -139,6 +139,9 @@ const FreeBulkActions = ( { contentType } ) => {
  *
  * @param {Object}   props                The props.
  * @param {boolean}  props.isPremium      Whether Premium is active.
+ * @param {boolean}  [props.isAiEnabled=true] Whether the AI feature is enabled in the global settings. Gates the AI
+ *                                         affordances (Free's upsell buttons; Premium fills its own slot only when on)
+ *                                         without touching any non-AI actions the band may host.
  * @param {boolean}  props.isActive       Whether this is the active tab. Only the active tab renders the slots, so the
  *                                        Premium fill has a single slot to target (each tab renders its own bar).
  * @param {number[]} props.selectedIds      The ids of the selected rows.
@@ -152,7 +155,7 @@ const FreeBulkActions = ( { contentType } ) => {
  * @returns {JSX.Element} The bulk actions row content.
  */
 export const BulkActions = ( {
-	isPremium, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
+	isPremium, isAiEnabled = true, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
 } ) => (
 	<div className="yst-flex yst-flex-col">
 		{ isActive && (
@@ -162,7 +165,7 @@ export const BulkActions = ( {
 			/>
 		) }
 		<div className="yst-flex yst-items-center yst-gap-3 yst-border-y yst-border-slate-200 yst-bg-slate-100 yst-px-4 yst-py-3">
-			{ ! isPremium && <FreeBulkActions contentType={ contentType } /> }
+			{ ! isPremium && isAiEnabled && <FreeBulkActions contentType={ contentType } /> }
 			{ isActive && <Slot name={ BULK_ACTIONS_SLOT } fillProps={ { selectedIds, activeFieldSet, contentType, hasUnsavedEdits } } /> }
 		</div>
 	</div>

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -139,7 +139,7 @@ const FreeBulkActions = ( { contentType } ) => {
  *
  * @param {Object}   props                The props.
  * @param {boolean}  props.isPremium      Whether Premium is active.
- * @param {boolean}  [props.isAiEnabled=true] Whether the AI feature is enabled in the global settings. Gates the AI
+ * @param {boolean}  [props.isAiEnabled=false] Whether the AI feature is enabled in the global settings. Gates the AI
  *                                         affordances (Free's upsell buttons; Premium fills its own slot only when on)
  *                                         without touching any non-AI actions the band may host.
  * @param {boolean}  props.isActive       Whether this is the active tab. Only the active tab renders the slots, so the
@@ -155,7 +155,7 @@ const FreeBulkActions = ( { contentType } ) => {
  * @returns {JSX.Element} The bulk actions row content.
  */
 export const BulkActions = ( {
-	isPremium, isAiEnabled = true, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
+	isPremium, isAiEnabled = false, isActive, selectedIds, activeFieldSet, contentType, contentTypeLabel, contentTypeSingularLabel, hasUnsavedEdits,
 } ) => (
 	<div className="yst-flex yst-flex-col">
 		{ isActive && (

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -58,12 +58,13 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 		() => Object.values( fieldSets ).map( ( { id, label } ) => ( { id, label } ) ),
 		[ fieldSets ]
 	);
-	const { activeFieldSet, selectedIds, isPremium, hasExternalPendingChanges } = useSelect( ( select ) => {
+	const { activeFieldSet, selectedIds, isPremium, isAiEnabled, hasExternalPendingChanges } = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
 		return {
 			activeFieldSet: store.selectActiveFieldSet(),
 			selectedIds: store.selectSelectedIds(),
 			isPremium: store.selectPreference( "isPremium", false ),
+			isAiEnabled: store.selectPreference( "isAiEnabled", false ),
 			// An external plugin (e.g. Premium's AI suggestions) reports pending changes so the switch can be guarded.
 			hasExternalPendingChanges: store.selectHasExternalPendingChanges(),
 		};
@@ -175,6 +176,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 						bulkActions={
 							<BulkActions
 								isPremium={ isPremium }
+								isAiEnabled={ isAiEnabled }
 								isActive={ tab.id === activeFieldSet }
 								selectedIds={ selectedIds }
 								activeFieldSet={ activeFieldSet }
@@ -184,7 +186,9 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 								hasUnsavedEdits={ hasUnsavedEdits }
 							/>
 						}
-						showBulkActions={ hasSelection }
+						// A selection only warrants the band while AI is enabled (its only current occupant is the AI
+						// affordances); with AI off the band collapses, so no empty row is shown.
+						showBulkActions={ hasSelection && isAiEnabled }
 						filters={ <BulkEditorFilters /> }
 						isLoading={ isPending }
 						footer={ total > 0

--- a/packages/js/tests/bulk-editor/bulk-action-bar.test.js
+++ b/packages/js/tests/bulk-editor/bulk-action-bar.test.js
@@ -90,7 +90,7 @@ describe( "SelectionToolbar", () => {
 
 describe( "BulkActions", () => {
 	it( "shows the Free AI generate affordances when not Premium", () => {
-		render( <BulkActions isPremium={ false } /> );
+		render( <BulkActions isPremium={ false } isAiEnabled={ true } /> );
 
 		expect( screen.getByRole( "button", { name: "Generate SEO titles" } ) ).toBeInTheDocument();
 		expect( screen.getByRole( "button", { name: "Generate meta descriptions" } ) ).toBeInTheDocument();
@@ -135,7 +135,7 @@ describe( "BulkActions", () => {
 	} );
 
 	it( "opens the upsell modal from a Free AI generate button", () => {
-		render( <BulkActions isPremium={ false } contentType="post" /> );
+		render( <BulkActions isPremium={ false } isAiEnabled={ true } contentType="post" /> );
 
 		// The modal stays closed until a Generate button is clicked.
 		expect( screen.queryByRole( "heading", { name: "Generate Metadata in Bulk" } ) ).not.toBeInTheDocument();

--- a/packages/js/tests/bulk-editor/bulk-action-bar.test.js
+++ b/packages/js/tests/bulk-editor/bulk-action-bar.test.js
@@ -102,6 +102,20 @@ describe( "BulkActions", () => {
 		expect( screen.queryByRole( "button", { name: "Generate SEO titles" } ) ).not.toBeInTheDocument();
 	} );
 
+	it( "hides the Free AI generate affordances when the AI feature is disabled", () => {
+		render( <BulkActions isPremium={ false } isAiEnabled={ false } /> );
+
+		expect( screen.queryByRole( "button", { name: "Generate SEO titles" } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( "button", { name: "Generate meta descriptions" } ) ).not.toBeInTheDocument();
+	} );
+
+	it( "shows the Free AI generate affordances when the AI feature is enabled", () => {
+		render( <BulkActions isPremium={ false } isAiEnabled={ true } /> );
+
+		expect( screen.getByRole( "button", { name: "Generate SEO titles" } ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Generate meta descriptions" } ) ).toBeInTheDocument();
+	} );
+
 	it( "passes the selection and active view to the Premium slot fill", () => {
 		let received = null;
 		render(

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\General\User_Interface\General_Page_Integration;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
@@ -79,6 +80,13 @@ class Bulk_Editor_Integration implements Integration_Interface {
 	private $endpoints_repository;
 
 	/**
+	 * Holds the Options_Helper.
+	 *
+	 * @var Options_Helper
+	 */
+	private $options_helper;
+
+	/**
 	 * Constructs the instance.
 	 *
 	 * @param WPSEO_Admin_Asset_Manager $asset_manager            The WPSEO_Admin_Asset_Manager.
@@ -88,6 +96,7 @@ class Bulk_Editor_Integration implements Integration_Interface {
 	 * @param Content_Types_Repository  $content_types_repository The Content_Types_Repository.
 	 * @param Nonce_Repository          $nonce_repository         The Nonce_Repository.
 	 * @param Endpoints_Repository      $endpoints_repository     The Endpoints_Repository.
+	 * @param Options_Helper            $options_helper           The Options_Helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
@@ -96,7 +105,8 @@ class Bulk_Editor_Integration implements Integration_Interface {
 		Short_Link_Helper $short_link_helper,
 		Content_Types_Repository $content_types_repository,
 		Nonce_Repository $nonce_repository,
-		Endpoints_Repository $endpoints_repository
+		Endpoints_Repository $endpoints_repository,
+		Options_Helper $options_helper
 	) {
 		$this->asset_manager            = $asset_manager;
 		$this->current_page_helper      = $current_page_helper;
@@ -105,6 +115,7 @@ class Bulk_Editor_Integration implements Integration_Interface {
 		$this->content_types_repository = $content_types_repository;
 		$this->nonce_repository         = $nonce_repository;
 		$this->endpoints_repository     = $endpoints_repository;
+		$this->options_helper           = $options_helper;
 	}
 
 	/**
@@ -208,9 +219,10 @@ class Bulk_Editor_Integration implements Integration_Interface {
 			'nonce'        => $this->nonce_repository->get_rest_nonce(),
 			'restRoot'     => \esc_url_raw( \rest_url() ),
 			'preferences'  => [
-				'isPremium' => $this->product_helper->is_premium(),
-				'isRtl'     => \is_rtl(),
-				'pluginUrl' => \plugins_url( '', \WPSEO_FILE ),
+				'isPremium'   => $this->product_helper->is_premium(),
+				'isAiEnabled' => $this->options_helper->get( 'enable_ai_generator' ) === true,
+				'isRtl'       => \is_rtl(),
+				'pluginUrl'   => \plugins_url( '', \WPSEO_FILE ),
 			],
 			'linkParams'   => $this->short_link_helper->get_query_params(),
 		];

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Abstract_Bulk_Editor_Integration_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Abstract_Bulk_Editor_Integration_Test.php
@@ -11,6 +11,7 @@ use Yoast\WP\SEO\Bulk_Editor\Application\Endpoints\Endpoints_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
 use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -79,6 +80,13 @@ abstract class Abstract_Bulk_Editor_Integration_Test extends TestCase {
 	protected $endpoints_repository;
 
 	/**
+	 * Holds the Options_Helper mock.
+	 *
+	 * @var Mockery\MockInterface|Options_Helper
+	 */
+	protected $options_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -93,6 +101,7 @@ abstract class Abstract_Bulk_Editor_Integration_Test extends TestCase {
 		$this->content_types_repository = Mockery::mock( Content_Types_Repository::class );
 		$this->nonce_repository         = Mockery::mock( Nonce_Repository::class );
 		$this->endpoints_repository     = Mockery::mock( Endpoints_Repository::class );
+		$this->options_helper           = Mockery::mock( Options_Helper::class );
 
 		$this->instance = new Bulk_Editor_Integration(
 			$this->asset_manager,
@@ -102,6 +111,7 @@ abstract class Abstract_Bulk_Editor_Integration_Test extends TestCase {
 			$this->content_types_repository,
 			$this->nonce_repository,
 			$this->endpoints_repository,
+			$this->options_helper,
 		);
 	}
 }

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Constructor_Test.php
@@ -9,6 +9,7 @@ use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Application\Endpoints\Endpoints_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Nonces\Nonce_Repository;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
+use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Helpers\Product_Helper;
 use Yoast\WP\SEO\Helpers\Short_Link_Helper;
 
@@ -54,6 +55,10 @@ final class Constructor_Test extends Abstract_Bulk_Editor_Integration_Test {
 		$this->assertInstanceOf(
 			Endpoints_Repository::class,
 			$this->getPropertyValue( $this->instance, 'endpoints_repository' ),
+		);
+		$this->assertInstanceOf(
+			Options_Helper::class,
+			$this->getPropertyValue( $this->instance, 'options_helper' ),
 		);
 	}
 }

--- a/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Bulk_Editor_Integration/Enqueue_Assets_Test.php
@@ -48,9 +48,10 @@ final class Enqueue_Assets_Test extends Abstract_Bulk_Editor_Integration_Test {
 			'nonce'        => 'rest-nonce',
 			'restRoot'     => 'https://example.com/wp-json/',
 			'preferences'  => [
-				'isPremium' => false,
-				'isRtl'     => false,
-				'pluginUrl' => 'https://example.com/wp-content/plugins/wordpress-seo',
+				'isPremium'   => false,
+				'isAiEnabled' => true,
+				'isRtl'       => false,
+				'pluginUrl'   => 'https://example.com/wp-content/plugins/wordpress-seo',
 			],
 			'linkParams'   => [ 'foo' => 'bar' ],
 		];
@@ -70,6 +71,7 @@ final class Enqueue_Assets_Test extends Abstract_Bulk_Editor_Integration_Test {
 		$this->nonce_repository->expects( 'get_rest_nonce' )->once()->andReturn( 'rest-nonce' );
 		Functions\expect( 'rest_url' )->once()->withNoArgs()->andReturn( 'https://example.com/wp-json/' );
 		$this->product_helper->expects( 'is_premium' )->once()->andReturn( false );
+		$this->options_helper->expects( 'get' )->once()->with( 'enable_ai_generator' )->andReturn( true );
 		Functions\expect( 'is_rtl' )->once()->withNoArgs()->andReturn( false );
 		Functions\expect( 'plugins_url' )
 			->once()


### PR DESCRIPTION
## Context

The new (innovation) React bulk editor showed the AI generation affordances even when the AI feature is turned off in Yoast's global settings: in Free the **Generate SEO titles** / **Generate meta descriptions** upsell buttons stayed visible, and in Premium an **empty toolbar row** was left where the AI buttons would be. The AI feature toggle (`enable_ai_generator`) was never passed to the bulk editor React app, so nothing gated the AI affordances on it.

Fixes Yoast/plugins-automated-testing#3066

## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unrelease bug where the bulk editor showed the AI generation buttons and an empty toolbar row when the AI feature was disabled.

## Relevant technical choices:

* **Deliver the flag:** `Bulk_Editor_Integration` now injects `Options_Helper` and adds `isAiEnabled` (from `enable_ai_generator`) to the localized `wpseoBulkEditorData.preferences` — the same option the metabox already exposes as `isAiFeatureActive`.
* **Gate per-affordance, not the whole toolbar:** `BulkActions` gates only the Free upsell buttons on `isAiEnabled`, and the empty row is avoided by *collapsing* the toolbar via `showBulkActions={ hasSelection && isAiEnabled }` rather than removing it. This is deliberate so the change composes with the in-flight batch Save/Cancel-edits work in #23437, which adds a non-AI occupant to the same toolbar; gating the whole band would have hidden those manual actions when AI is off.
* **Coordination with #23437:** expect a merge conflict on the `showBulkActions` line; the intended resolution is `( hasSelection && isAiEnabled ) || hasUnsavedEdits`. `isAiEnabled` defaults to `true` in `BulkActions`, so #23437's component tests stay green.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Free (only Yoast SEO Free active)**

1. Go to **Yoast SEO → Settings** and turn **off** the AI feature (the "AI" / AI generation toggle). Save.
2. Go to **Yoast SEO → Tools → Bulk editor**.
3. Select one or more rows using the row checkboxes.
4. Confirm that **no** "Generate SEO titles" / "Generate meta descriptions" buttons appear, and that there is **no empty grey bar/row** above the table.
5. Turn the AI feature back **on**, reload the bulk editor, and select rows again.
6. Confirm the two **Generate** buttons now appear in the toolbar as before.

**Premium (Yoast SEO Premium active)**

1. With the AI feature **off** and one or more rows selected, confirm **no empty toolbar row** appears (previously an empty grey bar was shown).
2. With the AI feature **on**, confirm the Generate buttons appear as before.


#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor page's bulk-actions toolbar (Free upsell buttons and the toolbar row's visibility).
* The bulk editor's localized script data (`wpseoBulkEditorData.preferences` gains `isAiEnabled`); `Bulk_Editor_Integration`'s constructor gains an `Options_Helper` dependency (DI auto-wired).
* The same toolbar is touched by #23437 (batch Save/Cancel edits) — see the coordination note above. No change to the Premium SlotFill contract (`fillProps` are unchanged).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3066
