### PR TITLE
fix(bulk-editor): guard unsaved edits and pending AI suggestions on content-type switch

### DIFF
--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -64,8 +64,13 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 		getActiveContentTypeFields( activeContentType );
 
 	// Selecting a content type requests a guarded switch (requestSwitch defers to the modal or switches straight away).
-	// Kept free of the active type so the handler stays referentially stable behind the memoized navigation item.
-	const onChangeContentType = useCallback( ( id ) => requestSwitch( { kind: "contentType", target: id } ), [ requestSwitch ] );
+	// The no-op check runs here against the resolved id: the store's active name can be "" (meaning "first content
+	// type"), which the store-level guard can't resolve, so clicking the active first type would otherwise switch.
+	const onChangeContentType = useCallback( ( id ) => {
+		if ( id !== activeContentTypeId ) {
+			requestSwitch( { kind: "contentType", target: id } );
+		}
+	}, [ activeContentTypeId, requestSwitch ] );
 
 	const { title, description } = getHeaderCopy( activeContentType );
 	// Fall back to the WP admin home when the data provider has no link.

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -63,13 +63,9 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
 		getActiveContentTypeFields( activeContentType );
 
-	// When switching content types, defers to the unsaved-changes / pending-AI modal when
-	// there are edits or pending suggestions, and switches straight away otherwise.
-	const onChangeContentType = useCallback( ( id ) => {
-		if ( id !== activeContentTypeId ) {
-			requestSwitch( { kind: "contentType", target: id } );
-		}
-	}, [ activeContentTypeId, requestSwitch ] );
+	// Selecting a content type requests a guarded switch (requestSwitch defers to the modal or switches straight away).
+	// Kept free of the active type so the handler stays referentially stable behind the memoized navigation item.
+	const onChangeContentType = useCallback( ( id ) => requestSwitch( { kind: "contentType", target: id } ), [ requestSwitch ] );
 
 	const { title, description } = getHeaderCopy( activeContentType );
 	// Fall back to the WP admin home when the data provider has no link.

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -1,4 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
+import { useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Paper, SidebarNavigation } from "@yoast/ui-library";
 import { BulkEditorContent } from "./components/bulk-editor-content";
