### PR TITLE
fix(editor): sync core/editor Yoast meta without AI feature

### DIFF
--- a/packages/js/src/ai-content-planner/initialize.js
+++ b/packages/js/src/ai-content-planner/initialize.js
@@ -10,7 +10,6 @@ import { App } from "./components/app";
 import "./blocks/content-suggestion-block";
 import { CONTENT_PLANNER_STORE } from "./constants";
 import { getIsBannerDismissedFromInput, getIsBannerRenderedFromInput } from "./helpers/fields";
-import { useYoastMetaSync } from "./hooks";
 import { registerStore } from "./store";
 import { AVAILABILITY_NAME } from "./store/availability";
 import { BANNER_NAME } from "./store/banner";
@@ -50,8 +49,10 @@ export function insertFirstParagraph( blocks, insertBlock, isBannerRendered ) {
 
 /**
  * Editor plugin that renders the shared FeatureModal controlled by the content
- * planner store, syncs Yoast meta fields on undo, and auto-inserts the inline
- * banner on new posts of the "post" type.
+ * planner store and auto-inserts the inline banner on new posts of the "post" type.
+ *
+ * Yoast meta sync (core/editor → yoast-seo/editor) lives on the always-registered
+ * yoast-seo block-editor plugin so it is not gated behind the AI feature.
  *
  * @returns {JSX.Element|null} The editor plugin component.
  */
@@ -72,8 +73,6 @@ export const ContentPlannerEditorPlugin = () => {
 	const hasConsent = useSelect( select => select( STORE_NAME_AI )?.selectHasAiGeneratorConsent() ?? false );
 
 	const { insertBlock } = useDispatch( "core/block-editor" );
-
-	useYoastMetaSync();
 
 	useEffect( () => {
 		if ( hasInserted.current || ! isNewPost || postType !== "post" || ! minPostsMet ) {

--- a/packages/js/src/initializers/block-editor-integration.js
+++ b/packages/js/src/initializers/block-editor-integration.js
@@ -28,6 +28,7 @@ import WincherPostPublish from "../containers/WincherPostPublish";
 import { isAnnotationAvailable } from "../decorator/gutenberg";
 import { link } from "../inline-links/edit-link";
 import initContentPlanner from "../ai-content-planner/initialize";
+import { useYoastMetaSync } from "../ai-content-planner/hooks";
 import { getIsAiFeatureEnabled } from "../redux/selectors/preferences";
 
 /**
@@ -130,55 +131,62 @@ function registerFills( store ) {
 	 *
 	 * @returns {Component} The editor fills component.
 	 */
-	const EditorFills = () => (
-		<Fragment>
-			<PluginSidebarMoreMenuItem
-				target="seo-sidebar"
-				icon={ <PluginIcon /> }
-			>
-				{ pluginTitle }
-			</PluginSidebarMoreMenuItem>
-			<PluginSidebar
-				name="seo-sidebar"
-				title={ pluginTitle }
-			>
-				<Root context={ blockSidebarContext }>
-					<SidebarSlot store={ store } theme={ theme } />
-				</Root>
-			</PluginSidebar>
+	const EditorFills = () => {
+		// Mirror core/editor Yoast meta into yoast-seo/editor so third-party
+		// editPost({ meta }) updates reach the sidebar and hidden fields,
+		// independent of the AI Content Planner feature toggle.
+		useYoastMetaSync();
+
+		return (
 			<Fragment>
-				<SidebarFill store={ store } theme={ theme } />
-				<Root context={ blockMetaboxContext }>
-					<MetaboxPortal target="wpseo-metabox-root" store={ store } theme={ theme } />
-				</Root>
+				<PluginSidebarMoreMenuItem
+					target="seo-sidebar"
+					icon={ <PluginIcon /> }
+				>
+					{ pluginTitle }
+				</PluginSidebarMoreMenuItem>
+				<PluginSidebar
+					name="seo-sidebar"
+					title={ pluginTitle }
+				>
+					<Root context={ blockSidebarContext }>
+						<SidebarSlot store={ store } theme={ theme } />
+					</Root>
+				</PluginSidebar>
+				<Fragment>
+					<SidebarFill store={ store } theme={ theme } />
+					<Root context={ blockMetaboxContext }>
+						<MetaboxPortal target="wpseo-metabox-root" store={ store } theme={ theme } />
+					</Root>
+				</Fragment>
+				{ analysesEnabled && <PluginPrePublishPanel
+					className="yoast-seo-sidebar-panel"
+					title={ __( "Yoast SEO", "wordpress-seo" ) }
+					initialOpen={ true }
+					icon={ <Fragment /> }
+				>
+					<PrePublish />
+				</PluginPrePublishPanel> }
+				<PluginPostPublishPanel
+					className="yoast-seo-sidebar-panel"
+					title={ __( "Yoast SEO", "wordpress-seo" ) }
+					initialOpen={ true }
+					icon={ <Fragment /> }
+				>
+					<PostPublish />
+					{ showWincherPanel && <WincherPostPublish /> }
+				</PluginPostPublishPanel>
+				{ analysesEnabled && <PluginDocumentSettingPanel
+					name="document-panel"
+					className="yoast-seo-sidebar-panel"
+					title={ __( "Yoast SEO", "wordpress-seo" ) }
+					icon={ <Fragment /> }
+				>
+					<DocumentSidebar />
+				</PluginDocumentSettingPanel> }
 			</Fragment>
-			{ analysesEnabled && <PluginPrePublishPanel
-				className="yoast-seo-sidebar-panel"
-				title={ __( "Yoast SEO", "wordpress-seo" ) }
-				initialOpen={ true }
-				icon={ <Fragment /> }
-			>
-				<PrePublish />
-			</PluginPrePublishPanel> }
-			<PluginPostPublishPanel
-				className="yoast-seo-sidebar-panel"
-				title={ __( "Yoast SEO", "wordpress-seo" ) }
-				initialOpen={ true }
-				icon={ <Fragment /> }
-			>
-				<PostPublish />
-				{ showWincherPanel && <WincherPostPublish /> }
-			</PluginPostPublishPanel>
-			{ analysesEnabled && <PluginDocumentSettingPanel
-				name="document-panel"
-				className="yoast-seo-sidebar-panel"
-				title={ __( "Yoast SEO", "wordpress-seo" ) }
-				icon={ <Fragment /> }
-			>
-				<DocumentSidebar />
-			</PluginDocumentSettingPanel> }
-		</Fragment>
-	);
+		);
+	};
 
 	registerPlugin( "yoast-seo", {
 		render: EditorFills,


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

Third-party and custom block-editor code can set Yoast post meta through the standard Gutenberg API:

```js
wp.data.dispatch( 'core/editor' ).editPost( {
	meta: { _yoast_wpseo_metadesc: 'My custom description' },
} );
```

That path only updated the Yoast sidebar and survived save when the AI feature was enabled. With AI off, `core/editor` state updated, but the Yoast store did not, so on save Yoast wrote its own (empty/template) value into the metabox hidden field and discarded the third-party value.

The bridge that mirrors `core/editor` meta into `yoast-seo/editor` already exists as `useYoastMetaSync`, but it was only mounted by the AI Content Planner plugin. This PR mounts that hook from the always-registered `yoast-seo` block-editor plugin so the bridge no longer depends on the AI feature toggle.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where post meta set via `editPost` was not reflected in the Yoast sidebar when the AI feature was disabled.

## Relevant technical choices:

* Reused the existing `useYoastMetaSync` hook without changing its logic (`isPost` guard and empty-value → template fallback stay as they are).
* Mounted the hook inside the always-registered `EditorFills` component in `block-editor-integration.js`, and removed the call from `ContentPlannerEditorPlugin` so the effect runs exactly once (AI on or off).
* Left the hook file under `ai-content-planner/hooks/` to keep the diff small; ownership can move later if needed.
* Sync still only runs for the `post` post type, matching the current REST meta registration (`object_subtype => 'post'` in `WPSEO_Meta`). Pages/CPTs are out of scope here.
* Related open work: #23324 decouples metabox hidden fields behind an opt-in filter and does not fix this default path.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Make sure the Yoast **AI feature is disabled**.
2. Open a **post** (not a page) in the block editor and open the Yoast SEO sidebar.
3. In the browser console, run:
   ```js
   wp.data.dispatch( 'core/editor' ).editPost( {
       meta: { _yoast_wpseo_metadesc: 'My custom description' },
   } );
   ```
4. Confirm the Yoast meta description field / snippet preview shows `My custom description`.
5. Save the post and reload the editor. Confirm the value is still there.
6. Repeat with title and focus keyphrase:
   ```js
   wp.data.dispatch( 'core/editor' ).editPost( {
       meta: {
           _yoast_wpseo_title: 'My custom SEO title',
           _yoast_wpseo_focuskw: 'my keyword',
       },
   } );
   ```
7. Confirm the sidebar updates and both values persist after save + reload.
8. **Regression — AI on:** enable the AI feature, repeat the `editPost` meta description step, then use Content Planner (apply outline if available) and editor Undo. Confirm undo still reverts Yoast title / meta description / focus keyphrase.
9. **Regression — sidebar edit:** with AI on or off, edit the meta description only in the Yoast sidebar UI, save and reload. Confirm it still persists.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

Browser console is required for the `editPost` reproduction steps. Block editor only (Classic/Elementor are unaffected). Sync is limited to the `post` post type by design.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as the acceptance test above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Block editor sidebar snippet fields (SEO title, meta description, focus keyphrase) when post meta is updated via `core/editor`
* AI Content Planner undo behaviour (meta sync still runs, but from the core plugin mount instead of the Content Planner plugin)
* Classic editor and Elementor should be unaffected

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23458