### PR TITLE
ci: report a PR's net contribution to the plugin zip size

### DIFF
--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -1,0 +1,169 @@
+/**
+ * Pure helper that turns two zip-size maps (base vs. head) into a check-run title and a
+ * markdown summary. Kept dependency-free and side-effect-free so it can be unit-tested and
+ * called from a thin `github-script` step. See .github/workflows/zip-size-report.yml.
+ *
+ * A size map has the shape { total: <bytes>, entries: { "<path>": <bytes>, ... } } as
+ * produced by the measure helper in zip-size-build.yml.
+ */
+
+// Most-changed entries and directories shown in the summary; the rest are collapsed into a
+// logged "+N more" line so the report never silently hides truncated rows.
+const MAX_ROWS = 20;
+
+/**
+ * Formats a byte count as a signed, human-readable string (e.g. "+23.4 kB", "-512 B").
+ *
+ * @param {number} bytes The (possibly negative) byte delta.
+ * @param {boolean} [signed] Whether to prefix non-negative values with "+". Default true.
+ * @returns {string} The formatted size.
+ */
+function formatBytes( bytes, signed = true ) {
+	const sign = bytes > 0 && signed ? "+" : bytes < 0 ? "-" : signed ? "+" : "";
+	const abs = Math.abs( bytes );
+	if ( abs < 1024 ) {
+		return `${ sign }${ abs } B`;
+	}
+	const units = [ "kB", "MB", "GB" ];
+	let value = abs / 1024;
+	let unit = 0;
+	while ( value >= 1024 && unit < units.length - 1 ) {
+		value /= 1024;
+		unit++;
+	}
+	return `${ sign }${ value.toFixed( value < 10 ? 2 : 1 ) } ${ units[ unit ] }`;
+}
+
+/**
+ * Formats a fraction as a signed percentage string (e.g. "+0.12%").
+ *
+ * @param {number} fraction The fraction (delta / base).
+ * @returns {string} The formatted percentage, or "n/a" when the base was zero.
+ */
+function formatPercent( fraction ) {
+	if ( ! isFinite( fraction ) ) {
+		return "n/a";
+	}
+	const pct = fraction * 100;
+	const sign = pct > 0 ? "+" : "";
+	return `${ sign }${ pct.toFixed( 2 ) }%`;
+}
+
+/**
+ * Rolls per-file sizes up into their top-level directory inside the plugin folder, so the
+ * summary can show which area of the plugin moved (e.g. "js/dist", "vendor_prefixed").
+ *
+ * @param {Object<string, number>} entries Map of file path to size.
+ * @returns {Object<string, number>} Map of directory to summed size.
+ */
+function rollUpDirectories( entries ) {
+	const dirs = {};
+	for ( const [ path, size ] of Object.entries( entries ) ) {
+		// Drop the leading "<pluginSlug>/" wrapper, then key on the next two segments so
+		// meaningful areas (e.g. "js/dist", "src/generated") stay distinct.
+		const parts = path.split( "/" ).slice( 1 );
+		const key = parts.length <= 1 ? "(root)" : parts.slice( 0, Math.min( 2, parts.length - 1 ) ).join( "/" );
+		dirs[ key ] = ( dirs[ key ] || 0 ) + size;
+	}
+	return dirs;
+}
+
+/**
+ * Computes per-key deltas between two size maps and returns them sorted by absolute change.
+ *
+ * @param {Object<string, number>} base Base size map.
+ * @param {Object<string, number>} head Head size map.
+ * @returns {Array<{key: string, base: number, head: number, delta: number}>} Sorted deltas.
+ */
+function diffMaps( base, head ) {
+	const keys = new Set( [ ...Object.keys( base ), ...Object.keys( head ) ] );
+	const rows = [];
+	for ( const key of keys ) {
+		const b = base[ key ] || 0;
+		const h = head[ key ] || 0;
+		if ( b !== h ) {
+			rows.push( { key, base: b, head: h, delta: h - b } );
+		}
+	}
+	rows.sort( ( a, b ) => Math.abs( b.delta ) - Math.abs( a.delta ) );
+	return rows;
+}
+
+/**
+ * Renders a markdown table for a set of delta rows, truncating to MAX_ROWS and appending a
+ * "+N more" note (also returned via `truncated` so the caller can log it).
+ *
+ * @param {Array<{key: string, base: number, head: number, delta: number}>} rows Delta rows.
+ * @param {string} label Column header for the first column.
+ * @returns {{table: string, truncated: number}} The markdown table and truncated-row count.
+ */
+function renderTable( rows, label ) {
+	if ( rows.length === 0 ) {
+		return { table: "_No changes._", truncated: 0 };
+	}
+	const shown = rows.slice( 0, MAX_ROWS );
+	const truncated = rows.length - shown.length;
+	const lines = [
+		`| ${ label } | Base | Head | Δ |`,
+		"| --- | ---: | ---: | ---: |",
+	];
+	for ( const row of shown ) {
+		const status = row.base === 0 ? " (new)" : row.head === 0 ? " (removed)" : "";
+		lines.push(
+			`| \`${ row.key }\`${ status } | ${ formatBytes( row.base, false ) } | ` +
+			`${ formatBytes( row.head, false ) } | ${ formatBytes( row.delta ) } |`
+		);
+	}
+	if ( truncated > 0 ) {
+		lines.push( "", `_…and ${ truncated } more changed ${ label.toLowerCase() } (largest ${ MAX_ROWS } shown)._` );
+	}
+	return { table: lines.join( "\n" ), truncated };
+}
+
+/**
+ * Builds the check-run title and markdown summary for a base→head zip-size comparison.
+ *
+ * @param {{total: number, entries: Object}} baseMap Base size map.
+ * @param {{total: number, entries: Object}} headMap Head size map.
+ * @returns {{title: string, summary: string, delta: number, truncated: number}} The report.
+ */
+function buildReport( baseMap, headMap ) {
+	const delta = headMap.total - baseMap.total;
+	const fraction = baseMap.total === 0 ? Infinity : delta / baseMap.total;
+
+	const title = delta === 0
+		? "No change to zip size"
+		: `${ formatBytes( delta ) } (${ formatPercent( fraction ) })`;
+
+	const fileRows = diffMaps( baseMap.entries, headMap.entries );
+	const dirRows = diffMaps( rollUpDirectories( baseMap.entries ), rollUpDirectories( headMap.entries ) );
+
+	const files = renderTable( fileRows, "File" );
+	const dirs = renderTable( dirRows, "Directory" );
+
+	const summary = [
+		`**Total zip size:** ${ formatBytes( baseMap.total, false ) } → ${ formatBytes( headMap.total, false ) } ` +
+			`(**${ formatBytes( delta ) }**, ${ formatPercent( fraction ) })`,
+		"",
+		"Sizes are the compressed (shipped) bytes of each entry in `artifact.zip`.",
+		"",
+		"### By directory",
+		"",
+		dirs.table,
+		"",
+		"### By file",
+		"",
+		files.table,
+	].join( "\n" );
+
+	return { title, summary, delta, truncated: files.truncated + dirs.truncated };
+}
+
+module.exports = {
+	buildReport,
+	// Exported for unit testing.
+	formatBytes,
+	formatPercent,
+	rollUpDirectories,
+	diffMaps,
+};

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -187,7 +187,7 @@ function renderTable( rows, label ) {
 		);
 	}
 	if ( truncated > 0 ) {
-		lines.push( "", `_…and ${ truncated } more changed ${ label.toLowerCase() } (largest ${ MAX_ROWS } shown)._` );
+		lines.push( "", `_…and ${ truncated } more not shown (largest ${ MAX_ROWS } listed)._` );
 	}
 	return { table: lines.join( "\n" ), truncated };
 }

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -7,8 +7,6 @@
  * produced by the measure helper in zip-size-build.yml.
  */
 
