### PR TITLE
feat(schema): add PodcastEpisode option to page and article type dropdowns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2378",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2384",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=254",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_coding_standards"
 		],
 		"check-cs-thresholds": [
-			"@putenv YOASTCS_THRESHOLD_ERRORS=2384",
+			"@putenv YOASTCS_THRESHOLD_ERRORS=2376",
 			"@putenv YOASTCS_THRESHOLD_WARNINGS=254",
 			"Yoast\\WP\\SEO\\Composer\\Actions::check_cs_thresholds"
 		],

--- a/src/config/schema-types.php
+++ b/src/config/schema-types.php
@@ -27,6 +27,7 @@ class Schema_Types {
 		'CheckoutPage'      => '',
 		'RealEstateListing' => '',
 		'SearchResultsPage' => '',
+		'PodcastEpisode'    => '',
 	];
 
 	/**
@@ -46,13 +47,14 @@ class Schema_Types {
 		'ScholarlyArticle'         => '',
 		'TechArticle'              => '',
 		'Report'                   => '',
+		'PodcastEpisode'           => '',
 		'None'                     => '',
 	];
 
 	/**
 	 * Gets the page type options.
 	 *
-	 * @return array[] The schema page type options.
+	 * @return array<int, array<string, string>> The schema page type options.
 	 */
 	public function get_page_type_options() {
 		return [
@@ -104,13 +106,17 @@ class Schema_Types {
 				'name'  => \__( 'Search Results Page', 'wordpress-seo' ),
 				'value' => 'SearchResultsPage',
 			],
+			[
+				'name'  => \__( 'Podcast Episode', 'wordpress-seo' ),
+				'value' => 'PodcastEpisode',
+			],
 		];
 	}
 
 	/**
 	 * Gets the article type options.
 	 *
-	 * @return array[] The schema article type options.
+	 * @return array<int, array<string, string>> The schema article type options.
 	 */
 	public function get_article_type_options() {
 		/**
@@ -158,6 +164,10 @@ class Schema_Types {
 				[
 					'name'  => \__( 'Report', 'wordpress-seo' ),
 					'value' => 'Report',
+				],
+				[
+					'name'  => \__( 'Podcast Episode', 'wordpress-seo' ),
+					'value' => 'PodcastEpisode',
 				],
 				[
 					'name'  => \__( 'None', 'wordpress-seo' ),

--- a/tests/Unit/Config/Schema_Types_Test.php
+++ b/tests/Unit/Config/Schema_Types_Test.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Yoast\WP\SEO\Tests\Unit\Config;
+
+use Brain\Monkey;
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Class Schema_Types_Test.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Config\Schema_Types
+ */
+final class Schema_Types_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Schema_Types
+	 */
+	protected $instance;
+
+	/**
+	 * Sets up the test.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Monkey\Functions\stubs(
+			[
+				'__' => null,
+			],
+		);
+
+		Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( $tag, $value ) {
+				return $value;
+			},
+		);
+
+		Monkey\Functions\when( 'wp_list_pluck' )->alias(
+			static function ( $items, $field ) {
+				return \array_map(
+					static function ( $item ) use ( $field ) {
+						return $item[ $field ];
+					},
+					$items,
+				);
+			},
+		);
+
+		$this->instance = new Schema_Types();
+	}
+
+	/**
+	 * Tests that the PodcastEpisode schema type is available as a page type.
+	 *
+	 * @covers ::get_page_type_options
+	 *
+	 * @return void
+	 */
+	public function test_page_type_options_contains_podcast_episode() {
+		$options = $this->instance->get_page_type_options();
+
+		$values = \wp_list_pluck( $options, 'value' );
+
+		self::assertContains( 'PodcastEpisode', $values );
+	}
+
+	/**
+	 * Tests that the PodcastEpisode schema type is available as an article type.
+	 *
+	 * @covers ::get_article_type_options
+	 *
+	 * @return void
+	 */
+	public function test_article_type_options_contains_podcast_episode() {
+		$options = $this->instance->get_article_type_options();
+
+		$values = \wp_list_pluck( $options, 'value' );
+
+		self::assertContains( 'PodcastEpisode', $values );
+	}
+}


### PR DESCRIPTION
## Context

Podcast sites that publish episodes as blog posts have no way to mark those posts as podcast episodes in the schema settings. The request in #23491 is to add "Podcast Episode" as an option in the schema dropdowns, so search engines and other consumers of structured data can understand that a post is a podcast episode.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a Podcast Episode option to the schema page type and article type dropdowns.

## Relevant technical choices:

* `PodcastEpisode` is added to both the `PAGE_TYPES` and `ARTICLE_TYPES` constants and to the matching label arrays in `Schema_Types`, so the option shows up in the metabox Schema tab and in the per-post-type defaults in the settings. All other consumers read from these constants, so no further wiring is needed.
* When selected as the article type, the existing wrapping logic in `Meta_Tags_Context` outputs `"@type": [ "Article", "PodcastEpisode" ]` in the Article piece. This multi-type notation is valid schema.org, and it is the same behaviour as other types that do not contain "Article" in their name, like Report.
* No JavaScript changes are needed, because the dropdown options are sent from the server.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Edit any post, open the Yoast SEO sidebar or metabox and go to the Schema tab. Verify that "Podcast Episode" is listed in both the Page type and the Article type dropdowns.
* Select "Podcast Episode" as the Article type, save the post and view the front end. Verify that the Article piece in the JSON-LD contains `"@type": [ "Article", "PodcastEpisode" ]`.
* Go to Yoast SEO > Settings > Content types and verify that "Podcast Episode" is also available as a default Article type for each post type.
* Edit an existing post that already has another article type selected and verify that the saved value and the schema output are unchanged.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

The dropdowns are rendered from the same server-side options on every post type, so it is worth checking a regular post plus one custom post type that supports the schema settings.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same as the acceptance test steps above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The schema page type and article type dropdowns in the post editor and in the settings.
* The schema output of posts that select the new Podcast Episode article type. Posts that keep their current selection are not affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23491

## Screen recording
[![Video](https://img.youtube.com/vi/RvAsuNmc4y0/0.jpg)](https://www.youtube.com/watch?v=RvAsuNmc4y0)
