### PR TITLE
fix: self-heal MyYoast registration data drifted from the server

### DIFF
--- a/src/myyoast-client/infrastructure/registration/client-registration.php
+++ b/src/myyoast-client/infrastructure/registration/client-registration.php
@@ -279,9 +279,15 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 		}
 
 		$body = $result->get_body();
-		if ( ! \is_array( $body ) ) {
+		if ( ! \is_array( $body ) || empty( $body['client_id'] ) ) {
 			throw new Registration_Failed_Exception( 'Invalid response from registration endpoint.' );
 		}
+
+		// The server is authoritative: heal local data that has drifted from it (for example when a
+		// site migration rewrote the stored redirect URIs directly in the database, bypassing the
+		// registration round-trip). The GET body carries no RAT, so store_credentials preserves the
+		// stored one.
+		$this->store_credentials( $body );
 
 		return $body;
 	}
@@ -537,16 +543,31 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 	/**
 	 * Stores the DCR response credentials securely.
 	 *
+	 * A registration read (RFC 7592 GET) response carries no registration access token; when the
+	 * body omits the RAT, the existing stored RAT is preserved rather than overwritten with an
+	 * empty value.
+	 *
 	 * @param array<string, string|array<string>> $response_body The parsed DCR response body.
 	 *
 	 * @return Registered_Client The stored credentials.
 	 */
 	private function store_credentials( array $response_body ): Registered_Client {
-		$option_key    = $this->get_option_key();
-		$encrypted_rat = $this->encryption->encrypt(
-			( $response_body['registration_access_token'] ?? '' ),
-			self::ENCRYPTION_CONTEXT,
-		);
+		$option_key = $this->get_option_key();
+		$existing   = $this->get_registered_client();
+
+		// The RFC 7592 GET response never re-sends the RAT, so a missing key means "keep the stored
+		// one" — encrypting the absent value would brick every future management call. Only a body
+		// that explicitly carries a RAT (DCR / PUT) replaces it.
+		if ( \array_key_exists( 'registration_access_token', $response_body ) ) {
+			$rat           = $response_body['registration_access_token'];
+			$encrypted_rat = $this->encryption->encrypt( $rat, self::ENCRYPTION_CONTEXT );
+		}
+		else {
+			// Reuse the already-decrypted RAT and its stored ciphertext rather than re-encrypting.
+			$rat           = ( $existing !== null ) ? $existing->get_registration_access_token() : '';
+			$stored        = \get_option( $option_key, [] );
+			$encrypted_rat = ( \is_array( $stored ) ) ? ( $stored['encrypted_rat'] ?? '' ) : '';
+		}
 
 		// Strip the RAT from metadata — it is stored encrypted separately.
 		$metadata = $response_body;
@@ -556,7 +577,6 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 		// reset it for a fresh registration: a new client_id means the redirect URIs must be
 		// re-validated from scratch. Always prune to the new redirect-URI set so a removed URI loses
 		// its verification and an added one starts unverified.
-		$existing       = $this->get_registered_client();
 		$validated_uris = [];
 		if ( $existing !== null && $existing->get_client_id() === $response_body['client_id'] ) {
 			$new_redirect_uris = ( $metadata['redirect_uris'] ?? [] );
@@ -579,7 +599,7 @@ class Client_Registration implements Client_Registration_Interface, LoggerAwareI
 
 		$this->cached_registered_clients[ $option_key ] = new Registered_Client(
 			$response_body['client_id'],
-			( $response_body['registration_access_token'] ?? '' ),
+			$rat,
 			( $response_body['registration_client_uri'] ?? '' ),
 			$metadata,
 			$validated_uris,

--- a/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
@@ -921,8 +921,8 @@ final class Client_Registration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_read_registration_heals_drifted_redirect_uris_and_preserves_rat() {
-		$old_uri = 'https://induction-buttons-seemed-blessed.trycloudflare.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
-		$new_uri = 'https://shoe-committed-mumbai-incorporate.trycloudflare.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
+		$old_uri = 'https://old.example.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
+		$new_uri = 'https://new.example.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
 
 		// Local drifted to the migrated URL (search-replace rewrote it in the DB) and marked verified.
 		Functions\expect( 'get_option' )

--- a/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Registration/Client_Registration_Test.php
@@ -911,6 +911,76 @@ final class Client_Registration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that a successful read heals drifted local redirect URIs from the authoritative server
+	 * body — the site-migration scenario where a database search-replace rewrote the stored URIs
+	 * without going through the registration round-trip — while preserving the stored RAT.
+	 *
+	 * @covers ::read_registration
+	 * @covers ::store_credentials
+	 *
+	 * @return void
+	 */
+	public function test_read_registration_heals_drifted_redirect_uris_and_preserves_rat() {
+		$old_uri = 'https://induction-buttons-seemed-blessed.trycloudflare.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
+		$new_uri = 'https://shoe-committed-mumbai-incorporate.trycloudflare.com/wp-admin/admin-post.php?action=yoast_myyoast_oauth_callback';
+
+		// Local drifted to the migrated URL (search-replace rewrote it in the DB) and marked verified.
+		Functions\expect( 'get_option' )
+			->with( self::OPTION_KEY, Mockery::any() )
+			->andReturn(
+				[
+					'client_id'               => 'cid',
+					'encrypted_rat'           => 'encrypted-rat',
+					'registration_client_uri' => 'https://my.yoast.com/api/oauth/reg/cid',
+					'metadata'                => [ 'redirect_uris' => [ $new_uri ] ],
+					'validated_uris'          => [ $new_uri ],
+				],
+			);
+
+		$this->encryption->expects( 'decrypt' )->with( 'encrypted-rat', Mockery::any() )->andReturn( 'decrypted-rat' );
+		// The server body carries no RAT, so the stored one must be preserved — never re-encrypted.
+		$this->encryption->expects( 'encrypt' )->never();
+
+		// The server still holds the pre-migration URL — that is the authority.
+		$this->http_client
+			->expects( 'authenticated_request' )
+			->once()
+			->with( 'GET', Mockery::any(), Mockery::any(), Mockery::any(), Mockery::any() )
+			->andReturn(
+				new HTTP_Response(
+					200,
+					[],
+					[
+						'client_id'                => 'cid',
+						'registration_client_uri'  => 'https://my.yoast.com/api/oauth/reg/cid',
+						'redirect_uris'            => [ $old_uri ],
+					],
+				),
+			);
+
+		// Local is rewritten to the server's URL, the RAT is kept, and the stale verification of the
+		// migrated URL is pruned (the server no longer lists it).
+		Functions\expect( 'update_option' )
+			->once()
+			->with(
+				self::OPTION_KEY,
+				Mockery::on(
+					static function ( $option ) use ( $old_uri ) {
+						return ( $option['metadata']['redirect_uris'] ?? null ) === [ $old_uri ]
+							&& ( $option['encrypted_rat'] ?? null ) === 'encrypted-rat'
+							&& ( $option['validated_uris'] ?? null ) === [];
+					},
+				),
+				false,
+			)
+			->andReturn( true );
+
+		$body = $this->instance->read_registration();
+
+		$this->assertSame( [ $old_uri ], $body['redirect_uris'] );
+	}
+
+	/**
 	 * Tests that the typed registration exceptions are still caught as Registration_Failed_Exception.
 	 *
 	 * @covers \Yoast\WP\SEO\MyYoast_Client\Application\Exceptions\Rate_Limited_Exception


### PR DESCRIPTION

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When a site is migrated with `wp db search-replace`, the tool rewrites the old site URL to the new one across `wp_options` — including *inside* the serialized `wpseo_myyoast_client_registration_*` option, where the registered client's `metadata.redirect_uris` live. This mutates our stored registration blob directly, bypassing the OAuth registration round-trip. The result is a three-way desync: local now holds the **new** URL, MyYoast (the authoritative server) still holds the **old** URL, and because `redirect_uris_match` compares local against "what the site would register today" it reports `true` — so the connection card looks perfectly synced while OAuth callbacks silently fail, since MyYoast only whitelists the old URL.

MyYoast is the source of truth, so this heals the local copy back to it rather than pushing the (accidentally rewritten) value up.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes an unreleased bug where the stored MyYoast connection kept redirect URLs that no longer matched the server after a site migration rewrote them directly in the database.

## Relevant technical choices:

* On a successful RFC 7592 registration read (`read_registration`), the returned body is now stored back into local so any drifted fields (`redirect_uris`, `registration_client_uri`, …) are healed from the authoritative server copy. This read is already auto-fired (throttled to once per hour) on the integrations page and via `wp yoast auth refresh-status`, so a migrated site self-heals on the next page load with no user action.
* The 7592 GET response carries no registration access token (RAT), so `store_credentials` now preserves the stored RAT and its ciphertext when the body omits it, instead of encrypting an empty string — which would otherwise brick every future management call and cascade into the registration being forgotten.
* `read_registration` keeps returning `array`, so the port interface and its callers (`refresh_registration_status`, the CLI) are unchanged — the heal is a side effect.
* After healing, `redirect_uris_match` correctly flips to `false`, surfacing the genuine "site URL changed" state so the user can push the real new URL up via the existing PUT resync.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Preconditions: a WordPress site connected to MyYoast (registration completed), so `wp yoast auth status` shows `registered: yes`.
* Simulate a migration that rewrites the stored URL locally without telling the server: change the site's URL (e.g. via a tunnel/`WP_HOME`/`WP_SITEURL` change, or `wp db search-replace '<old-url>' '<new-url>'`).
* Confirm the desync first: in the database, look for the `wpseo_myyoast_client_registration_*` option and verify that it holds a redirect_uri value for your new URL.
* Now trigger the heal: reload the WP SEO integrations page (or run `wp yoast auth refresh-status` once — note it is throttled to once per hour on the integrations page).
* Expected: `initialStatus.redirect_uris` is rewritten back to the URL known by MyYoast, `redirect_uris_match` becomes `false`, and the connection card prompts to reconnect. The connection is still registered (same `client_id`), and subsequent management calls still work (RAT preserved).


#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [x] Changes should be tested on multisite
<!-- Registration data is stored per blog (issuer key + blog id); worth a sanity check that the heal targets the correct subsite option on multisite. -->

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

*

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The MyYoast connection (OAuth client registration) on the WP SEO integrations page, and the `wp yoast auth refresh-status` WP-CLI command. Smoke test the AI features using the OAuth flow. No other subsystem is touched.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/3080