### PR TITLE
1353 bulk editor guard unsaved edits against hard navigation paths

### DIFF
--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -1,7 +1,7 @@
 import { useDispatch, useSelect } from "@wordpress/data";
 import { useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
-import { Paper, SidebarNavigation } from "@yoast/ui-library";
+import { Paper, SidebarNavigation, useBeforeUnload } from "@yoast/ui-library";
 import { BulkEditorContent } from "./components/bulk-editor-content";
 import { BulkEditorNavMenu } from "./components/bulk-editor-nav";
 import { BulkEditorPageHeader } from "./components/bulk-editor-page-header";
@@ -56,7 +56,20 @@ const getActiveContentTypeFields = ( contentType ) => ( {
 const App = ( { dataProvider, remoteDataProvider } ) => {
 	const activeContentTypeName = useSelect( ( select ) => select( STORE_NAME ).selectActiveContentTypeName(), [] );
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
+	// Manual inline edits or an external plugin's pending changes (Premium AI) both count as unsaved work that a
+	// hard exit (refresh/close/back button) would silently discard.
+	const hasUnsavedChanges = useSelect( ( select ) => {
+		const store = select( STORE_NAME );
+		return Object.keys( store.selectEditingRows() ).length > 0 || store.selectHasExternalPendingChanges();
+	}, [] );
 	const { requestSwitch } = useDispatch( STORE_NAME );
+
+	// The browser's native confirm dialog is the only guard available for refresh/close/back; the in-app links use
+	// the styled modal below via onNavigate instead.
+	useBeforeUnload(
+		hasUnsavedChanges,
+		__( "There are unsaved changes on this page. Leaving means that those changes will be lost. Are you sure you want to leave this page?", "wordpress-seo" )
+	);
 
 	// A hard-navigation link (logo, Back to Tools) requests a guarded switch: requestSwitch defers to the modal when
 	// there are unsaved changes, else navigates straight away. Modified clicks (open in new tab/window) don't leave

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -58,6 +58,18 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
 	const { requestSwitch } = useDispatch( STORE_NAME );
 
+	// A hard-navigation link (logo, Back to Tools) requests a guarded switch: requestSwitch defers to the modal when
+	// there are unsaved changes, else navigates straight away. Modified clicks (open in new tab/window) don't leave
+	// the current page, so they pass through to the browser unguarded.
+	const onNavigate = useCallback( ( event, href ) => {
+		const passThrough = [ event.defaultPrevented, event.button !== 0, event.metaKey, event.ctrlKey, event.shiftKey, event.altKey ];
+		if ( passThrough.some( Boolean ) ) {
+			return;
+		}
+		event.preventDefault();
+		requestSwitch( { kind: "navigate", target: href } );
+	}, [ requestSwitch ] );
+
 	const contentTypes = dataProvider.getContentTypes().map( ( { name, label, singularLabel } ) => ( { id: name, label, singularLabel } ) );
 	const activeContentType = contentTypes.find( ( { id } ) => id === activeContentTypeName ) ?? contentTypes[ 0 ];
 	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
@@ -81,6 +93,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 		contentTypes,
 		onChange: onChangeContentType,
 		backToToolsUrl,
+		onNavigate,
 		logoHref,
 		isPremium,
 	};

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { useCallback } from "@wordpress/element";
+import { useCallback, useRef } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Paper, SidebarNavigation, useBeforeUnload } from "@yoast/ui-library";
 import { BulkEditorContent } from "./components/bulk-editor-content";
@@ -88,14 +88,20 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
 		getActiveContentTypeFields( activeContentType );
 
+	// The resolved active id is read from a ref so the handler below can stay referentially stable: the sidebar
+	// navigation freezes the first click handler it receives, so a handler closing over activeContentTypeId would
+	// keep comparing against a stale value and silently drop a switch back to an earlier content type.
+	const activeContentTypeIdRef = useRef( activeContentTypeId );
+	activeContentTypeIdRef.current = activeContentTypeId;
+
 	// Selecting a content type requests a guarded switch (requestSwitch defers to the modal or switches straight away).
 	// The no-op check runs here against the resolved id: the store's active name can be "" (meaning "first content
 	// type"), which the store-level guard can't resolve, so clicking the active first type would otherwise switch.
 	const onChangeContentType = useCallback( ( id ) => {
-		if ( id !== activeContentTypeId ) {
+		if ( id !== activeContentTypeIdRef.current ) {
 			requestSwitch( { kind: "contentType", target: id } );
 		}
-	}, [ activeContentTypeId, requestSwitch ] );
+	}, [ requestSwitch ] );
 
 	const { title, description } = getHeaderCopy( activeContentType );
 	// Fall back to the WP admin home when the data provider has no link.

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -56,9 +56,7 @@ const getActiveContentTypeFields = ( contentType ) => ( {
 const App = ( { dataProvider, remoteDataProvider } ) => {
 	const activeContentTypeName = useSelect( ( select ) => select( STORE_NAME ).selectActiveContentTypeName(), [] );
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
-	// Only Free's own unsaved inline edits arm the native unload guard. An external plugin's pending changes
-	// (Premium's AI suggestions) are guarded by that plugin's own modal, and it owns any unload guard for its state;
-	// reading its flag here would double-prompt on a navigation the user has already confirmed through that modal.
+	// Free's unsaved inline edits trigger the native unload guard; Premium handles its own pending changes and unload prompts.
 	const hasUnsavedEdits = useSelect( ( select ) => Object.keys( select( STORE_NAME ).selectEditingRows() ).length > 0, [] );
 	const { requestSwitch } = useDispatch( STORE_NAME );
 
@@ -86,9 +84,8 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const { id: activeContentTypeId, label: activeContentTypeLabel, singularLabel: activeContentTypeSingularLabel } =
 		getActiveContentTypeFields( activeContentType );
 
-	// The resolved active id is read from a ref so the handler below can stay referentially stable: the sidebar
-	// navigation freezes the first click handler it receives, so a handler closing over activeContentTypeId would
-	// keep comparing against a stale value and silently drop a switch back to an earlier content type.
+	// The active ID is read from a ref to keep the click handler referentially stable,
+	// preventing stale comparisons that could silently drop a switch to an earlier content type.
 	const activeContentTypeIdRef = useRef( activeContentTypeId );
 	activeContentTypeIdRef.current = activeContentTypeId;
 

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -56,18 +56,16 @@ const getActiveContentTypeFields = ( contentType ) => ( {
 const App = ( { dataProvider, remoteDataProvider } ) => {
 	const activeContentTypeName = useSelect( ( select ) => select( STORE_NAME ).selectActiveContentTypeName(), [] );
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
-	// Manual inline edits or an external plugin's pending changes (Premium AI) both count as unsaved work that a
-	// hard exit (refresh/close/back button) would silently discard.
-	const hasUnsavedChanges = useSelect( ( select ) => {
-		const store = select( STORE_NAME );
-		return Object.keys( store.selectEditingRows() ).length > 0 || store.selectHasExternalPendingChanges();
-	}, [] );
+	// Only Free's own unsaved inline edits arm the native unload guard. An external plugin's pending changes
+	// (Premium's AI suggestions) are guarded by that plugin's own modal, and it owns any unload guard for its state;
+	// reading its flag here would double-prompt on a navigation the user has already confirmed through that modal.
+	const hasUnsavedEdits = useSelect( ( select ) => Object.keys( select( STORE_NAME ).selectEditingRows() ).length > 0, [] );
 	const { requestSwitch } = useDispatch( STORE_NAME );
 
 	// The browser's native confirm dialog is the only guard available for refresh/close/back; the in-app links use
 	// the styled modal below via onNavigate instead.
 	useBeforeUnload(
-		hasUnsavedChanges,
+		hasUnsavedEdits,
 		__( "There are unsaved changes on this page. Leaving means that those changes will be lost. Are you sure you want to leave this page?", "wordpress-seo" )
 	);
 

--- a/packages/js/src/bulk-editor/components/back-to-tools-link.js
+++ b/packages/js/src/bulk-editor/components/back-to-tools-link.js
@@ -1,21 +1,30 @@
 import ArrowLeftIcon from "@heroicons/react/solid/ArrowLeftIcon";
+import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Link } from "@yoast/ui-library";
+import { noop } from "lodash";
 
 /**
- * The "Back to Tools" link shown above the bulk editor sub-navigation.
+ * The "Back to Tools" link shown above the bulk editor sub-navigation. The click is routed through onNavigate so a
+ * hard page navigation can be guarded when there are unsaved edits.
  *
- * @param {Object} props      The props.
- * @param {string} props.href The URL of the Tools page (provided via localized data by Free-FE 1).
+ * @param {Object}   props              The props.
+ * @param {string}   props.href         The URL of the Tools page (provided via localized data by Free-FE 1).
+ * @param {Function} [props.onNavigate=noop] Called with (event, href) when the link is clicked, to guard the navigation.
  *
  * @returns {JSX.Element} The link.
  */
-export const BackToToolsLink = ( { href } ) => (
-	<Link
-		href={ href }
-		className="yst-flex yst-items-center yst-gap-1.5 yst-rounded-md yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-no-underline yst-text-slate-800 hover:yst-bg-slate-50 hover:yst-text-slate-900"
-	>
-		<ArrowLeftIcon className="yst-w-4 yst-h-4 yst-text-slate-400 rtl:yst-rotate-180" aria-hidden="true" />
-		{ __( "Back to Tools", "wordpress-seo" ) }
-	</Link>
-);
+export const BackToToolsLink = ( { href, onNavigate = noop } ) => {
+	const handleClick = useCallback( ( event ) => onNavigate( event, href ), [ onNavigate, href ] );
+
+	return (
+		<Link
+			href={ href }
+			onClick={ handleClick }
+			className="yst-flex yst-items-center yst-gap-1.5 yst-rounded-md yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-no-underline yst-text-slate-800 hover:yst-bg-slate-50 hover:yst-text-slate-900"
+		>
+			<ArrowLeftIcon className="yst-w-4 yst-h-4 yst-text-slate-400 rtl:yst-rotate-180" aria-hidden="true" />
+			{ __( "Back to Tools", "wordpress-seo" ) }
+		</Link>
+	);
+};

--- a/packages/js/src/bulk-editor/components/bulk-editor-nav.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-nav.js
@@ -2,6 +2,7 @@ import DuplicateIcon from "@heroicons/react/outline/DuplicateIcon";
 import { useCallback } from "@wordpress/element";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { Link, SidebarNavigation, useSvgAria } from "@yoast/ui-library";
+import { noop } from "lodash";
 import { YoastLogo } from "../../shared-admin/components";
 import { BackToToolsLink } from "./back-to-tools-link";
 
@@ -40,6 +41,35 @@ const ContentTypeItem = ( { contentType, onChange } ) => {
 };
 
 /**
+ * The Yoast logo link at the top of the menu. Its click routes through onNavigate so the hard page navigation to
+ * the dashboard can be guarded when there are unsaved edits.
+ *
+ * @param {Object}   props              The props.
+ * @param {string}   props.logoHref     Where the logo links to.
+ * @param {boolean}  props.isPremium    Whether Premium is active (affects the accessible label).
+ * @param {string}   props.idSuffix     Suffix appended to the element id to avoid duplicates.
+ * @param {Function} props.onNavigate   Called with (event, href) when the logo is clicked, to guard the navigation.
+ *
+ * @returns {JSX.Element} The logo link.
+ */
+const NavLogo = ( { logoHref, isPremium, idSuffix, onNavigate } ) => {
+	const svgAriaProps = useSvgAria();
+	const handleClick = useCallback( ( event ) => onNavigate( event, logoHref ), [ onNavigate, logoHref ] );
+
+	return (
+		<Link
+			id={ `link-bulk-editor-logo${ idSuffix }` }
+			href={ logoHref }
+			onClick={ handleClick }
+			className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500"
+			aria-label={ isPremium ? "Yoast SEO Premium" : "Yoast SEO" }
+		>
+			<YoastLogo className="yst-w-40" { ...svgAriaProps } />
+		</Link>
+	);
+};
+
+/**
  * The bulk editor menu content: the Yoast logo, a "Back to Tools" link and the content type list,
  * limited to `visibleLimit` items with a "Show N more" toggle.
  *
@@ -47,6 +77,8 @@ const ContentTypeItem = ( { contentType, onChange } ) => {
  * @param {BulkEditorContentType[]} props.contentTypes   The content types, in display order.
  * @param {Function}                props.onChange       Called with a content type id when one is selected.
  * @param {string}                  props.backToToolsUrl The URL of the Tools page.
+ * @param {Function}                [props.onNavigate=noop]   Called with (event, href) when a hard-navigation link (logo,
+ *                                                       Back to Tools) is clicked, to guard the navigation.
  * @param {string}                  [props.logoHref]     Where the Yoast SEO logo links to.
  * @param {boolean}                 [props.isPremium]    Whether Premium is active (affects the logo label).
  * @param {number}                  [props.visibleLimit] How many content types to show before "Show N more".
@@ -58,13 +90,13 @@ export const BulkEditorNavMenu = ( {
 	contentTypes,
 	onChange,
 	backToToolsUrl,
+	onNavigate = noop,
 	logoHref = "/wp-admin/",
 	isPremium = false,
 	visibleLimit = 5,
 	idSuffix = "",
 } ) => {
 	const hiddenCount = contentTypes.length - visibleLimit;
-	const svgAriaProps = useSvgAria();
 
 	const showMoreLabel = sprintf(
 		/* translators: %d expands to the number of additional content types. */
@@ -74,15 +106,8 @@ export const BulkEditorNavMenu = ( {
 
 	return (
 		<div className="yst-space-y-6">
-			<Link
-				id={ `link-bulk-editor-logo${ idSuffix }` }
-				href={ logoHref }
-				className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500"
-				aria-label={ isPremium ? "Yoast SEO Premium" : "Yoast SEO" }
-			>
-				<YoastLogo className="yst-w-40" { ...svgAriaProps } />
-			</Link>
-			<BackToToolsLink href={ backToToolsUrl } />
+			<NavLogo logoHref={ logoHref } isPremium={ isPremium } idSuffix={ idSuffix } onNavigate={ onNavigate } />
+			<BackToToolsLink href={ backToToolsUrl } onNavigate={ onNavigate } />
 			<SidebarNavigation.MenuItemWithLimiter
 				id={ `bulk-editor-nav-content-types${ idSuffix }` }
 				label={ __( "Bulk editor", "wordpress-seo" ) }

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -30,6 +30,9 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 		// Clear the deferral before leaving so a cancelled navigation (e.g. the user dismisses a still-armed
 		// beforeunload prompt) can't strand the pending switch and let the self-heal effect re-fire it.
 		dispatch.clearPendingSwitch();
+		// Security: target flows unvalidated into location.href, so it must stay a server-generated URL (the localized
+		// links in bulk-editor-integration.php). If a link ever derives from request input, validate it here first
+		// (same-origin and an http(s) scheme) to avoid an open redirect or a javascript: URI.
 		window.location.href = target;
 		return;
 	}

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -38,9 +38,8 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 		// Clear the deferral before exit so a cancelled navigation can’t leave a pending switch and cause the self-repair to re-trigger.
 		// beforeunload prompt) can't strand the pending switch and let the self-heal effect re-fire it.
 		dispatch.clearPendingSwitch();
-		// Security: target flows unvalidated into location.href, so it must stay a server-generated URL (the localized
-		// links in bulk-editor-integration.php). If a link ever derives from request input, validate it here first
-		// (same-origin and an http(s) scheme) to avoid an open redirect or a javascript: URI.
+		// Security: Now, `target` is a server-generated URL (see bulk-editor-integration.php).
+		// If it ever comes from input, it has to be validated to prevent open redirects or malicious URIs.
 		window.location.href = target;
 		return;
 	}
@@ -54,10 +53,9 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 };
 
 /**
- * Requests a switch, guarding it when manual edits are in progress or an external plugin (Premium AI) reports
- * pending changes: the switch is then held until the user resolves it, otherwise it commits immediately. A
- * "navigate" switch targets a URL rather than a view value, so it skips the no-op check that compares against the
- * current view.
+ * Requests a switch.
+ * Defers the request when manual edits are unsaved or an external plugin (Premium AI) reports pending changes.
+ * Otherwise, commits immediately. A "navigate" switch uses a URL target and skips current-view checks.
  *
  * @param {PendingSwitch} request The requested switch.
  *

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -36,7 +36,6 @@ const slice = createSlice( {
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 	if ( kind === "navigate" ) {
 		// Clear the deferral before exit so a cancelled navigation can’t leave a pending switch and cause the self-repair to re-trigger.
-		// beforeunload prompt) can't strand the pending switch and let the self-heal effect re-fire it.
 		dispatch.clearPendingSwitch();
 		// Security: Now, `target` is a server-generated URL (see bulk-editor-integration.php).
 		// If it ever comes from input, it has to be validated to prevent open redirects or malicious URIs.

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -27,7 +27,9 @@ const slice = createSlice( {
  */
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 	if ( kind === "navigate" ) {
-		// A hard navigation unloads the page, so there is no view state to reset or pending switch to clear.
+		// Clear the deferral before leaving so a cancelled navigation (e.g. the user dismisses a still-armed
+		// beforeunload prompt) can't strand the pending switch and let the self-heal effect re-fire it.
+		dispatch.clearPendingSwitch();
 		window.location.href = target;
 		return;
 	}

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -18,13 +18,19 @@ const slice = createSlice( {
 
 /**
  * Commits a switch. A content-type change also clears the unsaved edits, so a stale draft can't leak into the
- * newly shown type; the selection reset is handled by setActiveContentType itself.
+ * newly shown type; the selection reset is handled by setActiveContentType itself. A "navigate" switch leaves the
+ * page for a URL, discarding all view state, so it only hands off to the browser.
  *
  * @param {{kind: string, target: string}} pending The switch to commit.
  *
  * @returns {Function} The thunk.
  */
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
+	if ( kind === "navigate" ) {
+		// A hard navigation unloads the page, so there is no view state to reset or pending switch to clear.
+		window.location.href = target;
+		return;
+	}
 	if ( kind === "contentType" ) {
 		dispatch.setActiveContentType( target );
 		dispatch.stopEdit();
@@ -36,16 +42,20 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 
 /**
  * Requests a switch, guarding it when manual edits are in progress or an external plugin (Premium AI) reports
- * pending changes: the switch is then held until the user resolves it, otherwise it commits immediately.
+ * pending changes: the switch is then held until the user resolves it, otherwise it commits immediately. A
+ * "navigate" switch targets a URL rather than a view value, so it skips the no-op check that compares against the
+ * current view.
  *
  * @param {{kind: string, target: string}} request The requested switch.
  *
  * @returns {Function} The thunk.
  */
 export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) => {
-	const current = kind === "contentType" ? select.selectActiveContentTypeName() : select.selectActiveFieldSet();
-	if ( target === current ) {
-		return;
+	if ( kind !== "navigate" ) {
+		const current = kind === "contentType" ? select.selectActiveContentTypeName() : select.selectActiveFieldSet();
+		if ( target === current ) {
+			return;
+		}
 	}
 	const hasUnsavedEdits = Object.keys( select.selectEditingRows() ).length > 0;
 	if ( hasUnsavedEdits || select.selectHasExternalPendingChanges() ) {

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -2,7 +2,16 @@ import { createSlice } from "@reduxjs/toolkit";
 import { get } from "lodash";
 
 /**
- * @returns {null} The initial pending-switch state: no switch is deferred.
+ * A deferred switch, held until the unsaved-edits guard is resolved.
+ *
+ * @typedef {Object} PendingSwitch
+ *
+ * @property {"fieldSet"|"contentType"|"navigate"} kind What the switch targets: a field set, a content type, or a URL to navigate to.
+ * @property {string} target The field-set name, content-type name, or (for "navigate") the destination URL.
+ */
+
+/**
+ * @returns {?PendingSwitch} The initial pending-switch state: no switch is deferred.
  */
 export const createInitialPendingSwitchState = () => null;
 
@@ -10,7 +19,6 @@ const slice = createSlice( {
 	name: "pendingSwitch",
 	initialState: createInitialPendingSwitchState(),
 	reducers: {
-		// Holds a deferred switch ({ kind: "fieldSet" | "contentType", target }) until the guard is resolved.
 		setPendingSwitch: ( _state, { payload } ) => payload,
 		clearPendingSwitch: () => null,
 	},
@@ -21,7 +29,7 @@ const slice = createSlice( {
  * newly shown type; the selection reset is handled by setActiveContentType itself. A "navigate" switch leaves the
  * page for a URL, discarding all view state, so it only hands off to the browser.
  *
- * @param {{kind: string, target: string}} pending The switch to commit.
+ * @param {PendingSwitch} pending The switch to commit.
  *
  * @returns {Function} The thunk.
  */
@@ -51,7 +59,7 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
  * "navigate" switch targets a URL rather than a view value, so it skips the no-op check that compares against the
  * current view.
  *
- * @param {{kind: string, target: string}} request The requested switch.
+ * @param {PendingSwitch} request The requested switch.
  *
  * @returns {Function} The thunk.
  */
@@ -71,6 +79,11 @@ export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) =>
 };
 
 export const pendingSwitchSelectors = {
+	/**
+	 * @param {Object} state The root store state.
+	 *
+	 * @returns {?PendingSwitch} The deferred switch, or null when none is pending.
+	 */
 	selectPendingSwitch: ( state ) => get( state, "pendingSwitch", null ),
 };
 

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -27,7 +27,7 @@ const slice = createSlice( {
  */
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 	if ( kind === "navigate" ) {
-		// Clear the deferral before leaving so a cancelled navigation (e.g. the user dismisses a still-armed
+		// Clear the deferral before exit so a cancelled navigation can’t leave a pending switch and cause the self-repair to re-trigger.
 		// beforeunload prompt) can't strand the pending switch and let the self-heal effect re-fire it.
 		dispatch.clearPendingSwitch();
 		// Security: target flows unvalidated into location.href, so it must stay a server-generated URL (the localized

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -286,6 +286,24 @@ describe( "App", () => {
 			expect( screen.getByRole( "heading", { level: 1, name: "Bulk editor: Pages" } ) ).toBeInTheDocument();
 		} );
 
+		it( "can switch back to the first content type after switching away with pending edits discarded", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			// Edit on the first (resolved) content type while its stored name is still empty.
+			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
+			expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" );
+
+			// Switch to Posts and discard the edit.
+			fireEvent.click( screen.getByRole( "button", { name: "Posts" } ) );
+			fireEvent.click( screen.getByRole( "button", { name: "Continue without saving" } ) );
+			await waitFor( () => expect( screen.getByRole( "button", { name: "Posts" } ) ).toHaveAttribute( "aria-current", "page" ) );
+
+			// Switching back to Pages must still work: the click handler reads the current active id, not a stale one.
+			fireEvent.click( screen.getByRole( "button", { name: "Pages" } ) );
+			await waitFor( () => expect( screen.getByRole( "button", { name: "Pages" } ) ).toHaveAttribute( "aria-current", "page" ) );
+			expect( screen.getByRole( "heading", { level: 1, name: "Bulk editor: Pages" } ) ).toBeInTheDocument();
+		} );
+
 		it( "does not guard clicking the already-active first content type while the stored name is still empty", async() => {
 			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
 

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -325,19 +325,27 @@ describe( "App", () => {
 		const rowTitle = "What Is SEO and How It Works";
 		const beforeUnloadCount = ( addSpy ) => addSpy.mock.calls.filter( ( [ type ] ) => type === "beforeunload" ).length;
 
-		it( "attaches the native beforeunload guard only while there are unsaved changes", async() => {
+		it( "attaches the native beforeunload guard only for unsaved manual edits, not external pending changes", async() => {
 			const addSpy = jest.spyOn( window, "addEventListener" );
 			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
-			await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } );
+			const editButton = await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } );
 
 			// Nothing pending: no beforeunload listener is attached.
 			expect( beforeUnloadCount( addSpy ) ).toBe( 0 );
 
+			// An external plugin's pending changes (Premium AI) are that plugin's concern; they must not arm Free's
+			// guard, or the user would get a native prompt on top of Premium's already-confirmed modal.
 			await act( async() => {
 				dispatch( STORE_NAME ).setHasExternalPendingChanges( true );
 			} );
-			// A pending change attaches the native unload guard for refresh/close/back.
-			expect( beforeUnloadCount( addSpy ) ).toBeGreaterThan( 0 );
+			expect( beforeUnloadCount( addSpy ) ).toBe( 0 );
+
+			// A manual inline edit does arm the native unload guard for refresh/close/back.
+			await act( async() => {
+				dispatch( STORE_NAME ).setHasExternalPendingChanges( false );
+			} );
+			fireEvent.click( editButton );
+			await waitFor( () => expect( beforeUnloadCount( addSpy ) ).toBeGreaterThan( 0 ) );
 
 			addSpy.mockRestore();
 		} );

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -305,6 +305,24 @@ describe( "App", () => {
 
 	describe( "guarding hard-navigation paths", () => {
 		const rowTitle = "What Is SEO and How It Works";
+		const beforeUnloadCount = ( addSpy ) => addSpy.mock.calls.filter( ( [ type ] ) => type === "beforeunload" ).length;
+
+		it( "attaches the native beforeunload guard only while there are unsaved changes", async() => {
+			const addSpy = jest.spyOn( window, "addEventListener" );
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+			await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } );
+
+			// Nothing pending: no beforeunload listener is attached.
+			expect( beforeUnloadCount( addSpy ) ).toBe( 0 );
+
+			await act( async() => {
+				dispatch( STORE_NAME ).setHasExternalPendingChanges( true );
+			} );
+			// A pending change attaches the native unload guard for refresh/close/back.
+			expect( beforeUnloadCount( addSpy ) ).toBeGreaterThan( 0 );
+
+			addSpy.mockRestore();
+		} );
 
 		it( "guards the Back to Tools link with the unsaved-changes modal when there are edits", async() => {
 			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );

--- a/packages/js/tests/bulk-editor/app.test.js
+++ b/packages/js/tests/bulk-editor/app.test.js
@@ -302,4 +302,20 @@ describe( "App", () => {
 			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
 		} );
 	} );
+
+	describe( "guarding hard-navigation paths", () => {
+		const rowTitle = "What Is SEO and How It Works";
+
+		it( "guards the Back to Tools link with the unsaved-changes modal when there are edits", async() => {
+			render( <App dataProvider={ dataProvider } remoteDataProvider={ buildRemote() } /> );
+
+			fireEvent.click( await screen.findByRole( "button", { name: `Edit ${ rowTitle }` } ) );
+			expect( screen.getByRole( "textbox", { name: `SEO title for ${ rowTitle }` } ) ).toBeInTheDocument();
+
+			fireEvent.click( screen.getByRole( "link", { name: "Back to Tools" } ) );
+
+			// The click is intercepted (no full page navigation) and the confirmation modal is shown instead.
+			expect( screen.getByText( "Unsaved changes" ) ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/js/tests/bulk-editor/bulk-editor-nav.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-nav.test.js
@@ -78,6 +78,22 @@ describe( "BulkEditorNavMenu", () => {
 		expect( onChange ).toHaveBeenCalledWith( "post" );
 	} );
 
+	it( "routes the Back to Tools click through onNavigate with the target URL", () => {
+		const onNavigate = jest.fn( ( event ) => event.preventDefault() );
+		renderNav( { onNavigate } );
+
+		fireEvent.click( screen.getByRole( "link", { name: "Back to Tools" } ) );
+		expect( onNavigate ).toHaveBeenCalledWith( expect.objectContaining( { type: "click" } ), defaultProps.backToToolsUrl );
+	} );
+
+	it( "routes the logo click through onNavigate with the target URL", () => {
+		const onNavigate = jest.fn( ( event ) => event.preventDefault() );
+		renderNav( { onNavigate } );
+
+		fireEvent.click( screen.getByRole( "link", { name: "Yoast SEO" } ) );
+		expect( onNavigate ).toHaveBeenCalledWith( expect.objectContaining( { type: "click" } ), defaultProps.logoHref );
+	} );
+
 	it( "collapses content types beyond the limit behind a Show more toggle", () => {
 		renderNav();
 

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -69,6 +69,30 @@ describe( "requestSwitch thunk", () => {
 		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
 		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
 	} );
+
+	it( "commits a navigate switch straight away when nothing guards it", () => {
+		const args = makeThunkArgs();
+		requestSwitch( { kind: "navigate", target: "https://example.test/tools" } )( args );
+
+		expect( args.dispatch.commitSwitch ).toHaveBeenCalledWith( { kind: "navigate", target: "https://example.test/tools" } );
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers a navigate switch while manual edits are in progress", () => {
+		const args = makeThunkArgs( { editingRows: { 7: {} } } );
+		requestSwitch( { kind: "navigate", target: "https://example.test/tools" } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "navigate", target: "https://example.test/tools" } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers a navigate switch while an external plugin reports pending changes", () => {
+		const args = makeThunkArgs( { hasExternalPendingChanges: true } );
+		requestSwitch( { kind: "navigate", target: "https://example.test/tools" } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "navigate", target: "https://example.test/tools" } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
 } );
 
 describe( "commitSwitch thunk", () => {
@@ -99,5 +123,23 @@ describe( "commitSwitch thunk", () => {
 		// The selection slice resets on setActiveContentType, so commitSwitch does not deselect separately.
 		expect( dispatch.deselectAll ).not.toHaveBeenCalled();
 		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
+	} );
+
+	it( "navigates to the target URL for a navigate switch, leaving view state untouched", () => {
+		const dispatch = makeDispatch();
+		const original = window.location;
+		delete window.location;
+		window.location = { href: "" };
+
+		commitSwitch( { kind: "navigate", target: "https://example.test/tools" } )( { dispatch } );
+
+		expect( window.location.href ).toBe( "https://example.test/tools" );
+		expect( dispatch.setActiveContentType ).not.toHaveBeenCalled();
+		expect( dispatch.setActiveFieldSet ).not.toHaveBeenCalled();
+		expect( dispatch.stopEdit ).not.toHaveBeenCalled();
+		// The page unloads, so there is no pending switch to clear.
+		expect( dispatch.clearPendingSwitch ).not.toHaveBeenCalled();
+
+		window.location = original;
 	} );
 } );

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -137,8 +137,8 @@ describe( "commitSwitch thunk", () => {
 		expect( dispatch.setActiveContentType ).not.toHaveBeenCalled();
 		expect( dispatch.setActiveFieldSet ).not.toHaveBeenCalled();
 		expect( dispatch.stopEdit ).not.toHaveBeenCalled();
-		// The page unloads, so there is no pending switch to clear.
-		expect( dispatch.clearPendingSwitch ).not.toHaveBeenCalled();
+		// The deferral is cleared before leaving so a cancelled navigation can't strand and re-fire it.
+		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
 
 		window.location = original;
 	} );

--- a/src/bulk-editor/user-interface/bulk-editor-integration.php
+++ b/src/bulk-editor/user-interface/bulk-editor-integration.php
@@ -212,6 +212,9 @@ class Bulk_Editor_Integration implements Integration_Interface {
 		return [
 			'contentTypes' => $this->content_types_repository->get_content_types(),
 			'endpoints'    => $this->endpoints_repository->get_all_endpoints()->to_array(),
+			// These must stay server-generated URLs: the bulk editor assigns them to window.location.href for its
+			// "Back to Tools" / logo navigation. If a link ever derives from request input, validate it with
+			// wp_validate_redirect() here before exposing it, to avoid an open redirect on the front-end.
 			'links'        => [
 				'dashboard' => \admin_url( 'admin.php?page=' . General_Page_Integration::PAGE ),
 				'tools'     => \admin_url( 'admin.php?page=wpseo_tools' ),


### PR DESCRIPTION
## Context

Follow-up to #23447, which guarded unsaved inline edits and pending AI suggestions only for the two in-app view switches (appearance tabs and content types). Paths that leave the page entirely still dropped edits silently: the Yoast logo link, the "Back to Tools" link, and browser refresh / tab close / back button. This PR guards those.

It also fixes a switch-back regression from #23447: the content-type click handler compared against a stale active id, so returning to the initially selected content type did nothing.

## Summary

This PR can be summarized in the following changelog entries:

* Guards unsaved bulk editor edits against page navigations that leave the editor.
* Fixes an unreleased bug where returning to the initially selected bulk editor content type did nothing after switching away from it.

## Relevant technical choices:

* The two in-app links reuse the existing `requestSwitch`/`commitSwitch` guard via a new `navigate` kind, so the styled modal, the self-heal effect, and Premium's pending-changes slot all apply unchanged (including for pending AI suggestions).
* Refresh / close / back use a `beforeunload` listener, since the browser's native dialog can't route through the styled modal. It arms on Free's own inline edits only: an external plugin's pending changes (Premium AI) are guarded by that plugin's own modal, and Premium owns any unload guard for its state — reading its flag here would fire a native prompt on top of a navigation the user already confirmed.
* Modified clicks (open in new tab/window) pass through unguarded, as they don't leave the page.
* The switch-back fix keeps the content-type handler referentially stable by reading the active id from a ref: the sidebar navigation freezes the first click handler it receives, so a handler that closed over the active id went stale.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Hard-navigation links — manual edits (Free):
1. Open **Yoast SEO → Tools → Bulk editor → Posts**.
2. Click **Edit** on a row and change a field value.
3. Click the **Yoast logo** (or **Back to Tools**). The **Unsaved changes** modal appears and you stay on the page. Test each button, re-opening the edit before each:
   - **Cancel** → modal closes, you stay, the edit is intact.
   - **Continue without saving** → navigates away, the edit is discarded.
   - **Save changes** → the edit is saved (POST to the update endpoint), then navigates.
4. Re-open an edit and **Cmd/Ctrl-click** (or middle-click) the logo or **Back to Tools** → it opens in a new tab, no modal, the edit stays.

#### Refresh / tab close / browser back (Free):
1. With an open inline edit, refresh the page (or close the tab, or press the browser back button).
2. The browser's native "leave site?" dialog appears. **Leave** → navigates (edit lost); **Stay/Cancel** → remains, edit intact.
3. With no open edits, refresh → no dialog.

#### In-app view switches still guarded (regression check):
1. With an open edit, switch the **Search/Social** appearance tab, or switch **content type** → the **Unsaved changes** modal appears; **Cancel** keeps the edit, **Continue without saving** / **Save changes** proceed as above.

#### Content-type switch-back:
1. On the default content type (e.g. **Posts**), click **Edit** and change a value.
2. Switch to another content type and choose **Continue without saving**; you land on the new type.
3. Click the original content type again → it switches back (before this fix it did nothing).

#### Pending AI suggestions (Premium — requires the Premium counterpart on branch `1353-bulk-editor-guard-unsaved-edits-against-hard-navigation-paths`, Premium active with a valid subscription):
> [!NOTE]
> Accompanying PR: https://github.com/Yoast/wordpress-seo-premium/pull/5018 
1. On **Posts**, select a row with a focus keyphrase and click **Generate meta descriptions** (or SEO titles). Wait for the suggestion; do **not** apply it.
2. Click the **Yoast logo** (or **Back to Tools**). **Premium's "Pending AI suggestions" modal** appears (not the Free one). Test each button, re-generating a suggestion before each:
   - **Cancel** → stays, the suggestion is kept.
   - **Continue without applying** → the suggestion is discarded, then navigates.
   - **Apply all suggestions** → the suggestions are applied (saved), then navigates.
3. In every step-2 case, confirm **no second, native** "leave site?" dialog appears on top of the modal.
4. With a pending suggestion, refresh / close / back → the native dialog warns; with nothing pending → no dialog.
5. With **both** a manual edit and a pending suggestion, refresh → only a single native dialog appears.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The `beforeunload` dialog is browser-native, so its wording and behaviour vary per browser. In Free, the native refresh/close/back guard covers manual edits only; the pending-AI-suggestions equivalent lives in the Premium counterpart branch referenced above, which the Premium test steps require.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor navigation (logo and Back to Tools links), the unsaved-changes and pending-AI modals, browser unload handling, and content-type switching.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/reserved-tasks#1353
