### PR TITLE
fix(schema): correct wordCount for non-English content

### DIFF
--- a/src/generators/schema/article.php
+++ b/src/generators/schema/article.php
@@ -209,25 +209,23 @@ class Article extends Abstract_Schema_Piece {
 		// Strips all other tags.
 		$post_content = \wp_strip_all_tags( $post_content );
 
-		$characters = '';
+		// Remove any HTML entities still present in the content.
+		$post_content = \preg_replace( '/&(?:[a-zA-Z][a-zA-Z0-9]*|#[0-9]+|#x[0-9a-fA-F]+);/', ' ', $post_content );
 
-		if ( \preg_match( '@[а-я]@ui', $post_content ) ) {
-			// Correct counting of the number of words in the Russian and Ukrainian languages.
-			$alphabet = [
-				'ru' => 'абвгдеёжзийклмнопрстуфхцчшщъыьэюя',
-				'ua' => 'абвгґдеєжзиіїйклмнопрстуфхцчшщьюя',
-			];
+		// CJK scripts (e.g. Chinese, Japanese) don't separate words with spaces, so count their characters instead.
+		$cjk_pattern = '/[\p{Han}\p{Hiragana}\p{Katakana}]/u';
+		\preg_match_all( $cjk_pattern, $post_content, $cjk_matches );
+		$cjk_word_count = \count( $cjk_matches[0] );
+		$post_content   = \preg_replace( $cjk_pattern, ' ', $post_content );
 
-			$characters  = \implode( '', $alphabet );
-			$characters  = \preg_split( '//u', $characters, -1, \PREG_SPLIT_NO_EMPTY );
-			$characters  = \array_unique( $characters );
-			$characters  = \implode( '', $characters );
-			$characters .= \mb_strtoupper( $characters );
-		}
+		// Neutralize any other non-ASCII, non-letter characters so they can't be misread as word characters below.
+		$post_content = \preg_replace( '/[^\p{L}\x00-\x7F]/u', ' ', $post_content );
 
-		// Remove characters from HTML entities.
-		$post_content = \preg_replace( '@&[a-z0-9]+;@i', ' ', \htmlentities( $post_content ) );
+		// Any non-ASCII letters still present (Cyrillic, Arabic, Greek, Hebrew, etc.) need to be recognized
+		// as word characters, str_word_count() only knows Latin letters by default.
+		\preg_match_all( '/\p{L}/u', $post_content, $letter_matches );
+		$characters = \implode( '', \array_unique( $letter_matches[0] ) );
 
-		return \str_word_count( $post_content, 0, $characters );
+		return ( $cjk_word_count + \str_word_count( $post_content, 0, $characters ) );
 	}
 }

--- a/tests/Unit/Generators/Schema/Article_Test.php
+++ b/tests/Unit/Generators/Schema/Article_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Generators\Schema;
 
 use Brain\Monkey;
 use Mockery;
+use ReflectionMethod;
 use stdClass;
 use WP_User;
 use Yoast\WP\SEO\Generators\Schema\Article;
@@ -591,6 +592,78 @@ final class Article_Test extends TestCase {
 					'wordCount'        => 6,
 				],
 				'message'        => 'The terms are empty.',