@@ -55,12 +56,20 @@ const getActiveContentTypeFields = ( contentType ) => ( {
 const App = ( { dataProvider, remoteDataProvider } ) => {
 	const activeContentTypeName = useSelect( ( select ) => select( STORE_NAME ).selectActiveContentTypeName(), [] );
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
-	const { setActiveContentType } = useDispatch( STORE_NAME );
+	const { requestSwitch } = useDispatch( STORE_NAME );
 
 	const contentTypes = dataProvider.getContentTypes().map( ( { name, label, singularLabel } ) => ( { id: name, label, singularLabel } ) );
 	const activeContentType = contentTypes.find( ( { id } ) => id === activeContentTypeName ) ?? contentTypes[ 0 ];
 	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
 		getActiveContentTypeFields( activeContentType );
+
+	// When switching content types, defers to the unsaved-changes / pending-AI modal when
+	// there are edits or pending suggestions, and switches straight away otherwise.
+	const onChangeContentType = useCallback( ( id ) => {
+		if ( id !== activeContentTypeId ) {
+			requestSwitch( { kind: "contentType", target: id } );
+		}
+	}, [ activeContentTypeId, requestSwitch ] );
 
 	const { title, description } = getHeaderCopy( activeContentType );
 	// Fall back to the WP admin home when the data provider has no link.
@@ -69,7 +78,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 
 	const menuProps = {
 		contentTypes,
-		onChange: setActiveContentType,
+		onChange: onChangeContentType,
 		backToToolsUrl,
 		logoHref,
 		isPremium,

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -1,6 +1,6 @@
 import { Slot } from "@wordpress/components";
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useCallback, useEffect, useMemo, useState } from "@wordpress/element";
+import { useCallback, useEffect, useMemo } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { PENDING_CHANGES_MODAL_SLOT, STORE_NAME } from "../constants";
 import { getFieldSets } from "../field-sets";
@@ -58,7 +58,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 		() => Object.values( fieldSets ).map( ( { id, label } ) => ( { id, label } ) ),
 		[ fieldSets ]
 	);
-	const { activeFieldSet, selectedIds, isPremium, isAiEnabled, hasExternalPendingChanges } = useSelect( ( select ) => {
+	const { activeFieldSet, selectedIds, isPremium, isAiEnabled, hasExternalPendingChanges, pendingSwitch } = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
 		return {
 			activeFieldSet: store.selectActiveFieldSet(),
@@ -67,37 +67,28 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 			isAiEnabled: store.selectPreference( "isAiEnabled", false ),
 			// An external plugin (e.g. Premium's AI suggestions) reports pending changes so the switch can be guarded.
 			hasExternalPendingChanges: store.selectHasExternalPendingChanges(),
+			pendingSwitch: store.selectPendingSwitch(),
 		};
 	}, [] );
-	const { setActiveFieldSet, toggleRow, selectAll, deselectAll } = useDispatch( STORE_NAME );
+	const { requestSwitch, commitSwitch, clearPendingSwitch, toggleRow, selectAll, deselectAll } = useDispatch( STORE_NAME );
 
 	const { data: items = [], total = 0, totalPages = 0, isPending, updateItem } = usePosts( { dataProvider, remoteDataProvider, contentType } );
 	const { editing, stopEditing } = useInlineEdit( { dataProvider, remoteDataProvider, fieldSets, activeFieldSet, items, updateItem } );
 
-	// The tab the user wants to switch to while a switch is guarded (unsaved manual edits, or an external plugin
-	// reporting pending changes); drives the confirmation modal.
-	const [ pendingTab, setPendingTab ] = useState( null );
 	const editCount = Object.keys( editing.editingRows ).length;
 	const hasUnsavedEdits = editCount > 0;
 
-
+	// A tab click requests a field-set switch; requestSwitch guards it (defers to the modal) or commits it straight away.
 	const onChangeTab = useCallback( ( id ) => {
-		if ( id === activeFieldSet ) {
-			return;
+		if ( id !== activeFieldSet ) {
+			requestSwitch( { kind: "fieldSet", target: id } );
 		}
-		// Guard the switch when manual edits are in progress or an external plugin (Premium AI) reports pending
-		// changes; otherwise switch straight away. The guarded tab is held in pendingTab until the user decides.
-		if ( hasUnsavedEdits || hasExternalPendingChanges ) {
-			setPendingTab( id );
-			return;
-		}
-		setActiveFieldSet( id );
-	}, [ activeFieldSet, hasUnsavedEdits, hasExternalPendingChanges, setActiveFieldSet ] );
+	}, [ activeFieldSet, requestSwitch ] );
 
-	const onSaveAndSwitch = useCallback( () => {
-		// Save every open edit as one batch. On failure the drafts stay open, so the switch is not committed
-		// and no edits are silently lost.
-		editing.onApplyAll();
+	const onSaveAndSwitch = useCallback( async() => {
+		// Save every open edit as one batch, then let the self-heal effect commit the switch once the edits clear.
+		// On failure the drafts stay open, so nothing is committed and no edits are silently lost.
+		await editing.onApplyAll();
 	}, [ editing ] );
 
 	const onDiscardAndSwitch = useCallback( () => {
@@ -106,23 +97,24 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 		stopEditing();
 	}, [ stopEditing ] );
 
-	const onCancelSwitch = useCallback( () => setPendingTab( null ), [] );
+	const onCancelSwitch = useCallback( () => clearPendingSwitch(), [ clearPendingSwitch ] );
 
 	// Commits the deferred switch for an external guard (Premium fills the slot below and calls this once it has
 	// handled its own pending changes). Free's own manual edits use onSaveAndSwitch/onDiscardAndSwitch instead.
 	const onCommitSwitch = useCallback( () => {
-		setActiveFieldSet( pendingTab );
-		setPendingTab( null );
-	}, [ pendingTab, setActiveFieldSet ] );
+		if ( pendingSwitch ) {
+			commitSwitch( pendingSwitch );
+		}
+	}, [ pendingSwitch, commitSwitch ] );
 
 	// Self-heal a stranded switch: if a deferral is outstanding but nothing guards it any more (manual edits saved
-	// and the external plugin cleared its pending changes), complete the switch so the user can never get stuck on a
-	// tab with no modal to resolve.
+	// and the external plugin cleared its pending changes), complete the switch so the user can never get stuck
+	// with no modal to resolve.
 	useEffect( () => {
-		if ( pendingTab !== null && ! hasUnsavedEdits && ! hasExternalPendingChanges ) {
+		if ( pendingSwitch !== null && ! hasUnsavedEdits && ! hasExternalPendingChanges ) {
 			onCommitSwitch();
 		}
-	}, [ pendingTab, hasUnsavedEdits, hasExternalPendingChanges, onCommitSwitch ] );
+	}, [ pendingSwitch, hasUnsavedEdits, hasExternalPendingChanges, onCommitSwitch ] );
 
 	const { isAllSelected, isIndeterminate, selectedCount, totalCount, hasSelection } = getSelectionView( isPending, selectedIds, items, total );
 	const onSelectAll = useCallback( () => {
@@ -202,7 +194,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 				</BulkEditorTabPanel>
 			) ) }
 			<UnsavedChangesModal
