### PR TITLE
feat(alerts): warn when debug display is enabled in production

### DIFF
--- a/src/alerts/application/debug-display/debug-display-alert.php
+++ b/src/alerts/application/debug-display/debug-display-alert.php
@@ -1,0 +1,144 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Alerts\Application\Debug_Display;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+use Yoast_Notification;
+use Yoast_Notification_Center;
+
+/**
+ * Warns when PHP debug output may be visible on a production site.
+ */
+class Debug_Display_Alert implements Integration_Interface {
+
+	public const NOTIFICATION_ID = 'wpseo-debug-display-enabled';
+
+	/**
+	 * Learn more URL for WordPress debugging docs.
+	 */
+	public const LEARN_MORE_URL = 'https://wordpress.org/documentation/article/debugging-in-wordpress/';
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Yoast_Notification_Center
+	 */
+	private $notification_center;
+
+	/**
+	 * The environment helper.
+	 *
+	 * @var Environment_Helper
+	 */
+	private $environment_helper;
+
+	/**
+	 * Debug_Display_Alert constructor.
+	 *
+	 * @param Yoast_Notification_Center $notification_center The notification center.
+	 * @param Environment_Helper        $environment_helper  The environment helper.
+	 */
+	public function __construct(
+		Yoast_Notification_Center $notification_center,
+		Environment_Helper $environment_helper
+	) {
+		$this->notification_center = $notification_center;
+		$this->environment_helper  = $environment_helper;
+	}
+
+	/**
+	 * Returns the conditionals based on which this loadable should be active.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals() {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_action( 'admin_init', [ $this, 'add_notifications' ] );
+	}
+
+	/**
+	 * Adds or removes the notification based on debug display settings.
+	 *
+	 * @return void
+	 */
+	public function add_notifications() {
+		if ( ! $this->should_show_notification() ) {
+			$this->notification_center->remove_notification_by_id( self::NOTIFICATION_ID );
+			return;
+		}
+
+		$this->notification_center->add_notification( $this->get_notification() );
+	}
+
+	/**
+	 * Whether the debug display notification should be shown.
+	 *
+	 * @return bool
+	 */
+	protected function should_show_notification(): bool {
+		return $this->environment_helper->is_production_mode()
+			&& $this->is_debug_display_enabled();
+	}
+
+	/**
+	 * Whether WP debug display is enabled.
+	 *
+	 * Mirrors core: when WP_DEBUG is true and WP_DEBUG_DISPLAY is not defined,
+	 * WordPress defaults WP_DEBUG_DISPLAY to true.
+	 *
+	 * @return bool
+	 */
+	protected function is_debug_display_enabled(): bool {
+		if ( ! \defined( 'WP_DEBUG' ) || ! \WP_DEBUG ) {
+			return false;
+		}
+
+		return ! \defined( 'WP_DEBUG_DISPLAY' ) || \WP_DEBUG_DISPLAY;
+	}
+
+	/**
+	 * Builds the debug display notification.
+	 *
+	 * @return Yoast_Notification The notification.
+	 */
+	private function get_notification(): Yoast_Notification {
+		return new Yoast_Notification(
+			$this->get_message(),
+			[
+				'id'           => self::NOTIFICATION_ID,
+				'type'         => Yoast_Notification::WARNING,
+				'capabilities' => [ 'wpseo_manage_options' ],
+			],
+		);
+	}
+
+	/**
+	 * Returns the notification message as an HTML string.
+	 *
+	 * @return string The HTML string representation of the notification.
+	 */
+	private function get_message(): string {
+		return \sprintf(
+			/* translators: %1$s expands to the opening strong tag, %2$s expands to the closing strong tag, %3$s expands to the opening anchor tag, %4$s expands to the closing anchor tag. */
+			\esc_html__(
+				'%1$sSEO issue: PHP debug output may be visible on your site.%2$s Your site is running with WP_DEBUG and WP_DEBUG_DISPLAY enabled. Error messages can appear on the frontend and get indexed by search engines. In wp-config.php, set WP_DEBUG_DISPLAY to false (and prefer WP_DEBUG_LOG if you still need debugging). %3$sLearn more about debugging in WordPress%4$s.',
+				'wordpress-seo',
+			),
+			'<strong>',
+			'</strong>',
+			'<a href="' . \esc_url( self::LEARN_MORE_URL ) . '" target="_blank" rel="noopener noreferrer">',
+			'</a>',
+		);
+	}
+}

