### PR TITLE
docs: add PHP deprecation guide and wire it into AGENTS.md

### DIFF
--- a/.claude/skills/deprecate-php/SKILL.md
+++ b/.claude/skills/deprecate-php/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: deprecate-php
+description: Deprecate PHP methods, classes, filters, and actions in this repo following the official deprecation guide. The full procedure lives in DEPRECATING.md so it can be shared with Cursor, human contributors, and any other tool. This skill is a thin pointer; edit the guide, not this file, when the process changes.
+user_invocable: true
+---
+
+# deprecate-php
+
+Read [`DEPRECATING.md`](../../../DEPRECATING.md) and follow it exactly. That file is the single source of truth for deprecating PHP in this repo and is shared across tools.
+
+@../../../DEPRECATING.md
+
+The guide itself references:
+
+- [`AGENTS.md`](../../../AGENTS.md): agent behaviour rules, including the pointer to the guide.
+- [`config/dependency-injection/deprecated-classes.php`](../../../config/dependency-injection/deprecated-classes.php): the DI container's deprecated-classes list.
+
+If any step in the guide appears to conflict with `AGENTS.md` or `.github/CONTRIBUTING.md`, the rule files win. Edit them, then update the guide.

--- a/.gitignore
+++ b/.gitignore
@@ -114,4 +114,5 @@ dependencies.md
 ############
 # AI
 ############
-/.claude/
+/.claude/*
+!/.claude/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,4 +30,6 @@ If a rule appears to conflict between this file and `CONTRIBUTING.md` or [`.gith
 
 - **Keep changelog bullets to one short sentence.** Extra context goes in *Context* or *Relevant technical choices*, not in the bullet. See [CONTRIBUTING.md → "Changelog entry and label"](./.github/CONTRIBUTING.md#changelog-entry-and-label).
 
+- **Follow the deprecation guide when deprecating PHP.** When deprecating a PHP method, class, filter, or action, follow the step-by-step process in [`DEPRECATING.md`](./DEPRECATING.md). The guide covers `_deprecated_function()` placement, PHPDoc annotations, moving files to `src/deprecated/`, updating the DI container, and the yearly cleanup process.
+
 - **Default to CONTRIBUTING.md.** Anything not listed in this delta is in `CONTRIBUTING.md`, the PR template, or `src/README.md`. Read those before making assumptions.

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -13,7 +13,7 @@ Before making any changes, locate all existing usages:
 
 1. **Code:** Search the codebase for the method/class/hook name. Also search for the name as a string (it may be used as a hook callback that static analysis won't catch).
 2. **Docs:** Search the developer docs for mentions; note any that need updating or a deprecation notice.
-3. **Third parties:** Check [WPdirectory](https://wpdirectory.net/) and GitHub for external plugins/themes using the symbol. If an actively supported plugin depends on it, consider notifying the maintainer before the RC1 cut.
+3. **Third parties:** Check [Veloria (formerly WPDirectory)](https://https://veloria.dev/) and GitHub for external plugins/themes using the symbol. If an actively supported plugin depends on it, consider notifying the maintainer before the RC1 cut.
 
 If no usages are found, it is safe to proceed. If usages exist, decide whether an alternative should be provided and note it for the deprecation call.
 
@@ -26,7 +26,7 @@ If the functionality is being moved (e.g. util → helper), move the implementat
 1. Add the `_deprecated_function()` call as the **first line of the method body**:
 
 ```php
-_deprecated_function( __METHOD__, 'Yoast SEO X.Y', 'Alternative_Class::method_name' );
+\_deprecated_function( __METHOD__, 'Yoast SEO X.Y', 'Alternative_Class::method_name' );
 ```
 
 - First arg: `__METHOD__` (the called method).
@@ -56,7 +56,7 @@ _deprecated_function( __METHOD__, 'Yoast SEO X.Y', 'Alternative_Class::method_na
  * @return string The formatted name.
  */
 public function format_name( $name ) {
-    _deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
+    \_deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
     return YoastSEO()->helpers->formatter->format_name( $name );
 }
 ```
@@ -65,8 +65,8 @@ public function format_name( $name ) {
 
 1. Add `_deprecated_function( __METHOD__, 'Yoast SEO X.Y' )` to `__construct` — this is the single point that fires the notice for any caller that instantiates the class. Child classes that call `parent::__construct()` inherit the notice automatically.
 2. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the **class-level PHPDoc block** and to `__construct`'s PHPDoc block.
-3. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the PHPDoc of every other public method for documentation purposes, but **do not** add a `_deprecated_function()` call to each one — the constructor notice is sufficient and adding it to every method produces redundant noise.
-4. **Exception:** if an individual public method is also independently callable (e.g. called statically, or as a hook callback directly) without going through the constructor, deprecate it individually too.
+3. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the PHPDoc of every public method, and add a `_deprecated_function()` call as the **first line** of each deprecated public method body (this matches existing deprecated classes under `src/deprecated/src/`).
+4. If an individual public method is independently callable (e.g. used as a hook callback or called statically), ensure it has its own `_deprecated_function()` call even if the class also emits a notice elsewhere.
 5. Internal helper functions/methods that are only ever called by already-deprecated public API do **not** need a `_deprecated_function()` call — the public entry point already fires the notice. Add `@deprecated X.Y` and `@codeCoverageIgnore` to their PHPDoc for clarity.
 6. Move the file to `src/deprecated/` — especially when it is (or was) wired into the DI container or exposed on the surface API. Only skip this move if there is a specific technical reason.
 7. If the class is registered in the DI container, add it to `config/dependency-injection/deprecated-classes.php`.
@@ -81,6 +81,16 @@ public function format_name( $name ) {
 class WPSEO_Utils {
 
     /**
+     * Class constructor.
+     *
+     * @deprecated 20.0
+     * @codeCoverageIgnore
+     */
+    public function __construct() {
+        \_deprecated_function( __METHOD__, 'Yoast SEO 20.0' );
+    }
+
+    /**
      * Formats a name.
      *
      * @deprecated 20.0
@@ -91,7 +101,7 @@ class WPSEO_Utils {
      * @return string The formatted name.
      */
     public function format_name( $name ) {
-        _deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
+        \_deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
         return YoastSEO()->helpers->formatter->format_name( $name );
     }
 }
@@ -103,10 +113,10 @@ Use WordPress's built-in deprecated-hook wrappers in place of the original call:
 
 ```php
 // Action:
