### PR TITLE
fix(integrations): prevent unbounded postmeta growth on oembed_response_data reentry

### DIFF
--- a/src/integrations/front-end/open-graph-oembed.php
+++ b/src/integrations/front-end/open-graph-oembed.php
@@ -42,6 +42,18 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	private $post_meta;
 
 	/**
+	 * Whether `set_oembed_data()` is currently running.
+	 *
+	 * Guards against recursive invocations of the `oembed_response_data` filter,
+	 * which can be triggered when this callback's work causes additional oEmbed
+	 * resolutions to fire the same filter from within the same request.
+	 *
+	 * @since [version]
+	 * @var bool
+	 */
+	private $in_set_oembed_data = false;
+
+	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -84,18 +96,32 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	 * @return array An array of oEmbed data with modified values where appropriate.
 	 */
 	public function set_oembed_data( $data, $post ) {
-		// Data to be returned.
-		$this->data      = $data;
-		$this->post_id   = $post->ID;
-		$this->post_meta = $this->meta->for_post( $this->post_id );
-
-		if ( ! empty( $this->post_meta ) ) {
-			$this->set_title();
-			$this->set_description();
-			$this->set_image();
+		// Prevent nested invocations of this filter. When `oembed_response_data`
+		// re-fires while the callback is still running the outer frame would
+		// otherwise be clobbered and any new oEmbed resolutions could trigger
+		// additional recursive meta writes.
+		if ( $this->in_set_oembed_data ) {
+			return $data;
 		}
 
-		return $this->data;
+		$this->in_set_oembed_data = true;
+
+		try {
+			// Data to be returned.
+			$this->data      = $data;
+			$this->post_id   = $post->ID;
+			$this->post_meta = $this->meta->for_post( $this->post_id );
+
+			if ( ! empty( $this->post_meta ) ) {
+				$this->set_title();
+				$this->set_description();
+				$this->set_image();
+			}
+
+			return $this->data;
+		} finally {
+			$this->in_set_oembed_data = false;
+		}
 	}
 
 	/**

--- a/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
+++ b/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
@@ -4,6 +4,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Integrations\Front_End;
 
 use Brain\Monkey;
 use Mockery;
+use RuntimeException;
 use Yoast\WP\SEO\Conditionals\Front_End_Conditional;
 use Yoast\WP\SEO\Conditionals\Open_Graph_Conditional;
 use Yoast\WP\SEO\Integrations\Front_End\Open_Graph_OEmbed;
@@ -112,6 +113,151 @@ final class Open_Graph_OEmbed_Test extends TestCase {
 			->andReturn( (object) $meta_data );
 
 		$this->assertEquals( $expected, $this->instance->set_oembed_data( $expected, $post ) );
+	}
+
+	/**
+	 * Tests that a recursive invocation of `set_oembed_data()` returns the
+	 * unaltered data instead of re-running the meta lookup, and that the outer
+	 * call still enriches the result.
+	 *
+	 * @covers ::set_oembed_data
+	 *
+	 * @return void
+	 */
+	public function test_set_oembed_data_bails_on_reentry() {
+		$post         = (object) [ 'ID' => 1337 ];
+		$inner_data   = [ 'title' => 'core-title' ];
+		$inner_result = null;
+
+		// Simulate the recursive path: the meta lookup itself triggers a nested
+		// `oembed_response_data` filter callback via `set_oembed_data()`.
+		$this->meta
+			->expects( 'for_post' )
+			->once()
+			->with( 1337 )
+			->andReturnUsing(
+				function () use ( $post, $inner_data, &$inner_result ) {
+					$inner_result = $this->instance->set_oembed_data( $inner_data, $post );
+					return (object) [
+						'open_graph_title'       => 'yoast-title',
+						'open_graph_description' => 'yoast-description',
+						'open_graph_images'      => [],
+					];
+				},
+			);
+
+		$outer_result = $this->instance->set_oembed_data( [], $post );
+
+		// Inner call: returned unaltered.
+		$this->assertSame( $inner_data, $inner_result );
+		// Outer call: enriched.
+		$this->assertEquals(
+			[
+				'title'       => 'yoast-title',
+				'description' => 'yoast-description',
+			],
+			$outer_result,
+		);
+	}
+
+	/**
+	 * Tests that the reentrancy flag is reset between calls so subsequent
+	 * non-recursive invocations still enrich the response data.
+	 *
+	 * @covers ::set_oembed_data
+	 *
+	 * @return void
+	 */
+	public function test_set_oembed_data_resets_flag_between_calls() {
+		$post = (object) [ 'ID' => 1337 ];
+
+		$this->meta
+			->expects( 'for_post' )
+			->twice()
+			->with( 1337 )
+			->andReturn(
+				(object) [
+					'open_graph_title'       => 'title',
+					'open_graph_description' => 'description',
+					'open_graph_images'      => [],
+				],
+				(object) [
+					'open_graph_title'       => 'title',
+					'open_graph_description' => 'description',
+					'open_graph_images'      => [],
+				],
+			);
+
+		$first  = $this->instance->set_oembed_data( [], $post );
+		$second = $this->instance->set_oembed_data( [], $post );
+
+		$this->assertEquals(
+			[
+				'title'       => 'title',
+				'description' => 'description',
+			],
+			$first,
+		);
+		$this->assertEquals(
+			[
+				'title'       => 'title',
+				'description' => 'description',
+			],
+			$second,
+		);
+	}
+
+	/**
+	 * Tests that the reentrancy flag is reset after the meta lookup throws,
+	 * so a follow-up (non-recursive) call still runs the meta lookup and
+	 * returns the enriched data.
+	 *
+	 * @covers ::set_oembed_data
+	 *
+	 * @return void
+	 */
+	public function test_set_oembed_data_resets_flag_after_throw() {
+		$post     = (object) [ 'ID' => 1337 ];
+		$invoked  = 0;
+		$enriched = (object) [
+			'open_graph_title'       => 'title',
+			'open_graph_description' => 'description',
+			'open_graph_images'      => [],
+		];
+
+		// First invocation throws, second returns the meta object. Mockery does
+		// not have a fluent API for per-call exception returns, so drive it via
+		// a counter and `andReturnUsing`.
+		$this->meta
+			->expects( 'for_post' )
+			->twice()
+			->with( 1337 )
+			->andReturnUsing(
+				static function () use ( &$invoked, $enriched ) {
+					$invoked++;
+					if ( $invoked === 1 ) {
+						throw new RuntimeException( 'boom' );
+					}
+					return $enriched;
+				},
+			);
+
+		try {
+			$this->instance->set_oembed_data( [], $post );
+			$this->fail( 'Expected RuntimeException was not thrown.' );
+		} catch ( RuntimeException $e ) {
+			$this->assertSame( 'boom', $e->getMessage() );
+		}
+
+		// The flag must have been reset by the `finally` block, so this call
+		// reaches `for_post` and returns the enriched data.
+		$this->assertEquals(
+			[
+				'title'       => 'title',
+				'description' => 'description',
+			],
+			$this->instance->set_oembed_data( [], $post ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Context

When a post containing an embeddable URL is rendered on the front end, the Yoast head builder triggers the Open Graph description fallback, which runs `get_the_excerpt()` and walks through `the_content` and `WP_Embed::autoembed()`. Auto-embed fires `update_post_meta('_oembed_…')`, which re-applies the `oembed_response_data` filter, which calls Yoast's `Open_Graph_OEmbed::set_oembed_data()` again, which kicks off the same chain. The recursion is unbounded: `_oembed_*` rows accumulate on every render. The same callback also kept per-call state in instance properties (`$data`, `$post_id`, `$post_meta`), so nested invocations clobbered the outer frame.

Break the loop at the reentrancy boundary. Nested calls return their `$data` untouched; top-level calls still enrich the response data as before; the flag resets even when the meta lookup throws, so back-to-back calls still run.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where Yoast SEO caused `_oembed_*` postmeta to grow unbounded on front-end renders when a post contained an auto-embeddable URL.

## Relevant technical choices:

* Single-file additive fix in `src/integrations/front-end/open-graph-oembed.php`: add a private `bool $in_set_oembed_data` flag and short-circuit nested invocations with an early `return $data;`. The existing body runs inside `try { ... } finally { $this->in_set_oembed_data = false; }` so the flag is reset even when `Meta_Surface::for_post()` throws.
* Reset on `finally` matters because `Open_Graph_OEmbed` is a `shared autowired service` produced once per Symfony DI container (`src/generated/container.php:5100`), so a stale flag would lock enrichment off for the rest of the request.
* Three new unit tests under `tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php` cover the guard: nested call returns data untouched, sequential calls both enrich, and the flag resets after a thrown exception.
* Alternatives considered and not used here: self-detaching `add_filter`/`remove_filter` (would need exact priority and closure-identity match, plus its own `try/finally`); moving the registration to `rest_api_init` as a follow-up root-cause fix would change semantics for cached `_oembed_*` meta and deserves its own BC-review change.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. On a fresh WP install with Yoast SEO 27.7 (release) or `trunk` plus this branch, create a post that contains an embeddable URL on its own line (a YouTube link works) and publish it.
2. Delete any existing oembed rows for that post:
   `wp db query "DELETE FROM wp_postmeta WHERE post_id = <POST_ID> AND meta_key LIKE '\_oembed\_%';"`
3. Count the rows before browsing:
   `wp db query "SELECT COUNT(*) FROM wp_postmeta WHERE post_id = <POST_ID> AND meta_key LIKE '\_oembed\_%';"`
4. Reload the post on the front end 10 times (hard refresh, logged out so the head render runs each time).
5. Run the count query again.

   Expected before the fix: the count keeps climbing on every render.
   Expected after the fix: the count stays flat after the first visit. Core writes its normal `_oembed_<hash>` cache rows on the first render, nothing new is added on later visits.

6. Smoke-test that oembed enrichment did not regress:
   `curl "https://your-site.test/wp-json/oembed/1.0/embed?url=<POST_URL>" | jq '{title, description, thumbnail_url}'`
   The fields should reflect the Yoast Open Graph title, description, and social image set in the metabox.

7. View the post logged out and check your debug log (with `WP_DEBUG_LOG` on) for any PHP notices, warnings, or fatals introduced by the render path.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

Not applicable. The change is a runtime guard in a single integration; the acceptance tests above cover the user-visible behaviour. Internal logic is covered by the new unit tests.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The `oembed_response_data` filter callback in `Open_Graph_OEmbed` — covers the front-end head render path that produces Open Graph tags, the REST `/oembed/1.0/embed` endpoint, and any third-party code that reads `_oembed_*` postmeta. No other hooks, filters, endpoints, or REST routes are touched.
* A nested `oembed_response_data` invocation now passes `$data` through unchanged instead of re-running the meta lookup. In practice this only happens when Yoast's own excerpt fallback triggers the_content during the same request, and the outer frame still produces the enriched response.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23326.