### PR TITLE
feat: disable tabs and nav during AI generation to prevent mid-flight navigation

### DIFF
--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -58,6 +58,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 	const isPremium = useSelect( ( select ) => select( STORE_NAME ).selectPreference( "isPremium", false ), [] );
 	// Free's unsaved inline edits trigger the native unload guard; Premium handles its own pending changes and unload prompts.
 	const hasUnsavedEdits = useSelect( ( select ) => Object.keys( select( STORE_NAME ).selectEditingRows() ).length > 0, [] );
+	const isGenerating = useSelect( ( select ) => select( STORE_NAME ).selectHasExternalGeneration(), [] );
 	const { requestSwitch } = useDispatch( STORE_NAME );
 
 	// The browser's native confirm dialog is the only guard available for refresh/close/back; the in-app links use
@@ -107,6 +108,7 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 		contentTypes,
 		onChange: onChangeContentType,
 		backToToolsUrl,
+		disabled: isGenerating,
 		onNavigate,
 		logoHref,
 		isPremium,

--- a/packages/js/src/bulk-editor/components/back-to-tools-link.js
+++ b/packages/js/src/bulk-editor/components/back-to-tools-link.js
@@ -2,26 +2,38 @@ import ArrowLeftIcon from "@heroicons/react/solid/ArrowLeftIcon";
 import { useCallback } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 import { Link } from "@yoast/ui-library";
+import classNames from "classnames";
 import { noop } from "lodash";
 
 /**
  * The "Back to Tools" link shown above the bulk editor sub-navigation. The click is routed through onNavigate so a
  * hard page navigation can be guarded when there are unsaved edits.
  *
- * @param {Object}   props              The props.
- * @param {string}   props.href         The URL of the Tools page (provided via localized data by Free-FE 1).
+ * @param {Object}   props                   The props.
+ * @param {string}   props.href              The URL of the Tools page (provided via localized data by Free-FE 1).
+ * @param {boolean}  [props.disabled=false]  Whether the link is disabled (e.g. during AI generation).
  * @param {Function} [props.onNavigate=noop] Called with (event, href) when the link is clicked, to guard the navigation.
  *
  * @returns {JSX.Element} The link.
  */