-do_action_deprecated( 'wpseo_action', [ $arg1, $arg2 ], 'Yoast SEO 20.0', 'wpseo_new_action' );
+\do_action_deprecated( 'wpseo_action', [ $arg1, $arg2 ], 'Yoast SEO 20.0', 'wpseo_new_action' );
 
 // Filter:
-apply_filters_deprecated( 'wpseo_filter', [ $value, $extra_arg ], 'Yoast SEO 20.0', 'wpseo_new_filter' );
+\apply_filters_deprecated( 'wpseo_filter', [ $value, $extra_arg ], 'Yoast SEO 20.0', 'wpseo_new_filter' );
 ```
 
 Replace the existing `do_action` / `apply_filters` call with the deprecated variant; do not add a second call.

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -68,8 +68,9 @@ public function format_name( $name ) {
 3. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the PHPDoc of every public method, and add a `_deprecated_function()` call as the **first line** of each deprecated public method body (this matches existing deprecated classes under `src/deprecated/src/`).
 4. If an individual public method is independently callable (e.g. used as a hook callback or called statically), ensure it has its own `_deprecated_function()` call even if the class also emits a notice elsewhere.
 5. Internal helper functions/methods that are only ever called by already-deprecated public API do **not** need a `_deprecated_function()` call — the public entry point already fires the notice. Add `@deprecated X.Y` and `@codeCoverageIgnore` to their PHPDoc for clarity.
-6. Move the file to `src/deprecated/` — especially when it is (or was) wired into the DI container or exposed on the surface API. Only skip this move if there is a specific technical reason.
-7. If the class is registered in the DI container, add it to `config/dependency-injection/deprecated-classes.php`.
+6. Internal helper functions/methods that are not used anymore (e.g. because the public methods were changed to call the alternative implementation directly) can be removed, or shortcut to the new implementation, instead of being kept and annotated.
+7. Move the file to `src/deprecated/` — especially when it is (or was) wired into the DI container or exposed on the surface API. Only skip this move if there is a specific technical reason.
+8. If the class is registered in the DI container, add it to `config/dependency-injection/deprecated-classes.php`.
 
 **Full example:**
 

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -63,7 +63,7 @@ public function format_name( $name ) {
 
 ## Deprecating a class
 
-1. Add `_deprecated_function( __METHOD__, 'Yoast SEO X.Y' )` to `__construct` — this is the single point that fires the notice for any caller that instantiates the class. Child classes that call `parent::__construct()` inherit the notice automatically.
+1. If the class has a `__construct` (or adding one won’t change behavior), add `_deprecated_function( __METHOD__, 'Yoast SEO X.Y' )` as the **first line** of `__construct`. Child classes that call `parent::__construct()` inherit the notice automatically.
 2. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the **class-level PHPDoc block** and to `__construct`'s PHPDoc block.
 3. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the PHPDoc of every public method, and add a `_deprecated_function()` call as the **first line** of each deprecated public method body (this matches existing deprecated classes under `src/deprecated/src/`).
 4. If an individual public method is independently callable (e.g. used as a hook callback or called statically), ensure it has its own `_deprecated_function()` call even if the class also emits a notice elsewhere.

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -13,7 +13,7 @@ Before making any changes, locate all existing usages:
 
 1. **Code:** Search the codebase for the method/class/hook name. Also search for the name as a string (it may be used as a hook callback that static analysis won't catch).
 2. **Docs:** Search the developer docs for mentions; note any that need updating or a deprecation notice.
-3. **Third parties:** Check [Veloria (formerly WPDirectory)](https://https://veloria.dev/) and GitHub for external plugins/themes using the symbol. If an actively supported plugin depends on it, consider notifying the maintainer before the RC1 cut.
+3. **Third parties:** Check [Veloria (formerly WPDirectory)](https://veloria.dev/) and GitHub for external plugins/themes using the symbol. If an actively supported plugin depends on it, consider notifying the maintainer before the RC1 cut.
 
 If no usages are found, it is safe to proceed. If usages exist, decide whether an alternative should be provided and note it for the deprecation call.
 
@@ -140,8 +140,7 @@ Once a year, all deprecated functionality older than one year is removed. To fin
 
 - [ ] Searched codebase (including string searches for hook callbacks).
 - [ ] Checked docs for mentions.
-- [ ] Checked WPdirectory / GitHub for third-party usage.
-- [ ] Checked [veloria.dev](https://veloria.dev/) for third-party usage of the class/method/hook.
+- [ ] Checked [Veloria](https://veloria.dev/) and GitHub for third-party usage of the class/method/hook.
 - [ ] Alternative method identified (or confirmed none exists).
 - [ ] `_deprecated_function()` call added with `'Yoast SEO X.Y'` prefix.
 - [ ] `@deprecated X.Y` and `@codeCoverageIgnore` added to PHPDoc (method **and** class if deprecating the whole class).

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -1,8 +1,3 @@
----
-name: deprecate-php
-description: "Deprecate PHP methods, classes, filters, and actions in the Yoast wordpress-seo repository following the official deprecation guide. Handles finding usages, adding _deprecated_function() calls, PHPDoc annotations, moving files to src/deprecated/, updating the DI container deprecated-classes list, and deprecating hooks with do_action_deprecated/apply_filters_deprecated."
----
-
 # Deprecate PHP
 
 Follow this process to deprecate a PHP method, class, filter, or action in Yoast SEO.

--- a/DEPRECATING.md
+++ b/DEPRECATING.md
@@ -1,0 +1,141 @@
+---
+name: deprecate-php
+description: "Deprecate PHP methods, classes, filters, and actions in the Yoast wordpress-seo repository following the official deprecation guide. Handles finding usages, adding _deprecated_function() calls, PHPDoc annotations, moving files to src/deprecated/, updating the DI container deprecated-classes list, and deprecating hooks with do_action_deprecated/apply_filters_deprecated."
+---
+
+# Deprecate PHP
+
+Follow this process to deprecate a PHP method, class, filter, or action in Yoast SEO.
+
+## Step 1 — Find usages
+
+Before making any changes, locate all existing usages:
+
+1. **Code:** Search the codebase for the method/class/hook name. Also search for the name as a string (it may be used as a hook callback that static analysis won't catch).
+2. **Docs:** Search the developer docs for mentions; note any that need updating or a deprecation notice.
+3. **Third parties:** Check [WPdirectory](https://wpdirectory.net/) and GitHub for external plugins/themes using the symbol. If an actively supported plugin depends on it, consider notifying the maintainer before the RC1 cut.
+
+If no usages are found, it is safe to proceed. If usages exist, decide whether an alternative should be provided and note it for the deprecation call.
+
+## Step 2 — Is there an alternative?
+
+If the functionality is being moved (e.g. util → helper), move the implementation to the new location first, then have the old method delegate to it. Do **not** duplicate logic.
+
+## Deprecating a method
+
+1. Add the `_deprecated_function()` call as the **first line of the method body**:
+
+```php
+_deprecated_function( __METHOD__, 'Yoast SEO X.Y', 'Alternative_Class::method_name' );
+```
+
+- First arg: `__METHOD__` (the called method).
+- Second arg: `'Yoast SEO X.Y'` — always prefix with `'Yoast SEO '` so the version is identifiable in error logs.
+- Third arg: the alternative method (omit if there is none).
+
+2. If an alternative exists, call it with the correct arguments and return its result.
+
+3. Update the PHPDoc block — add **before** `@param`:
+
+```php
+ * @deprecated X.Y
+ * @codeCoverageIgnore
+```
+
+**Full example** (method moved to a helper):
+
+```php
+/**
+ * Formats a name.
+ *
+ * @deprecated 20.0
+ * @codeCoverageIgnore
+ *
+ * @param string $name The name to format.
+ *
+ * @return string The formatted name.
+ */
+public function format_name( $name ) {
+    _deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
+    return YoastSEO()->helpers->formatter->format_name( $name );
+}
+```
+
+## Deprecating a class
+
+1. Add `_deprecated_function( __METHOD__, 'Yoast SEO X.Y' )` to `__construct` — this is the single point that fires the notice for any caller that instantiates the class. Child classes that call `parent::__construct()` inherit the notice automatically.
+2. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the **class-level PHPDoc block** and to `__construct`'s PHPDoc block.
+3. Add `@deprecated X.Y` and `@codeCoverageIgnore` to the PHPDoc of every other public method for documentation purposes, but **do not** add a `_deprecated_function()` call to each one — the constructor notice is sufficient and adding it to every method produces redundant noise.
+4. **Exception:** if an individual public method is also independently callable (e.g. called statically, or as a hook callback directly) without going through the constructor, deprecate it individually too.
+5. Internal helper functions/methods that are only ever called by already-deprecated public API do **not** need a `_deprecated_function()` call — the public entry point already fires the notice. Add `@deprecated X.Y` and `@codeCoverageIgnore` to their PHPDoc for clarity.
+6. Move the file to `src/deprecated/` — especially when it is (or was) wired into the DI container or exposed on the surface API. Only skip this move if there is a specific technical reason.
+7. If the class is registered in the DI container, add it to `config/dependency-injection/deprecated-classes.php`.
+
+**Full example:**
+
+```php
+/**
+ * @deprecated 20.0
+ * @codeCoverageIgnore
+ */
+class WPSEO_Utils {
+
+    /**
+     * Formats a name.
+     *
+     * @deprecated 20.0
+     * @codeCoverageIgnore
+     *
+     * @param string $name The name to format.
+     *
+     * @return string The formatted name.
+     */
+    public function format_name( $name ) {
+        _deprecated_function( __METHOD__, 'Yoast SEO 20.0', 'Formatter::format_name' );
+        return YoastSEO()->helpers->formatter->format_name( $name );
+    }
+}
+```
+
+## Deprecating a filter or action
+
+Use WordPress's built-in deprecated-hook wrappers in place of the original call:
+
+```php
+// Action:
+do_action_deprecated( 'wpseo_action', [ $arg1, $arg2 ], 'Yoast SEO 20.0', 'wpseo_new_action' );
+
+// Filter:
+apply_filters_deprecated( 'wpseo_filter', [ $value, $extra_arg ], 'Yoast SEO 20.0', 'wpseo_new_filter' );
+```
+
+Replace the existing `do_action` / `apply_filters` call with the deprecated variant; do not add a second call.
+
+## DI container — deprecated classes
+
+When the deprecated class was wired into the Symfony DI container, open `config/dependency-injection/deprecated-classes.php` and add an entry for it. Run `composer compile-di` afterwards (or let the post-autoload-dump hook do it on the next `composer install`).
+
+## Yearly deprecation cleanup
+
+Once a year, all deprecated functionality older than one year is removed. To find the cutoff:
+
+1. Identify the plugin version released ~12 months ago.
+2. Remove everything deprecated before that version.
+3. In most cases no changelog entry is needed. Add one only when the removal is notable — especially for constants/methods/classes whose deprecation was not well communicated — e.g.:
+
+> * Removes the `WEBPAGE_HASH` constant that had been deprecated in Yoast SEO 19.3 (July 2022).
+
+## Checklist
+
+- [ ] Searched codebase (including string searches for hook callbacks).
+- [ ] Checked docs for mentions.
+- [ ] Checked WPdirectory / GitHub for third-party usage.
+- [ ] Checked [veloria.dev](https://veloria.dev/) for third-party usage of the class/method/hook.
+- [ ] Alternative method identified (or confirmed none exists).
+- [ ] `_deprecated_function()` call added with `'Yoast SEO X.Y'` prefix.
+- [ ] `@deprecated X.Y` and `@codeCoverageIgnore` added to PHPDoc (method **and** class if deprecating the whole class).
+- [ ] File moved to `src/deprecated/` (for DI-registered or surface-exposed classes).
+- [ ] `config/dependency-injection/deprecated-classes.php` updated if applicable.
+- [ ] `composer compile-di` run if DI config changed.
+- [ ] `composer check-branch-cs` passes.
+- [ ] `composer test` passes.


### PR DESCRIPTION
## Context

Adds `DEPRECATING.md`, a step-by-step guide for deprecating PHP methods, classes, filters, and actions, and registers it as a Claude Code skill so AI coding agents can invoke it on demand via `/deprecate-php`. Also adds a pointer in `AGENTS.md` so agents know the guide exists and should follow it when deprecating PHP.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a PHP deprecation guide as a Claude Code skill and references it from the agent behaviour guidelines.

## Relevant technical choices:

`DEPRECATING.md` is the single source of truth and lives in the repo root alongside `AGENTS.md` and `CLAUDE.md` rather than in `.github/`, since it is developer tooling rather than a GitHub platform file. The skill itself is a thin pointer at `.claude/skills/deprecate-php/SKILL.md` (the same pattern as the `create-pr` skill), because Claude Code only discovers skills under `.claude/skills/`. To let that pointer ship with the repo, `.gitignore` now ignores `/.claude/*` except `/.claude/skills/`; everything else under `.claude/` stays local.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

Not applicable — internal agent tooling only, no user-facing behaviour changed.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

Not applicable — no user-visible behaviour changed.

## Impact check

No plugin code was changed. Only `AGENTS.md`, `DEPRECATING.md`, `.gitignore` and the new `.claude/skills/deprecate-php/SKILL.md` are affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
