### PR TITLE
fix: fix incorrect MyYoast integration card copy

### DIFF
--- a/packages/js/src/integrations-page/myyoast-connection/myyoast-integration.js
+++ b/packages/js/src/integrations-page/myyoast-connection/myyoast-integration.js
@@ -455,7 +455,7 @@ export const MyyoastIntegration = () => {
 						<p>
 							{ sprintf(
 								/* translators: %1$s expands to MyYoast. %2$s expands to Yoast AI. */
-								__( "Connect your site to %1$s so %2$s works even when your site is offline, behind a firewall, or with the REST API disabled.", "wordpress-seo" ),
+								__( "Connect your site to %1$s so %2$s works even when your site is not publicly accessible, behind a firewall, or with the REST API disabled.", "wordpress-seo" ),
 								"MyYoast",
 								"Yoast AI"
 							) }


### PR DESCRIPTION

## Context

The MyYoast integration card on the integrations page claimed that Yoast AI "works even when your site is offline". As reported in [Yoast/plugins-automated-testing#3065](https://github.com/Yoast/plugins-automated-testing/issues/3065), this is contradictory: a site that is genuinely offline (no internet connection) cannot reach Yoast's services and therefore cannot use AI at all. The intended meaning is that the site does not need to be reachable from the public internet — which is why the same sentence also lists "behind a firewall" and "with the REST API disabled".

## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the MyYoast integration card claimed Yoast AI works even when the site is offline, which was misleading because an offline site cannot reach Yoast's services.

## Relevant technical choices:

* Replaced "offline" with "not publicly accessible", which reads naturally alongside the two adjacent conditions and accurately describes a site that is not reachable from the public internet.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Go to **Yoast SEO → Settings → Integrations** (or the page showing the MyYoast connection card).
* Locate the "Unlock more from Yoast with MyYoast" card.
* Verify the paragraph now reads: "Connect your site to MyYoast so Yoast AI works even when your site is **not publicly accessible**, behind a firewall, or with the REST API disabled."
* Confirm the word "offline" no longer appears in that sentence.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Only the copy of the MyYoast integration card on the integrations page. No behavioural change.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3065