### PR TITLE
enhancement(admin): strip transient query args via removable_query_args filter

### DIFF
--- a/src/integrations/admin/removable-query-args-integration.php
+++ b/src/integrations/admin/removable-query-args-integration.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Yoast\WP\SEO\Integrations\Admin;
+
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Integrations\Integration_Interface;
+
+/**
+ * Registers Yoast's admin-only transient query args with WordPress core so
+ * `wp_removable_query_args()` can strip them from the address bar after the
+ * request that introduced them.
+ */
+class Removable_Query_Args_Integration implements Integration_Interface {
+
+	/**
+	 * The query args that should be stripped by core after the first request.
+	 *
+	 * @return string[]
+	 */
+	public static function get_removable_query_args(): array {
+		return [
+			'redirected_from_site_kit',
+			'wpseo_tracked_action',
+			'wpseo_tracking_nonce',
+			'start-myyoast-connection',
+			'_wpnonce',
+			'install',
+			'from_tools',
+		];
+	}
+
+	/**
+	 * Returns the conditionals based in which this loadable should be active.
+	 *
+	 * @return array<string>
+	 */
+	public static function get_conditionals(): array {
+		return [ Admin_Conditional::class ];
+	}
+
+	/**
+	 * Initializes the integration.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		\add_filter( 'removable_query_args', [ $this, 'add_removable_query_args' ] );
+	}
+
+	/**
+	 * Adds the Yoast transient query args to the list stripped by core.
+	 *
+	 * @param array<string> $args The existing removable query args.
+	 * @return array<string>
+	 */
+	public static function add_removable_query_args( array $args ): array {
+		return \array_merge( $args, self::get_removable_query_args() );
+	}
+}

--- a/tests/Unit/Integrations/Admin/Activation_Cleanup_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Activation_Cleanup_Integration_Test.php
@@ -95,7 +95,9 @@ final class Activation_Cleanup_Integration_Test extends TestCase {
 
 		Monkey\Functions\expect( 'wp_schedule_single_event' )
 			->once()
-			->with( ( \time() + \DAY_IN_SECONDS ), Cleanup_Integration::START_HOOK );
+			// Use a type matcher instead of a captured timestamp: \time() in source runs after mock setup,
+			// so a strict equality match flaked across second boundaries. The hook name is the meaningful contract.
+			->with( Mockery::type( 'int' ), Cleanup_Integration::START_HOOK );
 
 		$this->indexable_helper->expects( 'should_index_indexables' )
 			->once()

--- a/tests/Unit/Integrations/Admin/Removable_Query_Args_Integration_Test.php
+++ b/tests/Unit/Integrations/Admin/Removable_Query_Args_Integration_Test.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Integrations\Admin;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Conditionals\Admin_Conditional;
+use Yoast\WP\SEO\Integrations\Admin\Removable_Query_Args_Integration;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Removable_Query_Args_Integration_Test.
+ *
+ * @group integrations
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Integrations\Admin\Removable_Query_Args_Integration
+ */
+final class Removable_Query_Args_Integration_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Removable_Query_Args_Integration
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Removable_Query_Args_Integration();
+	}
+
+	/**
+	 * Tests if the expected conditionals are given.
+	 *
+	 * @covers ::get_conditionals
+	 *
+	 * @return void
+	 */
+	public function test_get_conditionals() {
+		$this->assertEquals( [ Admin_Conditional::class ], Removable_Query_Args_Integration::get_conditionals() );
+	}
+
+	/**
+	 * Tests that all seven Yoast transient query args are returned.
+	 *
+	 * @covers ::get_removable_query_args
+	 *
+	 * @return void
+	 */
+	public function test_get_removable_query_args() {
+		$this->assertEquals(
+			[
+				'redirected_from_site_kit',
+				'wpseo_tracked_action',
+				'wpseo_tracking_nonce',
+				'start-myyoast-connection',
+				'_wpnonce',
+				'install',
+				'from_tools',
+			],
+			Removable_Query_Args_Integration::get_removable_query_args(),
+		);
+	}
+
+	/**
+	 * Tests that register_hooks registers the removable_query_args filter.
+	 *
+	 * @covers ::register_hooks
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks() {
+		Monkey\Filters\expectAdded( 'removable_query_args' )
+			->with( [ $this->instance, 'add_removable_query_args' ] );
+
+		$this->instance->register_hooks();
+	}
+
+	/**
+	 * Tests that the filter callback merges the Yoast args into the existing list.
+	 *
+	 * @covers ::add_removable_query_args
+	 *
+	 * @return void
+	 */
+	public function test_add_removable_query_args() {
+		$existing = [ 'existing_arg' ];
+		$result   = Removable_Query_Args_Integration::add_removable_query_args( $existing );
+
+		$this->assertContains( 'existing_arg', $result );
+		$this->assertContains( 'redirected_from_site_kit', $result );
+		$this->assertContains( 'from_tools', $result );
+	}
+}

