### PR TITLE
fix(bulk-editor): enforce edit permissions on the read path

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -29,8 +29,10 @@ export const getSelectionView = ( isLoading, selectedIds, items, total ) => {
 	if ( isLoading ) {
 		return { isAllSelected: false, isIndeterminate: false, selectedCount: 0, totalCount: 0, hasSelection: false };
 	}
+	// Only posts the user can edit are selectable, so "all selected" is measured against the editable rows.
+	const selectableCount = items.filter( ( item ) => item.editable ).length;
 	const selectedCount = selectedIds.length;
-	const isAllSelected = items.length > 0 && selectedCount === items.length;
+	const isAllSelected = selectableCount > 0 && selectedCount === selectableCount;
 	return {
 		isAllSelected,
 		isIndeterminate: selectedCount > 0 && ! isAllSelected,
@@ -127,7 +129,8 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 	const { isAllSelected, isIndeterminate, selectedCount, totalCount, hasSelection } = getSelectionView( isPending, selectedIds, items, total );
 	const onSelectAll = useCallback( () => {
 		if ( ! isPending ) {
-			selectAll( items.map( ( item ) => item.id ) );
+			// Only posts the user can edit are selectable for bulk editing.
+			selectAll( items.filter( ( item ) => item.editable ).map( ( item ) => item.id ) );
 		}
 	}, [ isPending, selectAll, items ] );
 	// Clicking the master checkbox clears the selection whenever anything is selected (all or a partial).

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -62,6 +62,8 @@ export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleR
 					aria-label={ sprintf( __( "Select %s", "wordpress-seo" ), item.title ) }
 					checked={ isSelected }
 					onChange={ handleToggle }
+					// A post the current user cannot edit is shown locked and cannot be selected for bulk editing.
+					disabled={ ! item.editable }
 				/>
 			</Table.Cell>
 			<TitleCell item={ item } fieldSetId={ fieldSetId } />
@@ -142,7 +144,8 @@ export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleR
 								className="yst--me-2.5"
 								onClick={ handleEdit }
 								aria-label={ editLabel }
-								disabled={ isSlotFilled || hasExternalPendingChanges }
+								// A post the current user cannot edit stays locked; its SEO data is not returned either.
+								disabled={ isSlotFilled || hasExternalPendingChanges || ! item.editable }
 							>
 								{ __( "Edit", "wordpress-seo" ) }
 							</Button>

--- a/packages/js/src/bulk-editor/field-sets.js
+++ b/packages/js/src/bulk-editor/field-sets.js
@@ -18,6 +18,7 @@ import { FIELD_SET_SEARCH, FIELD_SET_SOCIAL, FOCUS_KEYPHRASE_KEY } from "./const
  * @property {string} metaDescription   The meta description.
  * @property {string} socialTitle       The social title.
  * @property {string} socialDescription The social description.
+ * @property {boolean} editable         Whether the current user may edit the post; locked rows hide their SEO data.
  */
 
 /**

--- a/packages/js/src/bulk-editor/services/use-posts.js
+++ b/packages/js/src/bulk-editor/services/use-posts.js
@@ -19,6 +19,7 @@ const formatPost = ( post ) => ( {
 	metaDescription: post.meta_description,
 	socialTitle: post.social_title,
 	socialDescription: post.social_description,
+	editable: post.editable,
 } );
 
 /**

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -22,8 +22,8 @@ const remoteDataProvider = { fetchJson: jest.fn( () => new Promise( () => {} ) )
 // The rows the posts endpoint serves, in the API's snake_case shape (mapped by usePosts).
 /* eslint-disable camelcase -- The REST endpoint returns snake_case keys. */
 const postRows = [
-	{ id: 1, title: "What Is SEO and How It Works", status: "publish", edit_link: "https://example.com/1", focus_keyphrase: "what is seo", seo_title: "What Is SEO? Complete Guide", meta_description: "Learn what SEO is.", social_title: "Social: What Is SEO", social_description: "Social description." },
-	{ id: 2, title: "Keyword Research for Beginners", status: "publish", edit_link: "https://example.com/2", focus_keyphrase: "keyword research", seo_title: "Keyword Research Guide", meta_description: "Find keywords.", social_title: "Social: Keyword Research", social_description: "Social description 2." },
+	{ id: 1, title: "What Is SEO and How It Works", status: "publish", edit_link: "https://example.com/1", focus_keyphrase: "what is seo", seo_title: "What Is SEO? Complete Guide", meta_description: "Learn what SEO is.", social_title: "Social: What Is SEO", social_description: "Social description.", editable: true },
+	{ id: 2, title: "Keyword Research for Beginners", status: "publish", edit_link: "https://example.com/2", focus_keyphrase: "keyword research", seo_title: "Keyword Research Guide", meta_description: "Find keywords.", social_title: "Social: Keyword Research", social_description: "Social description 2.", editable: true },
 ];
 /* eslint-enable camelcase */
 

--- a/packages/js/tests/bulk-editor/bulk-editor-content.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-content.test.js
@@ -46,7 +46,7 @@ const renderContent = () => render(
 );
 
 describe( "getSelectionView", () => {
-	const items = [ { id: 1 }, { id: 2 }, { id: 3 } ];
+	const items = [ { id: 1, editable: true }, { id: 2, editable: true }, { id: 3, editable: true } ];
 
 	it( "presents a neutral selection while loading", () => {
 		expect( getSelectionView( true, [ 1, 2 ], items, 3 ) ).toEqual( {
@@ -87,6 +87,17 @@ describe( "getSelectionView", () => {
 
 		expect( view.selectedCount ).toBe( 2 );
 		expect( view.totalCount ).toBe( 42 );
+	} );
+
+	it( "treats only editable rows as selectable", () => {
+		const mixed = [ { id: 1, editable: true }, { id: 2, editable: false }, { id: 3, editable: true } ];
+
+		// Both editable rows are selected, so the master checkbox reads as fully selected even though a
+		// locked row remains.
+		const view = getSelectionView( false, [ 1, 3 ], mixed, 3 );
+
+		expect( view.isAllSelected ).toBe( true );
+		expect( view.isIndeterminate ).toBe( false );
 	} );
 } );
 

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -18,6 +18,7 @@ const items = [
 		metaDescription: "Learn what SEO is.",
 		socialTitle: "Social: What Is SEO",
 		socialDescription: "Social description for SEO.",
+		editable: true,
 	},
 	{
 		id: 2,
@@ -29,6 +30,7 @@ const items = [
 		metaDescription: "Follow this on-page checklist.",
 		socialTitle: "Social: On-Page SEO",
 		socialDescription: "Social description for on-page.",
+		editable: true,
 	},
 ];
 
@@ -135,6 +137,24 @@ describe( "BulkEditorTable", () => {
 		// A per-field save must not race the in-flight batch, so the row's own Save/Cancel lock too.
 		expect( screen.getByRole( "button", { name: "Save What Is SEO" } ) ).toBeDisabled();
 		expect( screen.getByRole( "button", { name: "Cancel editing What Is SEO" } ) ).toBeDisabled();
+	} );
+
+	it( "locks a post the current user cannot edit: its selection and Edit are disabled", () => {
+		const onToggleRow = jest.fn();
+		const rows = [ { ...items[ 0 ], editable: false } ];
+		render(
+			<BulkEditorTable
+				items={ rows }
+				fieldSet={ searchFieldSet }
+				selection={ { selectedIds: [], onToggleRow } }
+			/>
+		);
+
+		expect( screen.getByRole( "checkbox", { name: "Select What Is SEO" } ) ).toBeDisabled();
+		expect( screen.getByRole( "button", { name: "Edit What Is SEO" } ) ).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( "button", { name: "Edit What Is SEO" } ) );
+		expect( onToggleRow ).not.toHaveBeenCalled();
 	} );
 
 	it( "marks column and row headers with scope", () => {

--- a/packages/js/tests/bulk-editor/services/use-posts.test.js
+++ b/packages/js/tests/bulk-editor/services/use-posts.test.js
@@ -52,6 +52,7 @@ describe( "usePosts", () => {
 						meta_description: "A description.",
 						social_title: "Social hello",
 						social_description: "Social description.",
+						editable: true,
 					},
 				],
 				total: 42,
@@ -75,6 +76,7 @@ describe( "usePosts", () => {
 				metaDescription: "A description.",
 				socialTitle: "Social hello",
 				socialDescription: "Social description.",
+				editable: true,
 			},
 		] );
 		expect( result.current.total ).toBe( 42 );

--- a/src/bulk-editor/application/content-types/content-type-access-checker-interface.php
+++ b/src/bulk-editor/application/content-types/content-type-access-checker-interface.php
@@ -1,0 +1,34 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Bulk_Editor\Application\Content_Types;
+
+/**
+ * Describes the current user's editing rights for a content type.
+ */
+interface Content_Type_Access_Checker_Interface {
+
+	/**
+	 * Whether the current user can edit at least one post of the content type.
+	 *
+	 * This is a content-type-level check used to decide whether the type is offered at all;
+	 * the per-post edit permission is enforced separately when the posts are collected.
+	 *
+	 * @param string $content_type The content type (post type name).
+	 *
+	 * @return bool Whether the current user can edit at least one post of the content type.
+	 */
+	public function can_edit_any( string $content_type ): bool;
+
+	/**
+	 * Whether the current user can edit other users' posts of the content type.
+	 *
+	 * Used to scope the query to the user's own posts when they cannot edit other authors' posts,
+	 * which keeps pagination cheap before the exact per-post check runs on the page.
+	 *
+	 * @param string $content_type The content type (post type name).
+	 *
+	 * @return bool Whether the current user can edit other users' posts of the content type.
+	 */
+	public function can_edit_others( string $content_type ): bool;
+}

--- a/src/bulk-editor/domain/posts/post.php
+++ b/src/bulk-editor/domain/posts/post.php
@@ -72,6 +72,13 @@ class Post {
 	private $social_description;
 
 	/**
+	 * Whether the current user may edit this post.
+	 *
+	 * @var bool
+	 */
+	private $editable;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param int    $id                 The post ID.
@@ -83,6 +90,7 @@ class Post {
 	 * @param string $meta_description   The meta description.
 	 * @param string $social_title       The social title.
 	 * @param string $social_description The social description.
+	 * @param bool   $editable           Whether the current user may edit this post.
 	 */
 	public function __construct(
 		int $id,
@@ -93,7 +101,8 @@ class Post {
 		string $seo_title,
 		string $meta_description,
 		string $social_title,
-		string $social_description
+		string $social_description,
+		bool $editable
 	) {
 		$this->id                 = $id;
 		$this->title              = $title;
@@ -104,12 +113,13 @@ class Post {
 		$this->meta_description   = $meta_description;
 		$this->social_title       = $social_title;
 		$this->social_description = $social_description;
+		$this->editable           = $editable;
 	}
 
 	/**
 	 * Parses the post to the expected key value representation.
 	 *
-	 * @return array<string, int|string> The post presented as the expected key value representation.
+	 * @return array<string, int|string|bool> The post presented as the expected key value representation.
 	 */
 	public function to_array(): array {
 		return [
@@ -122,6 +132,7 @@ class Post {
 			'meta_description'   => $this->meta_description,
 			'social_title'       => $this->social_title,
 			'social_description' => $this->social_description,
+			'editable'           => $this->editable,
 		];
 	}
 }

--- a/src/bulk-editor/domain/posts/posts-query.php
+++ b/src/bulk-editor/domain/posts/posts-query.php
@@ -47,6 +47,13 @@ class Posts_Query {
 	private $statuses;
 
 	/**
+	 * The author to limit posts to, or null for no author restriction.
+	 *
+	 * @var int|null
+	 */
+	private $author_id;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param string        $content_type The content type to get posts for.
@@ -54,19 +61,22 @@ class Posts_Query {
 	 * @param int           $per_page     The number of posts per page.
 	 * @param string        $search       The search term, or an empty string for no search.
 	 * @param array<string> $statuses     The post statuses to include.
+	 * @param int|null      $author_id    The author to limit posts to, or null for no author restriction.
 	 */
 	public function __construct(
 		string $content_type,
 		int $page,
 		int $per_page,
 		string $search,
-		array $statuses
+		array $statuses,
+		?int $author_id = null
 	) {
 		$this->content_type = $content_type;
 		$this->page         = $page;
 		$this->per_page     = $per_page;
 		$this->search       = $search;
 		$this->statuses     = $statuses;
+		$this->author_id    = $author_id;
 	}
 
 	/**
@@ -121,6 +131,24 @@ class Posts_Query {
 	 */
 	public function get_statuses(): array {
 		return $this->statuses;
+	}
+
+	/**
+	 * Returns the author to limit posts to.
+	 *
+	 * @return int|null The author ID, or null for no author restriction.
+	 */
+	public function get_author_id(): ?int {
+		return $this->author_id;
+	}
+
+	/**
+	 * Returns whether posts are limited to a single author.
+	 *
+	 * @return bool Whether an author restriction is set.
+	 */
+	public function has_author_filter(): bool {
+		return $this->author_id !== null;
 	}
 
 	/**

--- a/src/bulk-editor/infrastructure/content-types/content-type-access-checker.php
+++ b/src/bulk-editor/infrastructure/content-types/content-type-access-checker.php
@@ -1,0 +1,58 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
+namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types;
+
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
+
+/**
+ * Checks the current user's editing rights for a content type through the WordPress APIs.
+ *
+ * For post types that map meta capabilities, the editing primitives (edit_posts, edit_published_posts,
+ * edit_others_posts) are used. For post types that do not, WordPress maps editing straight to the singular
+ * edit_post capability and never registers those primitives, so that single capability is used instead.
+ */
+class Content_Type_Access_Checker implements Content_Type_Access_Checker_Interface {
+
+	/**
+	 * Whether the current user can edit at least one post of the content type.
+	 *
+	 * @param string $content_type The content type (post type name).
+	 *
+	 * @return bool Whether the current user can edit at least one post of the content type.
+	 */
+	public function can_edit_any( string $content_type ): bool {
+		$post_type_object = \get_post_type_object( $content_type );
+		if ( $post_type_object === null ) {
+			return false;
+		}
+
+		if ( ! $post_type_object->map_meta_cap ) {
+			return \current_user_can( $post_type_object->cap->edit_post );
+		}
+
+		return \current_user_can( $post_type_object->cap->edit_posts )
+			|| \current_user_can( $post_type_object->cap->edit_published_posts )
+			|| \current_user_can( $post_type_object->cap->edit_others_posts );
+	}
+
+	/**
+	 * Whether the current user can edit other users' posts of the content type.
+	 *
+	 * @param string $content_type The content type (post type name).
+	 *
+	 * @return bool Whether the current user can edit other users' posts of the content type.
+	 */
+	public function can_edit_others( string $content_type ): bool {
+		$post_type_object = \get_post_type_object( $content_type );
+		if ( $post_type_object === null ) {
+			return false;
+		}
+
+		if ( ! $post_type_object->map_meta_cap ) {
+			return \current_user_can( $post_type_object->cap->edit_post );
+		}
+
+		return \current_user_can( $post_type_object->cap->edit_others_posts );
+	}
+}

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -3,6 +3,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong
 namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types;
 
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Type;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
@@ -20,12 +21,24 @@ class Content_Types_Collector {
 	private $post_type_helper;
 
 	/**
+	 * The content type access checker.
+	 *
+	 * @var Content_Type_Access_Checker_Interface
+	 */
+	private $access_checker;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param Post_Type_Helper $post_type_helper The post type helper.
+	 * @param Post_Type_Helper                      $post_type_helper The post type helper.
+	 * @param Content_Type_Access_Checker_Interface $access_checker   The content type access checker.
 	 */
-	public function __construct( Post_Type_Helper $post_type_helper ) {
+	public function __construct(
+		Post_Type_Helper $post_type_helper,
+		Content_Type_Access_Checker_Interface $access_checker
+	) {
 		$this->post_type_helper = $post_type_helper;
+		$this->access_checker   = $access_checker;
 	}
 
 	/**
@@ -39,6 +52,11 @@ class Content_Types_Collector {
 
 		foreach ( $post_types as $post_type_object ) {
 			if ( $post_type_object->show_ui === false ) {
+				continue;
+			}
+			// Offer the type when the user can edit at least one of its posts; the per-post edit
+			// permission is enforced when the posts themselves are collected.
+			if ( ! $this->access_checker->can_edit_any( $post_type_object->name ) ) {
 				continue;
 			}
 			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label, $post_type_object->labels->singular_name );

--- a/src/bulk-editor/infrastructure/posts/indexable-posts-collector.php
+++ b/src/bulk-editor/infrastructure/posts/indexable-posts-collector.php
@@ -30,16 +30,31 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 	private $indexable_repository;
 
 	/**
+	 * The resolver for the per-post edit permission.
+	 *
+	 * @var Post_Editability_Resolver
+	 */
+	private $post_editability_resolver;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param Indexable_Repository $indexable_repository The indexable repository.
+	 * @param Indexable_Repository      $indexable_repository      The indexable repository.
+	 * @param Post_Editability_Resolver $post_editability_resolver The resolver for the per-post edit permission.
 	 */
-	public function __construct( Indexable_Repository $indexable_repository ) {
-		$this->indexable_repository = $indexable_repository;
+	public function __construct(
+		Indexable_Repository $indexable_repository,
+		Post_Editability_Resolver $post_editability_resolver
+	) {
+		$this->indexable_repository      = $indexable_repository;
+		$this->post_editability_resolver = $post_editability_resolver;
 	}
 
 	/**
 	 * Collects a page of posts for the given query.
+	 *
+	 * A single page is fetched and counted through the database; the per-post edit permission is then
+	 * resolved for that page so posts the user cannot edit are returned locked and without their SEO data.
 	 *
 	 * @param Posts_Query $query The query describing the page to collect.
 	 *
@@ -52,23 +67,20 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 			->offset( $query->get_offset() )
 			->find_many();
 
-		$unique_indexables = [];
+		// Deduplicate on the post, keeping the query order.
+		$indexables_by_id = [];
 		foreach ( $indexables as $indexable ) {
-			$unique_indexables[ (int) $indexable->object_id ] = $indexable;
+			$indexables_by_id[ (int) $indexable->object_id ] = $indexable;
 		}
 
-		if ( $unique_indexables !== [] ) {
-			// Prime the post cache so get_the_title()/get_edit_post_link() read from cache instead of one query per post.
-			\_prime_post_caches( \array_keys( $unique_indexables ), false, false );
-		}
+		$total = $this->resolve_total( $query, \count( $indexables ), \count( $indexables_by_id ) );
+
+		$editability = $this->post_editability_resolver->resolve( \array_keys( $indexables_by_id ) );
 
 		$posts_list = new Posts_List();
-
-		foreach ( $unique_indexables as $indexable ) {
-			$posts_list->add( $this->build_post( $indexable ) );
+		foreach ( $indexables_by_id as $object_id => $indexable ) {
+			$posts_list->add( $this->build_post( $indexable, ( $editability[ $object_id ] ?? false ) ) );
 		}
-
-		$total = $this->resolve_total( $query, \count( $indexables ) );
 
 		return new Posts_Page( $posts_list, $total, $query->get_page(), $query->get_per_page() );
 	}
@@ -77,16 +89,20 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 	 * Resolves the total number of matching posts.
 	 *
 	 * A partially-filled page means the result set ended within it, so the total is known without a
-	 * second query. A full or empty page does not reveal the total, so it falls back to a count query.
+	 * second query: the offset plus the distinct posts on this page. Whether the page ended is judged
+	 * on the number of rows fetched, before duplicates are removed, since that is what reveals the
+	 * database had no more rows. A full or empty page does not reveal the total, so it falls back to a
+	 * count query. Non-editable posts are shown locked rather than removed, so they still count.
 	 *
-	 * @param Posts_Query $query The query that produced the page.
-	 * @param int         $found The number of rows the page returned.
+	 * @param Posts_Query $query    The query that produced the page.
+	 * @param int         $fetched  The number of rows the page returned, before duplicates are removed.
+	 * @param int         $distinct The number of distinct posts on the page, after duplicates are removed.
 	 *
 	 * @return int The total number of matching posts.
 	 */
-	private function resolve_total( Posts_Query $query, int $found ): int {
-		if ( $found > 0 && $found < $query->get_per_page() ) {
-			return ( $query->get_offset() + $found );
+	private function resolve_total( Posts_Query $query, int $fetched, int $distinct ): int {
+		if ( $fetched > 0 && $fetched < $query->get_per_page() ) {
+			return ( $query->get_offset() + $distinct );
 		}
 
 		return (int) $this->build_query( $query )->count();
@@ -108,6 +124,10 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 			->where_in( 'post_status', $query->get_statuses() )
 			// Password-protected posts (is_protected) are not shown in bulk editing.
 			->where( 'is_protected', 0 );
+
+		if ( $query->has_author_filter() ) {
+			$builder->where( 'author_id', $query->get_author_id() );
+		}
 
 		if ( $query->has_search() ) {
 			$this->apply_search( $builder, $query->get_search() );
@@ -149,18 +169,25 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 	/**
 	 * Builds a post from an indexable.
 	 *
-	 * The indexable does not store the post title or edit link, so those are read from WordPress.
+	 * The SEO data and edit link of a post the current user cannot edit are withheld, so the post is
+	 * shown in the list but stays locked and does not expose its metadata.
 	 *
 	 * @param Indexable $indexable The indexable.
+	 * @param bool      $editable  Whether the current user may edit the post.
 	 *
 	 * @return Post The post.
 	 */
-	private function build_post( Indexable $indexable ): Post {
+	private function build_post( Indexable $indexable, bool $editable ): Post {
 		$object_id = (int) $indexable->object_id;
+		$title     = $this->get_normalized_title( $object_id );
+
+		if ( ! $editable ) {
+			return new Post( $object_id, $title, (string) $indexable->post_status, '', '', '', '', '', '', false );
+		}
 
 		return new Post(
 			$object_id,
-			$this->get_normalized_title( $object_id ),
+			$title,
 			(string) $indexable->post_status,
 			(string) \get_edit_post_link( $object_id, 'raw' ),
 			(string) $indexable->primary_focus_keyword,
@@ -168,6 +195,7 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 			(string) $indexable->description,
 			(string) $indexable->open_graph_title,
 			(string) $indexable->open_graph_description,
+			true,
 		);
 	}
 }

--- a/src/bulk-editor/infrastructure/posts/post-editability-resolver.php
+++ b/src/bulk-editor/infrastructure/posts/post-editability-resolver.php
@@ -1,0 +1,57 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts;
+
+use Yoast\WP\SEO\Bulk_Editor\Application\Updates\Post_Access_Checker_Interface;
+
+/**
+ * Resolves, for a page of posts, whether the current user may edit each one.
+ *
+ * The database query narrows the candidates by post type, status and author (a sound approximation that
+ * keeps pagination cheap). This resolver then applies the exact per-post check, current_user_can(
+ * 'edit_post', $id ), so the collector can lock and blank the posts the update endpoint would refuse (for
+ * example a post that a plugin blocks for the current user through map_meta_cap). It runs on the page only,
+ * never the whole result set, so the cost stays bound to the page size.
+ */
+class Post_Editability_Resolver {
+
+	/**
+	 * The post access checker.
+	 *
+	 * @var Post_Access_Checker_Interface
+	 */
+	private $post_access_checker;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Post_Access_Checker_Interface $post_access_checker The post access checker.
+	 */
+	public function __construct( Post_Access_Checker_Interface $post_access_checker ) {
+		$this->post_access_checker = $post_access_checker;
+	}
+
+	/**
+	 * Returns, for each given post ID, whether the current user may edit it.
+	 *
+	 * @param array<int> $post_ids The post IDs on the current page.
+	 *
+	 * @return array<int, bool> A map of post ID to whether the current user may edit it.
+	 */
+	public function resolve( array $post_ids ): array {
+		if ( $post_ids === [] ) {
+			return [];
+		}
+
+		// Prime the post cache once so the per-post edit check does not run a query per post.
+		\_prime_post_caches( $post_ids, false, false );
+
+		$editability = [];
+		foreach ( $post_ids as $post_id ) {
+			$editability[ $post_id ] = $this->post_access_checker->can_edit( $post_id );
+		}
+
+		return $editability;
+	}
+}

--- a/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
+++ b/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
@@ -38,7 +38,26 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 	private $search_where = '';
 
 	/**
+	 * The resolver for the per-post edit permission.
+	 *
+	 * @var Post_Editability_Resolver
+	 */
+	private $post_editability_resolver;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param Post_Editability_Resolver $post_editability_resolver The resolver for the per-post edit permission.
+	 */
+	public function __construct( Post_Editability_Resolver $post_editability_resolver ) {
+		$this->post_editability_resolver = $post_editability_resolver;
+	}
+
+	/**
 	 * Collects a page of posts for the given query.
+	 *
+	 * A single page is fetched and counted through WP_Query; the per-post edit permission is then resolved
+	 * for that page so posts the user cannot edit are returned locked and without their SEO data.
 	 *
 	 * @param Posts_Query $query The query describing the page to collect.
 	 *
@@ -46,22 +65,13 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 	 */
 	public function get_posts( Posts_Query $query ): Posts_Page {
 		$wp_query = $this->run_query( $query );
+		$post_ids = \array_map( 'intval', $wp_query->posts );
+
+		$editability = $this->post_editability_resolver->resolve( $post_ids );
 
 		$posts_list = new Posts_List();
-		foreach ( $wp_query->posts as $post ) {
-			$posts_list->add(
-				new Post(
-					$post->ID,
-					$this->get_normalized_title( $post->ID ),
-					$post->post_status,
-					(string) \get_edit_post_link( $post->ID, 'raw' ),
-					$this->get_meta( $post->ID, 'focuskw' ),
-					$this->get_meta( $post->ID, 'title' ),
-					$this->get_meta( $post->ID, 'metadesc' ),
-					$this->get_meta( $post->ID, 'opengraph-title' ),
-					$this->get_meta( $post->ID, 'opengraph-description' ),
-				),
-			);
+		foreach ( $post_ids as $post_id ) {
+			$posts_list->add( $this->build_post( $post_id, ( $editability[ $post_id ] ?? false ) ) );
 		}
 
 		return new Posts_Page( $posts_list, (int) $wp_query->found_posts, $query->get_page(), $query->get_per_page() );
@@ -79,20 +89,7 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 	 * @return WP_Query The executed query.
 	 */
 	protected function run_query( Posts_Query $query ): WP_Query {
-		$args = [
-			'post_type'              => $query->get_content_type(),
-			'post_status'            => $query->get_statuses(),
-			// Exclude password-protected posts from bulk editing.
-			'has_password'           => false,
-			'posts_per_page'         => $query->get_per_page(),
-			'paged'                  => $query->get_page(),
-			// Order by post ID so the result matches the indexable collector's ordering.
-			'orderby'                => 'ID',
-			'order'                  => 'DESC',
-			'ignore_sticky_posts'    => true,
-			// We render the title, status and Yoast meta, but never the terms, so don't prime the term cache.
-			'update_post_term_cache' => false,
-		];
+		$args = $this->build_query_args( $query );
 
 		if ( ! $query->has_search() ) {
 			return new WP_Query( $args );
@@ -111,6 +108,37 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 	}
 
 	/**
+	 * Builds the WP_Query arguments for the given query.
+	 *
+	 * @param Posts_Query $query The query describing the page to collect.
+	 *
+	 * @return array<string, string|int|bool|array<string>> The WP_Query arguments.
+	 */
+	private function build_query_args( Posts_Query $query ): array {
+		$args = [
+			'post_type'              => $query->get_content_type(),
+			'post_status'            => $query->get_statuses(),
+			// Exclude password-protected posts from bulk editing.
+			'has_password'           => false,
+			'fields'                 => 'ids',
+			'posts_per_page'         => $query->get_per_page(),
+			'paged'                  => $query->get_page(),
+			// Order by post ID so the result matches the indexable collector's ordering.
+			'orderby'                => 'ID',
+			'order'                  => 'DESC',
+			'ignore_sticky_posts'    => true,
+			// We render the title, status and Yoast meta, but never the terms, so don't prime the term cache.
+			'update_post_term_cache' => false,
+		];
+
+		if ( $query->has_author_filter() ) {
+			$args['author'] = $query->get_author_id();
+		}
+
+		return $args;
+	}
+
+	/**
 	 * Appends the prepared search clause to our own query's WHERE.
 	 *
 	 * @param string   $where    The WHERE clause so far.
@@ -126,6 +154,40 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 		}
 
 		return $where;
+	}
+
+	/**
+	 * Builds a post from its ID.
+	 *
+	 * The SEO data and edit link of a post the current user cannot edit are withheld, so the post is
+	 * shown in the list but stays locked and does not expose its metadata.
+	 *
+	 * @param int  $post_id  The post ID.
+	 * @param bool $editable Whether the current user may edit the post.
+	 *
+	 * @return Post The post.
+	 */
+	private function build_post( int $post_id, bool $editable ): Post {
+		$post   = \get_post( $post_id );
+		$status = ( $post !== null ) ? (string) $post->post_status : '';
+		$title  = $this->get_normalized_title( $post_id );
+
+		if ( ! $editable ) {
+			return new Post( $post_id, $title, $status, '', '', '', '', '', '', false );
+		}
+
+		return new Post(
+			$post_id,
+			$title,
+			$status,
+			(string) \get_edit_post_link( $post_id, 'raw' ),
+			$this->get_meta( $post_id, 'focuskw' ),
+			$this->get_meta( $post_id, 'title' ),
+			$this->get_meta( $post_id, 'metadesc' ),
+			$this->get_meta( $post_id, 'opengraph-title' ),
+			$this->get_meta( $post_id, 'opengraph-description' ),
+			true,
+		);
 	}
 
 	/**

--- a/src/bulk-editor/user-interface/posts-route.php
+++ b/src/bulk-editor/user-interface/posts-route.php
@@ -6,11 +6,13 @@ namespace Yoast\WP\SEO\Bulk_Editor\User_Interface;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
 use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Application\Posts\Posts_Collector_Interface;
 use Yoast\WP\SEO\Bulk_Editor\Application\Posts\Posts_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
+use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
 
@@ -64,17 +66,37 @@ class Posts_Route implements Route_Interface {
 	private $content_types_repository;
 
 	/**
+	 * The content type access checker.
+	 *
+	 * @var Content_Type_Access_Checker_Interface
+	 */
+	private $content_type_access_checker;
+
+	/**
+	 * The user helper.
+	 *
+	 * @var User_Helper
+	 */
+	private $user_helper;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param Posts_Repository         $posts_repository         The posts repository.
-	 * @param Content_Types_Repository $content_types_repository The content types repository.
+	 * @param Posts_Repository                      $posts_repository            The posts repository.
+	 * @param Content_Types_Repository              $content_types_repository    The content types repository.
+	 * @param Content_Type_Access_Checker_Interface $content_type_access_checker The content type access checker.
+	 * @param User_Helper                           $user_helper                 The user helper.
 	 */
 	public function __construct(
 		Posts_Repository $posts_repository,
-		Content_Types_Repository $content_types_repository
+		Content_Types_Repository $content_types_repository,
+		Content_Type_Access_Checker_Interface $content_type_access_checker,
+		User_Helper $user_helper
 	) {
-		$this->posts_repository         = $posts_repository;
-		$this->content_types_repository = $content_types_repository;
+		$this->posts_repository            = $posts_repository;
+		$this->content_types_repository    = $content_types_repository;
+		$this->content_type_access_checker = $content_type_access_checker;
+		$this->user_helper                 = $user_helper;
 	}
 
 	/**
@@ -160,14 +182,24 @@ class Posts_Route implements Route_Interface {
 			$statuses = Posts_Collector_Interface::STATUSES;
 		}
 
+		// Narrow the query to the user's own posts when they cannot edit other authors' posts. This keeps
+		// pagination cheap; the exact per-post edit permission is still enforced when collecting the page.
+		$author_id = null;
+		if ( ! $this->content_type_access_checker->can_edit_others( $content_type ) ) {
+			$author_id = $this->user_helper->get_current_user_id();
+		}
+
 		$query = new Posts_Query(
 			$content_type,
 			(int) $request->get_param( 'page' ),
 			(int) $request->get_param( 'per_page' ),
 			(string) $request->get_param( 'search' ),
 			$statuses,
+			$author_id,
 		);
 
+		// Posts the current user cannot edit are returned locked and without their SEO data; the per-post
+		// permission is resolved while collecting the page.
 		return new WP_REST_Response( $this->posts_repository->get_posts( $query )->to_array() );
 	}
 

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Post_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Post_Test.php
@@ -32,6 +32,7 @@ final class Post_Test extends TestCase {
 			'A description.',
 			'Social hello',
 			'Social description.',
+			true,
 		);
 
 		$this->assertSame(
@@ -45,6 +46,32 @@ final class Post_Test extends TestCase {
 				'meta_description'   => 'A description.',
 				'social_title'       => 'Social hello',
 				'social_description' => 'Social description.',
+				'editable'           => true,
+			],
+			$instance->to_array(),
+		);
+	}
+
+	/**
+	 * Tests that a locked post reports itself as not editable.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_not_editable() {
+		$instance = new Post( 7, 'Hello world', 'draft', '', '', '', '', '', '', false );
+
+		$this->assertSame(
+			[
+				'id'                 => 7,
+				'title'              => 'Hello world',
+				'status'             => 'draft',
+				'edit_link'          => '',
+				'focus_keyphrase'    => '',
+				'seo_title'          => '',
+				'meta_description'   => '',
+				'social_title'       => '',
+				'social_description' => '',
+				'editable'           => false,
 			],
 			$instance->to_array(),
 		);

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Posts_List_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Posts_List_Test.php
@@ -83,6 +83,6 @@ final class Posts_List_Test extends TestCase {
 	 * @return Post The post.
 	 */
 	private function build_post( int $id ): Post {
-		return new Post( $id, 'Title', 'publish', 'edit', 'kw', 'seo', 'meta', 'social', 'social desc' );
+		return new Post( $id, 'Title', 'publish', 'edit', 'kw', 'seo', 'meta', 'social', 'social desc', true );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Page_Test.php
@@ -25,7 +25,7 @@ final class Posts_Page_Test extends TestCase {
 	 */
 	public function test_to_array() {
 		$posts_list = new Posts_List();
-		$posts_list->add( new Post( 7, 'Hello world', 'draft', 'edit', 'hello', 'SEO', 'Meta', 'OG', 'OG desc' ) );
+		$posts_list->add( new Post( 7, 'Hello world', 'draft', 'edit', 'hello', 'SEO', 'Meta', 'OG', 'OG desc', true ) );
 
 		$instance = new Posts_Page( $posts_list, 45, 2, 20 );
 
@@ -42,6 +42,7 @@ final class Posts_Page_Test extends TestCase {
 						'meta_description'   => 'Meta',
 						'social_title'       => 'OG',
 						'social_description' => 'OG desc',
+						'editable'           => true,
 					],
 				],
 				'total'       => 45,

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Query_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Query_Test.php
@@ -50,4 +50,32 @@ final class Posts_Query_Test extends TestCase {
 		$this->assertSame( 0, ( new Posts_Query( 'page', 1, 20, '', [] ) )->get_offset() );
 		$this->assertSame( 40, ( new Posts_Query( 'page', 3, 20, '', [] ) )->get_offset() );
 	}
+
+	/**
+	 * Tests that the author defaults to null when none is passed.
+	 *
+	 * @return void
+	 */
+	public function test_get_author_id_defaults_to_null() {
+		$this->assertNull( ( new Posts_Query( 'page', 1, 20, '', [] ) )->get_author_id() );
+	}
+
+	/**
+	 * Tests that the author is carried through when set.
+	 *
+	 * @return void
+	 */
+	public function test_get_author_id() {
+		$this->assertSame( 5, ( new Posts_Query( 'page', 1, 20, '', [], 5 ) )->get_author_id() );
+	}
+
+	/**
+	 * Tests that has_author_filter reflects whether an author is set.
+	 *
+	 * @return void
+	 */
+	public function test_has_author_filter() {
+		$this->assertTrue( ( new Posts_Query( 'page', 1, 20, '', [], 5 ) )->has_author_filter() );
+		$this->assertFalse( ( new Posts_Query( 'page', 1, 20, '', [] ) )->has_author_filter() );
+	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Abstract_Content_Type_Access_Checker_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Abstract_Content_Type_Access_Checker_Test.php
@@ -1,0 +1,34 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker;
+
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for the Content_Type_Access_Checker tests.
+ *
+ * @group bulk-editor
+ */
+abstract class Abstract_Content_Type_Access_Checker_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Content_Type_Access_Checker
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Content_Type_Access_Checker();
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Can_Edit_Any_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Can_Edit_Any_Test.php
@@ -1,0 +1,191 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests can_edit_any.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker::can_edit_any
+ */
+final class Can_Edit_Any_Test extends Abstract_Content_Type_Access_Checker_Test {
+
+	/**
+	 * Tests that the type is editable when the user can edit its own drafts.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_with_edit_posts() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [ 'edit_posts' => 'edit_books' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_books' )
+			->andReturnTrue();
+
+		$this->assertTrue( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that the type is editable when the user can only edit published posts.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_with_only_edit_published_posts() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [
+						'edit_posts'           => 'edit_books',
+						'edit_published_posts' => 'edit_published_books',
+					],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->twice()
+			->andReturnUsing(
+				static function ( $capability ) {
+					return $capability === 'edit_published_books';
+				},
+			);
+
+		$this->assertTrue( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that the type is editable when the user can only edit other authors' posts.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_with_only_edit_others_posts() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [
+						'edit_posts'           => 'edit_books',
+						'edit_published_posts' => 'edit_published_books',
+						'edit_others_posts'    => 'edit_others_books',
+					],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->times( 3 )
+			->andReturnUsing(
+				static function ( $capability ) {
+					return $capability === 'edit_others_books';
+				},
+			);
+
+		$this->assertTrue( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that the type is not editable when the user holds none of the editing capabilities.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_without_any_capability() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [
+						'edit_posts'           => 'edit_books',
+						'edit_published_posts' => 'edit_published_books',
+						'edit_others_posts'    => 'edit_others_books',
+					],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )->times( 3 )->andReturnFalse();
+
+		$this->assertFalse( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that the singular capability is used when meta-cap mapping is disabled.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_uses_singular_capability_when_mapping_disabled() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => false,
+					'cap'          => (object) [ 'edit_post' => 'edit_book' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_book' )
+			->andReturnTrue();
+
+		$this->assertTrue( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that the type is not editable when mapping is disabled and the singular capability is missing.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_without_singular_capability_when_mapping_disabled() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => false,
+					'cap'          => (object) [ 'edit_post' => 'edit_book' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_book' )
+			->andReturnFalse();
+
+		$this->assertFalse( $this->instance->can_edit_any( 'book' ) );
+	}
+
+	/**
+	 * Tests that an unknown post type is not editable.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_any_unknown_post_type() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'nonexistent' )
+			->andReturnNull();
+
+		Functions\expect( 'current_user_can' )->never();
+
+		$this->assertFalse( $this->instance->can_edit_any( 'nonexistent' ) );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Can_Edit_Others_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Type_Access_Checker/Can_Edit_Others_Test.php
@@ -1,0 +1,106 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests can_edit_others.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Type_Access_Checker::can_edit_others
+ */
+final class Can_Edit_Others_Test extends Abstract_Content_Type_Access_Checker_Test {
+
+	/**
+	 * Tests that can_edit_others checks the post type's own edit_others_posts capability.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_others() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [ 'edit_others_posts' => 'edit_others_books' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_others_books' )
+			->andReturnTrue();
+
+		$this->assertTrue( $this->instance->can_edit_others( 'book' ) );
+	}
+
+	/**
+	 * Tests that can_edit_others returns false when the user lacks the capability.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_others_without_capability() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'page' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => true,
+					'cap'          => (object) [ 'edit_others_posts' => 'edit_others_pages' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_others_pages' )
+			->andReturnFalse();
+
+		$this->assertFalse( $this->instance->can_edit_others( 'page' ) );
+	}
+
+	/**
+	 * Tests that the singular capability is used when meta-cap mapping is disabled,
+	 * since editing then does not depend on authorship.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_others_uses_singular_capability_when_mapping_disabled() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'book' )
+			->andReturn(
+				(object) [
+					'map_meta_cap' => false,
+					'cap'          => (object) [ 'edit_post' => 'edit_book' ],
+				],
+			);
+
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_book' )
+			->andReturnTrue();
+
+		$this->assertTrue( $this->instance->can_edit_others( 'book' ) );
+	}
+
+	/**
+	 * Tests that can_edit_others returns false for an unknown post type.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_others_unknown_post_type() {
+		Functions\expect( 'get_post_type_object' )
+			->once()
+			->with( 'nonexistent' )
+			->andReturnNull();
+
+		Functions\expect( 'current_user_can' )->never();
+
+		$this->assertFalse( $this->instance->can_edit_others( 'nonexistent' ) );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Abstract_Content_Types_Collector_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Abstract_Content_Types_Collector_Test.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
 
 use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
 use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -31,6 +32,13 @@ abstract class Abstract_Content_Types_Collector_Test extends TestCase {
 	protected $post_type_helper;
 
 	/**
+	 * Holds the content type access checker.
+	 *
+	 * @var Mockery\MockInterface|Content_Type_Access_Checker_Interface
+	 */
+	protected $access_checker;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -39,7 +47,8 @@ abstract class Abstract_Content_Types_Collector_Test extends TestCase {
 		parent::set_up();
 
 		$this->post_type_helper = Mockery::mock( Post_Type_Helper::class );
+		$this->access_checker   = Mockery::mock( Content_Type_Access_Checker_Interface::class );
 
-		$this->instance = new Content_Types_Collector( $this->post_type_helper );
+		$this->instance = new Content_Types_Collector( $this->post_type_helper, $this->access_checker );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Constructor_Test.php
@@ -4,6 +4,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
 
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
 use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 
 /**
@@ -24,6 +25,10 @@ final class Constructor_Test extends Abstract_Content_Types_Collector_Test {
 		$this->assertInstanceOf(
 			Post_Type_Helper::class,
 			$this->getPropertyValue( $this->instance, 'post_type_helper' ),
+		);
+		$this->assertInstanceOf(
+			Content_Type_Access_Checker_Interface::class,
+			$this->getPropertyValue( $this->instance, 'access_checker' ),
 		);
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -31,10 +31,53 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 			->once()
 			->andReturn( $indexable_post_type_objects );
 
+		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
+
 		$content_types_list = $this->instance->get_content_types();
 
 		$this->assertInstanceOf( Content_Types_List::class, $content_types_list );
 		$this->assertSame( $expected, $content_types_list->to_array() );
+	}
+
+	/**
+	 * Tests that content types the current user cannot edit are excluded.
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types_excludes_types_the_user_cannot_edit() {
+		$this->post_type_helper
+			->expects( 'get_indexable_post_type_objects' )
+			->once()
+			->andReturn(
+				[
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'page',
+						'label'   => 'Pages',
+						'labels'  => (object) [ 'singular_name' => 'Page' ],
+						'show_ui' => true,
+					],
+				],
+			);
+
+		$this->access_checker->expects( 'can_edit_any' )->with( 'post' )->andReturnTrue();
+		$this->access_checker->expects( 'can_edit_any' )->with( 'page' )->andReturnFalse();
+
+		$this->assertSame(
+			[
+				[
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
+				],
+			],
+			$this->instance->get_content_types()->to_array(),
+		);
 	}
 
 	/**

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Abstract_Indexable_Posts_Collector_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Abstract_Indexable_Posts_Collector_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Indexable_Pos
 
 use Mockery;
 use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
 use Yoast\WP\SEO\Repositories\Indexable_Repository;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -31,6 +32,13 @@ abstract class Abstract_Indexable_Posts_Collector_Test extends TestCase {
 	protected $indexable_repository;
 
 	/**
+	 * Holds the post editability resolver.
+	 *
+	 * @var Mockery\MockInterface|Post_Editability_Resolver
+	 */
+	protected $post_editability_resolver;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -38,8 +46,9 @@ abstract class Abstract_Indexable_Posts_Collector_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->indexable_repository = Mockery::mock( Indexable_Repository::class );
+		$this->indexable_repository      = Mockery::mock( Indexable_Repository::class );
+		$this->post_editability_resolver = Mockery::mock( Post_Editability_Resolver::class );
 
-		$this->instance = new Indexable_Posts_Collector( $this->indexable_repository );
+		$this->instance = new Indexable_Posts_Collector( $this->indexable_repository, $this->post_editability_resolver );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Get_Posts_Test.php
@@ -16,8 +16,8 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
  * @group bulk-editor
  *
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::get_posts
- * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::build_query
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::resolve_total
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::build_query
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::apply_search
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::build_post
  */
@@ -31,11 +31,12 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 	private const STATUSES = [ 'publish', 'draft', 'pending', 'future' ];
 
 	/**
-	 * Tests that a partially-filled page is mapped to posts and its total is derived without a count query.
+	 * Tests that an editable post is returned with its SEO data, and a partial page derives the total
+	 * without a count query.
 	 *
 	 * @return void
 	 */
-	public function test_get_posts() {
+	public function test_get_posts_editable() {
 		$indexable                         = new Indexable_Mock();
 		$indexable->object_id              = 7;
 		$indexable->post_status            = 'draft';
@@ -45,21 +46,12 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 		$indexable->open_graph_title       = 'Social hello';
 		$indexable->open_graph_description = 'Social description.';
 
-		$query = Mockery::mock( ORM::class );
-		$query->allows( 'where' )->with( 'object_type', 'post' )->andReturnSelf();
-		$query->allows( 'where' )->with( 'object_sub_type', 'page' )->andReturnSelf();
-		$query->allows( 'where_in' )->with( 'post_status', self::STATUSES )->andReturnSelf();
-		$query->expects( 'where' )->with( 'is_protected', 0 )->once()->andReturnSelf();
-		$query->allows( 'order_by_desc' )->with( 'object_id' )->andReturnSelf();
-		$query->allows( 'limit' )->with( 20 )->andReturnSelf();
-		$query->allows( 'offset' )->with( 0 )->andReturnSelf();
-		$query->expects( 'find_many' )->once()->andReturn( [ $indexable ] );
-		// The page is not full, so the total is offset + rows and no count query runs.
+		$query = $this->stub_page_query( [ $indexable ] );
+		// The page is not full, so the total is derived and no count query runs.
 		$query->expects( 'count' )->never();
 
-		$this->indexable_repository->expects( 'query' )->once()->andReturn( $query );
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
 
-		Functions\expect( '_prime_post_caches' )->once()->with( [ 7 ], false, false );
 		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Hello world' );
 		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'post.php?post=7&action=edit' );
 
@@ -76,6 +68,7 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 						'meta_description'   => 'A description.',
 						'social_title'       => 'Social hello',
 						'social_description' => 'Social description.',
+						'editable'           => true,
 					],
 				],
 				'total'       => 1,
@@ -88,38 +81,43 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 	}
 
 	/**
-	 * Tests that duplicate indexable rows for the same post yield a single post.
+	 * Tests that a non-editable post is returned locked and without its SEO data.
 	 *
 	 * @return void
 	 */
-	public function test_get_posts_deduplicates_indexables() {
+	public function test_get_posts_locks_non_editable_post() {
 		$indexable                        = new Indexable_Mock();
 		$indexable->object_id             = 7;
-		$indexable->post_status           = 'draft';
-		$indexable->primary_focus_keyword = 'hello';
-		$indexable->title                 = 'Hello | Site';
+		$indexable->post_status           = 'publish';
+		$indexable->primary_focus_keyword = 'secret';
+		$indexable->title                 = 'Secret | Site';
 
-		$duplicate            = new Indexable_Mock();
-		$duplicate->object_id = 7;
+		$query = $this->stub_page_query( [ $indexable ] );
+		$query->allows( 'count' );
 
-		$query = Mockery::mock( ORM::class );
-		$query->allows( 'where' )->andReturnSelf();
-		$query->allows( 'where_in' )->andReturnSelf();
-		$query->allows( 'order_by_desc' )->andReturnSelf();
-		$query->allows( 'limit' )->andReturnSelf();
-		$query->allows( 'offset' )->andReturnSelf();
-		$query->expects( 'find_many' )->once()->andReturn( [ $indexable, $duplicate ] );
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => false ] );
 
-		$this->indexable_repository->expects( 'query' )->once()->andReturn( $query );
-
-		Functions\expect( '_prime_post_caches' )->once()->with( [ 7 ], false, false );
-		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Hello world' );
-		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'post.php?post=7&action=edit' );
+		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Secret post' );
+		// A locked post exposes neither its edit link nor its SEO data.
+		Functions\expect( 'get_edit_post_link' )->never();
 
 		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES ) )->to_array();
 
-		$this->assertCount( 1, $result['posts'] );
-		$this->assertSame( 7, $result['posts'][0]['id'] );
+		$this->assertSame(
+			[
+				'id'                 => 7,
+				'title'              => 'Secret post',
+				'status'             => 'publish',
+				'edit_link'          => '',
+				'focus_keyphrase'    => '',
+				'seo_title'          => '',
+				'meta_description'   => '',
+				'social_title'       => '',
+				'social_description' => '',
+				'editable'           => false,
+			],
+			$result['posts'][0],
+		);
 	}
 
 	/**
@@ -141,9 +139,10 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 		$query->expects( 'find_many' )->once()->andReturn( [ $indexable ] );
 		$query->expects( 'count' )->once()->andReturn( 50 );
 
-		$this->indexable_repository->expects( 'query' )->twice()->andReturn( $query );
+		$this->indexable_repository->allows( 'query' )->andReturn( $query );
 
-		Functions\expect( '_prime_post_caches' )->once()->with( [ 7 ], false, false );
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
+
 		Functions\expect( 'get_the_title' )->once()->andReturn( 'Hello world' );
 		Functions\expect( 'get_edit_post_link' )->once()->andReturn( 'edit' );
 
@@ -164,11 +163,13 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 		$query->allows( 'where_in' )->andReturnSelf();
 		$query->allows( 'order_by_desc' )->andReturnSelf();
 		$query->allows( 'limit' )->with( 20 )->andReturnSelf();
-		$query->expects( 'offset' )->once()->with( 40 )->andReturnSelf();
+		$query->expects( 'offset' )->with( 40 )->andReturnSelf();
 		$query->expects( 'count' )->once()->andReturn( 100 );
 		$query->expects( 'find_many' )->once()->andReturn( [] );
 
 		$this->indexable_repository->allows( 'query' )->andReturn( $query );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [] )->andReturn( [] );
 
 		$result = $this->instance->get_posts( new Posts_Query( 'page', 3, 20, '', self::STATUSES ) )->to_array();
 
@@ -178,7 +179,35 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 	}
 
 	/**
-	 * Tests that a search term adds the catch-all clause to both the count and the page query.
+	 * Tests that duplicate indexable rows for the same post yield a single post and an accurate total.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_deduplicates_indexables() {
+		$indexable            = new Indexable_Mock();
+		$indexable->object_id = 7;
+
+		$duplicate            = new Indexable_Mock();
+		$duplicate->object_id = 7;
+
+		$query = $this->stub_page_query( [ $indexable, $duplicate ] );
+		// The page ended within the fetched rows, so the total comes from the distinct count, not a count query.
+		$query->expects( 'count' )->never();
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
+
+		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Hello world' );
+		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'edit' );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES ) )->to_array();
+
+		$this->assertCount( 1, $result['posts'] );
+		$this->assertSame( 7, $result['posts'][0]['id'] );
+		$this->assertSame( 1, $result['total'] );
+	}
+
+	/**
+	 * Tests that a search term adds the catch-all clause and an empty result yields an empty page.
 	 *
 	 * @return void
 	 */
@@ -186,6 +215,7 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 		global $wpdb;
 		$wpdb        = Mockery::mock();
 		$wpdb->posts = 'wp_posts';
+		// build_query runs twice (the page query and the count query), so the search clause is built twice.
 		$wpdb->expects( 'esc_like' )->twice()->with( 'seo' )->andReturn( 'seo' );
 
 		$query = Mockery::mock( ORM::class );
@@ -195,15 +225,37 @@ final class Get_Posts_Test extends Abstract_Indexable_Posts_Collector_Test {
 		$query->allows( 'limit' )->andReturnSelf();
 		$query->allows( 'offset' )->andReturnSelf();
 		$query->expects( 'where_raw' )->twice()->andReturnSelf();
-		$query->allows( 'count' )->andReturn( 0 );
 		$query->expects( 'find_many' )->once()->andReturn( [] );
+		$query->expects( 'count' )->once()->andReturn( 0 );
 
 		$this->indexable_repository->allows( 'query' )->andReturn( $query );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [] )->andReturn( [] );
 
 		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, 'seo', self::STATUSES ) )->to_array();
 
 		$this->assertSame( [], $result['posts'] );
 		$this->assertSame( 0, $result['total'] );
-		$this->assertSame( 0, $result['total_pages'] );
+	}
+
+	/**
+	 * Stubs the indexable query for a page that returns the given rows, without constraining count().
+	 *
+	 * @param array<Indexable_Mock> $rows The indexables the page query returns.
+	 *
+	 * @return Mockery\MockInterface|ORM The query mock, so the caller can add a count() expectation.
+	 */
+	private function stub_page_query( array $rows ) {
+		$query = Mockery::mock( ORM::class );
+		$query->allows( 'where' )->andReturnSelf();
+		$query->allows( 'where_in' )->andReturnSelf();
+		$query->allows( 'order_by_desc' )->andReturnSelf();
+		$query->allows( 'limit' )->andReturnSelf();
+		$query->allows( 'offset' )->andReturnSelf();
+		$query->expects( 'find_many' )->once()->andReturn( $rows );
+
+		$this->indexable_repository->allows( 'query' )->andReturn( $query );
+
+		return $query;
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Abstract_Post_Editability_Resolver_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Abstract_Post_Editability_Resolver_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
+
+use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Application\Updates\Post_Access_Checker_Interface;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Abstract class for the Post_Editability_Resolver tests.
+ *
+ * @group bulk-editor
+ */
+abstract class Abstract_Post_Editability_Resolver_Test extends TestCase {
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Post_Editability_Resolver
+	 */
+	protected $instance;
+
+	/**
+	 * Holds the post access checker.
+	 *
+	 * @var Mockery\MockInterface|Post_Access_Checker_Interface
+	 */
+	protected $post_access_checker;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->post_access_checker = Mockery::mock( Post_Access_Checker_Interface::class );
+
+		$this->instance = new Post_Editability_Resolver( $this->post_access_checker );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Constructor_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Constructor_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
+
+use Yoast\WP\SEO\Bulk_Editor\Application\Updates\Post_Access_Checker_Interface;
+
+/**
+ * Tests the Post_Editability_Resolver constructor.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver::__construct
+ */
+final class Constructor_Test extends Abstract_Post_Editability_Resolver_Test {
+
+	/**
+	 * Tests the constructor.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Post_Access_Checker_Interface::class,
+			$this->getPropertyValue( $this->instance, 'post_access_checker' ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Resolve_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Editability_Resolver/Resolve_Test.php
@@ -1,0 +1,50 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
+
+use Brain\Monkey\Functions;
+
+/**
+ * Tests resolve.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver::resolve
+ */
+final class Resolve_Test extends Abstract_Post_Editability_Resolver_Test {
+
+	/**
+	 * Tests that no post IDs yields an empty map without priming caches or checking permissions.
+	 *
+	 * @return void
+	 */
+	public function test_resolve_returns_empty_for_no_ids() {
+		$this->post_access_checker->expects( 'can_edit' )->never();
+
+		$this->assertSame( [], $this->instance->resolve( [] ) );
+	}
+
+	/**
+	 * Tests that each post ID is mapped to whether the current user may edit it.
+	 *
+	 * @return void
+	 */
+	public function test_resolve_maps_each_id_to_its_edit_permission() {
+		Functions\expect( '_prime_post_caches' )->once()->with( [ 1, 2, 3 ], false, false );
+
+		$this->post_access_checker->expects( 'can_edit' )->with( 1 )->andReturnTrue();
+		$this->post_access_checker->expects( 'can_edit' )->with( 2 )->andReturnFalse();
+		$this->post_access_checker->expects( 'can_edit' )->with( 3 )->andReturnTrue();
+
+		$this->assertSame(
+			[
+				1 => true,
+				2 => false,
+				3 => true,
+			],
+			$this->instance->resolve( [ 1, 2, 3 ] ),
+		);
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Abstract_Post_Meta_Posts_Collector_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Abstract_Post_Meta_Posts_Collector_Test.php
@@ -5,6 +5,7 @@
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Meta_Posts_Collector;
 
 use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Editability_Resolver;
 use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Meta_Posts_Collector;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -16,9 +17,16 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 abstract class Abstract_Post_Meta_Posts_Collector_Test extends TestCase {
 
 	/**
+	 * Holds the post editability resolver.
+	 *
+	 * @var Mockery\MockInterface|Post_Editability_Resolver
+	 */
+	protected $post_editability_resolver;
+
+	/**
 	 * Holds the instance.
 	 *
-	 * The WP_Query is instantiated internally, so we partial-mock the query_posts seam.
+	 * The WP_Query is instantiated internally, so we partial-mock the run_query seam.
 	 *
 	 * @var Mockery\MockInterface|Post_Meta_Posts_Collector
 	 */
@@ -32,7 +40,9 @@ abstract class Abstract_Post_Meta_Posts_Collector_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->instance = Mockery::mock( Post_Meta_Posts_Collector::class )
+		$this->post_editability_resolver = Mockery::mock( Post_Editability_Resolver::class );
+
+		$this->instance = Mockery::mock( Post_Meta_Posts_Collector::class, [ $this->post_editability_resolver ] )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 	}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
@@ -19,16 +19,18 @@ use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
 final class Get_Posts_Test extends Abstract_Post_Meta_Posts_Collector_Test {
 
 	/**
-	 * Tests that the queried posts are mapped to a page of posts, reading the raw Yoast meta.
+	 * The statuses passed in the query.
+	 *
+	 * @var array<string>
+	 */
+	private const STATUSES = [ 'publish', 'draft', 'pending', 'future' ];
+
+	/**
+	 * Tests that an editable post is returned with its status and raw Yoast meta.
 	 *
 	 * @return void
 	 */
-	public function test_get_posts() {
-		$post = (object) [
-			'ID'          => 7,
-			'post_title'  => 'Hello world',
-			'post_status' => 'draft',
-		];
+	public function test_get_posts_editable() {
 		$meta = [
 			'_yoast_wpseo_focuskw'               => 'hello',
 			'_yoast_wpseo_title'                 => 'Hello | Site',
@@ -37,12 +39,11 @@ final class Get_Posts_Test extends Abstract_Post_Meta_Posts_Collector_Test {
 			'_yoast_wpseo_opengraph-description' => 'Social description.',
 		];
 
-		$wp_query              = Mockery::mock( WP_Query::class );
-		$wp_query->posts       = [ $post ];
-		$wp_query->found_posts = 1;
+		$this->stub_run_query( [ 7 ], 1 );
 
-		$this->instance->expects( 'run_query' )->once()->with( Mockery::type( Posts_Query::class ) )->andReturn( $wp_query );
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
 
+		Functions\expect( 'get_post' )->once()->with( 7 )->andReturn( (object) [ 'post_status' => 'draft' ] );
 		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Hello world' );
 		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'post.php?post=7&action=edit' );
 		Functions\expect( 'get_post_meta' )
@@ -66,6 +67,7 @@ final class Get_Posts_Test extends Abstract_Post_Meta_Posts_Collector_Test {
 						'meta_description'   => 'A description.',
 						'social_title'       => 'Social hello',
 						'social_description' => 'Social description.',
+						'editable'           => true,
 					],
 				],
 				'total'       => 1,
@@ -73,61 +75,43 @@ final class Get_Posts_Test extends Abstract_Post_Meta_Posts_Collector_Test {
 				'page'        => 1,
 				'per_page'    => 20,
 			],
-			$this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', [ 'publish' ] ) )->to_array(),
+			$this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES ) )->to_array(),
 		);
 	}
 
 	/**
-	 * Tests that HTML entities in the post title are decoded so they render as text.
+	 * Tests that a non-editable post is returned locked and without its SEO data.
 	 *
 	 * @return void
 	 */
-	public function test_get_posts_decodes_html_entities_in_the_title() {
-		$post = (object) [
-			'ID'          => 7,
-			'post_status' => 'draft',
-		];
+	public function test_get_posts_locks_non_editable_post() {
+		$this->stub_run_query( [ 7 ], 1 );
 
-		$wp_query              = Mockery::mock( WP_Query::class );
-		$wp_query->posts       = [ $post ];
-		$wp_query->found_posts = 1;
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => false ] );
 
-		$this->instance->expects( 'run_query' )->once()->andReturn( $wp_query );
+		Functions\expect( 'get_post' )->once()->with( 7 )->andReturn( (object) [ 'post_status' => 'publish' ] );
+		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Secret post' );
+		// A locked post exposes neither its edit link nor its Yoast meta.
+		Functions\expect( 'get_edit_post_link' )->never();
+		Functions\expect( 'get_post_meta' )->never();
 
-		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Tips &amp; Tricks: &#8220;SEO&#8221;' );
-		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'post.php?post=7&action=edit' );
-		Functions\expect( 'get_post_meta' )->times( 5 )->andReturn( '' );
+		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES ) )->to_array();
 
-		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', [ 'publish' ] ) )->to_array();
-
-		$this->assertSame( 'Tips & Tricks: “SEO”', $result['posts'][0]['title'] );
-	}
-
-	/**
-	 * Tests that an empty post title falls back to the untitled-post convention.
-	 *
-	 * @return void
-	 */
-	public function test_get_posts_falls_back_when_the_title_is_empty() {
-		$post = (object) [
-			'ID'          => 7,
-			'post_status' => 'draft',
-		];
-
-		$wp_query              = Mockery::mock( WP_Query::class );
-		$wp_query->posts       = [ $post ];
-		$wp_query->found_posts = 1;
-
-		$this->instance->expects( 'run_query' )->once()->andReturn( $wp_query );
-
-		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( '' );
-		Functions\expect( '__' )->once()->with( '(no title)', 'wordpress-seo' )->andReturn( '(no title)' );
-		Functions\expect( 'get_edit_post_link' )->once()->with( 7, 'raw' )->andReturn( 'post.php?post=7&action=edit' );
-		Functions\expect( 'get_post_meta' )->times( 5 )->andReturn( '' );
-
-		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', [ 'publish' ] ) )->to_array();
-
-		$this->assertSame( '(no title)', $result['posts'][0]['title'] );
+		$this->assertSame(
+			[
+				'id'                 => 7,
+				'title'              => 'Secret post',
+				'status'             => 'publish',
+				'edit_link'          => '',
+				'focus_keyphrase'    => '',
+				'seo_title'          => '',
+				'meta_description'   => '',
+				'social_title'       => '',
+				'social_description' => '',
+				'editable'           => false,
+			],
+			$result['posts'][0],
+		);
 	}
 
 	/**
@@ -136,15 +120,34 @@ final class Get_Posts_Test extends Abstract_Post_Meta_Posts_Collector_Test {
 	 * @return void
 	 */
 	public function test_get_posts_reports_total_from_found_posts() {
-		$wp_query              = Mockery::mock( WP_Query::class );
-		$wp_query->posts       = [];
-		$wp_query->found_posts = 42;
+		$this->stub_run_query( [ 7 ], 42 );
 
-		$this->instance->expects( 'run_query' )->once()->andReturn( $wp_query );
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
 
-		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', [ 'publish' ] ) )->to_array();
+		Functions\expect( 'get_post' )->once()->andReturn( (object) [ 'post_status' => 'draft' ] );
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'Hello world' );
+		Functions\expect( 'get_edit_post_link' )->once()->andReturn( 'edit' );
+		Functions\expect( 'get_post_meta' )->times( 5 )->andReturn( '' );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES ) )->to_array();
 
 		$this->assertSame( 42, $result['total'] );
 		$this->assertSame( 3, $result['total_pages'] );
+	}
+
+	/**
+	 * Stubs run_query so it returns a WP_Query with the given post IDs and total.
+	 *
+	 * @param array<int> $post_ids    The post IDs the query returns.
+	 * @param int        $found_posts The total the query reports.
+	 *
+	 * @return void
+	 */
+	private function stub_run_query( array $post_ids, int $found_posts ) {
+		$wp_query              = Mockery::mock( WP_Query::class );
+		$wp_query->posts       = $post_ids;
+		$wp_query->found_posts = $found_posts;
+
+		$this->instance->expects( 'run_query' )->once()->with( Mockery::type( Posts_Query::class ) )->andReturn( $wp_query );
 	}
 }

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Title_Trait/Get_Normalized_Title_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Title_Trait/Get_Normalized_Title_Test.php
@@ -1,0 +1,45 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Title_Trait;
+
+use Brain\Monkey\Functions;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Title_Trait;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests get_normalized_title.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Title_Trait::get_normalized_title
+ */
+final class Get_Normalized_Title_Test extends TestCase {
+
+	use Post_Title_Trait;
+
+	/**
+	 * Tests that HTML entities in the title are decoded so they render as text.
+	 *
+	 * @return void
+	 */
+	public function test_decodes_html_entities() {
+		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( 'Tips &amp; Tricks: &#8220;SEO&#8221;' );
+
+		$this->assertSame( 'Tips & Tricks: “SEO”', $this->get_normalized_title( 7 ) );
+	}
+
+	/**
+	 * Tests that an empty title falls back to the untitled-post convention.
+	 *
+	 * @return void
+	 */
+	public function test_falls_back_when_the_title_is_empty() {
+		$this->stubTranslationFunctions();
+
+		Functions\expect( 'get_the_title' )->once()->with( 7 )->andReturn( '' );
+
+		$this->assertSame( '(no title)', $this->get_normalized_title( 7 ) );
+	}
+}

--- a/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Abstract_Posts_Route_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Abstract_Posts_Route_Test.php
@@ -5,9 +5,11 @@
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\User_Interface\Posts_Route;
 
 use Mockery;
+use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Type_Access_Checker_Interface;
 use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Application\Posts\Posts_Repository;
 use Yoast\WP\SEO\Bulk_Editor\User_Interface\Posts_Route;
+use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -41,6 +43,20 @@ abstract class Abstract_Posts_Route_Test extends TestCase {
 	protected $content_types_repository;
 
 	/**
+	 * Holds the content type access checker.
+	 *
+	 * @var Mockery\MockInterface|Content_Type_Access_Checker_Interface
+	 */
+	protected $content_type_access_checker;
+
+	/**
+	 * Holds the user helper.
+	 *
+	 * @var Mockery\MockInterface|User_Helper
+	 */
+	protected $user_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -48,9 +64,16 @@ abstract class Abstract_Posts_Route_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->posts_repository         = Mockery::mock( Posts_Repository::class );
-		$this->content_types_repository = Mockery::mock( Content_Types_Repository::class );
+		$this->posts_repository            = Mockery::mock( Posts_Repository::class );
+		$this->content_types_repository    = Mockery::mock( Content_Types_Repository::class );
+		$this->content_type_access_checker = Mockery::mock( Content_Type_Access_Checker_Interface::class );
+		$this->user_helper                 = Mockery::mock( User_Helper::class );
 
-		$this->instance = new Posts_Route( $this->posts_repository, $this->content_types_repository );
+		$this->instance = new Posts_Route(
+			$this->posts_repository,
+			$this->content_types_repository,
+			$this->content_type_access_checker,
+			$this->user_helper,
+		);
 	}
 }

--- a/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Get_Posts_Test.php
@@ -25,24 +25,11 @@ use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
 final class Get_Posts_Test extends Abstract_Posts_Route_Test {
 
 	/**
-	 * Tests that a valid content type builds a query and returns the posts in a response.
+	 * Tests that a user who can edit other authors' posts is not restricted by author.
 	 *
 	 * @return void
 	 */
-	public function test_get_posts_valid() {
-		$rows = [
-			'posts'       => [
-				[
-					'id'    => 7,
-					'title' => 'Hello world',
-				],
-			],
-			'total'       => 1,
-			'total_pages' => 1,
-			'page'        => 1,
-			'per_page'    => 20,
-		];
-
+	public function test_get_posts_without_author_restriction() {
 		$request = Mockery::mock( WP_REST_Request::class );
 		$request->expects( 'get_param' )->with( 'content_type' )->andReturn( 'page' );
 		$request->expects( 'get_param' )->with( 'page' )->andReturn( 1 );
@@ -62,10 +49,12 @@ final class Get_Posts_Test extends Abstract_Posts_Route_Test {
 				],
 			);
 
-		$posts_page = Mockery::mock( Posts_Page::class );
-		$posts_page->expects( 'to_array' )->once()->andReturn( $rows );
+		$this->content_type_access_checker->expects( 'can_edit_others' )->with( 'page' )->andReturnTrue();
 
-		// The selected statuses are carried through to the query unchanged.
+		$posts_page = Mockery::mock( Posts_Page::class );
+		$posts_page->expects( 'to_array' )->once()->andReturn( [] );
+
+		// The selected statuses are carried through unchanged and no author restriction is applied.
 		$this->posts_repository
 			->expects( 'get_posts' )
 			->once()
@@ -73,7 +62,57 @@ final class Get_Posts_Test extends Abstract_Posts_Route_Test {
 				Mockery::on(
 					static function ( $query ) {
 						return $query instanceof Posts_Query
-							&& $query->get_statuses() === [ 'draft', 'pending' ];
+							&& $query->get_statuses() === [ 'draft', 'pending' ]
+							&& $query->get_author_id() === null;
+					},
+				),
+			)
+			->andReturn( $posts_page );
+
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->get_posts( $request ) );
+	}
+
+	/**
+	 * Tests that a user who cannot edit other authors' posts is restricted to their own.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_restricts_to_own_posts_when_user_cannot_edit_others() {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'content_type' )->andReturn( 'page' );
+		$request->expects( 'get_param' )->with( 'page' )->andReturn( 1 );
+		$request->expects( 'get_param' )->with( 'per_page' )->andReturn( 20 );
+		$request->expects( 'get_param' )->with( 'search' )->andReturn( '' );
+		$request->expects( 'get_param' )->with( 'status' )->andReturn( [ 'publish' ] );
+
+		$this->content_types_repository
+			->expects( 'get_content_types' )
+			->once()
+			->andReturn(
+				[
+					[
+						'name'  => 'page',
+						'label' => 'Pages',
+					],
+				],
+			);
+
+		$this->content_type_access_checker->expects( 'can_edit_others' )->with( 'page' )->andReturnFalse();
+		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 5 );
+
+		$posts_page = Mockery::mock( Posts_Page::class );
+		$posts_page->expects( 'to_array' )->once()->andReturn( [] );
+
+		$this->posts_repository
+			->expects( 'get_posts' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $query ) {
+						return $query instanceof Posts_Query
+							&& $query->get_author_id() === 5;
 					},
 				),
 			)
@@ -108,6 +147,8 @@ final class Get_Posts_Test extends Abstract_Posts_Route_Test {
 					],
 				],
 			);
+
+		$this->content_type_access_checker->expects( 'can_edit_others' )->with( 'page' )->andReturnTrue();
 
 		$posts_page = Mockery::mock( Posts_Page::class );
 		$posts_page->expects( 'to_array' )->once()->andReturn( [] );


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

The bulk editor introduced in 28.1 gated its listing only by the Yoast management capability (`wpseo_manage_options`). Any user who could open the bulk editor received every post of a content type together with its SEO metadata, and every row was offered for editing, regardless of that user's per-post rights. The update endpoint already refuses per-post edits it is not allowed to make (`current_user_can( 'edit_post' )`), so the read path and the write path were inconsistent: the list showed and let people attempt to change content they could not actually edit. This PR aligns the read path with the write path.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the bulk editor could show and edit posts and their SEO data that the current user was not allowed to edit.

## Relevant technical choices:

* The exact per-post permission (`current_user_can( 'edit_post' )`, the same check the update endpoint enforces) is applied on the fetched page only, so it stays bound to the page size and pagination totals remain accurate.
* The database query is first narrowed cheaply (content type, status, and author when the user cannot edit other authors' posts); a coarse capability gate decides which content types appear in the navigation.
* Posts the user cannot edit are shown but locked instead of hidden: their SEO fields and edit link are withheld and their row cannot be selected or edited. This keeps pagination exact and the list predictable, while never exposing metadata the user may not read.
* Custom post types that do not map meta capabilities never receive the `edit_published_posts`/`edit_others_posts` primitives, so for those the checks fall back to the singular `edit_post` capability.
* The response carries an `editable` flag per post; the React app disables selection and editing for locked rows.
* Premium needs no matching change: its AI bulk suggestions are generated only for the current selection (which now excludes locked rows), and the AI suggestions route checks `current_user_can( 'edit_post' )` per post server-side, so it cannot act on posts the user may not edit.
* Coverage: unit tests were added for the new classes (the capability checker and the per-post editability resolver) and updated for the changed collectors, route, and React components.
* Coding standards: the branch-diff `check-branch-cs` run reports only two known false-positive sniffs (`Yoast.NamingConventions.NamespaceName.Invalid` and `Yoast.Files.FileName.InvalidClassFileName`), which also fire on unrelated pre-existing files in the same run; `lint-branch`, the full unit suite, targeted `phpcs`, the JavaScript tests and ESLint are all clean.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. As an administrator, open Yoast SEO → Tools → Bulk editor and choose the "Pages" content type. Confirm every page is listed with its SEO data and can be edited, and that searching and paging work with matching totals. This is the unchanged administrator experience.
2. Create a user with the "SEO Manager" role (a Yoast role that can open the bulk editor but is not an administrator), then log in as that user.
3. Open Yoast SEO → Tools → Bulk editor, choose the "Pages" content type, and confirm the list, search, and paging still work with matching totals, and that the pages are editable with their SEO data shown.
4. Confirm nothing is wrongly hidden or locked for this user. An SEO Manager can edit all standard posts and pages, so no rows are locked in this setup. A row is shown locked (present in the list, but with empty SEO columns, a disabled selection checkbox, and a disabled Edit button) when a user who can open the bulk editor is refused editing of a specific post, for example when a plugin blocks that post through the `map_meta_cap` filter. That locking path is covered by the unit tests in this PR. The following snippet, locks post with ID 123, for all users except user with ID 1, so if you add this in your site, that post appears locked in the bulk editor and with no visible SEO data:
```
// Refuse editing of post 123 for everyone except user 1: its bulk editor row shows locked.
add_filter( 'map_meta_cap', function ( $caps, $cap, $user_id, $args ) {
      if ( $cap === 'edit_post' && (int) ( $args[0] ?? 0 ) === 123 && (int) $user_id !== 1 ) {
              $caps[] = 'do_not_allow';
      }
      return $caps;
}, 10, 4 );
```
5. Author narrowing: a user who can open the bulk editor but not edit others' posts. If you add the following snippet, you give Authors the ability to open the bulk editor. But since Authors can't edit any page, you should see only "Posts" in the content-type navigation and in there, only posts that the author you're logged in published:
```
// Let Authors open the bulk editor; they lack edit_others_posts.
add_action( 'init', function () {
      get_role( 'author' )?->add_cap( 'wpseo_manage_options' );
} );
```
6. CPT with map_meta_cap disabled: Add the following snippet, that registers the "Books" CPT, with map_meta_cap equal to fale. The CPT shows up and is fully editable for any role holding the single `edit_book` cap (including for other authors' books — no per-post distinction without mapping):
```
add_action( 'init', function () {
      register_post_type( 'book', [
              'label'           => 'Books',
              'public'          => true,
              'show_ui'         => true,
              'supports'        => [ 'title', 'editor', 'author' ],
              'capability_type' => 'book',
              'map_meta_cap'    => false,
      ] );
      // With mapping disabled nobody has edit_book implicitly — not even admins — so grant it.
      get_role( 'administrator' )?->add_cap( 'edit_book' );
      get_role( 'author' )?->add_cap( 'edit_book' );
} );
```
Remove the cap for authors and the type vanishes from the navigation when logged in as author (You actually have to add `get_role( 'author' )?->remove_cap( 'edit_book' );` to do that)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->
Behaviour depends on the post type, the post status, and authorship: test a content type that maps meta capabilities (the built-in Posts and Pages) and, if available, a public custom post type registered with `map_meta_cap` disabled, which should stay fully editable for a user holding its single edit capability.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor listing (both the indexable-based and post-meta-based collectors) and its REST posts route.
* The bulk editor React application (row rendering, selection, and the edit controls).
* No code outside the bulk editor is touched.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1350

