### PR TITLE
fix(bulk-editor): guard pagination against unsaved edits and pending AI suggestions

### DIFF
--- a/packages/js/src/bulk-editor/components/bulk-editor-footer.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-footer.js
@@ -1,5 +1,5 @@
 import { useDispatch, useSelect } from "@wordpress/data";
-import { createInterpolateElement } from "@wordpress/element";
+import { createInterpolateElement, useCallback } from "@wordpress/element";
 import { __, sprintf } from "@wordpress/i18n";
 import { Pagination, useMediaQuery } from "@yoast/ui-library";
 import { PAGE_SIZE, STORE_NAME } from "../constants";
@@ -24,8 +24,11 @@ const MAX_PAGE_BUTTONS_SMALL = 5;
  */
 export const BulkEditorFooter = ( { total, totalPages, isPending } ) => {
 	const page = useSelect( ( select ) => select( STORE_NAME ).selectPage(), [] );
-	const { setPage } = useDispatch( STORE_NAME );
+	const { requestSwitch } = useDispatch( STORE_NAME );
 	const { matches: isLarge } = useMediaQuery( "(min-width: 640px)" );
+
+	// A page change with active suggestions is a guarded switch.
+	const onNavigate = useCallback( ( target ) => requestSwitch( { kind: "page", target } ), [ requestSwitch ] );
 
 	// Nothing to summarise or page through; the table itself shows the "no content" message.
 	if ( total === 0 ) {
@@ -61,7 +64,7 @@ export const BulkEditorFooter = ( { total, totalPages, isPending } ) => {
 				aria-label={ __( "Results pagination", "wordpress-seo" ) }
 				current={ page }
 				total={ totalPages }
-				onNavigate={ setPage }
+				onNavigate={ onNavigate }
 				maxPageButtons={ isLarge ? MAX_PAGE_BUTTONS_LARGE : MAX_PAGE_BUTTONS_SMALL }
 				disabled={ isPending }
 				/* translators: Hidden accessibility text. */

--- a/packages/js/src/bulk-editor/components/bulk-editor-footer.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-footer.js
@@ -27,7 +27,7 @@ export const BulkEditorFooter = ( { total, totalPages, isPending } ) => {
 	const { requestSwitch } = useDispatch( STORE_NAME );
 	const { matches: isLarge } = useMediaQuery( "(min-width: 640px)" );
 
-	// A page change with active suggestions is a guarded switch.
+	// A page change is a guarded switch when there are unsaved edits or AI pending changes.
 	const onNavigate = useCallback( ( target ) => requestSwitch( { kind: "page", target } ), [ requestSwitch ] );
 
 	// Nothing to summarise or page through; the table itself shows the "no content" message.

--- a/packages/js/src/bulk-editor/store/pending-switch.js
+++ b/packages/js/src/bulk-editor/store/pending-switch.js
@@ -6,8 +6,8 @@ import { get } from "lodash";
  *
  * @typedef {Object} PendingSwitch
  *
- * @property {"fieldSet"|"contentType"|"navigate"} kind What the switch targets: a field set, a content type, or a URL to navigate to.
- * @property {string} target The field-set name, content-type name, or (for "navigate") the destination URL.
+ * @property {"fieldSet"|"contentType"|"navigate"|"page"} kind What the switch targets.
+ * @property {string|number} target The field-set/content-type name, the destination URL, or (for "page") the 1-based page number.
  */
 
 /**
@@ -27,7 +27,8 @@ const slice = createSlice( {
 /**
  * Commits a switch. A content-type change also clears the unsaved edits, so a stale draft can't leak into the
  * newly shown type; the selection reset is handled by setActiveContentType itself. A "navigate" switch leaves the
- * page for a URL, discarding all view state, so it only hands off to the browser.
+ * page for a URL, discarding all view state, so it only hands off to the browser. A "page" switch changes the
+ * results page.
  *
  * @param {PendingSwitch} pending The switch to commit.
  *
@@ -40,6 +41,11 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
 		// Security: Now, `target` is a server-generated URL (see bulk-editor-integration.php).
 		// If it ever comes from input, it has to be validated to prevent open redirects or malicious URIs.
 		window.location.href = target;
+		return;
+	}
+	if ( kind === "page" ) {
+		dispatch.setPage( target );
+		dispatch.clearPendingSwitch();
 		return;
 	}
 	if ( kind === "contentType" ) {
@@ -61,11 +67,14 @@ export const commitSwitch = ( { kind, target } ) => ( { dispatch } ) => {
  * @returns {Function} The thunk.
  */
 export const requestSwitch = ( { kind, target } ) => ( { select, dispatch } ) => {
-	if ( kind !== "navigate" ) {
-		const current = kind === "contentType" ? select.selectActiveContentTypeName() : select.selectActiveFieldSet();
-		if ( target === current ) {
-			return;
-		}
+	const currentValueSelector = {
+		contentType: select.selectActiveContentTypeName,
+		fieldSet: select.selectActiveFieldSet,
+		page: select.selectPage,
+	}[ kind ];
+	// A no-op switch (to the value already shown) needs no guard.
+	if ( currentValueSelector && target === currentValueSelector() ) {
+		return;
 	}
 	const hasUnsavedEdits = Object.keys( select.selectEditingRows() ).length > 0;
 	if ( hasUnsavedEdits || select.selectHasExternalPendingChanges() ) {

--- a/packages/js/tests/bulk-editor/bulk-editor-footer.test.js
+++ b/packages/js/tests/bulk-editor/bulk-editor-footer.test.js
@@ -5,7 +5,7 @@ import { BulkEditorFooter } from "../../src/bulk-editor/components/bulk-editor-f
 jest.mock( "@wordpress/data", () => ( { useDispatch: jest.fn(), useSelect: jest.fn() } ) );
 
 describe( "BulkEditorFooter", () => {
-	let setPage;
+	let requestSwitch;
 
 	/**
 	 * Points the mocked store selector at a given current page.
@@ -40,8 +40,8 @@ describe( "BulkEditorFooter", () => {
 	};
 
 	beforeEach( () => {
-		setPage = jest.fn();
-		useDispatch.mockReturnValue( { setPage } );
+		requestSwitch = jest.fn();
+		useDispatch.mockReturnValue( { requestSwitch } );
 		mockCurrentPage( 1 );
 		// Default to the desktop viewport so the full set of page buttons renders.
 		mockViewport( true );
@@ -72,14 +72,14 @@ describe( "BulkEditorFooter", () => {
 		expect( screen.getByText( /Showing/ ) ).toHaveTextContent( "Showing 181 to 197 of 197 results" );
 	} );
 
-	it( "dispatches setPage with the requested page when a page button is clicked", () => {
+	it( "requests a guarded page switch when a page button is clicked", () => {
 		mockCurrentPage( 1 );
 
 		render( <BulkEditorFooter total={ 197 } totalPages={ 10 } isPending={ false } /> );
 
 		fireEvent.click( screen.getByRole( "button", { name: "3" } ) );
 
-		expect( setPage ).toHaveBeenCalledWith( 3 );
+		expect( requestSwitch ).toHaveBeenCalledWith( { kind: "page", target: 3 } );
 	} );
 
 	it( "shows fewer page buttons on a mobile viewport", () => {

--- a/packages/js/tests/bulk-editor/store/pending-switch.test.js
+++ b/packages/js/tests/bulk-editor/store/pending-switch.test.js
@@ -26,18 +26,23 @@ describe( "pendingSwitch slice", () => {
 } );
 
 describe( "requestSwitch thunk", () => {
-	const makeThunkArgs = ( { editingRows = {}, hasExternalPendingChanges = false, activeContentType = "", activeFieldSet = "search" } = {} ) => ( {
-		select: {
-			selectEditingRows: () => editingRows,
-			selectHasExternalPendingChanges: () => hasExternalPendingChanges,
-			selectActiveContentTypeName: () => activeContentType,
-			selectActiveFieldSet: () => activeFieldSet,
-		},
-		dispatch: {
-			setPendingSwitch: jest.fn(),
-			commitSwitch: jest.fn(),
-		},
-	} );
+	const DEFAULT_STATE = { editingRows: {}, hasExternalPendingChanges: false, activeContentType: "", activeFieldSet: "search", page: 1 };
+	const makeThunkArgs = ( overrides = {} ) => {
+		const state = { ...DEFAULT_STATE, ...overrides };
+		return {
+			select: {
+				selectEditingRows: () => state.editingRows,
+				selectHasExternalPendingChanges: () => state.hasExternalPendingChanges,
+				selectActiveContentTypeName: () => state.activeContentType,
+				selectActiveFieldSet: () => state.activeFieldSet,
+				selectPage: () => state.page,
+			},
+			dispatch: {
+				setPendingSwitch: jest.fn(),
+				commitSwitch: jest.fn(),
+			},
+		};
+	};
 
 	it( "commits immediately when nothing guards the switch", () => {
 		const args = makeThunkArgs();
@@ -93,12 +98,45 @@ describe( "requestSwitch thunk", () => {
 		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "navigate", target: "https://example.test/tools" } );
 		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
 	} );
+
+	it( "commits a page switch straight away when nothing guards it", () => {
+		const args = makeThunkArgs( { page: 1 } );
+		requestSwitch( { kind: "page", target: 2 } )( args );
+
+		expect( args.dispatch.commitSwitch ).toHaveBeenCalledWith( { kind: "page", target: 2 } );
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers a page switch while manual edits are in progress", () => {
+		const args = makeThunkArgs( { editingRows: { 7: {} }, page: 1 } );
+		requestSwitch( { kind: "page", target: 2 } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "page", target: 2 } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "defers a page switch while an external plugin reports pending changes", () => {
+		const args = makeThunkArgs( { hasExternalPendingChanges: true, page: 1 } );
+		requestSwitch( { kind: "page", target: 2 } )( args );
+
+		expect( args.dispatch.setPendingSwitch ).toHaveBeenCalledWith( { kind: "page", target: 2 } );
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+	} );
+
+	it( "ignores a page switch to the page already shown", () => {
+		const args = makeThunkArgs( { page: 3, editingRows: { 7: {} } } );
+		requestSwitch( { kind: "page", target: 3 } )( args );
+
+		expect( args.dispatch.commitSwitch ).not.toHaveBeenCalled();
+		expect( args.dispatch.setPendingSwitch ).not.toHaveBeenCalled();
+	} );
 } );
 
 describe( "commitSwitch thunk", () => {
 	const makeDispatch = () => ( {
 		setActiveContentType: jest.fn(),
 		setActiveFieldSet: jest.fn(),
+		setPage: jest.fn(),
 		deselectAll: jest.fn(),
 		stopEdit: jest.fn(),
 		clearPendingSwitch: jest.fn(),
@@ -122,6 +160,16 @@ describe( "commitSwitch thunk", () => {
 		expect( dispatch.stopEdit ).toHaveBeenCalled();
 		// The selection slice resets on setActiveContentType, so commitSwitch does not deselect separately.
 		expect( dispatch.deselectAll ).not.toHaveBeenCalled();
+		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
+	} );
+
+	it( "changes the page and clears the pending switch for a page switch", () => {
+		const dispatch = makeDispatch();
+		commitSwitch( { kind: "page", target: 2 } )( { dispatch } );
+
+		expect( dispatch.setPage ).toHaveBeenCalledWith( 2 );
+		expect( dispatch.setActiveContentType ).not.toHaveBeenCalled();
+		expect( dispatch.setActiveFieldSet ).not.toHaveBeenCalled();
 		expect( dispatch.clearPendingSwitch ).toHaveBeenCalled();
 	} );
 


### PR DESCRIPTION
## Context

Fixes Yoast/plugins-automated-testing#3082. In the bulk editor, changing the results **page** while there were unsaved changes on screen silently dropped them — an unsaved manual edit, or (with Premium) unsaved AI suggestions, were lost with no prompt. Content-type and field-set (tab) switches were already guarded by the pending-changes modal; pagination was not. (See 🧵 [thread ](https://yoast.slack.com/archives/C027BFR5L/p1784183428135089)). 

This routes the pager through the same guard (`requestSwitch`), so a page change now defers to the unsaved-changes modal when there is something to lose, and otherwise paginates immediately as before.

**Scope:** pagination only. Search and status-filter changes are intentionally **not** guarded — they don't lose data (Yoast/wordpress-seo-premium#5030 preserves unsaved AI suggestions across query changes, and manual edits survive a filter too), and guarding search-as-you-type would pop the modal mid-keystroke.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where changing the results page in the bulk editor discarded unsaved manual edits or pending AI suggestions without warning.

## Relevant technical choices:

* **Reuses the existing guard** — pagination's `onNavigate` in `bulk-editor-footer.js` now dispatches `requestSwitch( { kind: "page", target } )` instead of `setPage` directly; `pending-switch.js` gains a `"page"` kind whose `commitSwitch` runs `setPage`.
* **No desync on cancel** — the ui-library `Pagination` is controlled by `selectPage()`, so a deferred/cancelled switch leaves the pager on the current page.
* **No Premium change / no conflict with #5030** — deferral holds the target in `pendingSwitch` without touching the `query` slice, so Premium's `initialize.js` query subscription stays quiet until commit.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
Open **Yoast SEO → Tools → Bulk editor** with Premium active and AI enabled.

**Case 1 — unsaved manual edits**
1. Click **Edit** on a row (optionally change a field) so it has unsaved changes.
2. Click another page in the pager.
3. Expected: the **Unsaved changes** modal appears and the page does **not** change. **Cancel** keeps you on the page with the edit intact; **Continue without saving** moves to the new page and drops the edit.

**Case 2 — pending AI suggestions (Premium)**
1. Select several posts and generate SEO titles/meta descriptions; leave the suggestions unapplied.
2. Click another page in the pager.
3. Expected: the **Pending AI suggestions** modal appears and the page does **not** change. **Continue without applying** moves to the new page (suggestions dismissed); **Cancel** keeps you put.

**Case 3 — nothing pending**
1. With no unsaved edits and no pending suggestions, click another page.
2. Expected: it paginates immediately, no modal.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

All three cases were verified in the browser (both modals shown, page held on defer, committed on confirm, controlled pager with no desync on cancel).

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor pending-changes guard (`pending-switch.js`) and the results pager (`bulk-editor-footer.js`). Content-type/field-set switching is unchanged; only pagination gains the guard.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [x] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3082
