### PR TITLE
fix: output the article:published_time meta tag on pages

### DIFF
--- a/src/presentations/indexable-post-type-presentation.php
+++ b/src/presentations/indexable-post-type-presentation.php
@@ -264,7 +264,7 @@ class Indexable_Post_Type_Presentation extends Indexable_Presentation {
 	 * @return string The open graph article published time.
 	 */
 	public function generate_open_graph_article_published_time() {
-		if ( $this->model->object_sub_type !== 'post' ) {
+		if ( $this->model->object_sub_type !== 'post' && $this->model->object_sub_type !== 'page' ) {
 			/**
 			 * Filter: 'wpseo_opengraph_show_publish_date' - Allow showing publication date for other post types.
 			 *

--- a/tests/Unit/Presentations/Indexable_Post_Type_Presentation/Open_Graph_Article_Published_Time_Test.php
+++ b/tests/Unit/Presentations/Indexable_Post_Type_Presentation/Open_Graph_Article_Published_Time_Test.php
@@ -54,7 +54,7 @@ final class Open_Graph_Article_Published_Time_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that no published time is returned for a page.
+	 * Tests that the published time is returned for a page.
 	 *
 	 * @covers ::generate_open_graph_article_published_time
 	 *
@@ -63,26 +63,51 @@ final class Open_Graph_Article_Published_Time_Test extends TestCase {
 	public function test_generate_open_graph_article_published_time_page() {
 		$this->indexable->object_sub_type = 'page';
 
+		$source = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
+		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
+
+		$this->date
+			->expects( 'format' )
+			->with( '2019-10-08T12:26:31+00:00' )
+			->once()
+			->andReturn( '2019-10-08T12:26:31+00:00' );
+
+		$actual   = $this->instance->generate_open_graph_article_published_time();
+		$expected = '2019-10-08T12:26:31+00:00';
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Tests that no published time is returned for a custom post type.
+	 *
+	 * @covers ::generate_open_graph_article_published_time
+	 *
+	 * @return void
+	 */
+	public function test_generate_open_graph_article_published_time_custom_post_type() {
+		$this->indexable->object_sub_type = 'book';
+
 		$this->instance->expects( 'generate_source' )->andReturn( (object) [] );
 
 		$this->post
 			->expects( 'get_post_type' )
 			->once()
-			->andReturn( 'page' );
+			->andReturn( 'book' );
 
 		$actual = $this->instance->generate_open_graph_article_published_time();
 		$this->assertEmpty( $actual );
 	}
 
 	/**
-	 * Tests that a published time is returned for a page when the publish date is enabled with the wpseo_opengraph_show_publish_date filter.
+	 * Tests that a published time is returned for a custom post type when the publish date is enabled with the wpseo_opengraph_show_publish_date filter.
 	 *
 	 * @covers ::generate_open_graph_article_published_time
 	 *
 	 * @return void
 	 */
-	public function test_generate_open_graph_article_published_time_page_enabled() {
-		$this->indexable->object_sub_type = 'page';
+	public function test_generate_open_graph_article_published_time_custom_post_type_enabled() {
+		$this->indexable->object_sub_type = 'book';
 
 		$source = (object) [ 'post_date_gmt' => '2019-10-08T12:26:31+00:00' ];
 		$this->instance->expects( 'generate_source' )->once()->andReturn( $source );
@@ -96,7 +121,7 @@ final class Open_Graph_Article_Published_Time_Test extends TestCase {
 		$this->post
 			->expects( 'get_post_type' )
 			->once()
-			->andReturn( 'page' );
+			->andReturn( 'book' );
 
 		Monkey\Filters\expectApplied( 'wpseo_opengraph_show_publish_date' )
 			->once()


### PR DESCRIPTION
## Context

* Fixes #21433. Pages output `article:modified_time` and the `datePublished` schema property, but not `article:published_time`. In the issue, Yoast confirmed the intended behaviour: "On post and page post types, we should output both of these tags. On other post types, we should not output either."
* `Indexable_Post_Type_Presentation::generate_open_graph_article_published_time()` gated the tag to the `post` object sub type only, so pages fell through to the `wpseo_opengraph_show_publish_date` filter (default `false`) and returned an empty value.
* Note for reviewers: the current [OpenGraph functional specification](https://developer.yoast.com/features/opengraph/functional-specification/) says the tag is "Only populated on the `post` type", which appears to describe the current (buggy) behaviour rather than the intent confirmed in #21433. If the specification is leading instead, feel free to close this PR in favour of a documentation update and to close #21433 accordingly.
* Verified via the unit test suite (`composer test`, green) in a PHP 7.4 container. I could not run `composer test-wp-env` (Docker-in-Docker constraints in my environment); no WP integration tests cover this generator, so reviewers may want to do a quick manual front-end check using the test instructions below.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `article:published_time` meta tag was not output on pages.

## Relevant technical choices:

* Only the `page` sub type was added to the existing guard; custom post types keep the `wpseo_opengraph_show_publish_date` filter opt-in, and the `article:modified_time` behaviour is untouched.
* Because pages now always output the tag, the `wpseo_opengraph_show_publish_date` filter is no longer applied for pages. The filter could previously only opt pages *in* (default `false` short-circuits to an empty value), so no opt-out behaviour is lost.
* The unit test for pages now expects the published time to be returned, and the filter tests were moved to a custom post type (`book`) so the filter behaviour keeps its coverage.
* Disclosure: this patch was written with the assistance of an AI coding agent (Claude, by Anthropic), operated and reviewed by the PR author. Regarding the licensing note in the contribution guidelines: the change is a one-line logic tweak plus test updates modelled on the pre-existing test file — no external code was copied.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Create and publish a new page.
* View the page on the front end and inspect the page source.
* Verify a `<meta property="article:published_time" content="..." />` tag is present in the Yoast SEO output.
* Edit the page, save it, revisit the front end and verify `article:modified_time` is also present.
* Create and publish a post and verify `article:published_time` is still output there, as before.
* Register a custom post type, publish an item and verify it still outputs **no** `article:published_time`, unless the `wpseo_opengraph_show_publish_date` filter returns `true` for it.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Pages are the changed surface; posts and custom post types should be regression-checked as described in the steps above. Note that a static front page is a page, so it will now also output `article:published_time`.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Front-end Open Graph output for pages (including static front pages).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

(The OpenGraph functional specification on developer.yoast.com will need a small follow-up edit — "Only populated on the `post` type" becomes "the `post` and `page` types" — which I cannot make from this repository; flagged in Context.)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes #21433
