### PR TITLE
fix(ai): deprecate legacy AI_Consent consent module

### DIFF
--- a/config/dependency-injection/deprecated-classes.php
+++ b/config/dependency-injection/deprecated-classes.php
@@ -19,14 +19,22 @@
  */
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Yoast\WP\SEO\AI_Consent\Application\Consent_Handler;
+use Yoast\WP\SEO\AI_Consent\Infrastructure\Endpoints\Consent_Endpoint;
+use Yoast\WP\SEO\AI_Consent\User_Interface\Ai_Consent_Integration;
+use Yoast\WP\SEO\AI_Consent\User_Interface\Consent_Route;
 use Yoast\WP\SEO\Conditionals\Google_Site_Kit_Feature_Conditional;
 use Yoast\WP\SEO\Helpers\Request_Helper;
 use Yoast\WP\SEO\Integrations\Admin\Unsupported_PHP_Version_Notice;
 
 $deprecated_classes = [
-	Request_Helper::class                                          => '23.6',
-	Unsupported_PHP_Version_Notice::class                          => '25.0',
-	Google_Site_Kit_Feature_Conditional::class                     => '26.7',
+	Request_Helper::class                      => '23.6',
+	Unsupported_PHP_Version_Notice::class      => '25.0',
+	Google_Site_Kit_Feature_Conditional::class => '26.7',
+	Consent_Handler::class                     => '28.2',
+	Consent_Endpoint::class                    => '28.2',
+	Ai_Consent_Integration::class              => '28.2',
+	Consent_Route::class                       => '28.2',
 ];
 
 foreach ( $deprecated_classes as $original_class => $version ) {

--- a/src/deprecated/src/ai-consent/application/consent-handler-interface.php
+++ b/src/deprecated/src/ai-consent/application/consent-handler-interface.php
@@ -6,11 +6,17 @@ namespace Yoast\WP\SEO\AI_Consent\Application;
  * Interface Consent_Handler_Interface
  *
  * This interface defines the methods for handling user consent.
+ *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
  */
 interface Consent_Handler_Interface {
 
 	/**
 	 * Handles consent revoked by deleting the consent user metadata from the database.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @param int $user_id The user ID.
 	 *
@@ -20,6 +26,9 @@ interface Consent_Handler_Interface {
 
 	/**
 	 * Handles consent granted by adding the consent user metadata to the database.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @param int $user_id The user ID.
 	 *

--- a/src/deprecated/src/ai-consent/application/consent-handler.php
+++ b/src/deprecated/src/ai-consent/application/consent-handler.php
@@ -23,6 +23,9 @@ use Yoast\WP\SEO\Helpers\User_Helper;
  * Class Consent_Handler
  * Handles the consent given or revoked by the user, both locally (user meta) and remotely (Yoast AI service).
  *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
+ *
  * @makePublic
  */
 class Consent_Handler implements Consent_Handler_Interface {
@@ -51,6 +54,9 @@ class Consent_Handler implements Consent_Handler_Interface {
 	/**
 	 * Class constructor.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @param User_Helper     $user_helper     The user helper.
 	 * @param Token_Manager   $token_manager   The token manager, used to obtain a JWT for the consent endpoints.
 	 * @param Request_Handler $request_handler The request handler, used to call the AI service's consent endpoints.
@@ -60,6 +66,7 @@ class Consent_Handler implements Consent_Handler_Interface {
 		Token_Manager $token_manager,
 		Request_Handler $request_handler
 	) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\Application\Consent_Handler' );
 		$this->user_helper     = $user_helper;
 		$this->token_manager   = $token_manager;
 		$this->request_handler = $request_handler;
@@ -72,6 +79,9 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 *
 	 * Transactional: any HTTP-layer exception is propagated and the local meta is left untouched, so
 	 * the local and server state stay in sync.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @param int $user_id The user ID.
 	 *
@@ -90,6 +100,7 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 * @throws RuntimeException When the user is not found.
 	 */
 	public function grant_consent( int $user_id ) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\Application\Consent_Handler::grant_consent' );
 		$user = \get_user_by( 'id', $user_id );
 		if ( ! $user instanceof WP_User ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- false positive.
@@ -118,6 +129,9 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 * mint a fresh JWT, and invalidating afterwards catches that token too. Any HTTP-layer
 	 * exception is propagated and its management is deferred to the caller.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @param int $user_id The user ID.
 	 *
 	 * @return void
@@ -135,6 +149,7 @@ class Consent_Handler implements Consent_Handler_Interface {
 	 * @throws RuntimeException                When the user is not found.
 	 */
 	public function revoke_consent( int $user_id ) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\Application\Consent_Handler::revoke_consent' );
 		$user = \get_user_by( 'id', $user_id );
 		if ( ! $user instanceof WP_User ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- false positive.

--- a/src/deprecated/src/ai-consent/domain/endpoint/endpoint-interface.php
+++ b/src/deprecated/src/ai-consent/domain/endpoint/endpoint-interface.php
@@ -3,10 +3,19 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\AI_Consent\Domain\Endpoint;
 
+/**
+ * Interface Endpoint_Interface
+ *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
+ */
 interface Endpoint_Interface {
 
 	/**
 	 * Gets the name.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */
@@ -15,6 +24,9 @@ interface Endpoint_Interface {
 	/**
 	 * Gets the namespace.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_namespace(): string;
@@ -22,12 +34,18 @@ interface Endpoint_Interface {
 	/**
 	 * Gets the route.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_route(): string;
 
 	/**
 	 * Gets the URL.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @return string
 	 */

--- a/src/deprecated/src/ai-consent/infrastructure/endpoints/consent-endpoint.php
+++ b/src/deprecated/src/ai-consent/infrastructure/endpoints/consent-endpoint.php
@@ -9,43 +9,62 @@ use Yoast\WP\SEO\AI_Consent\User_Interface\Consent_Route;
 
 /**
  * Represents the setup steps tracking endpoint.
+ *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
  */
 class Consent_Endpoint implements Endpoint_Interface {
 
 	/**
 	 * Gets the name.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_name(): string {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		return 'consent';
 	}
 
 	/**
 	 * Gets the namespace.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_namespace(): string {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		return Consent_Route::ROUTE_NAMESPACE;
 	}
 
 	/**
 	 * Gets the route.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @throws Exception If the route prefix is not overwritten this throws.
 	 * @return string
 	 */
 	public function get_route(): string {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		return Consent_Route::ROUTE_PREFIX;
 	}
 
 	/**
 	 * Gets the URL.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return string
 	 */
 	public function get_url(): string {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		return \rest_url( $this->get_namespace() . $this->get_route() );
 	}
 }

--- a/src/deprecated/src/ai-consent/user-interface/ai-consent-integration.php
+++ b/src/deprecated/src/ai-consent/user-interface/ai-consent-integration.php
@@ -12,6 +12,9 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
  * Ai_Consent_Integration class.
+ *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
  */
 class Ai_Consent_Integration implements Integration_Interface {
 
@@ -46,14 +49,21 @@ class Ai_Consent_Integration implements Integration_Interface {
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return array<string>
 	 */
 	public static function get_conditionals(): array {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Ai_Consent_Integration::get_conditionals' );
 		return [ User_Profile_Conditional::class, Old_Premium_AI_Conditional::class ];
 	}
 
 	/**
 	 * Constructs the class.
+	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
 	 *
 	 * @param WPSEO_Admin_Asset_Manager    $asset_manager        The admin asset manager.
 	 * @param User_Helper                  $user_helper          The user helper.
@@ -66,6 +76,7 @@ class Ai_Consent_Integration implements Integration_Interface {
 		Short_Link_Helper $short_link_helper,
 		Consent_Endpoints_Repository $endpoints_repository
 	) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Ai_Consent_Integration' );
 		$this->asset_manager        = $asset_manager;
 		$this->user_helper          = $user_helper;
 		$this->short_link_helper    = $short_link_helper;
@@ -77,9 +88,13 @@ class Ai_Consent_Integration implements Integration_Interface {
 	 *
 	 * This is the place to register hooks and filters.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function register_hooks() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Ai_Consent_Integration::register_hooks' );
 		// Hide AI feature option in user profile if the user is not allowed to use it.
 		if ( \current_user_can( 'edit_posts' ) ) {
 			\add_action( 'wpseo_user_profile_additions', [ $this, 'render_user_profile' ], 12 );
@@ -90,9 +105,13 @@ class Ai_Consent_Integration implements Integration_Interface {
 	/**
 	 * Returns the script data for the AI consent button.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return array<string, string|bool>
 	 */
 	public function get_script_data(): array {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		return [
 			'hasConsent' => $this->user_helper->get_meta( $this->user_helper->get_current_user_id(), '_yoast_wpseo_ai_consent', true ),
 			'pluginUrl'  => \plugins_url( '', \WPSEO_FILE ),
@@ -105,9 +124,13 @@ class Ai_Consent_Integration implements Integration_Interface {
 	/**
 	 * Enqueues the required assets.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function enqueue_assets() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		$this->asset_manager->enqueue_style( 'ai-generator' );
 		$this->asset_manager->localize_script( 'ai-consent', 'wpseoAiConsent', $this->get_script_data() );
 		$this->asset_manager->enqueue_script( 'ai-consent' );
@@ -116,9 +139,13 @@ class Ai_Consent_Integration implements Integration_Interface {
 	/**
 	 * Renders the AI consent button for the user profile.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function render_user_profile() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		echo '<label for="ai-generator-consent-button">',
 		\esc_html__( 'AI features', 'wordpress-seo' ),
 		'</label>',

--- a/src/deprecated/src/ai-consent/user-interface/consent-route.php
+++ b/src/deprecated/src/ai-consent/user-interface/consent-route.php
@@ -18,6 +18,9 @@ use Yoast\WP\SEO\Routes\Route_Interface;
 /**
  * Registers a route toget suggestions from the AI API
  *
+ * @deprecated 28.2
+ * @codeCoverageIgnore
+ *
  * @makePublic
  *
  * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
@@ -62,20 +65,28 @@ class Consent_Route implements Route_Interface {
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return array<string> The conditionals.
 	 */
 	public static function get_conditionals() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Consent_Route::get_conditionals' );
 		return [ AI_Conditional::class, Old_Premium_AI_Conditional::class ];
 	}
 
 	/**
 	 * Class constructor.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @param Consent_Handler $consent_handler The consent handler.
 	 * @param Token_Manager   $token_manager   The token manager.
 	 * @param Logger          $logger          The logger.
 	 */
 	public function __construct( Consent_Handler $consent_handler, Token_Manager $token_manager, Logger $logger ) {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Consent_Route' );
 		$this->consent_handler = $consent_handler;
 		// @TODO: Remove the token manager as soon as we don't care about BC, because it's no longer used.
 		$this->token_manager = $token_manager;
@@ -85,9 +96,13 @@ class Consent_Route implements Route_Interface {
 	/**
 	 * Registers routes with WordPress.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return void
 	 */
 	public function register_routes() {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Consent_Route::register_routes' );
 		\register_rest_route(
 			self::ROUTE_NAMESPACE,
 			self::ROUTE_PREFIX,
@@ -109,11 +124,15 @@ class Consent_Route implements Route_Interface {
 	/**
 	 * Runs the callback to store the consent given by the user to use AI-based services.
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @param WP_REST_Request $request The request object.
 	 *
 	 * @return WP_REST_Response The response of the callback action.
 	 */
 	public function consent( WP_REST_Request $request ): WP_REST_Response {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Yoast\WP\SEO\AI\Consent\User_Interface\Consent_Route::consent' );
 		$user_id = \get_current_user_id();
 		$consent = (bool) $request->get_param( 'consent' );
 
@@ -140,9 +159,13 @@ class Consent_Route implements Route_Interface {
 	 * - if the user is logged
 	 * - if the user can edit posts
 	 *
+	 * @deprecated 28.2
+	 * @codeCoverageIgnore
+	 *
 	 * @return bool Whether the user is logged in, can edit posts and the feature is active.
 	 */
 	public function check_permissions(): bool {
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2' );
 		$user = \wp_get_current_user();
 		if ( $user === null || $user->ID < 1 ) {
 			return false;

--- a/tests/Unit/Values/OAuth/OAuth_Token_Test.php
+++ b/tests/Unit/Values/OAuth/OAuth_Token_Test.php
@@ -174,6 +174,7 @@ final class OAuth_Token_Test extends TestCase {
 		$this->assertEquals( '000001', $this->getPropertyValue( $instance, 'refresh_token' ) );
 		$this->assertEquals( 604_800, $this->getPropertyValue( $instance, 'expires' ) );
 		$this->assertEquals( false, $this->getPropertyValue( $instance, 'has_expired' ) );
-		$this->assertEquals( $this->created_at, $this->getPropertyValue( $instance, 'created_at' ) );
+		// Tolerate 1s drift: set_up() captures \time(), from_response() captures \time() again.
+		$this->assertEqualsWithDelta( $this->created_at, $this->getPropertyValue( $instance, 'created_at' ), 1 );
 	}
 }


### PR DESCRIPTION
## Context

Issue #23164 reports the AI consent input rendering twice on Admin > Users > Profile.

The double render came from two `Ai_Consent_Integration` classes — the legacy `src/ai-consent/` (`Yoast\WP\SEO\AI_Consent\...`) and the new `src/ai/consent/` (`Yoast\WP\SEO\AI\Consent\...`) — both hooking `wpseo_user_profile_additions` at priority 12. In 27.4 both loaded unconditionally. Commit `9b4297a0b3` added mutually exclusive conditional gates (`Old_Premium_AI_Conditional` / `New_Premium_Or_Free_AI_Conditional`) so the double render has not happened since 27.5, but the legacy classes were left in place and still wired into the Symfony DI container. This PR removes that dead code by following the deprecation process in `DEPRECATING.md`.

## Summary

This PR can be summarized in the following changelog entry:

* Deprecates the legacy `src/ai-consent/` consent module that was superseded by `src/ai/consent/` in Yoast SEO 27.5.

## Relevant technical choices:

* Moved the six legacy classes from `src/ai-consent/` to `src/deprecated/src/ai-consent/` and annotated them with `@deprecated 28.2`, `@codeCoverageIgnore`, and `_deprecated_function()` calls per `DEPRECATING.md`.
* Registered the four concrete classes (`Consent_Handler`, `Consent_Endpoint`, `Ai_Consent_Integration`, `Consent_Route`) in `config/dependency-injection/deprecated-classes.php`. The two interfaces are autoload-only and need no DI entry.
* The DI `Loader_Pass` skips deprecated definitions (`loader-pass.php:43`), so the legacy `register_integration` / `register_route` calls are dropped from the compiled container and the legacy hook no longer fires on any install.
* The legacy `Consent_Handler` stays resolvable for the two `src/ai-generator/` consumers that still type-hint it; they will emit a deprecation notice on each resolution until they are migrated in a follow-up.
* `src/generated/container.php` is gitignored and regenerated by `composer compile-di`, so it is intentionally not part of this commit.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

**1. Single consent input on the user profile (regression for the reported bug)**
1. Install Yoast SEO from this branch on a fresh WordPress site (no Premium).
2. Go to Admin > Users > Profile and scroll to the "AI features" section.
3. View source and count the `<label for="ai-generator-consent-button">` elements.
4. Expected: exactly one.

**2. Consent still works end-to-end**
1. On the same profile page, click the consent button.
2. Reload the page.
3. Expected: the consent state persists. The `_yoast_wpseo_ai_consent` user meta is set or cleared to match the toggle.

**3. AI generator still resolves the consent handler**
1. Open a post in the block editor and trigger the Yoast AI suggestions panel.
2. Toggle consent in the profile and refresh the editor.
3. Expected: the AI suggestions UI updates its consent state. No errors in the browser console.

**4. Deprecation notices (expected, not a failure)**
1. Enable `WP_DEBUG` and `WP_DEBUG_LOG`.
2. Toggle the AI consent in the profile.
3. Expected: at most one `_deprecated_function` notice per request. The new `AI\Consent` integration emits no notices.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable — this is a code cleanup with no user-visible change. The acceptance steps above cover the regression case.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* AI consent flow on the user profile (single render, toggle persistence).
* AI generator suggestions panel (consent state resolution via the legacy handler).

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23164
