### PR TITLE
fix(ai-content-planner): truncate recent_content description to 1000 chars

### DIFF
--- a/src/ai/content-planner/domain/post.php
+++ b/src/ai/content-planner/domain/post.php
@@ -8,6 +8,24 @@ namespace Yoast\WP\SEO\AI\Content_Planner\Domain;
 class Post {
 
 	/**
+	 * Max title length allowed when round-tripping via the REST API.
+	 *
+	 * Must stay in sync with the get_outline route schema.
+	 *
+	 * @var int
+	 */
+	public const MAX_TITLE_LENGTH = 500;
+
+	/**
+	 * Max description length allowed when round-tripping via the REST API.
+	 *
+	 * Must stay in sync with the get_outline route schema.
+	 *
+	 * @var int
+	 */
+	public const MAX_DESCRIPTION_LENGTH = 1000;
+
+	/**
 	 * The title.
 	 *
 	 * @var string
@@ -117,8 +135,8 @@ class Post {
 	 */
 	public function to_minimal_array(): array {
 		return [
-			'title'       => $this->title,
-			'description' => $this->description,
+			'title'       => \mb_substr( $this->title, 0, self::MAX_TITLE_LENGTH, 'UTF-8' ),
+			'description' => \mb_substr( $this->description, 0, self::MAX_DESCRIPTION_LENGTH, 'UTF-8' ),
 		];
 	}
 }

--- a/src/ai/content-planner/user-interface/get-outline-route.php
+++ b/src/ai/content-planner/user-interface/get-outline-route.php
@@ -8,6 +8,7 @@ use WP_REST_Request;
 use WP_REST_Response;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command;
 use Yoast\WP\SEO\AI\Content_Planner\Application\Content_Outline_Command_Handler;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Payment_Required_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Remote_Request_Exception;
 use Yoast\WP\SEO\AI\HTTP_Request\Domain\Exceptions\Too_Many_Requests_Exception;
@@ -147,12 +148,12 @@ class Get_Outline_Route implements Route_Interface {
 								'title'       => [
 									'type'      => 'string',
 									'required'  => true,
-									'maxLength' => 500,
+									'maxLength' => Post::MAX_TITLE_LENGTH,
 								],
 								'description' => [
 									'type'      => 'string',
 									'required'  => true,
-									'maxLength' => 1000,
+									'maxLength' => Post::MAX_DESCRIPTION_LENGTH,
 								],
 							],
 							'additionalProperties' => false,

--- a/tests/Unit/AI/Content_Planner/Domain/Post/To_Minimal_Array_Test.php
+++ b/tests/Unit/AI/Content_Planner/Domain/Post/To_Minimal_Array_Test.php
@@ -1,0 +1,102 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\AI\Content_Planner\Domain\Post;
+
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Category;
+use Yoast\WP\SEO\AI\Content_Planner\Domain\Post;
+
+/**
+ * Tests the Post's to_minimal_array method.
+ *
+ * @group ai-content-planner
+ *
+ * @covers \Yoast\WP\SEO\AI\Content_Planner\Domain\Post::to_minimal_array
+ */
+final class To_Minimal_Array_Test extends Abstract_Post {
+
+	/**
+	 * Tests that short title and description pass through unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_to_minimal_array_with_short_fields() {
+		$expected = [
+			'title'       => 'My Post Title',
+			'description' => 'A description of the post.',
+		];
+
+		$this->assertSame( $expected, $this->instance->to_minimal_array() );
+	}
+
+	/**
+	 * Tests that a description longer than the max is truncated.
+	 *
+	 * @return void
+	 */
+	public function test_to_minimal_array_truncates_long_description() {
+		$long_description = \str_repeat( 'a', ( Post::MAX_DESCRIPTION_LENGTH + 200 ) );
+		$post             = new Post(
+			'My Post Title',
+			$long_description,
+			new Category( 'Tech', 5 ),
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$result = $post->to_minimal_array();
+
+		$this->assertSame( Post::MAX_DESCRIPTION_LENGTH, \mb_strlen( $result['description'], 'UTF-8' ) );
+		$this->assertSame( \str_repeat( 'a', Post::MAX_DESCRIPTION_LENGTH ), $result['description'] );
+	}
+
+	/**
+	 * Tests that a title longer than the max is truncated.
+	 *
+	 * @return void
+	 */
+	public function test_to_minimal_array_truncates_long_title() {
+		$long_title = \str_repeat( 'b', ( Post::MAX_TITLE_LENGTH + 50 ) );
+		$post       = new Post(
+			$long_title,
+			'A description of the post.',
+			new Category( 'Tech', 5 ),
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$result = $post->to_minimal_array();
+
+		$this->assertSame( Post::MAX_TITLE_LENGTH, \mb_strlen( $result['title'], 'UTF-8' ) );
+		$this->assertSame( \str_repeat( 'b', Post::MAX_TITLE_LENGTH ), $result['title'] );
+	}
+
+	/**
+	 * Tests that truncation counts characters, not bytes.
+	 *
+	 * @return void
+	 */
+	public function test_to_minimal_array_truncates_multibyte_description_by_characters() {
+		// Each "é" is two bytes in UTF-8; truncate must keep 1000 characters, not 1000 bytes.
+		$long_description = \str_repeat( 'é', ( Post::MAX_DESCRIPTION_LENGTH + 1 ) );
+		$post             = new Post(
+			'My Post Title',
+			$long_description,
+			new Category( 'Tech', 5 ),
+			'focus keyword',
+			1,
+			'2024-01-15',
+			'BlogPosting',
+		);
+
+		$result = $post->to_minimal_array();
+
+		$this->assertSame( Post::MAX_DESCRIPTION_LENGTH, \mb_strlen( $result['description'], 'UTF-8' ) );
+		$this->assertSame( \str_repeat( 'é', Post::MAX_DESCRIPTION_LENGTH ), $result['description'] );
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The `get_outline` route rejects `recent_content[].description` values longer than 1000 characters. Those values come from the earlier `get_suggestions` response, which returns indexable meta descriptions without a length cap. A long meta description then caused the outline request to fail with a REST validation error.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where generating a content outline failed when a recent post had a meta description longer than 1000 characters.

## Relevant technical choices:

* Truncate only in `Post::to_minimal_array()`, which is the client round-trip payload used by `get_outline`. Leave `to_array()` untruncated so the AI suggestions request still receives full descriptions.
* Also cap the title at 500 characters in the minimal payload so both outline schema fields stay in sync.
* Introduce `Post::MAX_TITLE_LENGTH` and `Post::MAX_DESCRIPTION_LENGTH` and reuse them in the `get_outline` route schema so the limits cannot drift.
* Use `mb_substr( ..., 'UTF-8' )` so truncation is character-based, matching other length limits in the plugin.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Make sure Content Planner is available and the site has at least 5 published posts.
2. Edit a recent published post and set its Yoast SEO meta description to more than 1000 characters (for example about 1200 characters of plain text). Update the post.
3. Open Content Planner in wp-admin and generate content suggestions for that post type.
4. Confirm that suggestions load successfully.
5. Select any suggestion and generate an outline.
6. Confirm that the outline is generated successfully and there is no REST validation error about `description`.
7. Repeat the suggestions and outline flow with a post that has a short meta description and confirm it still works.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

Check the browser console and the Network tab for the `get_suggestions` and `get_outline` requests. The outline request should not return a 400 validation error for `recent_content`.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Same steps as the acceptance test above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* AI Content Planner: `get_suggestions` response shape for `recent_content`, and the follow-up `get_outline` request that reuses that data.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23446