### PR TITLE
feat(llms-txt): add wpseo_llmstxt_sitemap_url filter

### DIFF
--- a/src/llms-txt/infrastructure/markdown-services/sitemap-link-collector.php
+++ b/src/llms-txt/infrastructure/markdown-services/sitemap-link-collector.php
@@ -18,17 +18,32 @@ class Sitemap_Link_Collector {
 	 * @return Link The link for the sitemap.
 	 */
 	public function get_link(): ?Link {
+		$sitemap_url = null;
+
 		if ( WPSEO_Options::get( 'enable_xml_sitemap' ) ) {
 			$sitemap_url = WPSEO_Sitemaps_Router::get_base_url( 'sitemap_index.xml' );
-			return new Link( 'Sitemap index', $sitemap_url );
+		}
+		else {
+			$core_sitemap_url = \get_sitemap_url( 'index' );
+			if ( $core_sitemap_url !== false ) {
+				$sitemap_url = $core_sitemap_url;
+			}
 		}
 
-		$sitemap_url = \get_sitemap_url( 'index' );
+		/**
+		 * Filter: 'wpseo_llmstxt_sitemap_url' - Allows filtering the sitemap URL used in the llms.txt file,
+		 * for example to point to a third-party sitemap plugin's URL.
+		 *
+		 * @since 28.2
+		 *
+		 * @param string|null $sitemap_url The sitemap URL as resolved by Yoast SEO, or null if none was found.
+		 */
+		$sitemap_url = \apply_filters( 'wpseo_llmstxt_sitemap_url', $sitemap_url );
 
-		if ( $sitemap_url !== false ) {
-			return new Link( 'Sitemap index', $sitemap_url );
+		if ( empty( $sitemap_url ) ) {
+			return null;
 		}
 
-		return null;
+		return new Link( 'Sitemap index', $sitemap_url );
 	}
 }

--- a/tests/WP/Llms_Txt/Infrastructure/Sitemap_Link_Collector_Test.php
+++ b/tests/WP/Llms_Txt/Infrastructure/Sitemap_Link_Collector_Test.php
@@ -56,6 +56,47 @@ final class Sitemap_Link_Collector_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that the wpseo_llmstxt_sitemap_url filter can override the resolved sitemap URL.
+	 *
+	 * @return void
+	 */
+	public function test_filter_overrides_sitemap_url() {
+		WPSEO_Options::set( 'enable_xml_sitemap', true );
+
+		$filter = static function () {
+			return 'https://example.com/sitemap.xml';
+		};
+		\add_filter( 'wpseo_llmstxt_sitemap_url', $filter );
+
+		$link_result = $this->instance->get_link();
+
+		\remove_filter( 'wpseo_llmstxt_sitemap_url', $filter );
+
+		$this->assertInstanceOf( Link::class, $link_result );
+		$this->assertStringContainsString( 'https://example.com/sitemap.xml', $link_result->render() );
+	}
+
+	/**
+	 * Tests that the wpseo_llmstxt_sitemap_url filter can suppress the sitemap link entirely.
+	 *
+	 * @return void
+	 */
+	public function test_filter_can_suppress_sitemap_url() {
+		WPSEO_Options::set( 'enable_xml_sitemap', true );
+
+		$filter = static function () {
+			return null;
+		};
+		\add_filter( 'wpseo_llmstxt_sitemap_url', $filter );
+
+		$link_result = $this->instance->get_link();
+
+		\remove_filter( 'wpseo_llmstxt_sitemap_url', $filter );
+
+		$this->assertNull( $link_result );
+	}
+
+	/**
 	 * Data provider for test_get_title.
 	 *
 	 * @return Generator


### PR DESCRIPTION
## Context

The `llms.txt` file links to a sitemap in its Optional section, but it only knows about two sources: Yoast's own XML sitemap and the WordPress core sitemap. Sites running a third-party sitemap plugin (for example one that outputs `sitemap.xml`) get no sitemap link, or the wrong one, once both of those are unavailable. This PR adds a filter so any plugin or theme can supply its own sitemap URL.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a `wpseo_llmstxt_sitemap_url` filter to allow filtering the sitemap URL used in the llms.txt file.

## Relevant technical choices:

* Mirrors the existing `wpseo_llmstxt_*` filter pattern already used in this feature (`wpseo_llmstxt_link_description`, `wpseo_llmstxt_encoding_prefix`), same docblock style and naming convention.
* The filter receives whatever URL Yoast's own logic resolved (or `null`), and can return any string to override it, or `null`/falsy to suppress the sitemap link entirely.
* No behaviour change for sites that don't use the filter.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Enable the `llms.txt` feature (Yoast SEO → Settings → Site features → llms.txt).
* Visit `/llms.txt` and confirm the `Optional` section still links to the sitemap as before (Yoast XML sitemap or core sitemap), unchanged from current behaviour.
* Add this snippet to a must-use plugin or theme's `functions.php`: `add_filter( 'wpseo_llmstxt_sitemap_url', function () { return 'https://example.com/sitemap.xml'; } );`
* Reload `/llms.txt` and confirm the sitemap link now points to `https://example.com/sitemap.xml`.
* Replace the snippet with `add_filter( 'wpseo_llmstxt_sitemap_url', '__return_null' );` and confirm the sitemap link disappears.

#### Relevant test scenarios


### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The `llms.txt` file generation, specifically the sitemap link in the Optional section.

## Other environments

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes #22513