-				isOpen={ hasUnsavedEdits && pendingTab !== null }
+				isOpen={ hasUnsavedEdits && pendingSwitch !== null }
 				onSave={ onSaveAndSwitch }
 				onDiscard={ onDiscardAndSwitch }
 				onClose={ onCancelSwitch }
@@ -210,7 +202,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 			<Slot
 				name={ PENDING_CHANGES_MODAL_SLOT }
 				fillProps={ {
-					isOpen: pendingTab !== null && ! hasUnsavedEdits,
+					isOpen: pendingSwitch !== null && ! hasUnsavedEdits,
 					onCommit: onCommitSwitch,
 					onCancel: onCancelSwitch,
 				} }

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -78,12 +78,9 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 	const editCount = Object.keys( editing.editingRows ).length;
 	const hasUnsavedEdits = editCount > 0;
 
-	// A tab click requests a field-set switch; requestSwitch guards it (defers to the modal) or commits it straight away.
-	const onChangeTab = useCallback( ( id ) => {
-		if ( id !== activeFieldSet ) {
-			requestSwitch( { kind: "fieldSet", target: id } );
-		}
-	}, [ activeFieldSet, requestSwitch ] );
+	// A tab click requests a field-set switch; requestSwitch guards it (defers to the modal), skips a no-op switch,
+	// or commits straight away. Kept free of the active field set so the handler stays referentially stable.
+	const onChangeTab = useCallback( ( id ) => requestSwitch( { kind: "fieldSet", target: id } ), [ requestSwitch ] );
 
 	const onSaveAndSwitch = useCallback( async() => {
 		// Save every open edit as one batch, then let the self-heal effect commit the switch once the edits clear.

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -192,6 +192,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 			) ) }
 			<UnsavedChangesModal
 				isOpen={ hasUnsavedEdits && pendingSwitch !== null }
+				isSaving={ editing.isApplyingAll }
 				onSave={ onSaveAndSwitch }
 				onDiscard={ onDiscardAndSwitch }
 				onClose={ onCancelSwitch }

--- a/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
+++ b/packages/js/src/bulk-editor/components/unsaved-changes-modal.js
@@ -10,13 +10,15 @@ import { noop } from "lodash";
  *
  * @param {Object}   props             The props.
  * @param {boolean}  props.isOpen      Whether the modal is open.
+ * @param {boolean}  [props.isSaving]  Whether a save is in flight; disables Save and Discard so the in-flight
+ *                                     save can't be double-fired or discarded mid-flight.
  * @param {Function} [props.onSave]    Saves all edits and then switches tab (Save changes).
  * @param {Function} [props.onDiscard] Discards all edits and then switches tab (Continue without saving).
  * @param {Function} [props.onClose]   Closes the modal and stays on the current tab (Cancel / dismiss).
  *
  * @returns {JSX.Element} The modal.
  */