-/* eslint-env node */
-
 // Most-changed entries and directories shown in the summary; the rest are collapsed into a
 // logged "+N more" line so the report never silently hides truncated rows.
 const MAX_ROWS = 20;

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -3,13 +3,19 @@
  * markdown summary. Kept dependency-free and side-effect-free so it can be unit-tested and
  * called from a thin `github-script` step. See .github/workflows/zip-size-report.yml.
  *
- * A size map has the shape { total: <bytes>, entries: { "<path>": <bytes>, ... } } as
- * produced by the measure helper in zip-size-build.yml.
+ * A size map has the shape { archive: <bytes>, total: <bytes>, entries: { "<path>": <bytes>, ... } }
+ * as produced by the measure helper in zip-size-build.yml. `archive` is the on-disk .zip size
+ * (what verify-zip-size checks against the 5 MB budget); `total`/`entries` are the summed
+ * per-entry compressed sizes that drive the attribution tables.
  */
 
 // Most-changed entries and directories shown in the summary; the rest are collapsed into a
 // logged "+N more" line so the report never silently hides truncated rows.
 const MAX_ROWS = 20;
+
+// The plugin release budget verify-zip-size enforces against the on-disk artifact.zip size.
+// Kept in sync with config/grunt/custom-tasks/verify-zip-size.js (5 MB = 5242880 bytes).
+const ZIP_SIZE_BUDGET = 5242880;
 
 /**
  * Returns the sign prefix for a number. Negative always yields "-"; a non-negative value
@@ -189,17 +195,17 @@ function renderTable( rows, label ) {
 /**
  * Validates a size map read from the (untrusted) artifact and returns it unchanged. Throws
  * on anything that would produce NaN or corrupt arithmetic downstream — a non-finite
- * `total`, a missing/`null` `entries`, or any non-finite entry value. Keeping this at the
- * single entry point means `diffMaps`/`rollUpDirectories` can assume numeric input
- * regardless of caller, and a hostile artifact degrades to the neutral fallback rather
+ * `archive` or `total`, a missing/`null` `entries`, or any non-finite entry value. Keeping
+ * this at the single entry point means `diffMaps`/`rollUpDirectories` can assume numeric
+ * input regardless of caller, and a hostile artifact degrades to the neutral fallback rather
  * than rendering NaN or string-concatenated sizes.
  *
  * @param {*} map The candidate size map.
  * @param {string} name Label for the error message.
- * @returns {{total: number, entries: Object<string, number>}} The validated map.
+ * @returns {{archive: number, total: number, entries: Object<string, number>}} The validated map.
  */
 function normalizeMap( map, name ) {
-	if ( ! map || ! Number.isFinite( map.total ) || typeof map.entries !== "object" || map.entries === null ) {
+	if ( ! map || ! Number.isFinite( map.archive ) || ! Number.isFinite( map.total ) || typeof map.entries !== "object" || map.entries === null ) {
 		throw new Error( `Malformed ${ name } size map` );
 	}
 	for ( const size of Object.values( map.entries ) ) {
@@ -214,16 +220,19 @@ function normalizeMap( map, name ) {
  * Builds the check-run title and markdown summary for a base→head zip-size comparison.
  * Throws if either map is malformed; callers turn that into the neutral fallback check.
  *
- * @param {{total: number, entries: Object}} rawBaseMap Base size map (untrusted).
- * @param {{total: number, entries: Object}} rawHeadMap Head size map (untrusted).
+ * @param {{archive: number, total: number, entries: Object}} rawBaseMap Base size map (untrusted).
+ * @param {{archive: number, total: number, entries: Object}} rawHeadMap Head size map (untrusted).
  * @returns {{title: string, summary: string, delta: number, truncated: number}} The report.
  */
 function buildReport( rawBaseMap, rawHeadMap ) {
 	const baseMap = normalizeMap( rawBaseMap, "base" );
 	const headMap = normalizeMap( rawHeadMap, "head" );
 
-	const delta = headMap.total - baseMap.total;
-	const fraction = baseMap.total === 0 ? Infinity : delta / baseMap.total;
+	// Headline the on-disk archive delta: it is what verify-zip-size measures against the
+	// 5 MB budget, so it is the number that actually decides whether a release fits. The
+	// per-entry sums below only attribute where that change came from.
+	const delta = headMap.archive - baseMap.archive;
+	const fraction = baseMap.archive === 0 ? Infinity : delta / baseMap.archive;
 
 	const title = delta === 0
 		? "No change to zip size"
@@ -236,10 +245,12 @@ function buildReport( rawBaseMap, rawHeadMap ) {
 	const dirs = renderTable( dirRows, "Directory" );
 
 	const summary = [
-		`**Total zip size:** ${ formatBytes( baseMap.total, false ) } → ${ formatBytes( headMap.total, false ) } ` +
+		`**Zip size:** ${ formatBytes( baseMap.archive, false ) } → ${ formatBytes( headMap.archive, false ) } ` +
 			`(**${ formatBytes( delta ) }**, ${ formatPercent( fraction ) })`,
+		`**Budget:** ${ ( headMap.archive / ZIP_SIZE_BUDGET * 100 ).toFixed( 1 ) }% of ${ formatBytes( ZIP_SIZE_BUDGET, false ) } used.`,
 		"",
-		"Sizes are the compressed (shipped) bytes of each entry in `artifact.zip`.",
+		"Headline is the on-disk `artifact.zip` size (the 5 MB release budget). The tables " +
+			"below attribute the change using the compressed (shipped) bytes of each entry.",
 		"",
 		"### By directory",
 		"",

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -89,6 +89,29 @@ function diffMaps( base, head ) {
 	return rows;
 }
 
+// Longest entry path rendered in a cell; anything longer is middle-truncated.
+const MAX_KEY_LENGTH = 120;
+
+/**
+ * Sanitizes an entry path for safe rendering inside a markdown table code span. The path
+ * comes from an untrusted artifact, so characters that could break out of the cell or the
+ * code span (pipe, backtick, backslash, CR/LF) are stripped, and the length is capped, to
+ * prevent a tampered artifact from spoofing the check-run summary.
+ *
+ * @param {string} key The raw entry path.
+ * @returns {string} A single-line, length-bounded, table-safe string.
+ */
+function sanitizeKey( key ) {
+	// Coerce non-strings (a tampered map could carry anything as a key) and flatten
+	// newlines, then drop the markdown-significant characters.
+	let safe = String( key ).replace( /[\r\n]+/g, " " ).replace( /[`|\\]/g, "" );
+	if ( safe.length > MAX_KEY_LENGTH ) {
+		const half = Math.floor( ( MAX_KEY_LENGTH - 1 ) / 2 );
+		safe = `${ safe.slice( 0, half ) }…${ safe.slice( -half ) }`;
+	}
+	return safe;
+}
+
 /**
  * Renders a markdown table for a set of delta rows, truncating to MAX_ROWS and appending a
  * "+N more" note (also returned via `truncated` so the caller can log it).
@@ -110,7 +133,7 @@ function renderTable( rows, label ) {
 	for ( const row of shown ) {
 		const status = row.base === 0 ? " (new)" : row.head === 0 ? " (removed)" : "";
 		lines.push(
-			`| \`${ row.key }\`${ status } | ${ formatBytes( row.base, false ) } | ` +
+			`| \`${ sanitizeKey( row.key ) }\`${ status } | ${ formatBytes( row.base, false ) } | ` +
 			`${ formatBytes( row.head, false ) } | ${ formatBytes( row.delta ) } |`
 		);
 	}
@@ -166,4 +189,5 @@ module.exports = {
 	formatPercent,
 	rollUpDirectories,
 	diffMaps,
+	sanitizeKey,
 };

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -7,9 +7,44 @@
  * produced by the measure helper in zip-size-build.yml.
  */
 
+/* eslint-env node */
+
 // Most-changed entries and directories shown in the summary; the rest are collapsed into a
 // logged "+N more" line so the report never silently hides truncated rows.
 const MAX_ROWS = 20;
+
+/**
+ * Returns the sign prefix for a number. Negative always yields "-"; a non-negative value
+ * yields "+" only when `signed` is set (used for absolute columns that want no "+").
+ *
+ * @param {number} value The number to sign.
+ * @param {boolean} signed Whether non-negative values get a "+" prefix.
+ * @returns {string} "+", "-", or "".
+ */
+function signPrefix( value, signed ) {
+	if ( value < 0 ) {
+		return "-";
+	}
+	return signed ? "+" : "";
+}
+
+/**
+ * Scales an absolute byte count to the largest unit under 1024, returning the value and its
+ * unit label.
+ *
+ * @param {number} abs The absolute byte count.
+ * @returns {{value: number, unit: string}} The scaled value and its unit.
+ */
+function scaleBytes( abs ) {
+	const units = [ "B", "kB", "MB", "GB" ];
+	let value = abs;
+	let unit = 0;
+	while ( value >= 1024 && unit < units.length - 1 ) {
+		value /= 1024;
+		unit++;
+	}
+	return { value, unit: units[ unit ] };
+}
 
 /**
  * Formats a byte count as a signed, human-readable string (e.g. "+23.4 kB", "-512 B").
@@ -19,19 +54,12 @@ const MAX_ROWS = 20;
  * @returns {string} The formatted size.
  */
 function formatBytes( bytes, signed = true ) {
-	const sign = bytes > 0 && signed ? "+" : bytes < 0 ? "-" : signed ? "+" : "";
-	const abs = Math.abs( bytes );
-	if ( abs < 1024 ) {
-		return `${ sign }${ abs } B`;
+	const sign = signPrefix( bytes, signed );
+	const { value, unit } = scaleBytes( Math.abs( bytes ) );
+	if ( unit === "B" ) {
+		return `${ sign }${ value } ${ unit }`;
 	}
-	const units = [ "kB", "MB", "GB" ];
-	let value = abs / 1024;
-	let unit = 0;
-	while ( value >= 1024 && unit < units.length - 1 ) {
-		value /= 1024;
-		unit++;
-	}
-	return `${ sign }${ value.toFixed( value < 10 ? 2 : 1 ) } ${ units[ unit ] }`;
+	return `${ sign }${ value.toFixed( value < 10 ? 2 : 1 ) } ${ unit }`;
 }
 
 /**
@@ -45,8 +73,8 @@ function formatPercent( fraction ) {
 		return "n/a";
 	}
 	const pct = fraction * 100;
-	const sign = pct > 0 ? "+" : "";
-	return `${ sign }${ pct.toFixed( 2 ) }%`;
+	// signPrefix owns the sign, so format the absolute value to avoid a doubled "-".
+	return `${ signPrefix( pct, true ) }${ Math.abs( pct ).toFixed( 2 ) }%`;
 }
 
 /**
@@ -113,6 +141,23 @@ function sanitizeKey( key ) {
 }
 
 /**
+ * Returns a " (new)"/" (removed)" annotation for a delta row, or "" when the entry exists on
+ * both sides.
+ *
+ * @param {{base: number, head: number}} row The delta row.
+ * @returns {string} The status annotation.
+ */
+function rowStatus( row ) {
+	if ( row.base === 0 ) {
+		return " (new)";
+	}
+	if ( row.head === 0 ) {
+		return " (removed)";
+	}
+	return "";
+}
+
+/**
  * Renders a markdown table for a set of delta rows, truncating to MAX_ROWS and appending a
  * "+N more" note (also returned via `truncated` so the caller can log it).
  *
@@ -131,7 +176,7 @@ function renderTable( rows, label ) {
 		"| --- | ---: | ---: | ---: |",
 	];
 	for ( const row of shown ) {
-		const status = row.base === 0 ? " (new)" : row.head === 0 ? " (removed)" : "";
+		const status = rowStatus( row );
 		lines.push(
 			`| \`${ sanitizeKey( row.key ) }\`${ status } | ${ formatBytes( row.base, false ) } | ` +
 			`${ formatBytes( row.head, false ) } | ${ formatBytes( row.delta ) } |`

--- a/.github/scripts/zip-size-diff.js
+++ b/.github/scripts/zip-size-diff.js
@@ -144,13 +144,41 @@ function renderTable( rows, label ) {
 }
 
 /**
- * Builds the check-run title and markdown summary for a base→head zip-size comparison.
+ * Validates a size map read from the (untrusted) artifact and returns it unchanged. Throws
+ * on anything that would produce NaN or corrupt arithmetic downstream — a non-finite
+ * `total`, a missing/`null` `entries`, or any non-finite entry value. Keeping this at the
+ * single entry point means `diffMaps`/`rollUpDirectories` can assume numeric input
+ * regardless of caller, and a hostile artifact degrades to the neutral fallback rather
+ * than rendering NaN or string-concatenated sizes.
  *
- * @param {{total: number, entries: Object}} baseMap Base size map.
- * @param {{total: number, entries: Object}} headMap Head size map.
+ * @param {*} map The candidate size map.
+ * @param {string} name Label for the error message.
+ * @returns {{total: number, entries: Object<string, number>}} The validated map.
+ */
+function normalizeMap( map, name ) {
+	if ( ! map || ! Number.isFinite( map.total ) || typeof map.entries !== "object" || map.entries === null ) {
+		throw new Error( `Malformed ${ name } size map` );
+	}
+	for ( const size of Object.values( map.entries ) ) {
+		if ( ! Number.isFinite( size ) ) {
+			throw new Error( `Non-numeric entry size in ${ name } size map` );
+		}
+	}
+	return map;
+}
+
+/**
+ * Builds the check-run title and markdown summary for a base→head zip-size comparison.
+ * Throws if either map is malformed; callers turn that into the neutral fallback check.
+ *
+ * @param {{total: number, entries: Object}} rawBaseMap Base size map (untrusted).
+ * @param {{total: number, entries: Object}} rawHeadMap Head size map (untrusted).
  * @returns {{title: string, summary: string, delta: number, truncated: number}} The report.
  */
-function buildReport( baseMap, headMap ) {
+function buildReport( rawBaseMap, rawHeadMap ) {
+	const baseMap = normalizeMap( rawBaseMap, "base" );
+	const headMap = normalizeMap( rawHeadMap, "head" );
+
 	const delta = headMap.total - baseMap.total;
 	const fraction = baseMap.total === 0 ? Infinity : delta / baseMap.total;
 
@@ -190,4 +218,5 @@ module.exports = {
 	rollUpDirectories,
 	diffMaps,
 	sanitizeKey,
+	normalizeMap,
 };

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -107,7 +107,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: './.nvmrc'
           # Restore the yarn download cache (keyed on yarn.lock) so installs don't refetch
@@ -117,7 +117,7 @@ jobs:
       # --- Base branch: build only on cache miss, keyed on the base commit SHA. ---
       - name: Restore cached base zip size
         id: base-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/base-size.json
           key: zip-size-base-${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -39,6 +39,9 @@ jobs:
       # $GITHUB_ENV from a step, where the runner context is valid; later steps inherit
       # them as plain env vars.
       - name: Set up paths
+        # zizmor: ignore[template-injection]
+        # runner.temp is a fixed, GitHub-provided path, not attacker-controllable, so
+        # interpolating it into this run: block cannot inject anything.
         run: |
           {
             echo "MEASURE=${{ runner.temp }}/measure-zip.sh"

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -156,19 +156,14 @@ jobs:
         env:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
-      # PR number is display-only metadata; the report workflow trusts the head SHA from
-      # the event payload, never anything read out of this artifact. Copy only the maps
-      # that were produced so a failed build still uploads a (partial) artifact.
+      # Copy only the maps that were produced so a failed build still uploads a (partial)
+      # artifact. The report workflow trusts the head SHA from the event payload, so no PR
+      # metadata needs to travel through the artifact.
       - name: Stage report inputs
-        # PR number via env (not inline ${{ }}) to keep attacker-controllable values out of
-        # the shell; it is an integer here, but the env idiom is the safe default.
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           mkdir -p "$REPORT_DIR"
           if [ -f "$BASE_SIZE" ]; then cp "$BASE_SIZE" "$REPORT_DIR/base-size.json"; else echo "base-size.json missing"; fi
           if [ -f "$HEAD_SIZE" ]; then cp "$HEAD_SIZE" "$REPORT_DIR/head-size.json"; else echo "head-size.json missing"; fi
-          printf '{"pr":%s}\n' "$PR_NUMBER" > "$REPORT_DIR/pr-meta.json"
 
       - name: Upload size maps
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -57,11 +57,16 @@ jobs:
           cat > "$MEASURE" <<'EOF'
           #!/usr/bin/env bash
           # measure-zip.sh <zip> <out.json>
-          # Emits {"total": <bytes>, "entries": {"<path>": <compressed-bytes>, ...}} using
-          # the compressed column of `unzip -v`, i.e. the real shipped size (level-9).
+          # Emits {"archive": <bytes>, "total": <bytes>, "entries": {"<path>": <compressed-bytes>, ...}}.
+          # `archive` is the on-disk size of the .zip (what verify-zip-size checks against the
+          # 5 MB budget); it includes ZIP bookkeeping (local/central headers) that the per-entry
+          # sum omits. `total`/`entries` use the compressed column of `unzip -v`, i.e. the real
+          # shipped size per entry (level-9), and drive the attribution tables.
           set -euo pipefail
           zip="$1"
           export OUT="$2"
+          export ARCHIVE_SIZE
+          ARCHIVE_SIZE="$(stat -c %s "$zip")"
           unzip -v "$zip" | awk '
             # Columns: Length Method Size Cmpr Date Time CRC-32 Name. Data rows have a
             # numeric Length ($1) AND a non-numeric Method ($2); this excludes the totals
@@ -85,7 +90,8 @@ jobs:
               entries[name] = size;
               total += size;
             }
-            fs.writeFileSync(process.env.OUT, JSON.stringify({ total, entries }));
+            const archive = parseInt(process.env.ARCHIVE_SIZE, 10);
+            fs.writeFileSync(process.env.OUT, JSON.stringify({ archive, total, entries }));
           '
           EOF
           chmod +x "$MEASURE"

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -96,6 +96,26 @@ jobs:
           php-version: 7.4
           coverage: none
 
+      # Single checkout with full history so we can switch between the head and base SHAs
+      # in-place. node_modules (and all build output) are gitignored, so switching refs
+      # with `git checkout -f` preserves the installed dependencies — the second
+      # `yarn install` then exits fast when yarn.lock is unchanged and only does real work
+      # when the PR actually changes dependencies.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: './.nvmrc'
+          # Restore the yarn download cache (keyed on yarn.lock) so installs don't refetch
+          # packages. Matches the rest of the repo's workflows.
+          cache: 'yarn'
+
       # --- Base branch: build only on cache miss, keyed on the base commit SHA. ---
       - name: Restore cached base zip size
         id: base-cache
@@ -104,47 +124,31 @@ jobs:
           path: ${{ runner.temp }}/base-size.json
           key: zip-size-base-${{ github.event.pull_request.base.sha }}
 
-      - name: Checkout base
-        if: steps.base-cache.outputs.cache-hit != 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          persist-credentials: false
-
-      - name: Set up Node (base)
-        if: steps.base-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: './.nvmrc'
-
       - name: Build and measure base zip
         if: steps.base-cache.outputs.cache-hit != 'true'
         # A broken build must not turn this optional check red; the report workflow
-        # degrades to "failed to determine" when a size map is missing.
+        # degrades to "failed to determine" when a size map is missing. `git checkout -f`
+        # discards the working-tree changes grunt makes (e.g. baked credentials) while
+        # keeping the gitignored node_modules from the head checkout in place.
         continue-on-error: true
         run: |
+          git checkout -f "$BASE_SHA"
           yarn install
           grunt artifact
           "$MEASURE" artifact.zip "$BASE_SIZE"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
-      # --- PR head: always build fresh. ---
-      - name: Checkout head
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-
-      - name: Set up Node (head)
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: './.nvmrc'
-
+      # --- PR head: switch back and build fresh. ---
       - name: Build and measure head zip
         continue-on-error: true
         run: |
+          git checkout -f "$HEAD_SHA"
           yarn install
           grunt artifact
           "$MEASURE" artifact.zip "$HEAD_SIZE"
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       # PR number is display-only metadata; the report workflow trusts the head SHA from
       # the event payload, never anything read out of this artifact. Copy only the maps

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -96,16 +96,14 @@ jobs:
           php-version: 7.4
           coverage: none
 
-      # Single checkout with full history so we can switch between the head and base SHAs
-      # in-place. node_modules (and all build output) are gitignored, so switching refs
-      # with `git checkout -f` preserves the installed dependencies — the second
-      # `yarn install` then exits fast when yarn.lock is unchanged and only does real work
-      # when the PR actually changes dependencies.
+      # Shallow checkout of the head SHA. We switch to the base SHA in-place later with
+      # `git checkout -f`; node_modules (and all build output) are gitignored, so the ref
+      # switch preserves the installed dependencies — the second `yarn install` exits fast
+      # when yarn.lock is unchanged and only does real work when the PR changes deps.
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node
@@ -123,6 +121,14 @@ jobs:
         with:
           path: ${{ runner.temp }}/base-size.json
           key: zip-size-base-${{ github.event.pull_request.base.sha }}
+
+      # The shallow head checkout doesn't include the base commit, so fetch just that one
+      # commit (still shallow) before switching to it. Only needed on a cache miss.
+      - name: Fetch base commit
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        run: git fetch --depth=1 origin "$BASE_SHA"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
 
       - name: Build and measure base zip
         if: steps.base-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -1,0 +1,149 @@
+name: Zip Size (build)
+
+# Builds the plugin zip for both the PR head and its base, measures the compressed
+# size of every entry, and uploads the two size maps as an artifact. This workflow is
+# deliberately UNPRIVILEGED: it checks out and runs untrusted PR build scripts
+# (yarn/grunt/composer), so it must never have write permissions or secrets. The
+# privileged reporting happens in a separate `workflow_run` workflow
+# (zip-size-report.yml) that only ever reads this artifact as data.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Least privilege: read-only, no secrets. Running attacker-controllable build scripts
+# here cannot compromise the repository.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and measure zip size
+    runs-on: ubuntu-latest
+    # Don't run on forks: the base build is cached per base SHA and reporting needs a
+    # same-repo context. Fork PRs simply get no zip-size report.
+    if: >
+      github.repository_owner == 'Yoast' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      # Kept outside the workspace so `checkout` never wipes them.
+      MEASURE: ${{ runner.temp }}/measure-zip.sh
+      BASE_SIZE: ${{ runner.temp }}/base-size.json
+      HEAD_SIZE: ${{ runner.temp }}/head-size.json
+
+    steps:
+      # Emit the measure helper into a checkout-safe location up front, so it does not
+      # matter which ref (head or base) is checked out when we run it.
+      - name: Prepare measure helper
+        run: |
+          cat > "$MEASURE" <<'EOF'
+          #!/usr/bin/env bash
+          # measure-zip.sh <zip> <out.json>
+          # Emits {"total": <bytes>, "entries": {"<path>": <compressed-bytes>, ...}} using
+          # the compressed column of `unzip -v`, i.e. the real shipped size (level-9).
+          set -euo pipefail
+          zip="$1"
+          export OUT="$2"
+          unzip -v "$zip" | awk '
+            # Columns: Length Method Size Cmpr Date Time CRC-32 Name. Data rows have a
+            # numeric Length ($1) AND a non-numeric Method ($2); this excludes the totals
+            # footer row (whose $2 is the numeric size total).
+            $1 ~ /^[0-9]+$/ && $2 !~ /^[0-9]+$/ {
+              size=$3
+              name=$8
+              for (i=9; i<=NF; i++) name=name" "$i   # names may contain spaces.
+              printf "%s\t%s\n", size, name
+            }
+          ' | node -e '
+            const fs = require("fs");
+            const entries = {};
+            let total = 0;
+            for (const line of fs.readFileSync(0, "utf8").split("\n")) {
+              if (!line.trim()) continue;
+              const tab = line.indexOf("\t");
+              const size = parseInt(line.slice(0, tab), 10);
+              const name = line.slice(tab + 1);
+              if (name.endsWith("/")) continue;        // skip directory entries.
+              entries[name] = size;
+              total += size;
+            }
+            fs.writeFileSync(process.env.OUT, JSON.stringify({ total, entries }));
+          '
+          EOF
+          chmod +x "$MEASURE"
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      # --- Base branch: build only on cache miss, keyed on the base commit SHA. ---
+      - name: Restore cached base zip size
+        id: base-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ runner.temp }}/base-size.json
+          key: zip-size-base-${{ github.event.pull_request.base.sha }}
+
+      - name: Checkout base
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Set up Node (base)
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: './.nvmrc'
+
+      - name: Build and measure base zip
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        # A broken build must not turn this optional check red; the report workflow
+        # degrades to "failed to determine" when a size map is missing.
+        continue-on-error: true
+        run: |
+          yarn install
+          grunt artifact
+          "$MEASURE" artifact.zip "$BASE_SIZE"
+
+      # --- PR head: always build fresh. ---
+      - name: Checkout head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Set up Node (head)
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: './.nvmrc'
+
+      - name: Build and measure head zip
+        continue-on-error: true
+        run: |
+          yarn install
+          grunt artifact
+          "$MEASURE" artifact.zip "$HEAD_SIZE"
+
+      # PR number is display-only metadata; the report workflow trusts the head SHA from
+      # the event payload, never anything read out of this artifact. Copy only the maps
+      # that were produced so a failed build still uploads a (partial) artifact.
+      - name: Stage report inputs
+        run: |
+          dest="${{ runner.temp }}/zip-size-report"
+          mkdir -p "$dest"
+          if [ -f "$BASE_SIZE" ]; then cp "$BASE_SIZE" "$dest/base-size.json"; else echo "base-size.json missing"; fi
+          if [ -f "$HEAD_SIZE" ]; then cp "$HEAD_SIZE" "$dest/head-size.json"; else echo "head-size.json missing"; fi
+          printf '{"pr":%s}\n' "${{ github.event.pull_request.number }}" > "$dest/pr-meta.json"
+
+      - name: Upload size maps
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zip-size-report
+          path: ${{ runner.temp }}/zip-size-report/
+          retention-days: 1

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -33,14 +33,20 @@ jobs:
       github.repository_owner == 'Yoast' &&
       github.event.pull_request.head.repo.full_name == github.repository
 
-    env:
-      # Kept outside the workspace so `checkout` never wipes them.
-      MEASURE: ${{ runner.temp }}/measure-zip.sh
-      BASE_SIZE: ${{ runner.temp }}/base-size.json
-      HEAD_SIZE: ${{ runner.temp }}/head-size.json
-      REPORT_DIR: ${{ runner.temp }}/zip-size-report
-
     steps:
+      # These paths live under runner.temp (outside the workspace) so `checkout` never
+      # wipes them. runner.* is not available in a job-level env: block, so export them to
+      # $GITHUB_ENV from a step, where the runner context is valid; later steps inherit
+      # them as plain env vars.
+      - name: Set up paths
+        run: |
+          {
+            echo "MEASURE=${{ runner.temp }}/measure-zip.sh"
+            echo "BASE_SIZE=${{ runner.temp }}/base-size.json"
+            echo "HEAD_SIZE=${{ runner.temp }}/head-size.json"
+            echo "REPORT_DIR=${{ runner.temp }}/zip-size-report"
+          } >> "$GITHUB_ENV"
+
       # Emit the measure helper into a checkout-safe location up front, so it does not
       # matter which ref (head or base) is checked out when we run it.
       - name: Prepare measure helper

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+# Only the latest push per PR needs measuring; cancel superseded runs so rapid pushes
+# don't pile up double-builds.
+concurrency:
+  group: zip-size-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build and measure zip size
@@ -32,6 +38,7 @@ jobs:
       MEASURE: ${{ runner.temp }}/measure-zip.sh
       BASE_SIZE: ${{ runner.temp }}/base-size.json
       HEAD_SIZE: ${{ runner.temp }}/head-size.json
+      REPORT_DIR: ${{ runner.temp }}/zip-size-report
 
     steps:
       # Emit the measure helper into a checkout-safe location up front, so it does not
@@ -134,12 +141,15 @@ jobs:
       # the event payload, never anything read out of this artifact. Copy only the maps
       # that were produced so a failed build still uploads a (partial) artifact.
       - name: Stage report inputs
+        # PR number via env (not inline ${{ }}) to keep attacker-controllable values out of
+        # the shell; it is an integer here, but the env idiom is the safe default.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          dest="${{ runner.temp }}/zip-size-report"
-          mkdir -p "$dest"
-          if [ -f "$BASE_SIZE" ]; then cp "$BASE_SIZE" "$dest/base-size.json"; else echo "base-size.json missing"; fi
-          if [ -f "$HEAD_SIZE" ]; then cp "$HEAD_SIZE" "$dest/head-size.json"; else echo "head-size.json missing"; fi
-          printf '{"pr":%s}\n' "${{ github.event.pull_request.number }}" > "$dest/pr-meta.json"
+          mkdir -p "$REPORT_DIR"
+          if [ -f "$BASE_SIZE" ]; then cp "$BASE_SIZE" "$REPORT_DIR/base-size.json"; else echo "base-size.json missing"; fi
+          if [ -f "$HEAD_SIZE" ]; then cp "$HEAD_SIZE" "$REPORT_DIR/head-size.json"; else echo "head-size.json missing"; fi
+          printf '{"pr":%s}\n' "$PR_NUMBER" > "$REPORT_DIR/pr-meta.json"
 
       - name: Upload size maps
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/zip-size-build.yml
+++ b/.github/workflows/zip-size-build.yml
@@ -120,21 +120,39 @@ jobs:
           # packages. Matches the rest of the repo's workflows.
           cache: 'yarn'
 
-      # --- Base branch: build only on cache miss, keyed on the base commit SHA. ---
+      # Resolve the PR's merge base, not the base-branch tip. github.event.pull_request.base.sha
+      # is the base branch's *current* tip captured at event time; on an older PR the base can
+      # have moved on since the fork point, so diffing head against it would attribute unrelated
+      # base-branch changes to the PR (often inverted). The compare API's merge_base_commit.sha
+      # is the actual fork point, giving the PR's true net contribution. Read-only, so it works
+      # with this workflow's contents: read permission.
+      - name: Resolve merge base
+        id: merge-base
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.compareCommitsWithBasehead({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              basehead: `${context.payload.pull_request.base.sha}...${context.payload.pull_request.head.sha}`,
+            });
+            core.setOutput("sha", data.merge_base_commit.sha);
+
+      # --- Base (merge base): build only on cache miss, keyed on the merge-base SHA. ---
       - name: Restore cached base zip size
         id: base-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/base-size.json
-          key: zip-size-base-${{ github.event.pull_request.base.sha }}
+          key: zip-size-base-${{ steps.merge-base.outputs.sha }}
 
-      # The shallow head checkout doesn't include the base commit, so fetch just that one
+      # The shallow head checkout doesn't include the merge-base commit, so fetch just that one
       # commit (still shallow) before switching to it. Only needed on a cache miss.
       - name: Fetch base commit
         if: steps.base-cache.outputs.cache-hit != 'true'
         run: git fetch --depth=1 origin "$BASE_SHA"
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.merge-base.outputs.sha }}
 
       - name: Build and measure base zip
         if: steps.base-cache.outputs.cache-hit != 'true'
@@ -149,7 +167,7 @@ jobs:
           grunt artifact
           "$MEASURE" artifact.zip "$BASE_SIZE"
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.merge-base.outputs.sha }}
 
       # --- PR head: switch back and build fresh. ---
       - name: Build and measure head zip

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -39,12 +39,15 @@ jobs:
       checks: write    # Publish the "Zip size" check-run.
       actions: read    # Download the build workflow's artifact via the API.
       contents: read   # Check out this repo's default-branch reporting script.
-    # Deliberately does not gate on workflow_run.conclusion: when the build failed we
-    # still want to publish the neutral "Failed to determine zip size" check.
+    # Deliberately does not gate on a *failed* conclusion: when the build failed we still
+    # want to publish the neutral "Failed to determine zip size" check. A *cancelled* run is
+    # different — the concurrency group cancels superseded builds, whose completion would
+    # otherwise publish a stale report against an already-outdated commit — so skip those.
     if: >
       github.repository_owner == 'Yoast' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.workflow_run.conclusion != 'cancelled'
 
     steps:
       # Only the diff helper is needed; check out the trusted default-branch code.

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -53,7 +53,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: './.nvmrc'
 

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -43,7 +43,8 @@ jobs:
     # still want to publish the neutral "Failed to determine zip size" check.
     if: >
       github.repository_owner == 'Yoast' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
 
     steps:
       # Only the diff helper is needed; check out the trusted default-branch code.

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -1,0 +1,121 @@
+name: Zip Size (report)
+
+# Privileged half of the zip-size feature. Triggered by the completion of the
+# unprivileged "Zip Size (build)" workflow, it downloads that run's size-map artifact and
+# publishes a check-run with the net contribution to the plugin zip.
+#
+# SECURITY: this workflow has write access (checks: write) and therefore MUST NOT check
+# out or execute any pull-request code. It only reads the artifact as untrusted DATA, and
+# it attaches the check-run to the head SHA taken from the trusted event payload
+# (workflow_run.head_sha), never from the artifact. The `zip-size-diff.js` helper it runs
+# comes from the repository's default branch (workflow_run always uses default-branch
+# workflow source), not from the PR.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+
+on:
+  workflow_run:
+    workflows: [ "Zip Size (build)" ]
+    types: [ completed ]
+
+# Least privilege: only what is needed to read the artifact and write a check-run.
+permissions:
+  checks: write
+  actions: read
+  contents: read
+
+jobs:
+  report:
+    name: Report zip size
+    runs-on: ubuntu-latest
+    # Deliberately does not gate on workflow_run.conclusion: when the build failed we
+    # still want to publish the neutral "Failed to determine zip size" check.
+    if: >
+      github.repository_owner == 'Yoast' &&
+      github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      # Only the diff helper is needed; check out the trusted default-branch code.
+      - name: Checkout reporting scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: './.nvmrc'
+
+      # continue-on-error so a missing artifact (e.g. the build job never uploaded one)
+      # does not fail the job; the reporting step below then emits the neutral fallback.
+      - name: Download size maps
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zip-size-report
+          path: zip-size-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Publish zip-size check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+
+            // Trust the head SHA from the event payload, never from the artifact.
+            const headSha = context.payload.workflow_run.head_sha;
+
+            const base = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: "Zip size",
+              head_sha: headSha,
+              status: "completed",
+              // Always neutral: this report must never block a merge.
+              conclusion: "neutral",
+            };
+
+            // Read a size map as DATA only; any parse failure falls through to the
+            // "failed to determine" path rather than throwing.
+            const readMap = (file) => {
+              const map = JSON.parse(fs.readFileSync(path.join("zip-size-report", file), "utf8"));
+              // The artifact is untrusted data; reject anything that would render as NaN so
+              // a corrupt-but-parseable map degrades to the neutral fallback below.
+              if (!Number.isFinite(map.total) || typeof map.entries !== "object" || map.entries === null) {
+                throw new Error(`Malformed size map in ${file}`);
+              }
+              for (const size of Object.values(map.entries)) {
+                if (!Number.isFinite(size)) {
+                  throw new Error(`Non-numeric entry size in ${file}`);
+                }
+              }
+              return map;
+            };
+
+            try {
+              const baseMap = readMap("base-size.json");
+              const headMap = readMap("head-size.json");
+              const { buildReport } = require(path.resolve(".github/scripts/zip-size-diff.js"));
+              const report = buildReport(baseMap, headMap);
+              if (report.truncated > 0) {
+                core.info(`Zip-size report truncated ${report.truncated} row(s); largest changes shown in the check summary.`);
+              }
+              await github.rest.checks.create({
+                ...base,
+                output: { title: report.title, summary: report.summary },
+              });
+              core.info(`Published zip-size check: ${report.title}`);
+            } catch (error) {
+              core.warning(`Could not determine zip size: ${error.message}`);
+              await github.rest.checks.create({
+                ...base,
+                output: {
+                  title: "Failed to determine zip size",
+                  summary: "The zip-size build did not produce usable size data for this run, " +
+                    "so the net contribution could not be computed. This does not block the pull request.\n\n" +
+                    `Reason: \`${error.message}\``,
+                },
+              });
+            }

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -13,20 +13,32 @@ name: Zip Size (report)
 # See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is the *recommended* trigger here, not a misuse: it is the privileged
+  # half of the split "pwn request" mitigation. It never checks out or executes PR code —
+  # it only reads the build artifact as data — so the usual workflow_run risk does not
+  # apply. See the SECURITY note above and https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   workflow_run:
     workflows: [ "Zip Size (build)" ]
     types: [ completed ]
 
-# Least privilege: only what is needed to read the artifact and write a check-run.
-permissions:
-  checks: write
-  actions: read
-  contents: read
+# Deny-all default; the job below grants only what it needs.
+permissions: {}
+
+# One report per build run is enough; drop superseded runs for the same head commit.
+concurrency:
+  group: zip-size-report-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
 
 jobs:
   report:
     name: Report zip size
     runs-on: ubuntu-latest
+    # Job-scoped least privilege.
+    permissions:
+      checks: write    # Publish the "Zip size" check-run.
+      actions: read    # Download the build workflow's artifact via the API.
+      contents: read   # Check out this repo's default-branch reporting script.
     # Deliberately does not gate on workflow_run.conclusion: when the build failed we
     # still want to publish the neutral "Failed to determine zip size" check.
     if: >

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -108,6 +108,9 @@ jobs:
               });
               core.info(`Published zip-size check: ${report.title}`);
             } catch (error) {
+              // The artifact is untrusted: log the real error to the (trusted) run log,
+              // but never reflect its message into the check summary, which renders
+              // markdown and would otherwise let a tampered artifact spoof CI output.
               core.warning(`Could not determine zip size: ${error.message}`);
               await github.rest.checks.create({
                 ...base,
@@ -115,7 +118,7 @@ jobs:
                   title: "Failed to determine zip size",
                   summary: "The zip-size build did not produce usable size data for this run, " +
                     "so the net contribution could not be computed. This does not block the pull request.\n\n" +
-                    `Reason: \`${error.message}\``,
+                    "See the workflow run log for the underlying reason.",
                 },
               });
             }

--- a/.github/workflows/zip-size-report.yml
+++ b/.github/workflows/zip-size-report.yml
@@ -77,22 +77,11 @@ jobs:
               conclusion: "neutral",
             };
 
