### PR TITLE
fix(yoastseo): exclude empty results from SEO overall score

### DIFF
--- a/packages/yoastseo/spec/scoring/assessors/seoAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/assessors/seoAssessorSpec.js
@@ -1,5 +1,7 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher.js";
 import Assessor from "../../../src/scoring/assessors/seoAssessor.js";
+import ValidOnlyResultsScoreAggregator from "../../../src/scoring/scoreAggregators/ValidOnlyResultsScoreAggregator.js";
+import AssessmentResult from "../../../src/values/AssessmentResult.js";
 import Paper from "../../../src/values/Paper.js";
 import { checkAssessmentAvailability, checkUrls } from "../../specHelpers/scoring/seoAssessorTests.js";
 
@@ -12,4 +14,22 @@ describe( "running assessments in the assessor", function() {
 
 describe( "has the correct assessment URLs", () => {
 	checkUrls( assessor );
+} );
+
+describe( "score aggregator", () => {
+	it( "uses ValidOnlyResultsScoreAggregator so empty results do not dilute the overall score", () => {
+		// Researcher is unused for aggregation; pass a stub to avoid loading language packages.
+		const seoAssessor = new Assessor( {} );
+
+		expect( seoAssessor.getScoreAggregator() ).toBeInstanceOf( ValidOnlyResultsScoreAggregator );
+
+		// Mirrors functionWordsInKeyphrase on a content-word keyphrase: applicable, but no score/text.
+		const results = [
+			new AssessmentResult( { score: 9 } ),
+			new AssessmentResult(),
+			new AssessmentResult( { score: 9 } ),
+		];
+
+		expect( seoAssessor.getScoreAggregator().aggregate( results ) ).toBe( 100 );
+	} );
 } );

--- a/packages/yoastseo/spec/scoring/assessors/taxonomyAssessorSpec.js
+++ b/packages/yoastseo/spec/scoring/assessors/taxonomyAssessorSpec.js
@@ -1,5 +1,7 @@
 import EnglishResearcher from "../../../src/languageProcessing/languages/en/Researcher.js";
 import Assessor from "../../../src/scoring/assessors/taxonomyAssessor.js";
+import ValidOnlyResultsScoreAggregator from "../../../src/scoring/scoreAggregators/ValidOnlyResultsScoreAggregator.js";
+import AssessmentResult from "../../../src/values/AssessmentResult.js";
 import Paper from "../../../src/values/Paper.js";
 import { checkAssessmentAvailability, checkUrls } from "../../specHelpers/scoring/seoAssessorTests.js";
 
@@ -32,4 +34,22 @@ describe( "has the correct configuration overrides", () => {
 
 describe( "has the correct assessment URLs", () => {
 	checkUrls( assessor );
+} );
+
+describe( "score aggregator", () => {
+	it( "uses ValidOnlyResultsScoreAggregator so empty results do not dilute the overall score", () => {
+		// Researcher is unused for aggregation; pass a stub to avoid loading language packages.
+		const taxonomyAssessor = new Assessor( {} );
+
+		expect( taxonomyAssessor.getScoreAggregator() ).toBeInstanceOf( ValidOnlyResultsScoreAggregator );
+
+		// Mirrors functionWordsInKeyphrase on a content-word keyphrase: applicable, but no score/text.
+		const results = [
+			new AssessmentResult( { score: 9 } ),
+			new AssessmentResult(),
+			new AssessmentResult( { score: 9 } ),
+		];
+
+		expect( taxonomyAssessor.getScoreAggregator().aggregate( results ) ).toBe( 100 );
+	} );
 } );

--- a/packages/yoastseo/src/scoring/assessors/seoAssessor.js
+++ b/packages/yoastseo/src/scoring/assessors/seoAssessor.js
@@ -16,7 +16,7 @@ import OutboundLinks from "../assessments/seo/OutboundLinksAssessment";
 import TitleWidth from "../assessments/seo/PageTitleWidthAssessment";
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment";
 import SingleH1Assessment from "../assessments/seo/SingleH1Assessment";
-import SEOScoreAggregator from "../scoreAggregators/SEOScoreAggregator";
+import ValidOnlyResultsScoreAggregator from "../scoreAggregators/ValidOnlyResultsScoreAggregator";
 
 /**
  * The SEOAssessor class is used for the general SEO analysis.
@@ -55,6 +55,6 @@ export default class SEOAssessor extends Assessor {
 			new SingleH1Assessment(),
 		];
 
-		this._scoreAggregator = new SEOScoreAggregator();
+		this._scoreAggregator = new ValidOnlyResultsScoreAggregator();
 	}
 }

--- a/packages/yoastseo/src/scoring/assessors/taxonomyAssessor.js
+++ b/packages/yoastseo/src/scoring/assessors/taxonomyAssessor.js
@@ -11,7 +11,7 @@ import PageTitleWidthAssessment from "../assessments/seo/PageTitleWidthAssessmen
 import FunctionWordsInKeyphrase from "../assessments/seo/FunctionWordsInKeyphraseAssessment.js";
 import SingleH1Assessment from "../assessments/seo/SingleH1Assessment.js";
 import { createAnchorOpeningTag } from "../../helpers";
-import SEOScoreAggregator from "../scoreAggregators/SEOScoreAggregator";
+import ValidOnlyResultsScoreAggregator from "../scoreAggregators/ValidOnlyResultsScoreAggregator";
 
 /**
  * Returns the text length assessment to use.
@@ -63,6 +63,6 @@ export default class TaxonomyAssessor extends Assessor {
 			new SingleH1Assessment(),
 		];
 
-		this._scoreAggregator = new SEOScoreAggregator();
+		this._scoreAggregator = new ValidOnlyResultsScoreAggregator();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When the focus keyphrase contains content words, `functionWordsInKeyphrase` correctly returns an empty assessment result (no score, no text) so it stays hidden in the UI. The main SEO and taxonomy assessors still counted that empty row in the overall score denominator, which dropped a full-green analysis from about 99 to about 94.

Related-keyphrase and collection-page assessors already use `ValidOnlyResultsScoreAggregator`. This PR aligns the main SEO and taxonomy assessors with that same pattern.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bug fix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the overall SEO score was lowered when the focus keyphrase did not consist of function words only. Props to @faisalahammad.
* [yoastseo 0.1.0 bugfix] Fixes a bug where SEO assessor and Taxonomy assessor didn't filter out empty assessment results.

## Relevant technical choices:

* Switched `SEOAssessor` and `TaxonomyAssessor` from `SEOScoreAggregator` to the existing `ValidOnlyResultsScoreAggregator`, which skips results without a score. Subclasses (cornerstone, product, store posts/pages, store blog) inherit the fix. Collection and related-keyphrase assessors already used ValidOnly and are unchanged.
* Left `SEOScoreAggregator` itself alone so remaining callers keep their current math.
* Overall score is computed inside the analysis worker before serialize, so filtering empty results there is enough for this bug.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Use an English site and open the block editor on a new post.
2. Set the focus keyphrase to something with content words, for example `sports banner photography`.
3. Fill the title, slug, meta description, body, images, and links until every SEO analysis item is green.
4. Open the browser console and run:
   `wp.data.select( "yoast-seo/editor" ).getSeoResults()`
5. Confirm `overallScore` is 99 (or 100 if every individual assessment scores 9), not around 94.
6. Confirm `functionWordsInKeyphrase` does not show as a visible analysis bullet while the keyphrase is fine.
7. Change the focus keyphrase to only function words, for example `someone was here`.
8. Confirm `functionWordsInKeyphrase` appears with feedback and the overall score drops because that assessment now has a real score of 0.
9. Optional: repeat steps 2–5 on a category or tag edit screen.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

Console: use `getSeoResults()` and check `overallScore`. Posts/pages and taxonomies both use the assessors changed here. Classic/Elementor and multisite are not required for this scoring change.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

Same steps as the acceptance test above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Overall SEO score calculation for posts, pages, and taxonomies (including cornerstone, product, and Woo store assessors that extend `SEOAssessor`).
* Posts that previously had empty SEO assessment rows may show a slightly higher overall score. That is the intended fix.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23400