### PR TITLE
fix(bulk-editor): load the HelpScout support beacon on the bulk editor page

### DIFF
--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -102,7 +102,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 						<BulkEditorNavMenu { ...menuProps } />
 					</SidebarNavigation.Sidebar>
 				</aside>
-				<div className="yst-grow yst-max-w-page yst-min-w-0">
+				<div className="yst-grow yst-max-w-page yst-min-w-0 yst-mb-8">
 					<Paper as="main">
 						<BulkEditorPageHeader title={ title } description={ description } />
 						<BulkEditorContent

--- a/src/integrations/admin/helpscout-beacon.php
+++ b/src/integrations/admin/helpscout-beacon.php
@@ -6,6 +6,7 @@ use WPSEO_Addon_Manager;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Tracking_Server_Data;
 use WPSEO_Utils;
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\User_Can_Manage_Wpseo_Options_Conditional;
 use Yoast\WP\SEO\Config\Migration_Status;
@@ -99,6 +100,7 @@ class HelpScout_Beacon implements Integration_Interface {
 		Plans_Page_Integration::PAGE,
 		'wpseo_workouts',
 		Integrations_Page::PAGE,
+		Bulk_Editor_Integration::PAGE,
 	];
 
 	/**

--- a/tests/Unit/Integrations/Admin/HelpScout_Beacon_Test.php
+++ b/tests/Unit/Integrations/Admin/HelpScout_Beacon_Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Mockery;
+use WPSEO_Addon_Manager;
+use WPSEO_Admin_Asset_Manager;
+use Yoast\WP\SEO\Bulk_Editor\User_Interface\Bulk_Editor_Integration;
+use Yoast\WP\SEO\Config\Migration_Status;
+use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Integrations\Admin\HelpScout_Beacon;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class HelpScout_Beacon_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\HelpScout_Beacon
+ */
+final class HelpScout_Beacon_Test extends TestCase {
+
+	/**
+	 * Tests that the bulk editor is one of the pages the support beacon is shown on.
+	 *
+	 * @covers ::__construct
+	 *
+	 * @return void
+	 */
+	public function test_beacon_is_enabled_on_the_bulk_editor_page() {
+		$options       = Mockery::mock( Options_Helper::class );
+		$asset_manager = Mockery::mock( WPSEO_Admin_Asset_Manager::class );
+		$migration     = Mockery::mock( Migration_Status::class );
+		$addon_manager = Mockery::mock( WPSEO_Addon_Manager::class );
+
+		$options->allows( 'get' )->with( 'tracking' )->andReturn( true );
+		$addon_manager->allows( 'has_active_addons' )->andReturn( false );
+
+		$instance = new HelpScout_Beacon( $options, $asset_manager, $migration, $addon_manager );
+
+		$this->assertArrayHasKey( Bulk_Editor_Integration::PAGE, $this->getPropertyValue( $instance, 'pages_ids' ) );
+	}
+}


### PR DESCRIPTION
## Context

Fixes plugins-automated-testing#3074: the HelpScout support beacon (the "Chat with us" widget shown on every other Yoast SEO admin page) was not loaded on the bulk editor page. The beacon only renders on an allowlist of admin pages, and the bulk editor page was missing from that list.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the HelpScout support beacon was missing on the bulk editor page.

## Relevant technical choices:

* **Beacon page allowlist** — added `Bulk_Editor_Integration::PAGE` (`wpseo_page_bulk_edit`) to `HelpScout_Beacon::$base_pages`, so `is_beacon_page()` enqueues the beacon on the bulk editor like every other Yoast admin page. No constructor/DI change.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Open **Yoast SEO → Tools → Bulk editor** (any content type).
2. Confirm the HelpScout support beacon (the "Chat with us" / help widget, bottom-right) is present — the same one shown on other Yoast SEO admin pages (Dashboard, Settings, Tools, etc.).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The HelpScout beacon page allowlist (`HelpScout_Beacon`) — one page added; other pages unaffected.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3074
