### PR TITLE
fix: prevent PHP 8.5 null array offset deprecation in memoizers

### DIFF
--- a/src/memoizers/meta-tags-context-memoizer.php
+++ b/src/memoizers/meta-tags-context-memoizer.php
@@ -132,7 +132,8 @@ class Meta_Tags_Context_Memoizer {
 	 * @return Meta_Tags_Context The meta tags context.
 	 */
 	public function get( Indexable $indexable, $page_type ) {
-		if ( ! isset( $this->cache[ $indexable->id ] ) ) {
+		$cache_key = $indexable->id ?? '';
+		if ( ! isset( $this->cache[ $cache_key ] ) ) {
 			$blocks = [];
 			$post   = null;
 			if ( $indexable->object_type === 'post' ) {
@@ -151,10 +152,10 @@ class Meta_Tags_Context_Memoizer {
 
 			$context->presentation = $this->presentation_memoizer->get( $indexable, $context, $page_type );
 
-			$this->cache[ $indexable->id ] = $context;
+			$this->cache[ $cache_key ] = $context;
 		}
 
-		return $this->cache[ $indexable->id ];
+		return $this->cache[ $cache_key ];
 	}
 
 	/**
@@ -166,7 +167,7 @@ class Meta_Tags_Context_Memoizer {
 	 */
 	public function clear( $indexable = null ) {
 		if ( $indexable instanceof Indexable ) {
-			unset( $this->cache[ $indexable->id ] );
+			unset( $this->cache[ $indexable->id ?? '' ] );
 			$this->presentation_memoizer->clear( $indexable->id );
 			return;
 		}

--- a/src/memoizers/presentation-memoizer.php
+++ b/src/memoizers/presentation-memoizer.php
@@ -46,7 +46,8 @@ class Presentation_Memoizer {
 	 * @return Indexable_Presentation The indexable presentation.
 	 */
 	public function get( Indexable $indexable, Meta_Tags_Context $context, $page_type ) {
-		if ( ! isset( $this->cache[ $indexable->id ] ) ) {
+		$cache_key = $indexable->id ?? '';
+		if ( ! isset( $this->cache[ $cache_key ] ) ) {
 			$presentation = $this->container->get( "Yoast\WP\SEO\Presentations\Indexable_{$page_type}_Presentation", ContainerInterface::NULL_ON_INVALID_REFERENCE );
 
 			if ( ! $presentation ) {
@@ -60,10 +61,10 @@ class Presentation_Memoizer {
 				],
 			);
 
-			$this->cache[ $indexable->id ] = $context->presentation;
+			$this->cache[ $cache_key ] = $context->presentation;
 		}
 
-		return $this->cache[ $indexable->id ];
+		return $this->cache[ $cache_key ];
 	}
 
 	/**
@@ -75,7 +76,7 @@ class Presentation_Memoizer {
 	 */
 	public function clear( $indexable = null ) {
 		if ( $indexable instanceof Indexable ) {
-			unset( $this->cache[ $indexable->id ] );
+			unset( $this->cache[ $indexable->id ?? '' ] );
 			return;
 		}
 		if ( \is_int( $indexable ) ) {


### PR DESCRIPTION
## Context

When an indexable has not been persisted yet (e.g. a Fallback page type with `object_type = 'unknown'`), its `id` property is `null`. Both `Meta_Tags_Context_Memoizer` and `Presentation_Memoizer` use `$indexable->id` directly as an array key for their internal cache, which triggers a PHP deprecation warning on PHP 8.1+ and a fatal deprecation on PHP 8.5+.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where PHP `Deprecated: Using null as an array offset` warnings were emitted when `$indexable->id` was null in the meta tags context and presentation memoizers, caused by unindexed/fallback indexables being used as cache keys.

## Relevant technical choices:

* Replaces direct `$this->cache[ $indexable->id ]` with `$cache_key = $indexable->id ?? ''` so a null ID safely maps to an empty-string key instead of triggering the deprecation.
* Applied the same fix in the `clear()` methods of both classes.
* PHP's array-key semantics treat `''` identically to what was previously a null-coerced-to-`''` on older PHP versions, so this is a no-op for PHP < 8.1.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Set up a WordPress site running PHP 8.5+ with `WP_DEBUG` and `WP_DEBUG_LOG` enabled.
2. Install and activate Yoast SEO from this branch.
3. Navigate to Posts → Add New.
4. Check `wp-content/debug.log` — no `Deprecated: Using null as an array offset` warnings from Yoast's memoizer classes should appear.
5. Verify that the post editor loads correctly and the Yoast SEO metabox functions normally.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

This is an internal PHP fix with no frontend or editor-specific changes. Testing on a single post type is sufficient.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a non-user-facing PHP deprecation fix. The acceptance test steps above are sufficient.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO metabox initialization and page rendering — the memoizers are called early during admin page loads and frontend page rendering.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23397