--- a/tests/Unit/Alerts/Application/Debug_Display/Abstract_Debug_Display_Alert_Test.php
+++ b/tests/Unit/Alerts/Application/Debug_Display/Abstract_Debug_Display_Alert_Test.php
@@ -1,0 +1,59 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Debug_Display;
+
+use Mockery;
+use Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert;
+use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+use Yoast_Notification_Center;
+
+/**
+ * Base class for the debug display alert application tests.
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+abstract class Abstract_Debug_Display_Alert_Test extends TestCase {
+
+	/**
+	 * The notifications center.
+	 *
+	 * @var Mockery\MockInterface|Yoast_Notification_Center
+	 */
+	protected $notification_center;
+
+	/**
+	 * The environment helper.
+	 *
+	 * @var Mockery\MockInterface|Environment_Helper
+	 */
+	protected $environment_helper;
+
+	/**
+	 * Holds the instance.
+	 *
+	 * @var Debug_Display_Alert
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->notification_center = Mockery::mock( Yoast_Notification_Center::class );
+		$this->environment_helper  = Mockery::mock( Environment_Helper::class );
+
+		$this->instance = new Debug_Display_Alert(
+			$this->notification_center,
+			$this->environment_helper,
+		);
+	}
+}

--- a/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Add_Notifications_Test.php
+++ b/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Add_Notifications_Test.php
@@ -1,0 +1,132 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Debug_Display;
+
+use Brain\Monkey\Functions;
+use Generator;
+use Mockery;
+use WP_User;
+use Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert;
+
+/**
+ * Test class adding notifications.
+ *
+ * @group Debug_Display
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::add_notifications
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::should_show_notification
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::get_notification
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::get_message
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Debug_Display_Alert_Add_Notifications_Test extends Abstract_Debug_Display_Alert_Test {
+
+	/**
+	 * Tests adding notifications.
+	 *
+	 * @dataProvider add_notifications_data
+	 *
+	 * @param bool   $is_production             Whether the site is in production mode.
+	 * @param bool   $is_debug_display_enabled  Whether debug display is enabled.
+	 * @param int    $remove_notification_times The number of times we are removing a notification.
+	 * @param int    $add_notification_times    The number of times we are adding a notification.
+	 * @param string $expected_message          The expected notification message.
+	 *
+	 * @return void
+	 */
+	public function test_add_notifications(
+		$is_production,
+		$is_debug_display_enabled,
+		$remove_notification_times,
+		$add_notification_times,
+		$expected_message
+	) {
+		$admin_user     = Mockery::mock( WP_User::class );
+		$admin_user->ID = 1;
+
+		Functions\expect( 'get_current_user_id' )
+			->andReturn( $admin_user->ID );
+
+		$instance = Mockery::mock(
+			Debug_Display_Alert::class,
+			[
+				$this->notification_center,
+				$this->environment_helper,
+			],
+		)->makePartial()->shouldAllowMockingProtectedMethods();
+
+		$this->environment_helper
+			->expects( 'is_production_mode' )
+			->once()
+			->andReturn( $is_production );
+
+		if ( $is_production ) {
+			$instance
+				->expects( 'is_debug_display_enabled' )
+				->once()
+				->andReturn( $is_debug_display_enabled );
+		}
+		else {
+			$instance
+				->expects( 'is_debug_display_enabled' )
+				->never();
+		}
+
+		$this->notification_center
+			->expects( 'remove_notification_by_id' )
+			->times( $remove_notification_times )
+			->with( 'wpseo-debug-display-enabled' );
+
+		$this->notification_center
+			->expects( 'add_notification' )
+			->times( $add_notification_times )
+			->withArgs(
+				static function ( $notification ) use ( $expected_message ) {
+					$notification_array = $notification->to_array();
+					$options            = $notification_array['options'];
+
+					return $notification_array['message'] === $expected_message
+						&& $options['id'] === 'wpseo-debug-display-enabled'
+						&& $options['type'] === 'warning'
+						&& $options['capabilities'] === [ 'wpseo_manage_options' ];
+				},
+			);
+
+		$instance->add_notifications();
+	}
+
+	/**
+	 * Data provider for the test_add_notifications test.
+	 *
+	 * @return Generator Test data to use.
+	 */
+	public static function add_notifications_data() {
+		$expected_message = '<strong>SEO issue: PHP debug output may be visible on your site.</strong> Your site is running with WP_DEBUG and WP_DEBUG_DISPLAY enabled. Error messages can appear on the frontend and get indexed by search engines. In wp-config.php, set WP_DEBUG_DISPLAY to false (and prefer WP_DEBUG_LOG if you still need debugging). <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/" target="_blank" rel="noopener noreferrer">Learn more about debugging in WordPress</a>.';
+
+		yield 'Production with debug display - adds notification' => [
+			'is_production'             => true,
+			'is_debug_display_enabled'  => true,
+			'remove_notification_times' => 0,
+			'add_notification_times'    => 1,
+			'expected_message'          => $expected_message,
+		];
+
+		yield 'Production with debug display off - removes notification' => [
+			'is_production'             => true,
+			'is_debug_display_enabled'  => false,
+			'remove_notification_times' => 1,
+			'add_notification_times'    => 0,
+			'expected_message'          => 'irrelevant',
+		];
+
+		yield 'Non-production with debug display - removes notification' => [
+			'is_production'             => false,
+			'is_debug_display_enabled'  => true,
+			'remove_notification_times' => 1,
+			'add_notification_times'    => 0,
+			'expected_message'          => 'irrelevant',
+		];
+	}
+}