-            // Read a size map as DATA only; any parse failure falls through to the
-            // "failed to determine" path rather than throwing.
-            const readMap = (file) => {
-              const map = JSON.parse(fs.readFileSync(path.join("zip-size-report", file), "utf8"));
-              // The artifact is untrusted data; reject anything that would render as NaN so
-              // a corrupt-but-parseable map degrades to the neutral fallback below.
-              if (!Number.isFinite(map.total) || typeof map.entries !== "object" || map.entries === null) {
-                throw new Error(`Malformed size map in ${file}`);
-              }
-              for (const size of Object.values(map.entries)) {
-                if (!Number.isFinite(size)) {
-                  throw new Error(`Non-numeric entry size in ${file}`);
-                }
-              }
-              return map;
-            };
+            // Read a size map as DATA only. Shape/number validation lives in buildReport
+            // (normalizeMap); a parse failure here or a malformed map there both fall
+            // through to the "failed to determine" path below.
+            const readMap = (file) =>
+              JSON.parse(fs.readFileSync(path.join("zip-size-report", file), "utf8"));
 
             try {
               const baseMap = readMap("base-size.json");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,7 @@ export default [
 		},
 	},
 	{
-		files: [ "*.config.js", "config/**", "Gruntfile.js" ],
+		files: [ "*.config.js", "config/**", "Gruntfile.js", ".github/scripts/**" ],
 		languageOptions: {
 			globals: {
 				...globals.node,


### PR DESCRIPTION
## Context

Ideally we keep Yoast SEO Free zip size below the 5 MB ceiling. IIRC, any bigger than that will prevent some common config setups to reject the zip upload request. There is no per-PR visibility into how much a change grows or shrinks the zip. There's no direct feedbackloop.

This PR adds an optional, non-disruptive GitHub Actions check that reports a PR's net contribution to the shipped zip (total delta plus a per-file and per-directory breakdown), Coveralls-style, so reviewers can see the size impact before merging. GHA is free on public repos, so it is cheap to run on Free.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a CI check that reports how much a pull request changes the plugin zip size.

## Relevant technical choices:

* **Split `workflow_run` design (security).** Measuring the size means building the PR (`yarn`/`grunt`/`composer` run PR-author-controlled build scripts) *and* publishing the result needs write access — the exact combination behind "pwn request" repo compromises. The feature is therefore split into two workflows following the [GitHub Security Lab guidance](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/):
  * `zip-size-build.yml` (`on: pull_request`) is unprivileged (`contents: read`, no secrets): it builds the head and base zips, measures each entry's compressed size, and uploads the two size maps as an artifact.
  * `zip-size-report.yml` (`on: workflow_run`) is privileged (`checks: write`) but never checks out or executes PR code — it reads the artifact as untrusted data, computes the delta via `.github/scripts/zip-size-diff.js`, and publishes the check-run. The check SHA comes from the event payload, never the artifact.
* **Always neutral.** The check is always published with `conclusion: neutral`, so a size increase or a broken build never blocks a PR; unusable data degrades to a "Failed to determine zip size" check.
* **Untrusted-artifact hardening.** The diff helper validates every size map (rejects non-finite totals/entry sizes) and sanitizes entry paths before rendering them into markdown, so a tampered artifact cannot inject `NaN`, corrupt arithmetic, or spoof the check summary.
* **Build efficiency.** The base build is cached by base commit SHA (`actions/cache`), so repeat PRs against the same base skip it entirely. When the base *is* rebuilt, a single shallow checkout of the head is reused: the base commit is shallow-fetched (`git fetch --depth=1`) and switched to in place with `git checkout -f`, so the gitignored `node_modules` survives the ref switch and the second `yarn install` exits fast unless the PR changed dependencies. `setup-node`'s `cache: 'yarn'` caches downloads on top. In practice this took the second build from ~7m to ~2.5m. Forks are skipped.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

The `pull_request` build half already runs on this PR and has been verified here: the build ran end-to-end, the base-SHA cache and the shallow-fetch/`git checkout -f` base rebuild both work, and both size maps are produced and uploaded. The `workflow_run` report half executes from the **default branch**, so the "Zip size" check itself only appears once this PR is merged to `trunk`. After merge, on the next few PRs:

* [ ] Confirm a **"Zip size"** check appears on the PR with a title like `+23.4 kB (+0.47%)` (or "No change to zip size").
* [ ] Open the check summary and confirm the **by-directory** and **by-file** breakdown tables render.
* [ ] On a second push to the same PR, confirm the build log shows a **cache hit** on the base SHA and skips the base rebuild.
* [ ] If a PR happens to break the build, confirm the "Zip size" check still shows as **neutral "Failed to determine zip size"** and does not go red or block the PR.
* [ ] Confirm a fork PR produces **no** report (build job skipped by the fork gate).

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — this is internal CI tooling with no user-facing behaviour.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* CI only. No plugin runtime code, PHP, or shipped JS is touched. The change adds two workflow files (`zip-size-build.yml`, `zip-size-report.yml`) and one CI helper (`.github/scripts/zip-size-diff.js`), plus a one-line addition to `eslint.config.mjs` that lints `.github/scripts/**` with Node globals (no change to rules or other paths).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
  <!-- The diff/measure logic was verified with ad-hoc Node scripts (deltas, edge cases, hostile inputs) but no committed test suite exists for .github/scripts yet; the repo has no JS test harness wired for that path. -->
* [x] `zizmor` reports no findings on the new workflows (regular and auditor personas).
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).
