### PR TITLE
fix(bulk-editor): expose generic error alert for consent flow

### DIFF
--- a/packages/js/src/bulk-editor/initialize.js
+++ b/packages/js/src/bulk-editor/initialize.js
@@ -6,6 +6,7 @@ import { PluginArea } from "@wordpress/plugins";
 import { RemoteDataProvider } from "@yoast/dashboard-frontend";
 import { get } from "lodash";
 import { createHashRouter, createRoutesFromElements, Route, RouterProvider } from "react-router-dom";
+import { GenericAlert } from "../ai-generator/components/errors";
 import { fixWordPressMenuScrolling } from "../shared-admin/helpers";
 import { LINK_PARAMS_NAME } from "../shared-admin/store";
 import App from "./app";
@@ -15,11 +16,12 @@ import { useAiUpsell } from "./hooks/use-ai-upsell";
 import { DataProvider } from "./services";
 import registerStore from "./store";
 
-// Expose the bulk AI upsell so Premium can reuse the same modal instead of duplicating it. Premium's bulk-editor
-// bundle depends on this script, so the global is set before Premium reads it.
+// Expose the bulk AI upsell and the generic error alert so Premium can reuse them instead of duplicating: the
+// upsell modal, and the error alert its consent flow shows when granting consent fails. Premium's bulk-editor
+// bundle depends on this script, so the globals are set before Premium reads them.
 window.yoast = window.yoast || {};
 window.yoast.bulkEditor = window.yoast.bulkEditor || {};
-window.yoast.bulkEditor.components = { ...window.yoast.bulkEditor.components, UpsellModal };
+window.yoast.bulkEditor.components = { ...window.yoast.bulkEditor.components, UpsellModal, GenericAlert };
 window.yoast.bulkEditor.hooks = { ...window.yoast.bulkEditor.hooks, useAiUpsell };
 
 domReady( () => {


### PR DESCRIPTION
## Context
Yoast SEO Premium's bulk editor shows a consent modal when a user has not yet granted Yoast AI consent. When granting consent fails (for example on a firewalled site whose server cannot reach the Yoast AI service), Premium needs to show an error inside that modal. The normal (post) editor already uses Free's `GenericAlert` for this, but that component lives in the Free app bundle and cannot be imported from Premium's separate bundle. This PR exposes it on the bulk editor's `window` global so Premium can reuse it — the same mechanism already used for the bulk upsell modal.

## Summary
This PR can be summarized in the following changelog entry:

* Exposes the generic AI error alert on `window.yoast.bulkEditor.components` so Yoast SEO Premium can reuse it in the bulk editor consent flow.

## Relevant technical choices:

* Reuses the existing `window.yoast.bulkEditor.components` seam (which already carries `UpsellModal`) rather than `window.yoast.editorModules`, which is not enqueued on the bulk editor page.
* No behaviour changes in Free on its own; the user-facing fix lands in the companion Premium PR Yoast/wordpress-seo-premium#5031.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR is not independently testable: it only exposes an already-tested component (`GenericAlert`) on the bulk editor `window` global for Premium to consume. The user-facing behaviour and its full test instructions live on the companion Premium PR **Yoast/wordpress-seo-premium#5031** — test the two PRs together using the steps there.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR via the companion Premium PR Yoast/wordpress-seo-premium#5031.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor page's JS global (`window.yoast.bulkEditor.components`).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

The change is a one-line global exposure of an already-tested component; the behaviour it enables is covered by the companion Premium PR's unit tests.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3085