-export const BackToToolsLink = ( { href, onNavigate = noop } ) => {
-	const handleClick = useCallback( ( event ) => onNavigate( event, href ), [ onNavigate, href ] );
+export const BackToToolsLink = ( { href, disabled = false, onNavigate = noop } ) => {
+	const handleClick = useCallback( ( event ) => {
+		if ( disabled ) {
+			event.preventDefault();
+			return;
+		}
+		onNavigate( event, href );
+	}, [ disabled, onNavigate, href ] );
 
 	return (
 		<Link
 			href={ href }
 			onClick={ handleClick }
-			className="yst-flex yst-items-center yst-gap-1.5 yst-rounded-md yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-no-underline yst-text-slate-800 hover:yst-bg-slate-50 hover:yst-text-slate-900"
+			aria-disabled={ disabled }
+			className={ classNames(
+				"yst-flex yst-items-center yst-gap-1.5 yst-rounded-md yst-px-3 yst-py-2 yst-text-sm yst-font-medium yst-no-underline yst-text-slate-800 hover:yst-bg-slate-50 hover:yst-text-slate-900",
+				{ "yst-opacity-50 yst-cursor-not-allowed hover:yst-bg-transparent hover:yst-text-slate-800": disabled }
+			) }
 		>
 			<ArrowLeftIcon className="yst-w-4 yst-h-4 yst-text-slate-400 rtl:yst-rotate-180" aria-hidden="true" />
 			{ __( "Back to Tools", "wordpress-seo" ) }

--- a/packages/js/src/bulk-editor/components/bulk-editor-content.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-content.js
@@ -149,6 +149,7 @@ export const BulkEditorContent = ( { dataProvider, remoteDataProvider, contentTy
 				<BulkEditorTabs
 					tabs={ tabs }
 					activeTab={ activeFieldSet }
+					disabled={ hasExternalGeneration }
 					onChange={ onChangeTab }
 					label={ __( "Bulk editor views", "wordpress-seo" ) }
 				/>

--- a/packages/js/src/bulk-editor/components/bulk-editor-nav.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-nav.js
@@ -2,6 +2,7 @@ import DuplicateIcon from "@heroicons/react/outline/DuplicateIcon";
 import { useCallback } from "@wordpress/element";
 import { __, _n, sprintf } from "@wordpress/i18n";
 import { Link, SidebarNavigation, useSvgAria } from "@yoast/ui-library";
+import classNames from "classnames";
 import { noop } from "lodash";
 import { YoastLogo } from "../../shared-admin/components";
 import { BackToToolsLink } from "./back-to-tools-link";
@@ -20,11 +21,12 @@ import { BackToToolsLink } from "./back-to-tools-link";
  *
  * @param {Object}                props             The props.
  * @param {BulkEditorContentType} props.contentType The content type.
+ * @param {boolean}               props.disabled    Whether the item is disabled.
  * @param {Function}              props.onChange    Called with the content type id when selected.
  *
  * @returns {JSX.Element} The item.
  */
-const ContentTypeItem = ( { contentType, onChange } ) => {
+const ContentTypeItem = ( { contentType, disabled, onChange } ) => {
 	const handleClick = useCallback( () => onChange( contentType.id ), [ onChange, contentType.id ] );
 
 	return (
@@ -34,8 +36,9 @@ const ContentTypeItem = ( { contentType, onChange } ) => {
 			pathProp="value"
 			value={ contentType.id }
 			label={ contentType.label }
+			disabled={ disabled }
 			onClick={ handleClick }
-			className="yst-w-full"
+			className={ classNames( "yst-w-full", { "yst-opacity-50": disabled } ) }
 		/>
 	);
 };
@@ -48,20 +51,28 @@ const ContentTypeItem = ( { contentType, onChange } ) => {
  * @param {string}   props.logoHref     Where the logo links to.
  * @param {boolean}  props.isPremium    Whether Premium is active (affects the accessible label).
  * @param {string}   props.idSuffix     Suffix appended to the element id to avoid duplicates.
+ * @param {boolean}  [props.disabled]   Whether the logo link is disabled (e.g. during AI generation).
  * @param {Function} props.onNavigate   Called with (event, href) when the logo is clicked, to guard the navigation.
  *
  * @returns {JSX.Element} The logo link.
  */
-const NavLogo = ( { logoHref, isPremium, idSuffix, onNavigate } ) => {
+const NavLogo = ( { logoHref, isPremium, idSuffix, disabled, onNavigate } ) => {
 	const svgAriaProps = useSvgAria();
-	const handleClick = useCallback( ( event ) => onNavigate( event, logoHref ), [ onNavigate, logoHref ] );
+	const handleClick = useCallback( ( event ) => {
+		if ( disabled ) {
+			event.preventDefault();
+			return;
+		}
+		onNavigate( event, logoHref );
+	}, [ disabled, onNavigate, logoHref ] );
 
 	return (
 		<Link
 			id={ `link-bulk-editor-logo${ idSuffix }` }
 			href={ logoHref }
 			onClick={ handleClick }
-			className="yst-inline-block yst-rounded-md focus:yst-ring-primary-500"
+			aria-disabled={ disabled }
+			className={ classNames( "yst-inline-block yst-rounded-md focus:yst-ring-primary-500", { "yst-opacity-50 yst-cursor-not-allowed": disabled } ) }
 			aria-label={ isPremium ? "Yoast SEO Premium" : "Yoast SEO" }
 		>
 			<YoastLogo className="yst-w-40" { ...svgAriaProps } />
@@ -77,6 +88,7 @@ const NavLogo = ( { logoHref, isPremium, idSuffix, onNavigate } ) => {
  * @param {BulkEditorContentType[]} props.contentTypes   The content types, in display order.
  * @param {Function}                props.onChange       Called with a content type id when one is selected.
  * @param {string}                  props.backToToolsUrl The URL of the Tools page.
+ * @param {boolean}                 [props.disabled]     Whether navigation links and content type items are disabled.
  * @param {Function}                [props.onNavigate=noop]   Called with (event, href) when a hard-navigation link (logo,
  *                                                       Back to Tools) is clicked, to guard the navigation.
  * @param {string}                  [props.logoHref]     Where the Yoast SEO logo links to.
@@ -90,6 +102,7 @@ export const BulkEditorNavMenu = ( {
 	contentTypes,
 	onChange,
 	backToToolsUrl,
+	disabled,
 	onNavigate = noop,
 	logoHref = "/wp-admin/",
 	isPremium = false,
@@ -106,8 +119,8 @@ export const BulkEditorNavMenu = ( {
 
 	return (
 		<div className="yst-space-y-6">
-			<NavLogo logoHref={ logoHref } isPremium={ isPremium } idSuffix={ idSuffix } onNavigate={ onNavigate } />
-			<BackToToolsLink href={ backToToolsUrl } onNavigate={ onNavigate } />
+			<NavLogo logoHref={ logoHref } isPremium={ isPremium } idSuffix={ idSuffix } disabled={ disabled } onNavigate={ onNavigate } />
+			<BackToToolsLink href={ backToToolsUrl } disabled={ disabled } onNavigate={ onNavigate } />
 			<SidebarNavigation.MenuItemWithLimiter
 				id={ `bulk-editor-nav-content-types${ idSuffix }` }
 				label={ __( "Bulk editor", "wordpress-seo" ) }
@@ -119,7 +132,7 @@ export const BulkEditorNavMenu = ( {
 				showLessLabel={ __( "Show less", "wordpress-seo" ) }
 			>
 				{ contentTypes.map( ( contentType ) => (
-					<ContentTypeItem key={ contentType.id } contentType={ contentType } onChange={ onChange } />
+					<ContentTypeItem key={ contentType.id } contentType={ contentType } disabled={ disabled } onChange={ onChange } />
 				) ) }
 			</SidebarNavigation.MenuItemWithLimiter>
 		</div>

--- a/packages/js/src/bulk-editor/components/bulk-editor-tabs.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-tabs.js
@@ -57,12 +57,13 @@ const getNextTabIndex = ( key, currentIndex, tabCount, isRtl ) => {
  * @param {Object}        props           The props.
  * @param {BulkEditorTab} props.tab       The tab definition.
  * @param {boolean}       props.isActive  Whether this tab is active.
+ * @param {boolean}       props.disabled  Whether the tab is disabled.
  * @param {Function}      props.onChange  Called with the tab id when the tab is activated.
  * @param {Function}      props.onKeyDown The shared tablist keydown handler.
  *
  * @returns {JSX.Element} The tab button.
  */
-const Tab = ( { tab, isActive, onChange, onKeyDown } ) => {
+const Tab = ( { tab, isActive, disabled = false, onChange, onKeyDown } ) => {
 	const handleClick = useCallback( () => onChange( tab.id ), [ onChange, tab.id ] );
 
 	return (
@@ -73,6 +74,7 @@ const Tab = ( { tab, isActive, onChange, onKeyDown } ) => {
 			aria-selected={ isActive }
 			aria-controls={ getTabPanelId( tab.id ) }
 			tabIndex={ isActive ? 0 : -1 }
+			disabled={ disabled }
 			onClick={ handleClick }
 			onKeyDown={ onKeyDown }
 			className={ classNames(
@@ -90,18 +92,22 @@ const Tab = ( { tab, isActive, onChange, onKeyDown } ) => {
  *
  * Controlled and store-free.
  *
- * @param {Object}          props           The props.
- * @param {BulkEditorTab[]} props.tabs      The tabs, in display order.
- * @param {string}          props.activeTab The id of the active tab.
- * @param {Function}        props.onChange  Called with a tab id when a tab is activated.
- * @param {string}          props.label     The accessible name for the tab list.
+ * @param {Object}          props             The props.
+ * @param {BulkEditorTab[]} props.tabs        The tabs, in display order.
+ * @param {string}          props.activeTab   The id of the active tab.
+ * @param {boolean}         props.disabled    Whether all tabs are disabled.
+ * @param {Function}        props.onChange    Called with a tab id when a tab is activated.
+ * @param {string}          props.label       The accessible name for the tab list.
  *
  * @returns {JSX.Element} The tab list.
  */
-export const BulkEditorTabs = ( { tabs, activeTab, onChange, label } ) => {
+export const BulkEditorTabs = ( { tabs, activeTab, disabled = false, onChange, label } ) => {
 	const listRef = useRef( null );
 
 	const handleKeyDown = useCallback( ( event ) => {
+		if ( disabled ) {
+			return;
+		}
 		const currentIndex = tabs.findIndex( ( tab ) => tab.id === activeTab );
 		const isRtl = listRef.current ? getComputedStyle( listRef.current ).direction === "rtl" : false;
 		const nextIndex = getNextTabIndex( event.key, currentIndex, tabs.length, isRtl );
@@ -113,7 +119,7 @@ export const BulkEditorTabs = ( { tabs, activeTab, onChange, label } ) => {
 		const nextTab = tabs[ nextIndex ];
 		onChange( nextTab.id );
 		document.getElementById( getTabId( nextTab.id ) )?.focus();
-	}, [ tabs, activeTab, onChange ] );
+	}, [ tabs, activeTab, onChange, disabled ] );
 
 	return (
 		<div ref={ listRef } role="tablist" aria-label={ label } className="yst-flex yst-gap-4">
@@ -122,6 +128,7 @@ export const BulkEditorTabs = ( { tabs, activeTab, onChange, label } ) => {
 					key={ tab.id }
 					tab={ tab }
 					isActive={ tab.id === activeTab }
+					disabled={ disabled }
 					onChange={ onChange }
 					onKeyDown={ handleKeyDown }
 				/>

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -36,7 +36,7 @@ const slice = createSlice( {
  */
 export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 	if ( kind === "navigate" ) {
-		// Clear the deferral before exit so a cancelled navigation can’t leave a pending switch and cause the self-repair to re-trigger.
+		// Clear the deferral before exit so a cancelled navigation can't leave a pending switch and cause the self-repair to re-trigger.
 		dispatch.clearPendingSwitch();
 		// Security: Now, `target` is a server-generated URL (see bulk-editor-integration.php).
 		// If it ever comes from input, it has to be validated to prevent open redirects or malicious URIs.
@@ -60,7 +60,9 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 /**
  * Requests a switch.
  * Defers the request when manual edits are unsaved or an external plugin (Premium AI) reports pending changes.
- * Otherwise, commits immediately. A "navigate" switch uses a URL target and skips current-view checks.
+ * Otherwise, commits immediately. In-app switches ("contentType", "fieldSet", "page") are silently dropped
+ * when already at the target or while external generation is in flight; hard navigation ("navigate") bypasses
+ * both guards because a page unload cancels any in-flight request regardless.
  *
  * @param {PendingSwitch} request The requested switch.
  *
@@ -72,9 +74,14 @@ export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) =>
 		fieldSet: select.selectActiveFieldSet,
 		page: select.selectPage,
 	}[ kind ];
-	// A no-op switch (to the value already shown) needs no guard.
-	if ( currentValueSelector && target === currentValueSelector() ) {
-		return;
+	if ( currentValueSelector ) {
+		// A no-op switch (to the value already shown) needs no guard.
+		if ( target === currentValueSelector() ) {
+			return;
+		}
+		if ( select.selectHasExternalGeneration() ) {
+			return;
+		}
 	}
 	const hasUnsavedEdits = Object.keys( select.selectEditingRows() ).length > 0;
 	if ( hasUnsavedEdits || select.selectHasExternalPendingChanges() ) {

--- a/packages/js/tests/bulk-editor/bulk-editor-nav.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-nav.test.js
@@ -110,4 +110,43 @@ describe( "BulkEditorNavMenu", () => {
 
 		expect( screen.queryByRole( "button", { name: /Show \d+ more/ } ) ).not.toBeInTheDocument();
 	} );
+
+	it( "does not call onChange when disabled and a content type is clicked", () => {
+		const onChange = jest.fn();
+		renderNav( { onChange, disabled: true } );
+
+		fireEvent.click( screen.getByRole( "button", { name: "Posts" } ) );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	it( "does not call onNavigate when disabled and the Back to Tools link is clicked", () => {
+		const onNavigate = jest.fn();
+		renderNav( { onNavigate, disabled: true } );
+
+		fireEvent.click( screen.getByRole( "link", { name: "Back to Tools" } ) );
+
+		expect( onNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( "does not call onNavigate when disabled and the logo is clicked", () => {
+		const onNavigate = jest.fn();
+		renderNav( { onNavigate, disabled: true } );
+
+		fireEvent.click( screen.getByRole( "link", { name: "Yoast SEO" } ) );
+
+		expect( onNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( "marks the Back to Tools link as aria-disabled when disabled", () => {
+		renderNav( { disabled: true } );
+
+		expect( screen.getByRole( "link", { name: "Back to Tools" } ) ).toHaveAttribute( "aria-disabled", "true" );
+	} );
+
+	it( "marks the logo as aria-disabled when disabled", () => {
+		renderNav( { disabled: true } );
+
+		expect( screen.getByRole( "link", { name: "Yoast SEO" } ) ).toHaveAttribute( "aria-disabled", "true" );
+	} );
 } );

--- a/packages/js/tests/bulk-editor/bulk-editor-tabs.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-tabs.test.js
@@ -95,4 +95,22 @@ describe( "BulkEditorTabs", () => {
 		expect( screen.getAllByRole( "tabpanel" ) ).toHaveLength( 1 );
 		expect( screen.getByText( "Social content" ) ).not.toBeVisible();
 	} );
+
+	it( "ignores clicks when disabled", () => {
+		const onChange = jest.fn();
+		render( <BulkEditorTabs tabs={ tabs } activeTab="search" disabled={ true } onChange={ onChange } label="Bulk editor tabs" /> );
+
+		fireEvent.click( screen.getByRole( "tab", { name: "Social appearance" } ) );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
+
+	it( "ignores arrow-key navigation when disabled", () => {
+		const onChange = jest.fn();
+		render( <BulkEditorTabs tabs={ tabs } activeTab="search" disabled={ true } onChange={ onChange } label="Bulk editor tabs" /> );
+
+		fireEvent.keyDown( screen.getByRole( "tab", { name: "Search appearance" } ), { key: "ArrowRight" } );
+
+		expect( onChange ).not.toHaveBeenCalled();
+	} );
 } );

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -26,13 +26,14 @@ describe( "pendingSwitch slice", () => {
 } );
 
 describe( "requestSwitch thunk", () => {
-	const DEFAULT_STATE = { editingRows: {}, hasExternalPendingChanges: false, activeContentType: "", activeFieldSet: "search", page: 1 };
+	const DEFAULT_STATE = { editingRows: {}, hasExternalPendingChanges: false, hasExternalGeneration: false, activeContentType: "", activeFieldSet: "search", page: 1 };
 	const makeThunkArgs = ( overrides = {} ) => {
 		const state = { ...DEFAULT_STATE, ...overrides };
 		return {
 			select: {
 				selectEditingRows: () => state.editingRows,
 				selectHasExternalPendingChanges: () => state.hasExternalPendingChanges,
+				selectHasExternalGeneration: () => state.hasExternalGeneration,
 				selectActiveContentTypeName: () => state.activeContentType,
 				selectActiveFieldSet: () => state.activeFieldSet,
 				selectPage: () => state.page,
@@ -99,6 +100,22 @@ describe( "requestSwitch thunk", () => {
 		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
 	} );
 
+	it( "commits a navigate switch straight away even while external generation is in flight", () => {
+		const args = makeThunkArgs( { hasExternalGeneration: true } );
+		requestSwitch( { kind: "navigate", target: "https://example.test/tools" } )( args );
+
+		expect( args.dispatch.commitSwitch ).toHaveBeenCalledWith( { kind: "navigate", target: "https://example.test/tools" } );
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "silently no-ops an in-app switch while external generation is in flight", () => {
+		const args = makeThunkArgs( { hasExternalGeneration: true } );
+		requestSwitch( { kind: "contentType", target: "product" } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
 	it( "commits a page switch straight away when nothing guards it", () => {
 		const args = makeThunkArgs( { page: 1 } );
 		requestSwitch( { kind: "page", target: 2 } )( args );
@@ -120,6 +137,14 @@ describe( "requestSwitch thunk", () => {
 		requestSwitch( { kind: "page", target: 2 } )( args );
 
 		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "page", target: 2 } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "silently no-ops a page switch while external generation is in flight", () => {
+		const args = makeThunkArgs( { hasExternalGeneration: true, page: 1 } );
+		requestSwitch( { kind: "page", target: 2 } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
 		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
 	} );
 


### PR DESCRIPTION
Adds a \`disabled\` prop to \`BulkEditorTabs\` and \`BulkEditorNavMenu\` so Premium can block tab and content-type switches while a bulk suggestion request is in flight, avoiding stale UI without aborting the request. The store-level \`requestSwitch\` guard provides a backstop for keyboard/programmatic navigation that bypasses the visual disable.

## Context

This is PR 1 of 2 for fixing cancelled bulk-suggestion requests incorrectly affecting the usage count. The current behaviour aborts the in-flight AI request when the user navigates away, which counts as a used suggestion. The fix prevents navigation instead: tabs and content-type buttons are visually disabled while generation is in flight, and the store's \`requestSwitch\` silently no-ops so keyboard/programmatic navigation cannot sneak through.

This free-plugin PR adds the disable mechanism. The companion Premium PR ([#5029](https://github.com/Yoast/wordpress-seo-premium/pull/5029)) wires the AI loading state to \`setHasExternalGeneration\` and removes the abort/reset subscriber.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a flag to detect AI request loading.

## Relevant technical choices

* \`requestSwitch\` now silently no-ops when \`selectHasExternalGeneration()\\ is true, acting as a keyboard/programmatic backstop in addition to the visual disable.
* The ternary inside \`requestSwitch\` was extracted into a \`selectCurrentTarget\` helper to make room for the new guard without exceeding the project's cyclomatic complexity limit of 6.
* \`classNames\` object notation (\`{ "yst-opacity-50": disabled }\`) is used in \`ContentTypeItem\` instead of \`&&\` for the same reason.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR adds infrastructure consumed by the companion Premium PR — no visible behaviour change occurs without it. Acceptance testing here is a regression check on the normal bulk-editor flow.

**Prerequisites:** Yoast SEO free activated; navigate to **SEO → Tools → Bulk editor**.

1. Verify the **Search appearance** and **Social appearance** tabs still switch correctly on click and with the arrow and Home/End keys.
2. Verify clicking a content type in the sidebar (e.g. Posts → Pages) still switches the view.
3. With unsaved inline edits, click a different tab or content type and confirm the **unsaved changes modal** still appears.
4. Verify the **Back to Tools** link and Yoast logo still navigate (with the unsaved-changes guard when edits are present).
5. Open the browser console and confirm there are no new JS errors.

#### Relevant test scenarios
* [X] Changes should be tested with the browser console open

### Test instructions for QA when the code is in the RC

Not applicable — no user-facing behaviour change in the free plugin alone. The full end-to-end behaviour is covered by the Premium companion PR.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Bulk editor field-set tabs and sidebar content-type navigation (regression check only).
* The \`requestSwitch\` store thunk (covered by updated unit tests).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with \`[shopify-seo]\`, added test instructions for Shopify and attached the \`Shopify\` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with \`[yoast-doc-extension]\`, added test instructions for Yoast SEO for Google Docs and attached the \`Google Docs Add-on\` label to this PR.

## Documentation

* [X] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [X] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run \`grunt build:images\` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [X] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the \`innovation\` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/plugins-automated-testing/issues/3083