### PR TITLE
fix(bulk-editor): wrap long words in the value cell instead of overflowing

### DIFF
--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -74,6 +74,11 @@
 	max-width: 576px;
 }
 
+/* Wrap long unbroken words within its column instead of overflowing into the next. */
+.yst-root .yst-bulk-editor-cell-value {
+	overflow-wrap: break-word;
+}
+
 /* The row title links to the post editor. */
 .yst-root .yst-bulk-editor-title-link,
 .yst-root .yst-bulk-editor-title-link:visited {

--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -74,7 +74,7 @@
 	max-width: 576px;
 }
 
-/* Wrap long unbroken words within its column instead of overflowing into the next. */
+/* Wrap long unbroken words within the column instead of overflowing into the next. */
 .yst-root .yst-bulk-editor-cell-value {
 	overflow-wrap: break-word;
 }

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -91,7 +91,7 @@ export const BulkEditorRow = ( { item, fields, fieldSetId, isSelected, onToggleR
 
 								if ( ! openFields.includes( field.key ) ) {
 									return (
-										<Table.Cell key={ field.key } className={ getFieldTextClasses( field.key, false ) }>
+										<Table.Cell key={ field.key } className={ `yst-bulk-editor-cell-value ${ getFieldTextClasses( field.key, false ) }` }>
 											{ item[ field.key ] }
 										</Table.Cell>
 									);

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -48,6 +48,7 @@ describe( "BulkEditorTable", () => {
 		// Row data for the Search field set.
 		expect( screen.getByText( "What Is SEO? Complete Guide" ) ).toBeInTheDocument();
 		expect( screen.getByText( "Learn what SEO is." ) ).toBeInTheDocument();
+		expect( screen.getByText( "What Is SEO? Complete Guide" ).closest( "td" ) ).toHaveClass( "yst-bulk-editor-cell-value" );
 	} );
 
 	it( "renders the Social field set columns and values", () => {

--- a/packages/js/tests/bulk-editor/bulk-editor-table.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-table.test.js
@@ -48,7 +48,7 @@ describe( "BulkEditorTable", () => {
 		// Row data for the Search field set.
 		expect( screen.getByText( "What Is SEO? Complete Guide" ) ).toBeInTheDocument();
 		expect( screen.getByText( "Learn what SEO is." ) ).toBeInTheDocument();
-		expect( screen.getByText( "What Is SEO? Complete Guide" ).closest( "td" ) ).toHaveClass( "yst-bulk-editor-cell-value" );
+		expect( screen.getByRole( "cell", { name: "What Is SEO? Complete Guide" } ) ).toHaveClass( "yst-bulk-editor-cell-value" );
 	} );
 
 	it( "renders the Social field set columns and values", () => {


### PR DESCRIPTION
## Context

Fixes plugins-automated-testing#3073: in the bulk editor, a long unbroken word wraps correctly inside the edit textarea, but once saved the read-only value cell did not wrap and overflowed across the neighbouring columns (Meta description, Actions).

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a long unbroken word overflowed into the next column in the bulk editor after saving.

## Relevant technical choices:

* **Value-cell wrapping** — the read-only field value cell now carries a `yst-bulk-editor-cell-value` hook, styled with `overflow-wrap: break-word` in `bulk-editor-page.css`, so long words wrap within their column like the edit textarea already does.
* **Why CSS, not a utility class** — `yst-break-words` is not part of the compiled utility CSS the page loads, so the rule lives in `bulk-editor-page.css` (which is loaded), following its existing `.yst-root .yst-bulk-editor-*` hook convention.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Open **Yoast SEO → Tools → Bulk editor → Posts**.
2. Click **Edit** on a row and type a very long word with no spaces (e.g. `Supercalifragilisticexpialidocioushippopotomonstrosesquippedaliophobia`) into the **SEO title** field. Note it wraps inside the field.
3. Click the row's **Save**.
4. The saved value wraps within the **SEO title** column and no longer overflows into the Meta description / Actions columns.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor table's read-only value cells (Search and Social field sets) — display wrapping only.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3073

