### PR TITLE
Broaden MyYoast connection rollout to 20%

### DIFF
--- a/src/conditionals/myyoast-connection-conditional.php
+++ b/src/conditionals/myyoast-connection-conditional.php
@@ -29,7 +29,7 @@ class MyYoast_Connection_Conditional extends Gradual_Rollout_Conditional {
 	 * @return int The rollout share in per-mille.
 	 */
 	protected function get_rollout_share(): int {
-		// 1%.
-		return 10;
+		// 20%.
+		return 200;
 	}
 }

--- a/tests/Unit/Conditionals/MyYoast_Connection_Conditional_Test.php
+++ b/tests/Unit/Conditionals/MyYoast_Connection_Conditional_Test.php
@@ -45,14 +45,14 @@ final class MyYoast_Connection_Conditional_Test extends TestCase {
 
 	/**
 	 * Tests that, with no constant defined, the decision falls back to the gradual-rollout
-	 * cohort. For the harness site URL the connection's bucket sits above the current rollout
-	 * share, so the site is not (yet) in the cohort.
+	 * cohort. For the harness site URL the connection's bucket (35) sits below the current
+	 * rollout share (200 per-mille, 20%), so the site is in the cohort.
 	 *
 	 * @covers ::is_met
 	 *
 	 * @return void
 	 */
 	public function test_is_met_falls_back_to_cohort_when_constant_not_defined() {
-		$this->assertFalse( $this->instance->is_met() );
+		$this->assertTrue( $this->instance->is_met() );
 	}
 }


### PR DESCRIPTION

## Context

The MyYoast connection feature (OAuth client, WP-CLI commands, key-rotation cron) is gated behind the `YOAST_SEO_MYYOAST_CONNECTION` flag and additionally rolled out to a deterministic share of sites via `Gradual_Rollout_Conditional`. As the rollout has proven stable at 1%, this PR widens the share to 20% for the next release.

## Summary

This PR can be summarized in the following changelog entry:

* Increases the MyYoast connection rollout share from 1% to 20%.

## Relevant technical choices:

* The rollout share is expressed in per-mille (0–1000), so 20% is `200`; the value was raised from `10` to `200` in `MyYoast_Connection_Conditional::get_rollout_share()`.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Because the rollout is deterministic per site, verifying an exact 20% share is not practical on a single install; confirm the value is `200` in `src/conditionals/myyoast-connection-conditional.php` and that a site opted into the flag still connects as before.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — this only changes the internal rollout percentage of a feature-flag-gated connection and has no directly observable user-facing behaviour.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The MyYoast connection (OAuth client, WP-CLI commands, key-rotation cron); more sites will be eligible for the connection than before.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