+			],
+		];
+	}
+
+	/**
+	 * Tests the word_count method with content in various scripts.
+	 *
+	 * @covers ::word_count
+	 *
+	 * @dataProvider provider_for_word_count
+	 *
+	 * @param string $post_content The post content to count.
+	 * @param string $post_title   The post title to count.
+	 * @param int    $expected     The expected word count.
+	 * @param string $message      The failure message.
+	 *
+	 * @return void
+	 */
+	public function test_word_count( $post_content, $post_title, $expected, $message ) {
+		$reflection = new ReflectionMethod( Article::class, 'word_count' );
+
+		$this->assertSame( $expected, $reflection->invoke( $this->instance, $post_content, $post_title ), $message );
+	}
+
+	/**
+	 * Provides data to the word_count test.
+	 *
+	 * @return array<string, array<int, string|int>> The data to use.
+	 */
+	public static function provider_for_word_count() {
+		return [
+			'English content'          => [
+				'This is test content.',
+				'Test title',
+				6,
+				'Latin-script content should still count correctly.',
+			],
+			'Cyrillic content'         => [
+				'Привет привет мир тест текст',
+				'',
+				5,
+				'Cyrillic words should be counted individually.',
+			],
+			'Arabic content'           => [
+				'مرحبا بالعالم هذا اختبار',
+				'',
+				4,
+				'Arabic words should be counted individually.',
+			],
+			'Japanese content'         => [
+				'これは日本語のテストです',
+				'',
+				12,
+				'Japanese has no spaces between words, so characters are counted instead.',
+			],
+			'Chinese content'          => [
+				'你好世界这是一个测试',
+				'',
+				10,
+				'Chinese characters are counted individually, including Han ideographs beyond the basic block.',
+			],
+			'Mixed Latin and Japanese' => [
+				'Hello world これは日本語です end',
+				'',
+				11,
+				'Latin words and Japanese characters should both be counted.',
+			],
+			'Accented Latin content'   => [
+				'café résumé naïve',
+				'',
+				3,
+				'Accented Latin letters should not be treated as HTML entities.',
 			],
 		];
 	}


### PR DESCRIPTION
## Context

The Article JSON-LD schema `wordCount` was wrong for non-Latin scripts. Reported for Arabic in #22402 and confirmed there for Japanese. The same function silently corrupted accented Latin (e.g. French `café`) and Greek, but that was never reported because the surface symptom is small.

A previous partial fix (PR #17774) handled only Cyrillic by hardcoding the Russian/Ukrainian alphabets. Every other script still went through `str_word_count()` with an empty extra-characters list, and any character with a named HTML entity was first round-tripped through `htmlentities()` and then stripped as the entity, dropping the original character entirely.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the `wordCount` value in the Article JSON-LD schema was incorrect for non-English content. Arabic, Japanese, Greek and accented Latin (e.g. French) were all affected; the count for Cyrillic content (already partly fixed in #17774) is preserved.

## Relevant technical choices:

* `str_word_count()` is byte-based and only knows Latin letters, so it cannot tokenize multibyte text on its own. The fix has two parts: count CJK characters individually (since those scripts have no spaces between words) and pass every other non-ASCII letter still present in the buffer to `str_word_count()` as its extra-characters argument. Cyrillic, Arabic, Greek, Hebrew and any future space-delimited script now work without per-language alphabet tables.
* The `htmlentities()` round-trip is replaced with a regex that strips only literal entity syntax (`&name;`, `&#123;`, `&#x1F;`). It was previously turning any letter with an HTML4 named entity into its entity string, then deleting it, which destroyed every accented Latin letter and every Greek letter.
* CJK range uses Unicode properties (`\p{Han}\p{Hiragana}\p{Katakana}`) instead of a fixed codepoint range, so CJK Extension A/B and supplementary-plane Han ideographs count too. Matches the character-counting convention Yoast's own JS content-analysis package already uses for Japanese.
* Stray non-ASCII non-letter characters (punctuation, marks, symbols) are neutralized to spaces before the final `str_word_count()` pass so they cannot be misread by the byte-wise scan.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set Yoast SEO → Settings → Site representation to a company or person (organization name and logo). Without this, the Article schema `wordCount` field is not emitted.
* Create a Post and set the body to Arabic text, for example: `مرحبا بالعالم هذا اختبار للمحتوى العربي`.
* In the Yoast SEO meta box, open the Schema tab and set the Article type to "Default for Posts (Article)".
* Publish the post and view it on the frontend.
* View the page source and search for `"wordCount"`. The value should equal the number of words in the Arabic text (6 for the example above), not a near-zero or wrong number.
* Repeat with Japanese text, for example `これは日本語のテストです` — the value should match the number of CJK characters (12), not 0 or 1.
* Repeat with French text, for example `café résumé naïve` — the value should be 3, not 5 (the previous code corrupted accented letters).
* Cross-check against the English and Cyrillic behavior in `Article_Test::test_generate` and `Article_Test::test_word_count` to confirm no regression.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Use the same Arabic, Japanese and French test posts from the acceptance test steps. Inspect the page source of each and confirm the `wordCount` value is correct.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Article JSON-LD schema output. All other generators and the Insights/Readability analyses use different code paths and are not affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #22402