### PR TITLE
fix(presenters): drop XHTML slash from frontend meta and link tags

### DIFF
--- a/src/presenters/abstract-indexable-tag-presenter.php
+++ b/src/presenters/abstract-indexable-tag-presenter.php
@@ -9,9 +9,9 @@ namespace Yoast\WP\SEO\Presenters;
  */
 abstract class Abstract_Indexable_Tag_Presenter extends Abstract_Indexable_Presenter {
 
-	public const META_PROPERTY_CONTENT = '<meta property="%2$s" content="%1$s"%3$s />';
-	public const META_NAME_CONTENT     = '<meta name="%2$s" content="%1$s"%3$s />';
-	public const LINK_REL_HREF         = '<link rel="%2$s" href="%1$s"%3$s />';
+	public const META_PROPERTY_CONTENT = '<meta property="%2$s" content="%1$s"%3$s>';
+	public const META_NAME_CONTENT     = '<meta name="%2$s" content="%1$s"%3$s>';
+	public const LINK_REL_HREF         = '<link rel="%2$s" href="%1$s"%3$s>';
 	public const DEFAULT_TAG_FORMAT    = self::META_NAME_CONTENT;
 
 	/**

--- a/src/presenters/open-graph/image-presenter.php
+++ b/src/presenters/open-graph/image-presenter.php
@@ -51,14 +51,14 @@ class Image_Presenter extends Abstract_Indexable_Presenter {
 
 			$class = \is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : '';
 
-			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '"' . $class . ' />';
+			$return .= '<meta property="og:image" content="' . \esc_url( $image_url, null, 'attribute' ) . '"' . $class . '>';
 
 			foreach ( static::$image_tags as $key => $value ) {
 				if ( empty( $image_meta[ $key ] ) ) {
 					continue;
 				}
 
-				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . \esc_attr( $image_meta[ $key ] ) . '"' . $class . ' />';
+				$return .= \PHP_EOL . "\t" . '<meta property="og:image:' . \esc_attr( $key ) . '" content="' . \esc_attr( $image_meta[ $key ] ) . '"' . $class . '>';
 			}
 		}
 

--- a/src/presenters/robots-presenter.php
+++ b/src/presenters/robots-presenter.php
@@ -23,7 +23,7 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 		$robots = \implode( ', ', $this->get() );
 
 		if ( \is_string( $robots ) && $robots !== '' ) {
-			return \sprintf( '<meta name="robots" content="%s" />', \esc_attr( $robots ) );
+			return \sprintf( '<meta name="robots" content="%s">', \esc_attr( $robots ) );
 		}
 
 		return '';
@@ -32,7 +32,7 @@ class Robots_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Gets the raw value of a presentation.
 	 *
-	 * @return array The raw value.
+	 * @return array<string, string> The raw value.
 	 */
 	public function get() {
 		return $this->presentation->robots;

--- a/src/presenters/slack/enhanced-data-presenter.php
+++ b/src/presenters/slack/enhanced-data-presenter.php
@@ -28,8 +28,8 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 		$i             = 1;
 		$class         = \is_admin_bar_showing() ? ' class="yoast-seo-meta-tag"' : '';
 		foreach ( $enhanced_data as $label => $value ) {
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s"' . $class . ' />' . "\n", $i, \esc_attr( $label ) );
-			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s"' . $class . ' />' . "\n", $i, \esc_attr( $value ) );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:label%1$d" content="%2$s"' . $class . '>' . "\n", $i, \esc_attr( $label ) );
+			$twitter_tags .= \sprintf( "\t" . '<meta name="twitter:data%1$d" content="%2$s"' . $class . '>' . "\n", $i, \esc_attr( $value ) );
 			++$i;
 		}
 
@@ -39,7 +39,7 @@ class Enhanced_Data_Presenter extends Abstract_Indexable_Presenter {
 	/**
 	 * Gets the enhanced data array.
 	 *
-	 * @return array The enhanced data array
+	 * @return array<string, string> The enhanced data array
 	 */
 	public function get() {
 		$data                   = [];

--- a/tests/Unit/Presenters/Canonical_Presenter_Test.php
+++ b/tests/Unit/Presenters/Canonical_Presenter_Test.php
@@ -49,7 +49,7 @@ final class Canonical_Presenter_Test extends TestCase {
 		$presented_canonical = $instance->present();
 
 		$this->assertEquals(
-			'<link rel="canonical" href="https://permalink" />',
+			'<link rel="canonical" href="https://permalink">',
 			$presented_canonical,
 		);
 	}
@@ -96,7 +96,7 @@ final class Canonical_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<link rel="canonical" href="https://filtered" />',
+			'<link rel="canonical" href="https://filtered">',
 			$instance->present(),
 		);
 	}
@@ -141,7 +141,7 @@ final class Canonical_Presenter_Test extends TestCase {
 		$presented_canonical = $instance->present();
 
 		$this->assertEquals(
-			'<link rel="canonical" href="https://permalink" class="yoast-seo-meta-tag" />',
+			'<link rel="canonical" href="https://permalink" class="yoast-seo-meta-tag">',
 			$presented_canonical,
 		);
 	}

--- a/tests/Unit/Presenters/Meta_Author_Presenter_Test.php
+++ b/tests/Unit/Presenters/Meta_Author_Presenter_Test.php
@@ -108,7 +108,7 @@ final class Meta_Author_Presenter_Test extends TestCase {
 			->andReturn( 'John Doe' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$output = '<meta name="author" content="John Doe" />';
+		$output = '<meta name="author" content="John Doe">';
 
 		Monkey\Filters\expectApplied( 'wpseo_meta_author' );
 		$this->assertSame( $output, $this->instance->present() );
@@ -192,7 +192,7 @@ final class Meta_Author_Presenter_Test extends TestCase {
 			->andReturn( 'John Doe' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$output = '<meta name="author" content="John Doe" class="yoast-seo-meta-tag" />';
+		$output = '<meta name="author" content="John Doe" class="yoast-seo-meta-tag">';
 
 		$this->assertSame( $output, $this->instance->present() );
 	}

--- a/tests/Unit/Presenters/Meta_Description_Presenter_Test.php
+++ b/tests/Unit/Presenters/Meta_Description_Presenter_Test.php
@@ -107,7 +107,7 @@ final class Meta_Description_Presenter_Test extends TestCase {
 			->with( 'the_meta_description' )
 			->andReturn( 'the_meta_description' );
 
-		$output = '<meta name="description" content="the_meta_description" />';
+		$output = '<meta name="description" content="the_meta_description">';
 
 		$this->assertEquals( $output, $this->instance->present() );
 	}
@@ -213,7 +213,7 @@ final class Meta_Description_Presenter_Test extends TestCase {
 			->with( 'the_meta_description' )
 			->andReturn( 'the_meta_description' );
 
-		$output = '<meta name="description" content="the_meta_description" class="yoast-seo-meta-tag" />';
+		$output = '<meta name="description" content="the_meta_description" class="yoast-seo-meta-tag">';
 
 		$this->assertEquals( $output, $this->instance->present() );
 	}

--- a/tests/Unit/Presenters/Open_Graph/Article_Author_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Article_Author_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Article_Author_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:author" content="https://facebook.com/author" />';
+		$expected = '<meta property="article:author" content="https://facebook.com/author">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -98,7 +98,7 @@ final class Article_Author_Presenter_Test extends TestCase {
 			->andReturn( 'https://facebook.com/newauthor' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:author" content="https://facebook.com/newauthor" />';
+		$expected = '<meta property="article:author" content="https://facebook.com/newauthor">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -116,7 +116,7 @@ final class Article_Author_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="article:author" content="https://facebook.com/author" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="article:author" content="https://facebook.com/author" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Article_Modified_Time_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Article_Modified_Time_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Article_Modified_Time_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" />';
+		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -107,7 +107,7 @@ final class Article_Modified_Time_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="article:modified_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Article_Published_Time_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Article_Published_Time_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Article_Published_Time_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" />';
+		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -107,7 +107,7 @@ final class Article_Published_Time_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="article:published_time" content="2019-10-08T12:26:31+00:00" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Article_Publisher_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Article_Publisher_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Article_Publisher_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:publisher" content="https://example.com" />';
+		$expected = '<meta property="article:publisher" content="https://example.com">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -98,7 +98,7 @@ final class Article_Publisher_Presenter_Test extends TestCase {
 			->andReturn( 'https://otherpublisher.com' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="article:publisher" content="https://otherpublisher.com" />';
+		$expected = '<meta property="article:publisher" content="https://otherpublisher.com">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -116,7 +116,7 @@ final class Article_Publisher_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="article:publisher" content="https://example.com" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="article:publisher" content="https://example.com" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Description_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Description_Presenter_Test.php
@@ -103,7 +103,7 @@ final class Description_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:description" content="My description" />';
+		$expected = '<meta property="og:description" content="My description">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -142,7 +142,7 @@ final class Description_Presenter_Test extends TestCase {
 			->andReturn( 'My filtered description' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:description" content="My filtered description" />';
+		$expected = '<meta property="og:description" content="My filtered description">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -160,7 +160,7 @@ final class Description_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:description" content="My description" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:description" content="My description" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Image_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Image_Presenter_Test.php
@@ -86,7 +86,7 @@ final class Image_Presenter_Test extends TestCase {
 			->andReturn( false );
 
 		$this->assertEquals(
-			'<meta property="og:image" content="https://example.com/image.jpg" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" />',
+			'<meta property="og:image" content="https://example.com/image.jpg">' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100">' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100">',
 			$this->instance->present(),
 		);
 	}
@@ -223,7 +223,7 @@ final class Image_Presenter_Test extends TestCase {
 			->andReturn( false );
 
 		$this->assertEquals(
-			'<meta property="og:image" content="https://example.com/image.jpg" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag" />',
+			'<meta property="og:image" content="https://example.com/image.jpg" class="yoast-seo-meta-tag">' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag">' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}
@@ -263,7 +263,7 @@ final class Image_Presenter_Test extends TestCase {
 			->andReturnFirstArg();
 
 		$this->assertEquals(
-			'<meta property="og:image" content="https://example.com/image" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag" />' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag" />',
+			'<meta property="og:image" content="https://example.com/image" class="yoast-seo-meta-tag">' . \PHP_EOL . "\t" . '<meta property="og:image:width" content="100" class="yoast-seo-meta-tag">' . \PHP_EOL . "\t" . '<meta property="og:image:height" content="100" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Open_Graph/Locale_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Locale_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Locale_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:locale" content="nl_BE" />';
+		$expected = '<meta property="og:locale" content="nl_BE">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -82,7 +82,7 @@ final class Locale_Presenter_Test extends TestCase {
 			->andReturn( 'nl_BE' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:locale" content="nl_BE" />';
+		$expected = '<meta property="og:locale" content="nl_BE">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -100,7 +100,7 @@ final class Locale_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:locale" content="nl_BE" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:locale" content="nl_BE" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Site_Name_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Site_Name_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Site_Name_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:site_name" content="My Site" />';
+		$expected = '<meta property="og:site_name" content="My Site">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -98,7 +98,7 @@ final class Site_Name_Presenter_Test extends TestCase {
 			->andReturn( 'My Site' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:site_name" content="My Site" />';
+		$expected = '<meta property="og:site_name" content="My Site">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -116,7 +116,7 @@ final class Site_Name_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:site_name" content="My Site" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:site_name" content="My Site" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Title_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Title_Presenter_Test.php
@@ -100,7 +100,7 @@ final class Title_Presenter_Test extends TestCase {
 			);
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:title" content="example_title" />';
+		$expected = '<meta property="og:title" content="example_title">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -154,7 +154,7 @@ final class Title_Presenter_Test extends TestCase {
 			->andReturn( 'exampletitle' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:title" content="exampletitle" />';
+		$expected = '<meta property="og:title" content="exampletitle">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -179,7 +179,7 @@ final class Title_Presenter_Test extends TestCase {
 			);
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:title" content="example_title" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:title" content="example_title" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Type_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Type_Presenter_Test.php
@@ -60,7 +60,7 @@ final class Type_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:type" content="article" />';
+		$expected = '<meta property="og:type" content="article">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -99,7 +99,7 @@ final class Type_Presenter_Test extends TestCase {
 			->andReturn( 'article' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:type" content="article" />';
+		$expected = '<meta property="og:type" content="article">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -117,7 +117,7 @@ final class Type_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:type" content="article" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:type" content="article" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Open_Graph/Url_Presenter_Test.php
+++ b/tests/Unit/Presenters/Open_Graph/Url_Presenter_Test.php
@@ -59,7 +59,7 @@ final class Url_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:url" content="www.example.com" />';
+		$expected = '<meta property="og:url" content="www.example.com">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -95,7 +95,7 @@ final class Url_Presenter_Test extends TestCase {
 			->andReturn( 'www.example.com' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta property="og:url" content="www.example.com" />';
+		$expected = '<meta property="og:url" content="www.example.com">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -113,7 +113,7 @@ final class Url_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta property="og:url" content="www.example.com" class="yoast-seo-meta-tag" />';
+		$expected = '<meta property="og:url" content="www.example.com" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Rel_Next_Presenter_Test.php
+++ b/tests/Unit/Presenters/Rel_Next_Presenter_Test.php
@@ -99,7 +99,7 @@ final class Rel_Next_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<link rel="next" href="https://filtered" />',
+			'<link rel="next" href="https://filtered">',
 			$this->instance->present(),
 		);
 	}
@@ -122,7 +122,7 @@ final class Rel_Next_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<link rel="next" href="https://permalink/post/2" class="yoast-seo-meta-tag" />',
+			'<link rel="next" href="https://permalink/post/2" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Rel_Prev_Presenter_Test.php
+++ b/tests/Unit/Presenters/Rel_Prev_Presenter_Test.php
@@ -56,7 +56,7 @@ final class Rel_Prev_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<link rel="prev" href="https://permalink/post/2" />',
+			'<link rel="prev" href="https://permalink/post/2">',
 			$this->instance->present(),
 		);
 	}
@@ -122,7 +122,7 @@ final class Rel_Prev_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<link rel="prev" href="https://filtered" />',
+			'<link rel="prev" href="https://filtered">',
 			$this->instance->present(),
 		);
 	}
@@ -145,7 +145,7 @@ final class Rel_Prev_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<link rel="prev" href="https://permalink/post/2" class="yoast-seo-meta-tag" />',
+			'<link rel="prev" href="https://permalink/post/2" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Robots_Presenter_Test.php
+++ b/tests/Unit/Presenters/Robots_Presenter_Test.php
@@ -63,7 +63,7 @@ final class Robots_Presenter_Test extends TestCase {
 		];
 
 		$actual   = $this->instance->present();
-		$expected = '<meta name="robots" content="index, nofollow" />';
+		$expected = '<meta name="robots" content="index, nofollow">';
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/Unit/Presenters/Slack/Enhanced_Data_Presenter_Test.php
+++ b/tests/Unit/Presenters/Slack/Enhanced_Data_Presenter_Test.php
@@ -80,10 +80,10 @@ final class Enhanced_Data_Presenter_Test extends TestCase {
 		Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			"<meta name=\"twitter:label1\" content=\"Written by\" />\n"
-			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\" />\n"
-			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\" />\n"
-			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\" />",
+			"<meta name=\"twitter:label1\" content=\"Written by\">\n"
+			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\">\n"
+			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\">\n"
+			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\">",
 			$this->instance->present(),
 		);
 	}
@@ -116,8 +116,8 @@ final class Enhanced_Data_Presenter_Test extends TestCase {
 		Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			"<meta name=\"twitter:label1\" content=\"Est. reading time\" />\n"
-			. "\t<meta name=\"twitter:data1\" content=\"40 minutes\" />",
+			"<meta name=\"twitter:label1\" content=\"Est. reading time\">\n"
+			. "\t<meta name=\"twitter:data1\" content=\"40 minutes\">",
 			$this->instance->present(),
 		);
 	}
@@ -150,10 +150,10 @@ final class Enhanced_Data_Presenter_Test extends TestCase {
 		Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			"<meta name=\"twitter:label1\" content=\"Written by\" class=\"yoast-seo-meta-tag\" />\n"
-			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\" class=\"yoast-seo-meta-tag\" />\n"
-			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\" class=\"yoast-seo-meta-tag\" />\n"
-			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\" class=\"yoast-seo-meta-tag\" />",
+			"<meta name=\"twitter:label1\" content=\"Written by\" class=\"yoast-seo-meta-tag\">\n"
+			. "\t<meta name=\"twitter:data1\" content=\"Agatha Christie\" class=\"yoast-seo-meta-tag\">\n"
+			. "\t<meta name=\"twitter:label2\" content=\"Est. reading time\" class=\"yoast-seo-meta-tag\">\n"
+			. "\t<meta name=\"twitter:data2\" content=\"40 minutes\" class=\"yoast-seo-meta-tag\">",
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Twitter/Card_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Card_Presenter_Test.php
@@ -54,7 +54,7 @@ final class Card_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<meta name="twitter:card" content="summary" />',
+			'<meta name="twitter:card" content="summary">',
 			$this->instance->present(),
 		);
 	}
@@ -91,7 +91,7 @@ final class Card_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<meta name="twitter:card" content="summary" class="yoast-seo-meta-tag" />',
+			'<meta name="twitter:card" content="summary" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Twitter/Creator_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Creator_Presenter_Test.php
@@ -61,7 +61,7 @@ final class Creator_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<meta name="twitter:creator" content="@TwitterHandle" />',
+			'<meta name="twitter:creator" content="@TwitterHandle">',
 			$this->instance->present(),
 		);
 	}
@@ -107,7 +107,7 @@ final class Creator_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<meta name="twitter:creator" content="@TwitterHandle" class="yoast-seo-meta-tag" />',
+			'<meta name="twitter:creator" content="@TwitterHandle" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Twitter/Description_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Description_Presenter_Test.php
@@ -70,7 +70,7 @@ final class Description_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<meta name="twitter:description" content="This is the twitter description" />',
+			'<meta name="twitter:description" content="This is the twitter description">',
 			$this->instance->present(),
 		);
 	}
@@ -116,7 +116,7 @@ final class Description_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<meta name="twitter:description" content="This is the twitter description" class="yoast-seo-meta-tag" />',
+			'<meta name="twitter:description" content="This is the twitter description" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Twitter/Image_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Image_Presenter_Test.php
@@ -61,7 +61,7 @@ final class Image_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
+		$expected = '<meta name="twitter:image" content="relative_image.jpg">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -98,7 +98,7 @@ final class Image_Presenter_Test extends TestCase {
 			->andReturn( 'relative_image.jpg' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta name="twitter:image" content="relative_image.jpg" />';
+		$expected = '<meta name="twitter:image" content="relative_image.jpg">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -116,7 +116,7 @@ final class Image_Presenter_Test extends TestCase {
 
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta name="twitter:image" content="relative_image.jpg" class="yoast-seo-meta-tag" />';
+		$expected = '<meta name="twitter:image" content="relative_image.jpg" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/Unit/Presenters/Twitter/Site_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Site_Presenter_Test.php
@@ -79,7 +79,7 @@ final class Site_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<meta name="twitter:site" content="@AlteredTwitterHandle" />',
+			'<meta name="twitter:site" content="@AlteredTwitterHandle">',
 			$this->instance->present(),
 		);
 	}
@@ -98,7 +98,7 @@ final class Site_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertEquals(
-			'<meta name="twitter:site" content="@TwitterHandle" />',
+			'<meta name="twitter:site" content="@TwitterHandle">',
 			$this->instance->present(),
 		);
 	}
@@ -169,7 +169,7 @@ final class Site_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertEquals(
-			'<meta name="twitter:site" content="@TwitterHandle" class="yoast-seo-meta-tag" />',
+			'<meta name="twitter:site" content="@TwitterHandle" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Twitter/Title_Presenter_Test.php
+++ b/tests/Unit/Presenters/Twitter/Title_Presenter_Test.php
@@ -78,7 +78,7 @@ final class Title_Presenter_Test extends TestCase {
 			);
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta name="twitter:title" content="twitter_example_title" />';
+		$expected = '<meta name="twitter:title" content="twitter_example_title">';
 		$actual   = $this->instance->present();
 		$this->assertEquals( $expected, $actual );
 	}
@@ -130,7 +130,7 @@ final class Title_Presenter_Test extends TestCase {
 			->andReturn( 'twitterexampletitle' );
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
-		$expected = '<meta name="twitter:title" content="twitterexampletitle" />';
+		$expected = '<meta name="twitter:title" content="twitterexampletitle">';
 		$actual   = $this->instance->present();
 
 		$this->assertEquals( $expected, $actual );
@@ -155,7 +155,7 @@ final class Title_Presenter_Test extends TestCase {
 			);
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
-		$expected = '<meta name="twitter:title" content="twitter_example_title" class="yoast-seo-meta-tag" />';
+		$expected = '<meta name="twitter:title" content="twitter_example_title" class="yoast-seo-meta-tag">';
 		$actual   = $this->instance->present();
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/Unit/Presenters/Webmaster/Baidu_Presenter_Test.php
+++ b/tests/Unit/Presenters/Webmaster/Baidu_Presenter_Test.php
@@ -72,7 +72,7 @@ final class Baidu_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertSame(
-			'<meta name="baidu-site-verification" content="baidu" />',
+			'<meta name="baidu-site-verification" content="baidu">',
 			$this->instance->present(),
 		);
 	}
@@ -140,7 +140,7 @@ final class Baidu_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertSame(
-			'<meta name="baidu-site-verification" content="baidu" class="yoast-seo-meta-tag" />',
+			'<meta name="baidu-site-verification" content="baidu" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Webmaster/Bing_Presenter_Test.php
+++ b/tests/Unit/Presenters/Webmaster/Bing_Presenter_Test.php
@@ -72,7 +72,7 @@ final class Bing_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertSame(
-			'<meta name="msvalidate.01" content="bing-ver" />',
+			'<meta name="msvalidate.01" content="bing-ver">',
 			$this->instance->present(),
 		);
 	}
@@ -124,7 +124,7 @@ final class Bing_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertSame(
-			'<meta name="msvalidate.01" content="bing-ver" class="yoast-seo-meta-tag" />',
+			'<meta name="msvalidate.01" content="bing-ver" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Webmaster/Google_Presenter_Test.php
+++ b/tests/Unit/Presenters/Webmaster/Google_Presenter_Test.php
@@ -72,7 +72,7 @@ final class Google_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertSame(
-			'<meta name="google-site-verification" content="google-ver" />',
+			'<meta name="google-site-verification" content="google-ver">',
 			$this->instance->present(),
 		);
 	}
@@ -124,7 +124,7 @@ final class Google_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertSame(
-			'<meta name="google-site-verification" content="google-ver" class="yoast-seo-meta-tag" />',
+			'<meta name="google-site-verification" content="google-ver" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Webmaster/Pinterest_Presenter_Test.php
+++ b/tests/Unit/Presenters/Webmaster/Pinterest_Presenter_Test.php
@@ -72,7 +72,7 @@ final class Pinterest_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertSame(
-			'<meta name="p:domain_verify" content="pinterest-ver" />',
+			'<meta name="p:domain_verify" content="pinterest-ver">',
 			$this->instance->present(),
 		);
 	}
@@ -124,7 +124,7 @@ final class Pinterest_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertSame(
-			'<meta name="p:domain_verify" content="pinterest-ver" class="yoast-seo-meta-tag" />',
+			'<meta name="p:domain_verify" content="pinterest-ver" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}

--- a/tests/Unit/Presenters/Webmaster/Yandex_Presenter_Test.php
+++ b/tests/Unit/Presenters/Webmaster/Yandex_Presenter_Test.php
@@ -72,7 +72,7 @@ final class Yandex_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( false );
 
 		$this->assertSame(
-			'<meta name="yandex-verification" content="yandex-ver" />',
+			'<meta name="yandex-verification" content="yandex-ver">',
 			$this->instance->present(),
 		);
 	}
@@ -124,7 +124,7 @@ final class Yandex_Presenter_Test extends TestCase {
 		Monkey\Functions\expect( 'is_admin_bar_showing' )->andReturn( true );
 
 		$this->assertSame(
-			'<meta name="yandex-verification" content="yandex-ver" class="yoast-seo-meta-tag" />',
+			'<meta name="yandex-verification" content="yandex-ver" class="yoast-seo-meta-tag">',
 			$this->instance->present(),
 		);
 	}


### PR DESCRIPTION
## Context

The frontend `<meta>` and `<link>` tags Yoast SEO outputs in the page head use XHTML self-closing syntax (`<meta ... />`). WordPress never serves pages as `application/xhtml+xml`, so the trailing slash is dead XHTML compatibility that HTML5 does not require and that the W3 validator flags. WordPress core is making the same cleanup under [Trac #59883](https://core.trac.wordpress.org/ticket/59883). A prior Yoast PR (#16952) added these slashes; they have been outdated for years.

This PR removes the trailing slash from all frontend meta and link tags so the output is plain HTML5.

## Summary

This PR can be summarized in the following changelog entry:

* Removes the trailing slash from frontend meta and link tags output by Yoast SEO.

Attach label: `changelog: enhancement`

## Relevant technical choices:

All frontend head tags are generated in PHP. The output goes through one shared base class, `Abstract_Indexable_Tag_Presenter`, which holds three tag format constants (`META_PROPERTY_CONTENT`, `META_NAME_CONTENT`, `LINK_REL_HREF`) used by 26 presenters (Open Graph, Twitter, Webmaster, meta description, meta author, canonical, rel-next, rel-prev). Dropping the slash from those three constants fixes the whole family in one place.

Three presenters build their tags standalone instead of using the base constants, so they were updated directly: `Robots_Presenter`, `Open_Graph\Image_Presenter`, and `Slack\Enhanced_Data_Presenter`.

Admin and non-head markup (`<input>`, `<br>`, `<img>` in wp-admin) were left unchanged, since issue #21858 is about the frontend meta tags a visitor sees in page source.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Install this branch on a test site and activate Yoast SEO.
2. Open any published post on the frontend and view the page source.
3. In the `<head>`, find the Yoast tags and confirm each ends with `>` and not ` />`. Check `<meta name="description">`, `<meta name="robots">`, `<link rel="canonical">`, the `<meta property="og:*">` tags, and the `<meta name="twitter:*">` tags.
4. Run the post URL through https://validator.w3.org/ and confirm there are no Yoast related void element slash warnings.
5. Repeat on a category archive, the homepage, and a page.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The change is head markup only, so it applies the same way across posts, pages, taxonomies, and custom post types. Editors, browsers, and multisite do not affect the output.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

QA can use the acceptance test steps above: view page source on a post, page, taxonomy archive, and homepage, and confirm all Yoast `<meta>` and `<link>` tags end with `>` and not ` />`. Optionally run the page through the W3 validator.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

The frontend head output for meta tags and link tags: Open Graph, Twitter Cards, Webmaster verification, robots, canonical, rel-next, rel-prev, meta description, meta author, and Slack enhanced data. The change is cosmetic (the ` /` before `>` is removed) and does not change tag attributes, values, escaping, or filters. A third party that string-matches on the ` />` suffix of Yoast output would need to update their match.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #21858
