### PR TITLE
Exclude attachments from the bulk editor

### DIFF
--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -47,10 +47,14 @@ class Content_Types_Collector {
 	 * @return Content_Types_List The content types in a list.
 	 */
 	public function get_content_types(): Content_Types_List {
-		$content_types_list = new Content_Types_List();
-		$post_types         = $this->post_type_helper->get_indexable_post_type_objects();
+		$content_types_list  = new Content_Types_List();
+		$post_types          = $this->post_type_helper->get_indexable_post_type_objects();
+		$excluded_post_types = $this->get_excluded_post_types();
 
 		foreach ( $post_types as $post_type_object ) {
+			if ( \in_array( $post_type_object->name, $excluded_post_types, true ) ) {
+				continue;
+			}
 			if ( $post_type_object->show_ui === false ) {
 				continue;
 			}
@@ -64,5 +68,26 @@ class Content_Types_Collector {
 		}
 
 		return $content_types_list;
+	}
+
+	/**
+	 * Returns the post types that are excluded from the bulk editor.
+	 *
+	 * @return array<string> The post types excluded from the bulk editor.
+	 */
+	private function get_excluded_post_types(): array {
+		/**
+		 * Filter: 'wpseo_bulk_editor_excluded_post_types' - Allows excluding post types from the bulk editor.
+		 *
+		 * @param array<string> $excluded_post_types The post types excluded from the bulk editor.
+		 */
+		$excluded_post_types = \apply_filters( 'wpseo_bulk_editor_excluded_post_types', [ 'attachment' ] );
+
+		// Failsafe, to always make sure that the filtered value is an array.
+		if ( ! \is_array( $excluded_post_types ) ) {
+			return [ 'attachment' ];
+		}
+
+		return $excluded_post_types;
 	}
 }

--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -79,7 +79,7 @@ class Content_Types_Collector {
 		/**
 		 * Filter: 'wpseo_bulk_editor_excluded_post_types' - Allows excluding post types from the bulk editor.
 		 *
-		 * @param array<string> $excluded_post_types The post types excluded from the bulk editor.
+		 * @param array<string> $excluded_post_types The list of post types excluded from the bulk editor. Defaults to including the attachment post type.
 		 */
 		$excluded_post_types = \apply_filters( 'wpseo_bulk_editor_excluded_post_types', [ 'attachment' ] );
 

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -4,6 +4,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Content_Types\Content_Types_Collector;
 
+use Brain\Monkey\Filters;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Content_Types\Content_Types_List;
 
 /**
@@ -81,6 +82,95 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 	}
 
 	/**
+	 * Tests that post types added via the exclusion filter are excluded.
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types_excludes_filtered_post_types() {
+		$this->post_type_helper
+			->expects( 'get_indexable_post_type_objects' )
+			->once()
+			->andReturn(
+				[
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'book',
+						'label'   => 'Books',
+						'labels'  => (object) [ 'singular_name' => 'Book' ],
+						'show_ui' => true,
+					],
+				],
+			);
+
+		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
+			->once()
+			->with( [ 'attachment' ] )
+			->andReturn( [ 'attachment', 'book' ] );
+
+		$this->assertSame(
+			[
+				[
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
+				],
+			],
+			$this->instance->get_content_types()->to_array(),
+		);
+	}
+
+	/**
+	 * Tests that the default exclusions apply when the filter returns a non-array.
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types_falls_back_to_default_exclusions_when_filter_returns_non_array() {
+		$this->post_type_helper
+			->expects( 'get_indexable_post_type_objects' )
+			->once()
+			->andReturn(
+				[
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'attachment',
+						'label'   => 'Media',
+						'labels'  => (object) [ 'singular_name' => 'Media item' ],
+						'show_ui' => true,
+					],
+				],
+			);
+
+		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
+			->once()
+			->andReturn( 'attachment' );
+
+		$this->assertSame(
+			[
+				[
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
+				],
+			],
+			$this->instance->get_content_types()->to_array(),
+		);
+	}
+
+	/**
 	 * Data provider for test_get_content_types.
 	 *
 	 * @return array<string, array<string, array<object|array<string, string>>>>
@@ -128,6 +218,29 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 						'label'   => 'Hidden',
 						'labels'  => (object) [ 'singular_name' => 'Hidden item' ],
 						'show_ui' => false,
+					],
+				],
+				'expected'                    => [
+					[
+						'name'          => 'post',
+						'label'         => 'Posts',
+						'singularLabel' => 'Post',
+					],
+				],
+			],
+			'attachment post type is skipped' => [
+				'indexable_post_type_objects' => [
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'attachment',
+						'label'   => 'Media',
+						'labels'  => (object) [ 'singular_name' => 'Media item' ],
+						'show_ui' => true,
 					],
 				],
 				'expected'                    => [

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -34,6 +34,11 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 
 		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
 
+		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
+			->once()
+			->with( [ 'attachment' ] )
+			->andReturnFirstArg();
+
 		$content_types_list = $this->instance->get_content_types();
 
 		$this->assertInstanceOf( Content_Types_List::class, $content_types_list );
@@ -68,6 +73,11 @@ final class Get_Content_Types_Test extends Abstract_Content_Types_Collector_Test
 
 		$this->access_checker->expects( 'can_edit_any' )->with( 'post' )->andReturnTrue();
 		$this->access_checker->expects( 'can_edit_any' )->with( 'page' )->andReturnFalse();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
+			->once()
+			->with( [ 'attachment' ] )
+			->andReturnFirstArg();
 
 		$this->assertSame(
 			[


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Removes attachments (Media) from the bulk editor.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Test the fix
* Yoast SEO → Settings → Content types → Media pages and toggle Enable media pages on (this makes attachments public)
* Go to Yoast SEO → Bulk editor.
* Confirm Media is no longer listed in the sidebar.
  * Without this PR, it was 

#### Test the filter
Test the filter (optional)
1. Add this snippet via a mu-plugin or your theme's functions.php:
```
add_filter(
    'wpseo_bulk_editor_excluded_post_types',
    static function ( $excluded_post_types ) {
        $excluded_post_types[] = 'page';
        return $excluded_post_types;
    }
);
```
3. Reload the Bulk editor and confirm Pages is now also hidden from the sidebar.
4. Remove the snippet and confirm Pages reappears.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