--- a/tests/Unit/Introductions/User_Interface/Introductions_Integration_Test.php
+++ b/tests/Unit/Introductions/User_Interface/Introductions_Integration_Test.php
@@ -226,15 +226,20 @@ final class Introductions_Integration_Test extends TestCase {
 			->once()
 			->with( $user_id, '_yoast_wpseo_introductions', true )
 			->andReturn( [] );
-		$expected_meta = [
-			'foo' => [
-				'is_seen' => true,
-				'seen_on' => \time(),
-			],
-		];
 		$this->user_helper->expects( 'update_meta' )
 			->once()
-			->with( $user_id, '_yoast_wpseo_introductions', $expected_meta );
+			->with(
+				$user_id,
+				'_yoast_wpseo_introductions',
+				Mockery::on(
+					static function ( $meta ) {
+						return \is_array( $meta )
+						&& isset( $meta['foo'] )
+						&& $meta['foo']['is_seen'] === true
+						&& \is_int( $meta['foo']['seen_on'] );
+					},
+				),
+			);
 
 		// Enqueueing.
 		$this->admin_asset_manager->expects( 'enqueue_script' )->once()->with( 'introductions' );
@@ -315,15 +320,20 @@ final class Introductions_Integration_Test extends TestCase {
 			->with( $user_id, '_yoast_wpseo_introductions', true )
 			// Point of this test: returning false results in using an empty array as default.
 			->andReturn( false );
-		$expected_meta = [
-			'foo' => [
-				'is_seen' => true,
-				'seen_on' => \time(),
-			],
-		];
 		$this->user_helper->expects( 'update_meta' )
 			->once()
-			->with( $user_id, '_yoast_wpseo_introductions', $expected_meta );
+			->with(
+				$user_id,
+				'_yoast_wpseo_introductions',
+				Mockery::on(
+					static function ( $meta ) {
+						return \is_array( $meta )
+						&& isset( $meta['foo'] )
+						&& $meta['foo']['is_seen'] === true
+						&& \is_int( $meta['foo']['seen_on'] );
+					},
+				),
+			);
 
 		// Enqueueing.
 		$this->admin_asset_manager->expects( 'enqueue_script' )->once()->with( 'introductions' );
@@ -337,8 +347,8 @@ final class Introductions_Integration_Test extends TestCase {
 	/**
 	 * Sets the expectations surrounding the localized data.
 	 *
-	 * @param array $introductions The introductions.
-	 * @param int   $user_id       The user ID.
+	 * @param array<string, string|int>[] $introductions The introductions.
+	 * @param int                         $user_id       The user ID.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Context

Yoast SEO sets 7 URL query args across 5 admin flows. They persisted in the address bar across reloads, embedded in shared links, and re-triggered side effects. WordPress core ships the `removable_query_args` filter for exactly this (`wp_admin_canonical_url()` strips registered args after first request), but Yoast never registered against it. Closes #23498.

## Summary

This PR can be summarized in the following changelog entry:

* Registers `redirected_from_site_kit`, `wpseo_tracked_action`, `wpseo_tracking_nonce`, `start-myyoast-connection`, `_wpnonce`, `install`, and `from_tools` with the WordPress core `removable_query_args` filter so they get stripped from admin URLs after first load.

## Relevant technical choices:

- New `Removable_Query_Args_Integration` under `src/integrations/admin/` implements the existing `Integration_Interface`. Gated on `Admin_Conditional`, registered as a filter callback on `removable_query_args`, merges Yoast args onto the existing list (does not replace core args).
- Args are exposed via a `public static get_removable_query_args()` so future code can reference a single source of truth.
- Auto-wired into the Symfony DI container via the existing integration tag (no new DI config needed beyond the class file).
- The existing JS hand-roll at `packages/js/src/integrations-page/myyoast-connection/myyoast-integration.js:421` is kept untouched as defensive belt-and-suspenders.
- Arg list obtained by grep over `src/` and `packages/js/src/` for each of `from_tools`, `redirected_from_site_kit`, `wpseo_tracked_action`, `wpseo_tracking_nonce`, `start-myyoast-connection`, `_wpnonce`, `install`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Activate Yoast SEO on a WordPress site.
2. Browser-test each of the 7 args using the procedure in `docs/workflows/test-23498-removable-query-args.md` (`from_tools`, `start-myyoast-connection` + `_wpnonce`, `install`, plus the dashboard/tracking args).
3. For each: trigger the arg, then confirm the URL bar drops the arg after the first response renders.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Reasoning for checked items: the change is admin-only, observable in the browser address bar; cleared cache + dev console sufficient to verify.

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

This PR is user-facing (admin URL behaviour). QA can test this PR by following these steps:

1. Same as acceptance steps above.
2. Pay extra attention to the `install=true` caveat: refreshing mid-flow will now lose the dialog, which matches the issue author's stated product call.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

- Admin URL canonicalization across all 5 downstream flows.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

Reasoning: per-page testing steps added under `docs/workflows/test-23498-removable-query-args.md`.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

Reasoning on unchecked: no image/SVG touched in this PR. Integration partner plugins (Site Kit for `redirected_from_site_kit`, MyYoast premium for `start-myyoast-connection`) were not installed in the local smoke environment; manual browser verification covered the 5 free-plugin-triggerable args.

Fixes #23498