--- a/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Constructor_Test.php
+++ b/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Constructor_Test.php
@@ -1,0 +1,35 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Debug_Display;
+
+use Yoast\WP\SEO\Helpers\Environment_Helper;
+use Yoast_Notification_Center;
+
+/**
+ * Test class for the constructor.
+ *
+ * @group Debug_Display
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::__construct
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Debug_Display_Alert_Constructor_Test extends Abstract_Debug_Display_Alert_Test {
+
+	/**
+	 * Tests if the needed attributes are set correctly.
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+		$this->assertInstanceOf(
+			Yoast_Notification_Center::class,
+			$this->getPropertyValue( $this->instance, 'notification_center' ),
+		);
+		$this->assertInstanceOf(
+			Environment_Helper::class,
+			$this->getPropertyValue( $this->instance, 'environment_helper' ),
+		);
+	}
+}

--- a/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Get_Conditionals_Test.php
+++ b/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Get_Conditionals_Test.php
@@ -1,0 +1,29 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Debug_Display;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+
+/**
+ * Test class getting the conditionals.
+ *
+ * @group Debug_Display
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::get_conditionals
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Debug_Display_Alert_Get_Conditionals_Test extends Abstract_Debug_Display_Alert_Test {
+
+	/**
+	 * Tests the get_conditionals method.
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$expected = [ Admin_Conditional::class ];
+
+		$this->assertEquals( $expected, $this->instance::get_conditionals() );
+	}
+}

--- a/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Register_Hooks_Test.php
+++ b/tests/Unit/Alerts/Application/Debug_Display/Debug_Display_Alert_Register_Hooks_Test.php
@@ -1,0 +1,33 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Alerts\Application\Debug_Display;
+
+/**
+ * Test class for registering hooks.
+ *
+ * @group Debug_Display
+ *
+ * @covers Yoast\WP\SEO\Alerts\Application\Debug_Display\Debug_Display_Alert::register_hooks
+ *
+ * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
+ */
+final class Debug_Display_Alert_Register_Hooks_Test extends Abstract_Debug_Display_Alert_Test {
+
+	/**
+	 * Tests the registration of the hooks.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		$this->instance->register_hooks();
+
+		$this->assertEquals(
+			10,
+			\has_action(
+				'admin_init',
+				[ $this->instance, 'add_notifications' ],
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

When `WP_DEBUG` and `WP_DEBUG_DISPLAY` are enabled on a production site, PHP notices and warnings can appear on the frontend. Search engines can pick those up in results. After WordPress 6.7 this became more visible. This PR warns site owners in the Yoast Alert Center so they can fix `wp-config.php`.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shows a warning when WP_DEBUG_DISPLAY is enabled on a production site.

## Relevant technical choices:

* Follows the existing `Indexables_Disabled_Alert` pattern under `src/alerts/application/`.
* Only runs on production (`Environment_Helper::is_production_mode()`), so local and staging sites with debug on stay quiet.
* Treats undefined `WP_DEBUG_DISPLAY` as enabled when `WP_DEBUG` is on, matching WordPress core defaults.
* Surfaces through the existing Alert Center via `Yoast_Notification_Center` (type `warning`). No new JS and no Site Health check (core already covers that).
* No permanent ignore option: the alert clears when the constants are fixed and returns if they are turned back on.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Use a site with environment type production (WordPress default if unset), or set `define( 'WP_ENVIRONMENT_TYPE', 'production' );` in `wp-config.php`.
2. In `wp-config.php`, set:
   ```php
   define( 'WP_DEBUG', true );
   define( 'WP_DEBUG_DISPLAY', true );
   ```
3. Log in as an administrator and open **Yoast SEO → General** (Alert Center / Notifications).
4. Confirm a warning is shown about PHP debug output being visible, with a link to the WordPress debugging docs.
5. Change the config to `define( 'WP_DEBUG_DISPLAY', false );`, reload the Alert Center, and confirm the warning is gone.
6. Set `define( 'WP_ENVIRONMENT_TYPE', 'local' );` with debug display still on, reload, and confirm the warning does not appear.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

Same steps as the acceptance test above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Yoast SEO General page / Alert Center notifications list.
* No editor, frontend, or settings UI changes.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21845
