### PR TITLE
Keep topbar for pending changes visible when changing pages

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -185,8 +185,10 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 						}
 						// A selection only warrants the band while AI is enabled (the AI affordances are its only
 						// selection-driven occupant); with AI off the band collapses. Unsaved manual edits are a
-						// separate, non-AI occupant, so they keep it open regardless of the AI toggle.
-						showBulkActions={ ( hasSelection && isAiEnabled ) || hasUnsavedEdits }
+						// separate, non-AI occupant, so they keep it open regardless of the AI toggle. External
+						// pending changes (Premium's AI suggestions) also keep it open: a filter, search, or page
+						// change clears the selection but must leave the pending suggestions actionable.
+						showBulkActions={ ( hasSelection && isAiEnabled ) || hasUnsavedEdits || hasExternalPendingChanges }
 						filters={ <BulkEditorFilters /> }
 						isLoading={ isPending }
 						hasExternalPendingChanges={ hasExternalPendingChanges }

--- a/packages/js/tests/bulk-editor/bulk-editor-content.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-content.test.js
@@ -45,6 +45,36 @@ const renderContent = () => render(
 	</SlotFillProvider>
 );
 
+// The store registers once for the whole file: the WP data registry is global, so a second register would clash.
+beforeAll( () => {
+	registerStore();
+} );
+
+// The store lives in the global registry: reset the state each test touches so tests stay order-independent.
+beforeEach( () => {
+	dispatch( STORE_NAME ).setActiveFieldSet( FIELD_SET_SEARCH );
+	dispatch( STORE_NAME ).setHasExternalPendingChanges( false );
+	dispatch( STORE_NAME ).stopEdit();
+	dispatch( STORE_NAME ).clearPendingSwitch();
+	dispatch( STORE_NAME ).setSearch( "" );
+	dispatch( STORE_NAME ).setStatuses( [] );
+} );
+
+/**
+ * Asserts every bulk-actions band row (one per tab table) is expanded or collapsed, via the aria-hidden
+ * that mirrors `showBulkActions`.
+ *
+ * @param {HTMLElement} container  The render container.
+ * @param {boolean}     isExpanded Whether the band should be expanded.
+ *
+ * @returns {void}
+ */
+const expectBandExpanded = ( container, isExpanded ) => {
+	const rows = Array.from( container.querySelectorAll( "tr[aria-hidden]" ) );
+	expect( rows ).not.toHaveLength( 0 );
+	rows.forEach( ( row ) => expect( row ).toHaveAttribute( "aria-hidden", String( ! isExpanded ) ) );
+};
+
 describe( "getSelectionView", () => {
 	const items = [ { id: 1, editable: true }, { id: 2, editable: true }, { id: 3, editable: true } ];
 
@@ -102,18 +132,6 @@ describe( "getSelectionView", () => {
 } );
 
 describe( "BulkEditorContent tab-switch guard", () => {
-	beforeAll( () => {
-		registerStore();
-	} );
-
-	beforeEach( () => {
-		// The store lives in the global registry: reset the guard state so tests stay order-independent.
-		dispatch( STORE_NAME ).setActiveFieldSet( FIELD_SET_SEARCH );
-		dispatch( STORE_NAME ).setHasExternalPendingChanges( false );
-		dispatch( STORE_NAME ).stopEdit();
-		dispatch( STORE_NAME ).clearPendingSwitch();
-	} );
-
 	it( "switches immediately when nothing guards the switch", () => {
 		renderContent();
 
@@ -164,5 +182,58 @@ describe( "BulkEditorContent tab-switch guard", () => {
 
 		expect( screen.getByRole( "tab", { name: "Social appearance" } ) ).toHaveAttribute( "aria-selected", "true" );
 		await waitFor( () => expect( screen.getByTestId( "slot-probe" ) ).toHaveAttribute( "data-open", "false" ) );
+	} );
+} );
+
+describe( "BulkEditorContent pending changes across query changes", () => {
+	it( "keeps the action band expanded across filter and search changes while an external plugin reports pending changes", () => {
+		const { container } = renderContent();
+
+		// Collapsed while nothing is pending or selected.
+		expectBandExpanded( container, false );
+
+		setExternalPending( true );
+		expectBandExpanded( container, true );
+
+		// A filter or search resets the selection, but the pending suggestions must stay actionable.
+		// The block bodies keep act() synchronous: the dispatch returns a promise, which a concise body would
+		// hand to act and turn it into an unawaited async scope.
+		act( () => {
+			dispatch( STORE_NAME ).setStatuses( [ "draft" ] );
+		} );
+		expectBandExpanded( container, true );
+
+		act( () => {
+			dispatch( STORE_NAME ).setSearch( "seo" );
+		} );
+		expectBandExpanded( container, true );
+
+		// A filter is not a guarded view switch: the pending-changes slot stays closed.
+		expect( screen.getByTestId( "slot-probe" ) ).toHaveAttribute( "data-open", "false" );
+	} );
+
+	it( "keeps pending manual edits and their action bar when a filter or search is applied", () => {
+		const { container } = renderContent();
+
+		act( () => {
+			dispatch( STORE_NAME ).startEdit( { id: 1, draft: { seoTitle: "Draft title" } } );
+		} );
+		expectBandExpanded( container, true );
+
+		act( () => {
+			dispatch( STORE_NAME ).setStatuses( [ "draft" ] );
+		} );
+		act( () => {
+			dispatch( STORE_NAME ).setSearch( "seo" );
+		} );
+
+		// The edit survives the query changes: the summary, the batch actions and the expanded band all remain.
+		expect( screen.getByText( "1 row with unsaved changes" ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Save edits" } ) ).toBeInTheDocument();
+		expect( screen.getByRole( "button", { name: "Cancel edits" } ) ).toBeInTheDocument();
+		expectBandExpanded( container, true );
+
+		// No unsaved-changes modal: filters never request a guarded switch.
+		expect( screen.queryByRole( "dialog" ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/js/tests/bulk-editor/bulk-editor-content.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-content.test.js
@@ -58,6 +58,7 @@ beforeEach( () => {
 	dispatch( STORE_NAME ).clearPendingSwitch();
 	dispatch( STORE_NAME ).setSearch( "" );
 	dispatch( STORE_NAME ).setStatuses( [] );
+	dispatch( STORE_NAME ).setPage( 1 );
 } );
 
 /**
@@ -186,7 +187,7 @@ describe( "BulkEditorContent tab-switch guard", () => {
 } );
 
 describe( "BulkEditorContent pending changes across query changes", () => {
-	it( "keeps the action band expanded across filter and search changes while an external plugin reports pending changes", () => {
+	it( "keeps the action band expanded across filter, search and page changes while an external plugin reports pending changes", () => {
 		const { container } = renderContent();
 
 		// Collapsed while nothing is pending or selected.
@@ -195,7 +196,7 @@ describe( "BulkEditorContent pending changes across query changes", () => {
 		setExternalPending( true );
 		expectBandExpanded( container, true );
 
-		// A filter or search resets the selection, but the pending suggestions must stay actionable.
+		// A filter, search or page change resets the selection, but the pending suggestions must stay actionable.
 		// The block bodies keep act() synchronous: the dispatch returns a promise, which a concise body would
 		// hand to act and turn it into an unawaited async scope.
 		act( () => {
@@ -208,7 +209,12 @@ describe( "BulkEditorContent pending changes across query changes", () => {
 		} );
 		expectBandExpanded( container, true );
 
-		// A filter is not a guarded view switch: the pending-changes slot stays closed.
+		act( () => {
+			dispatch( STORE_NAME ).setPage( 2 );
+		} );
+		expectBandExpanded( container, true );
+
+		// A filter/search/page change is not a guarded view switch: the pending-changes slot stays closed.
 		expect( screen.getByTestId( "slot-probe" ) ).toHaveAttribute( "data-open", "false" );
 	} );
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Keeps pending AI suggestions and manual edits actionable when a filter is selected.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Have Premium enabled
* Go to the bulk editor, select a couple of posts with keywords to be generated with SEO titles or meta descriptions
* When the suggestions arrive, dont save them
* Select `draft` from the filter
  * or select a different page from the pagination counter
  * or search for a post that's not one of the posts that you generated SEO data for
* Confirm that you still see the `Apply all | Discard all` bar, even if the posts you generated suggestion for are not visible
  * Without this PR, the bar is not visible
* Selecting `Apply all` actually applies the generated suggestion. Refresh the page to confirm
* Now do the same, but instead of generating AI suggestions, attempt a couple of manual editing without saving them
  * When on a different filtered value (or paginated page, or searched item), you still see the `Save edits | Cancel edits` topbar, which is still functional
  * This was already happening without this PR, but we want to regression test it.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
