### PR TITLE
fix: Replace current_user_can( 'edit_files' ) checks on the robots.txt/.htaccess editor with the internal WPSEO_Utils::allow_system_file_edit() method

### DIFF
--- a/admin/views/tool-file-editor.php
+++ b/admin/views/tool-file-editor.php
@@ -22,7 +22,7 @@ $robots_file    = $home_path . 'robots.txt';
 $ht_access_file = $home_path . '.htaccess';
 
 if ( isset( $_POST['create_robots'] ) ) {
-	if ( ! current_user_can( 'edit_files' ) ) {
+	if ( ! WPSEO_Utils::allow_system_file_edit() ) {
 		$die_msg = sprintf(
 			/* translators: %s expands to robots.txt. */
 			__( 'You cannot create a %s file.', 'wordpress-seo' ),
@@ -43,7 +43,7 @@ if ( isset( $_POST['create_robots'] ) ) {
 }
 
 if ( isset( $_POST['submitrobots'] ) ) {
-	if ( ! current_user_can( 'edit_files' ) ) {
+	if ( ! WPSEO_Utils::allow_system_file_edit() ) {
 		$die_msg = sprintf(
 			/* translators: %s expands to robots.txt. */
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),
@@ -70,7 +70,7 @@ if ( isset( $_POST['submitrobots'] ) ) {
 }
 
 if ( isset( $_POST['submithtaccess'] ) ) {
-	if ( ! current_user_can( 'edit_files' ) ) {
+	if ( ! WPSEO_Utils::allow_system_file_edit() ) {
 		$die_msg = sprintf(
 			/* translators: %s expands to ".htaccess". */
 			__( 'You cannot edit the %s file.', 'wordpress-seo' ),


### PR DESCRIPTION
## Context
Permissions for editing the robots.txt and .htaccess are handled inconsistently. The internal filterable method `WPSEO_Utils::allow_system_file_edit()` is used to determine whether the editor can be accessed, but the WordPress core `current_user_can( 'edit_files' )` function is called to verify permissions when actually saving the forms. This results in an experience where a user may be able to access the editor but be unable to use the editor. There is also no indication of the inability to edit like there is when the files are not writable. This also prevents security hardening practises or lower privileged user roles that prevent editing theme and plugin files from making an exemption to still allow for these files to be modified, and renders the `wpseo_allow_system_file_edit` filter redundant.

## Summary
This PR can be summarized in the following changelog entry:

* Replaces the `current_user_can( 'edit_files' )` function calls with the `WPSEO_Utils::allow_system_file_edit()` method, providing consistent user permissions handling across the robots.txt/.htaccess file editor.

## Relevant technical choices:

* Used already existing permissions method as opposed to adding context to the `current_user_can` function calls, which could be an alternative approach

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Access the WordPress admin as a user without the `edit_files` capability
* Add the snippet `apply_filters( 'wpseo_allow_system_file_edit', '__return_true )` to the site via MU plugin/theme functions file/code snippets plugin etc.
* Go to the Yoast > Tools > File Editor admin page
* Save changes to the robots.txt. 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

## Impact check
I do not believe this PR would affect any other aspects of the plugin

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #15919