-export const UnsavedChangesModal = ( { isOpen, onSave = noop, onDiscard = noop, onClose = noop } ) => {
+export const UnsavedChangesModal = ( { isOpen, isSaving = false, onSave = noop, onDiscard = noop, onClose = noop } ) => {
 	const svgAriaProps = useSvgAria();
 	const saveRef = useRef( null );
 
@@ -37,10 +39,10 @@ export const UnsavedChangesModal = ( { isOpen, onSave = noop, onDiscard = noop, 
 					</div>
 				</div>
 				<div className="yst-flex yst-flex-col yst-gap-2 yst-mt-6">
-					<Button ref={ saveRef } type="button" variant="primary" onClick={ onSave }>
+					<Button ref={ saveRef } type="button" variant="primary" onClick={ onSave } disabled={ isSaving }>
 						{ __( "Save changes", "wordpress-seo" ) }
 					</Button>
-					<Button type="button" variant="secondary" onClick={ onDiscard }>
+					<Button type="button" variant="secondary" onClick={ onDiscard } disabled={ isSaving }>
 						{ __( "Continue without saving", "wordpress-seo" ) }
 					</Button>
 					<Button type="button" variant="tertiary" onClick={ onClose }>

--- a/packages/js/src/bulk-editor/store/index.js
+++ b/packages/js/src/bulk-editor/store/index.js
@@ -10,6 +10,7 @@ import externalPendingChanges, {
 	externalPendingChangesActions,
 	externalPendingChangesSelectors,
 } from "./external-pending-changes";
+import pendingSwitch, { createInitialPendingSwitchState, pendingSwitchActions, pendingSwitchSelectors } from "./pending-switch";
 import preferences, { createInitialPreferencesState, preferencesActions, preferencesSelectors } from "./preferences";
 import query, { createInitialQueryState, queryActions, querySelectors } from "./query";
 import selection, { createInitialSelectionState, selectionActions, selectionSelectors } from "./selection";
@@ -31,6 +32,7 @@ const createStore = ( { initialState } ) => {
 			...selectionActions,
 			...editsActions,
 			...externalPendingChangesActions,
+			...pendingSwitchActions,
 		},
 		selectors: {
 			...linkParamsSelectors,
@@ -41,6 +43,7 @@ const createStore = ( { initialState } ) => {
 			...selectionSelectors,
 			...editsSelectors,
 			...externalPendingChangesSelectors,
+			...pendingSwitchSelectors,
 		},
 		initialState: merge(
 			{},
@@ -53,6 +56,7 @@ const createStore = ( { initialState } ) => {
 				selection: createInitialSelectionState(),
 				edits: createInitialEditsState(),
 				externalPendingChanges: createInitialExternalPendingChangesState(),
+				pendingSwitch: createInitialPendingSwitchState(),
 			},
 			initialState
 		),
@@ -65,6 +69,7 @@ const createStore = ( { initialState } ) => {
 			selection,
 			edits,
 			externalPendingChanges,
+			pendingSwitch,
 		} ),
 	} );
 };

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -17,8 +17,8 @@ const slice = createSlice( {
 } );
 
 /**
- * Commits a switch. A content-type change also resets the per-type selection and edits, so a stale selection or
- * unsaved draft can't leak into the newly-shown type.
+ * Commits a switch. A content-type change also clears the unsaved edits, so a stale draft can't leak into the
+ * newly shown type; the selection reset is handled by setActiveContentType itself.
  *
  * @param {{kind: string, target: string}} pending The switch to commit.
  *
@@ -27,7 +27,6 @@ const slice = createSlice( {
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 	if ( kind === "contentType" ) {
 		dispatch.setActiveContentType( target );
-		dispatch.deselectAll();
 		dispatch.stopEdit();
 	} else {
 		dispatch.setActiveFieldSet( target );

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -1,0 +1,65 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { get } from "lodash";
+
+/**
+ * @returns {null} The initial pending-switch state: no switch is deferred.
+ */
+export const createInitialPendingSwitchState = () => null;
+
+const slice = createSlice( {
+	name: "pendingSwitch",
+	initialState: createInitialPendingSwitchState(),
+	reducers: {
+		// Holds a deferred switch ({ kind: "fieldSet" | "contentType", target }) until the guard is resolved.
+		setPendingSwitch: ( _state, { payload } ) => payload,
+		clearPendingSwitch: () => null,
+	},
+} );
+
+/**
+ * Commits a switch. A content-type change also resets the per-type selection and edits, so a stale selection or
+ * unsaved draft can't leak into the newly-shown type.
+ *
+ * @param {{kind: string, target: string}} pending The switch to commit.
+ *
+ * @returns {Function} The thunk.
+ */
+export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
+	if ( kind === "contentType" ) {
+		dispatch.setActiveContentType( target );
+		dispatch.deselectAll();
+		dispatch.stopEdit();
+	} else {
+		dispatch.setActiveFieldSet( target );
+	}
+	dispatch.clearPendingSwitch();
+};
+
+/**
+ * Requests a switch, guarding it when manual edits are in progress or an external plugin (Premium AI) reports
+ * pending changes: the switch is then held until the user resolves it, otherwise it commits immediately.
+ *
+ * @param {{kind: string, target: string}} request The requested switch.
+ *
+ * @returns {Function} The thunk.
+ */
+export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) => {
+	const hasUnsavedEdits = Object.keys( select.selectEditingRows() ).length > 0;
+	if ( hasUnsavedEdits || select.selectHasExternalPendingChanges() ) {
+		dispatch.setPendingSwitch( { kind, target } );
+		return;
+	}
+	dispatch.commitSwitch( { kind, target } );
+};
+
+export const pendingSwitchSelectors = {
+	selectPendingSwitch: ( state ) => get( state, "pendingSwitch", null ),
+};
+
+export const pendingSwitchActions = {
+	...slice.actions,
+	requestSwitch,
+	commitSwitch,
+};
+
+export default slice.reducer;

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -44,6 +44,10 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
  * @returns {Function} The thunk.
  */
 export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) => {
+	const current = kind === "contentType" ? select.selectActiveContentTypeName() : select.selectActiveFieldSet();
+	if ( target === current ) {
+		return;
+	}
 	const hasUnsavedEdits = Object.keys( select.selectEditingRows() ).length > 0;
 	if ( hasUnsavedEdits || select.selectHasExternalPendingChanges() ) {
 		dispatch.setPendingSwitch( { kind, target } );

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -285,5 +285,21 @@ describe( "App", () => {
 			expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" );
 			expect( screen.getByRole( "heading", { level: 1, name: "Bulk editor: Pages" } ) ).toBeInTheDocument();
 		} );
+
+		it( "does not guard clicking the already-active first content type while the stored name is still empty", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			// Enter edit mode so any spurious switch would be guarded by the modal.
+			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+
+			// "Pages" is the resolved default while the stored active name is still "" (never switched).
+			expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" );
+			fireEvent.click( screen.getByRole( "button", { name: "Pages" } ) );
+
+			// Clicking the content type you are already on is a no-op: no confirmation modal, the edit stays open.
+			expect( screen.queryByText( "Unsaved changes" ) ).not.toBeInTheDocument();
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -43,6 +43,7 @@ describe( "App", () => {
 		dispatch( STORE_NAME ).setActiveFieldSet( FIELD_SET_SEARCH );
 		dispatch( STORE_NAME ).setActiveContentType( "" );
 		dispatch( STORE_NAME ).stopEdit();
+		dispatch( STORE_NAME ).clearPendingSwitch();
 	} );
 
 	it( "renders the header, tabs and panel in a single card with the header separator", () => {

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -1,5 +1,5 @@
 import { dispatch } from "@wordpress/data";
-import { fireEvent, render, screen, waitFor } from "../test-utils";
+import { act, fireEvent, render, screen, waitFor } from "../test-utils";
 import App from "../../src/bulk-editor/app";
 import { FIELD_SET_SEARCH, STORE_NAME } from "../../src/bulk-editor/constants";
 import { getFieldSets } from "../../src/bulk-editor/field-sets";
@@ -44,6 +44,7 @@ describe( "App", () => {
 		dispatch( STORE_NAME ).setActiveContentType( "" );
 		dispatch( STORE_NAME ).stopEdit();
 		dispatch( STORE_NAME ).clearPendingSwitch();
+		dispatch( STORE_NAME ).setHasExternalPendingChanges( false );
 	} );
 
 	it( "renders the header, tabs and panel in a single card with the header separator", () => {
@@ -252,6 +253,37 @@ describe( "App", () => {
 				expect.objectContaining( { method: "POST" } )
 			);
 			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( "switching content types with pending changes", () => {
+		const rowTitle = "What Is SEO and How It Works";
+
+		it( "shows the confirmation modal and stays on the content type when there are unsaved edits", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+			fireEvent.click( screen.getByRole( "button", { name: "Posts" } ) );
+
+			expect( screen.getByText( "Unsaved changes" ) ).toBeInTheDocument();
+			// The content type has not switched while the modal is open.
+			expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" );
+			expect( screen.getByRole( "heading", { level: 1, name: "Bulk editor: Pages" } ) ).toBeInTheDocument();
+		} );
+
+		it( "defers the switch while an external plugin reports pending changes", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+			await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } );
+
+			await act( async() => {
+				dispatch( STORE_NAME ).setHasExternalPendingChanges( true );
+			} );
+			fireEvent.click( screen.getByRole( "button", { name: "Posts" } ) );
+
+			// The switch is held (Premium would fill the slot to resolve it); the content type does not change.
+			expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" );
+			expect( screen.getByRole( "heading", { level: 1, name: "Bulk editor: Pages" } ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/packages/js/tests/bulk-editor/bulk-editor-content.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-content.test.js
@@ -99,6 +99,8 @@ describe( "BulkEditorContent tab-switch guard", () => {
 		// The store lives in the global registry: reset the guard state so tests stay order-independent.
 		dispatch( STORE_NAME ).setActiveFieldSet( FIELD_SET_SEARCH );
 		dispatch( STORE_NAME ).setHasExternalPendingChanges( false );
+		dispatch( STORE_NAME ).stopEdit();
+		dispatch( STORE_NAME ).clearPendingSwitch();
 	} );
 
 	it( "switches immediately when nothing guards the switch", () => {

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -1,0 +1,92 @@
+import reducer, {
+	commitSwitch,
+	createInitialPendingSwitchState,
+	pendingSwitchActions,
+	pendingSwitchSelectors,
+	requestSwitch,
+} from "../../../src/bulk-editor/store/pending-switch";
+
+describe( "pendingSwitch slice", () => {
+	it( "defaults to no switch pending", () => {
+		expect( createInitialPendingSwitchState() ).toBe( null );
+	} );
+
+	it( "holds and clears a deferred switch", () => {
+		const held = reducer( null, pendingSwitchActions.setPendingSwitch( { kind: "contentType", target: "page" } ) );
+		expect( held ).toEqual( { kind: "contentType", target: "page" } );
+
+		expect( reducer( held, pendingSwitchActions.clearPendingSwitch() ) ).toBe( null );
+	} );
+
+	it( "selects the pending switch", () => {
+		expect( pendingSwitchSelectors.selectPendingSwitch( { pendingSwitch: { kind: "fieldSet", target: "social" } } ) )
+			.toEqual( { kind: "fieldSet", target: "social" } );
+		expect( pendingSwitchSelectors.selectPendingSwitch( {} ) ).toBe( null );
+	} );
+} );
+
+describe( "requestSwitch thunk", () => {
+	const makeThunkArgs = ( { editingRows = {}, hasExternalPendingChanges = false } = {} ) => ( {
+		select: {
+			selectEditingRows: () => editingRows,
+			selectHasExternalPendingChanges: () => hasExternalPendingChanges,
+		},
+		dispatch: {
+			setPendingSwitch: jest.fn(),
+			commitSwitch: jest.fn(),
+		},
+	} );
+
+	it( "commits immediately when nothing guards the switch", () => {
+		const args = makeThunkArgs();
+		requestSwitch( { kind: "contentType", target: "page" } )( args );
+
+		expect( args.dispatch.commitSwitch ).toHaveBeenCalledWith( { kind: "contentType", target: "page" } );
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers the switch while manual edits are in progress", () => {
+		const args = makeThunkArgs( { editingRows: { 7: {} } } );
+		requestSwitch( { kind: "fieldSet", target: "social" } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "fieldSet", target: "social" } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers the switch while an external plugin reports pending changes", () => {
+		const args = makeThunkArgs( { hasExternalPendingChanges: true } );
+		requestSwitch( { kind: "contentType", target: "product" } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "contentType", target: "product" } );
+	} );
+} );
+
+describe( "commitSwitch thunk", () => {
+	const makeDispatch = () => ( {
+		setActiveContentType: jest.fn(),
+		setActiveFieldSet: jest.fn(),
+		deselectAll: jest.fn(),
+		stopEdit: jest.fn(),
+		clearPendingSwitch: jest.fn(),
+	} );
+
+	it( "changes the field set and clears the pending switch for a field-set switch", () => {
+		const dispatch = makeDispatch();
+		commitSwitch( { kind: "fieldSet", target: "social" } )( { dispatch } );
+
+		expect( dispatch.setActiveFieldSet ).toHaveBeenCalledWith( "social" );
+		expect( dispatch.setActiveContentType ).not.toHaveBeenCalled();
+		expect( dispatch.deselectAll ).not.toHaveBeenCalled();
+		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
+	} );
+
+	it( "changes the content type and resets per-type selection and edits", () => {
+		const dispatch = makeDispatch();
+		commitSwitch( { kind: "contentType", target: "page" } )( { dispatch } );
+
+		expect( dispatch.setActiveContentType ).toHaveBeenCalledWith( "page" );
+		expect( dispatch.deselectAll ).toHaveBeenCalled();
+		expect( dispatch.stopEdit ).toHaveBeenCalled();
+		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -26,10 +26,12 @@ describe( "pendingSwitch slice", () => {
 } );
 
 describe( "requestSwitch thunk", () => {
-	const makeThunkArgs = ( { editingRows = {}, hasExternalPendingChanges = false } = {} ) => ( {
+	const makeThunkArgs = ( { editingRows = {}, hasExternalPendingChanges = false, activeContentType = "", activeFieldSet = "search" } = {} ) => ( {
 		select: {
 			selectEditingRows: () => editingRows,
 			selectHasExternalPendingChanges: () => hasExternalPendingChanges,
+			selectActiveContentTypeName: () => activeContentType,
+			selectActiveFieldSet: () => activeFieldSet,
 		},
 		dispatch: {
 			setPendingSwitch: jest.fn(),
@@ -58,6 +60,14 @@ describe( "requestSwitch thunk", () => {
 		requestSwitch( { kind: "contentType", target: "product" } )( args );
 
 		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "contentType", target: "product" } );
+	} );
+
+	it( "ignores a switch to what is already active", () => {
+		const args = makeThunkArgs( { activeContentType: "page", editingRows: { 7: {} } } );
+		requestSwitch( { kind: "contentType", target: "page" } )( args );
+
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -90,13 +90,14 @@ describe( "commitSwitch thunk", () => {
 		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
 	} );
 
-	it( "changes the content type and resets per-type selection and edits", () => {
+	it( "changes the content type and clears the edits, delegating the selection reset to setActiveContentType", () => {
 		const dispatch = makeDispatch();
 		commitSwitch( { kind: "contentType", target: "page" } )( { dispatch } );
 
 		expect( dispatch.setActiveContentType ).toHaveBeenCalledWith( "page" );
-		expect( dispatch.deselectAll ).toHaveBeenCalled();
 		expect( dispatch.stopEdit ).toHaveBeenCalled();
+		// The selection slice resets on setActiveContentType, so commitSwitch does not deselect separately.
+		expect( dispatch.deselectAll ).not.toHaveBeenCalled();
 		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/js/tests/bulk-editor/unsaved-changes-modal.test.js
+++ b/packages/js/tests/bulk-editor/unsaved-changes-modal.test.js
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "../test-utils";
+import { UnsavedChangesModal } from "../../src/bulk-editor/components/unsaved-changes-modal";
+
+describe( "UnsavedChangesModal", () => {
+	it( "wires each action to its handler", () => {
+		const onSave = jest.fn();
+		const onDiscard = jest.fn();
+		const onClose = jest.fn();
+		render( <UnsavedChangesModal isOpen={ true } onSave={ onSave } onDiscard={ onDiscard } onClose={ onClose } /> );
+
+		fireEvent.click( screen.getByRole( "button", { name: "Save changes" } ) );
+		fireEvent.click( screen.getByRole( "button", { name: "Continue without saving" } ) );
+		fireEvent.click( screen.getByRole( "button", { name: "Cancel" } ) );
+
+		expect( onSave ).toHaveBeenCalledTimes( 1 );
+		expect( onDiscard ).toHaveBeenCalledTimes( 1 );
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( "disables Save and Discard while a save is in flight, keeping Cancel available", () => {
+		render( <UnsavedChangesModal isOpen={ true } isSaving={ true } /> );
+
+		expect( screen.getByRole( "button", { name: "Save changes" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Continue without saving" } ) ).toBeDisabled();
+		// Cancel stays enabled so a stalled save can't trap the user in the modal.
+		expect( screen.getByRole( "button", { name: "Cancel" } ) ).toBeEnabled();
+	} );
+} );


### PR DESCRIPTION
## Context

Fixes plugins-automated-testing#3067: the bulk editor guarded unsaved changes only when switching **appearance tabs** (Search/Social), not when switching **content types** (Posts → Pages → Products) via the sidebar. So pending AI suggestions and manual edits were silently dropped on a content-type switch, and stale per-type state (selection, "posts" errors) leaked into the new type.

The tab-switch guard and the content-type switch now funnel through one guarded action, reusing the single pending-changes modal slot that Premium fills.

## Summary

This PR can be summarized in the following changelog entry:

* Guards unsaved edits and pending AI suggestions when switching content types in the bulk editor, matching the appearance-tab behaviour.

## Relevant technical choices:

* **Unified guard** — a `pendingSwitch = { kind: 'fieldSet' | 'contentType', target }` store slice plus a `requestSwitch` thunk (defers to the modal when there are edits or external pending changes, else commits) and a `commitSwitch` thunk; both the tabs and the sidebar nav route through it.
* **Single modal slot** — `BulkEditorContent` keeps the guard (and the one `PENDING_CHANGES_MODAL_SLOT` Premium fills); the nav feeds its request in via the store, so `BulkEditorContent` re-renders (not remounts) and Premium's pending-AI modal works unchanged.
* **State reset on content-type commit** — `commitSwitch` also clears the selection and edits for a content-type change, so stale per-type state no longer leaks.
* **Stable handlers** — the "same-target" no-op check lives in the thunk (reads fresh store state), so the tab/nav click handlers stay referentially stable and don't go stale behind the memoized navigation item.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

**Manual edits (Free):**
1. Open **Yoast SEO → Tools → Bulk editor → Posts**.
2. Click **Edit** on a row, change a field value, then click **Pages** in the left sidebar.
3. The **Unsaved changes** modal appears and you stay on Posts. **Continue without saving** switches to Pages with the edit discarded; **Cancel** stays on Posts with the edit intact.
4. Repeat, and this time click **Save changes**: the edit is saved (POST to the update endpoint) and you switch to Pages; back on Posts the row is no longer in edit mode and shows the saved value.

**Save in progress — actions locked (Free, "Unsaved changes" modal only):**
This checks the manual-edits modal (**Save changes** / **Continue without saving** / **Cancel**), not the Premium "Pending AI suggestions" modal — so you need open inline edits, not AI suggestions.
1. Open DevTools → **Network** and enable throttling (**Slow 3G**, or a custom profile with high latency — the payload is tiny, so latency, not bandwidth, is what widens the window).
2. Click **Edit** on a row and change a field value, then click another content type/tab to open the **Unsaved changes** modal, and click **Save changes**.
3. While the save POST is in flight, **Save changes** and **Continue without saving** are disabled; **Cancel** stays enabled. Clicking Save again or Continue during this window has no effect.
4. Once the request resolves, the switch completes as in the manual-edits flow above.

**Pending AI suggestions (Premium, with an active subscription):**
1. On **Posts**, select a row that has a focus keyphrase and click **Generate meta descriptions** (or SEO titles). Wait for the suggestion; do **not** apply it.
2. Click **Pages** in the sidebar → the **Pending AI suggestions** modal appears and you stay on Posts. **Continue without applying** switches to Pages and the suggestion is dismissed; the new type is clean (no leftover selection or errors).

**No-pending switch:** with nothing pending, clicking another content type switches immediately, and repeated switches keep working.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The pending-AI path requires Yoast SEO Premium active with a valid subscription.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor tab switching, content-type navigation, and the unsaved-changes / pending-AI-suggestions confirmation modals.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation


* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#3067](https://github.com/Yoast/plugins-automated-testing/issues/3067)


