### PR TITLE
Allow new abilities only on posts that the user can edit

### DIFF
--- a/src/abilities/application/post-seo-data-collector.php
+++ b/src/abilities/application/post-seo-data-collector.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Abilities\Application;
 
 use WP_Error;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_Identifier_Resolver;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 
@@ -12,6 +13,7 @@ use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
  *
  * Doubles as a discovery tool: a title keyword search returns full SEO data for
  * every matching post. A request must carry an identifier; an empty request is an error.
+ * Only posts the current user may edit are exposed.
  */
 class Post_SEO_Data_Collector {
 
@@ -30,17 +32,27 @@ class Post_SEO_Data_Collector {
 	private $field_map;
 
 	/**
+	 * The post access checker.
+	 *
+	 * @var Post_Access_Checker
+	 */
+	private $post_access_checker;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param Post_Identifier_Resolver $resolver  The post identifier resolver.
-	 * @param Post_SEO_Field_Map       $field_map The post SEO field map.
+	 * @param Post_Identifier_Resolver $resolver            The post identifier resolver.
+	 * @param Post_SEO_Field_Map       $field_map           The post SEO field map.
+	 * @param Post_Access_Checker      $post_access_checker The post access checker.
 	 */
 	public function __construct(
 		Post_Identifier_Resolver $resolver,
-		Post_SEO_Field_Map $field_map
+		Post_SEO_Field_Map $field_map,
+		Post_Access_Checker $post_access_checker
 	) {
-		$this->resolver  = $resolver;
-		$this->field_map = $field_map;
+		$this->resolver            = $resolver;
+		$this->field_map           = $field_map;
+		$this->post_access_checker = $post_access_checker;
 	}
 
 	/**
@@ -57,6 +69,14 @@ class Post_SEO_Data_Collector {
 			return $indexables;
 		}
 
-		return $this->field_map->indexables_to_arrays( $indexables );
+		$editable = $this->post_access_checker->filter_editable( $indexables );
+
+		// Every match was a post the user may not edit; an already empty match list
+		// (a title-search page past the last result) stays a valid empty result.
+		if ( $editable === [] && $indexables !== [] ) {
+			return $this->post_access_checker->forbidden_error();
+		}
+
+		return $this->field_map->indexables_to_arrays( $editable );
 	}
 }

--- a/src/abilities/application/post-seo-data-updater.php
+++ b/src/abilities/application/post-seo-data-updater.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Abilities\Application;
 
 use WP_Error;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_Identifier_Resolver;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
@@ -34,6 +35,13 @@ class Post_SEO_Data_Updater {
 	private $field_map;
 
 	/**
+	 * The post access checker.
+	 *
+	 * @var Post_Access_Checker
+	 */
+	private $post_access_checker;
+
+	/**
 	 * The indexable-to-postmeta helper.
 	 *
 	 * @var Indexable_To_Postmeta_Helper
@@ -52,17 +60,20 @@ class Post_SEO_Data_Updater {
 	 *
 	 * @param Post_Identifier_Resolver     $resolver              The post identifier resolver.
 	 * @param Post_SEO_Field_Map           $field_map             The post SEO field map.
+	 * @param Post_Access_Checker          $post_access_checker   The post access checker.
 	 * @param Indexable_To_Postmeta_Helper $indexable_to_postmeta The indexable-to-postmeta helper.
 	 * @param Indexable_Builder            $indexable_builder     The indexable builder.
 	 */
 	public function __construct(
 		Post_Identifier_Resolver $resolver,
 		Post_SEO_Field_Map $field_map,
+		Post_Access_Checker $post_access_checker,
 		Indexable_To_Postmeta_Helper $indexable_to_postmeta,
 		Indexable_Builder $indexable_builder
 	) {
 		$this->resolver              = $resolver;
 		$this->field_map             = $field_map;
+		$this->post_access_checker   = $post_access_checker;
 		$this->indexable_to_postmeta = $indexable_to_postmeta;
 		$this->indexable_builder     = $indexable_builder;
 	}
@@ -82,6 +93,14 @@ class Post_SEO_Data_Updater {
 
 		if ( $indexable instanceof WP_Error ) {
 			return $indexable;
+		}
+
+		// The wpseo_manage_options gate on the ability is site-wide; the write itself is
+		// only allowed on posts the user could also edit through the regular editors.
+		$can_edit = $this->post_access_checker->ensure_can_edit( (int) $indexable->object_id );
+
+		if ( $can_edit instanceof WP_Error ) {
+			return $can_edit;
 		}
 
 		$changed_columns = $this->field_map->apply_to_indexable( $input, $indexable );

--- a/src/abilities/application/post-seo-data-updater.php
+++ b/src/abilities/application/post-seo-data-updater.php
@@ -95,7 +95,7 @@ class Post_SEO_Data_Updater {
 			return $indexable;
 		}
 
-		// The wpseo_manage_options gate on the ability is site-wide; the write itself is
+		// The capability gate on the ability is site-wide; the write itself is
 		// only allowed on posts the user could also edit through the regular editors.
 		$can_edit = $this->post_access_checker->ensure_can_edit( (int) $indexable->object_id );
 

--- a/src/abilities/infrastructure/post-access-checker.php
+++ b/src/abilities/infrastructure/post-access-checker.php
@@ -1,0 +1,66 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\Infrastructure;
+
+use WP_Error;
+use Yoast\WP\SEO\Models\Indexable;
+
+/**
+ * Checks whether the current user may edit the posts behind indexables.
+ *
+ * The abilities are gated site-wide by the wpseo_manage_options capability, but that
+ * capability must not grant access to posts the user could not otherwise edit. This
+ * checker applies the exact per-post WordPress check, current_user_can( 'edit_post', $id ),
+ * mirroring the bulk editor's access rules.
+ */
+class Post_Access_Checker {
+
+	/**
+	 * Ensures the current user may edit the given post.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return true|WP_Error True when the post is editable, or a 403 error.
+	 */
+	public function ensure_can_edit( int $post_id ) {
+		if ( \current_user_can( 'edit_post', $post_id ) ) {
+			return true;
+		}
+
+		return $this->forbidden_error();
+	}
+
+	/**
+	 * Builds the 403 error for posts the current user may not edit.
+	 *
+	 * Mirrors WP core's rest_cannot_edit wording.
+	 *
+	 * @return WP_Error The forbidden error.
+	 */
+	public function forbidden_error(): WP_Error {
+		return new WP_Error(
+			'yoast_seo_cannot_edit_post',
+			\__( 'Sorry, you are not allowed to edit this post.', 'wordpress-seo' ),
+			[ 'status' => 403 ],
+		);
+	}
+
+	/**
+	 * Filters a list of post indexables down to the ones the current user may edit.
+	 *
+	 * @param Indexable[] $indexables The post indexables.
+	 *
+	 * @return Indexable[] The editable indexables, reindexed.
+	 */
+	public function filter_editable( array $indexables ): array {
+		$editable = \array_filter(
+			$indexables,
+			static function ( $indexable ) {
+				return \current_user_can( 'edit_post', (int) $indexable->object_id );
+			},
+		);
+
+		return \array_values( $editable );
+	}
+}

--- a/src/abilities/infrastructure/post-access-checker.php
+++ b/src/abilities/infrastructure/post-access-checker.php
@@ -9,8 +9,8 @@ use Yoast\WP\SEO\Models\Indexable;
 /**
  * Checks whether the current user may edit the posts behind indexables.
  *
- * The abilities are gated site-wide by the wpseo_manage_options capability, but that
- * capability must not grant access to posts the user could not otherwise edit. This
+ * The abilities are gated site-wide by a capability check, but that capability
+ * must not grant access to posts the user could not otherwise edit. This
  * checker applies the exact per-post WordPress check, current_user_can( 'edit_post', $id ),
  * mirroring the bulk editor's access rules.
  */

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -134,25 +134,14 @@ class Abilities_Integration implements Integration_Interface {
 	/**
 	 * Checks whether the current user can manage Yoast SEO.
 	 *
-	 * Gates the score abilities behind the Yoast SEO management capability.
+	 * Gates every ability — reading scores, reading post SEO data, and updating it —
+	 * behind the same Yoast SEO management capability. The post SEO data abilities
+	 * additionally enforce per-post edit access in their execute callbacks.
 	 *
 	 * @return bool Whether the current user can manage Yoast SEO.
 	 */
 	public function can_manage_seo(): bool {
 		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
-	}
-
-	/**
-	 * Checks whether the current user can edit posts.
-	 *
-	 * Gates the post SEO data abilities. The gate is deliberately broad: the abilities
-	 * themselves enforce per-post edit access, so any user who can edit posts (or manage
-	 * Yoast SEO — the capability helper grants either) may reach them.
-	 *
-	 * @return bool Whether the current user can edit posts.
-	 */
-	public function can_edit_posts(): bool {
-		return $this->capability_helper->current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -246,7 +235,6 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_post_identifier_input_schema(),
 					'output_schema'       => $this->wrap_in_array_schema( $this->get_post_seo_data_output_schema() ),
-					'permission_callback' => [ $this, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 				],
 			),
@@ -267,7 +255,6 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_update_post_seo_data_input_schema(),
 					'output_schema'       => $this->get_post_seo_data_output_schema(),
-					'permission_callback' => [ $this, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => [
 						'show_in_rest' => true,

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -134,13 +134,25 @@ class Abilities_Integration implements Integration_Interface {
 	/**
 	 * Checks whether the current user can manage Yoast SEO.
 	 *
-	 * Gates every ability — reading scores, reading post SEO data, and updating it —
-	 * behind the same Yoast SEO management capability.
+	 * Gates the score abilities behind the Yoast SEO management capability.
 	 *
 	 * @return bool Whether the current user can manage Yoast SEO.
 	 */
 	public function can_manage_seo(): bool {
 		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Checks whether the current user can edit posts.
+	 *
+	 * Gates the post SEO data abilities. The gate is deliberately broad: the abilities
+	 * themselves enforce per-post edit access, so any user who can edit posts (or manage
+	 * Yoast SEO — the capability helper grants either) may reach them.
+	 *
+	 * @return bool Whether the current user can edit posts.
+	 */
+	public function can_edit_posts(): bool {
+		return $this->capability_helper->current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -234,6 +246,7 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_post_identifier_input_schema(),
 					'output_schema'       => $this->wrap_in_array_schema( $this->get_post_seo_data_output_schema() ),
+					'permission_callback' => [ $this, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 				],
 			),
@@ -254,6 +267,7 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_update_post_seo_data_input_schema(),
 					'output_schema'       => $this->get_post_seo_data_output_schema(),
+					'permission_callback' => [ $this, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => [
 						'show_in_rest' => true,

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -231,7 +231,7 @@ class Abilities_Integration implements Integration_Interface {
 			$this->get_shared_ability_args(
 				[
 					'label'               => \__( 'Get Post SEO Data', 'wordpress-seo' ),
-					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required.', 'wordpress-seo' ),
+					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_post_identifier_input_schema(),
 					'output_schema'       => $this->wrap_in_array_schema( $this->get_post_seo_data_output_schema() ),
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
@@ -251,7 +251,7 @@ class Abilities_Integration implements Integration_Interface {
 			$this->get_shared_ability_args(
 				[
 					'label'               => \__( 'Update Post SEO Data', 'wordpress-seo' ),
-					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field.', 'wordpress-seo' ),
+					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_update_post_seo_data_input_schema(),
 					'output_schema'       => $this->get_post_seo_data_output_schema(),
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -134,14 +134,26 @@ class Abilities_Integration implements Integration_Interface {
 	/**
 	 * Checks whether the current user can manage Yoast SEO.
 	 *
-	 * Gates every ability — reading scores, reading post SEO data, and updating it —
-	 * behind the same Yoast SEO management capability. The post SEO data abilities
-	 * additionally enforce per-post edit access in their execute callbacks.
+	 * Gates the score abilities behind the Yoast SEO management capability.
 	 *
 	 * @return bool Whether the current user can manage Yoast SEO.
 	 */
 	public function can_manage_seo(): bool {
 		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+
+	/**
+	 * Checks whether the current user can edit advanced SEO metadata.
+	 *
+	 * Gates the post SEO data abilities on the same capability that gates the advanced
+	 * and schema fields in the editors, so the abilities can never grant a field the
+	 * editor UI denies. The capability helper also passes wpseo_manage_options holders.
+	 * Per-post edit access is enforced on top, in the execute callbacks.
+	 *
+	 * @return bool Whether the current user can edit advanced SEO metadata.
+	 */
+	public function can_edit_advanced_metadata(): bool {
+		return $this->capability_helper->current_user_can( 'wpseo_edit_advanced_metadata' );
 	}
 
 	/**
@@ -235,6 +247,7 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_post_identifier_input_schema(),
 					'output_schema'       => $this->wrap_in_array_schema( $this->get_post_seo_data_output_schema() ),
+					'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 				],
 			),
@@ -255,6 +268,7 @@ class Abilities_Integration implements Integration_Interface {
 					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
 					'input_schema'        => $this->get_update_post_seo_data_input_schema(),
 					'output_schema'       => $this->get_post_seo_data_output_schema(),
+					'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => [
 						'show_in_rest' => true,

--- a/tests/Unit/Abilities/Application/Post_SEO_Data_Collector_Test.php
+++ b/tests/Unit/Abilities/Application/Post_SEO_Data_Collector_Test.php
@@ -6,8 +6,10 @@ namespace Yoast\WP\SEO\Tests\Unit\Abilities\Application;
 use Mockery;
 use WP_Error;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_Identifier_Resolver;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -34,6 +36,13 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 	private $field_map;
 
 	/**
+	 * The post access checker mock.
+	 *
+	 * @var Mockery\MockInterface|Post_Access_Checker
+	 */
+	private $post_access_checker;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Post_SEO_Data_Collector
@@ -50,24 +59,26 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 
 		Mockery::mock( WP_Error::class );
 
-		$this->resolver  = Mockery::mock( Post_Identifier_Resolver::class );
-		$this->field_map = Mockery::mock( Post_SEO_Field_Map::class );
+		$this->resolver            = Mockery::mock( Post_Identifier_Resolver::class );
+		$this->field_map           = Mockery::mock( Post_SEO_Field_Map::class );
+		$this->post_access_checker = Mockery::mock( Post_Access_Checker::class );
 
 		$this->instance = new Post_SEO_Data_Collector(
 			$this->resolver,
 			$this->field_map,
+			$this->post_access_checker,
 		);
 	}
 
 	/**
-	 * Tests that get_post_seo_data maps every resolved post.
+	 * Tests that a title search maps only the posts the user may edit.
 	 *
 	 * @covers ::__construct
 	 * @covers ::get_post_seo_data
 	 *
 	 * @return void
 	 */
-	public function test_get_post_seo_data_maps_all_matches() {
+	public function test_get_post_seo_data_maps_editable_matches() {
 		$first  = Mockery::mock();
 		$second = Mockery::mock();
 
@@ -77,24 +88,60 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 			->with( [ 'title' => 'guide' ] )
 			->andReturn( [ $first, $second ] );
 
+		$this->post_access_checker
+			->expects( 'filter_editable' )
+			->once()
+			->with( [ $first, $second ] )
+			->andReturn( [ $first ] );
+
 		$this->field_map
 			->expects( 'indexables_to_arrays' )
 			->once()
-			->with( [ $first, $second ] )
+			->with( [ $first ] )
 			->andReturn(
 				[
 					[ 'post_id' => 1 ],
-					[ 'post_id' => 2 ],
 				],
 			);
 
 		$this->assertSame(
 			[
 				[ 'post_id' => 1 ],
-				[ 'post_id' => 2 ],
 			],
 			$this->instance->get_post_seo_data( [ 'title' => 'guide' ] ),
 		);
+	}
+
+	/**
+	 * Tests that matches existing while none are editable is refused with the forbidden error.
+	 *
+	 * @covers ::get_post_seo_data
+	 *
+	 * @return void
+	 */
+	public function test_get_post_seo_data_no_editable_matches() {
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_id = 42;
+		$error                = Mockery::mock( WP_Error::class );
+
+		$this->resolver
+			->expects( 'resolve_many' )
+			->once()
+			->with( [ 'post_id' => 42 ] )
+			->andReturn( [ $indexable ] );
+
+		$this->post_access_checker
+			->expects( 'filter_editable' )
+			->once()
+			->with( [ $indexable ] )
+			->andReturn( [] );
+
+		$this->post_access_checker
+			->expects( 'forbidden_error' )
+			->once()
+			->andReturn( $error );
+
+		$this->assertSame( $error, $this->instance->get_post_seo_data( [ 'post_id' => 42 ] ) );
 	}
 
 	/**
@@ -116,7 +163,7 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that get_post_seo_data returns an empty array when nothing matches.
+	 * Tests that an already empty match list stays a valid empty result, not a forbidden error.
 	 *
 	 * @covers ::get_post_seo_data
 	 *
@@ -126,6 +173,12 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 		$this->resolver
 			->expects( 'resolve_many' )
 			->once()
+			->andReturn( [] );
+
+		$this->post_access_checker
+			->expects( 'filter_editable' )
+			->once()
+			->with( [] )
 			->andReturn( [] );
 
 		$this->field_map

--- a/tests/Unit/Abilities/Application/Post_SEO_Data_Collector_Test.php
+++ b/tests/Unit/Abilities/Application/Post_SEO_Data_Collector_Test.php
@@ -141,6 +141,8 @@ final class Post_SEO_Data_Collector_Test extends TestCase {
 			->once()
 			->andReturn( $error );
 
+		$this->field_map->expects( 'indexables_to_arrays' )->never();
+
 		$this->assertSame( $error, $this->instance->get_post_seo_data( [ 'post_id' => 42 ] ) );
 	}
 

--- a/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
+++ b/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
@@ -212,6 +212,11 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->with( 42 )
 			->andReturn( $error );
 
+		$this->field_map->expects( 'apply_to_indexable' )->never();
+		$this->field_map->expects( 'to_seo_array' )->never();
+		$this->indexable_to_postmeta->expects( 'map_column_to_postmeta' )->never();
+		$this->indexable_builder->expects( 'build_for_id_and_type' )->never();
+
 		$this->assertSame( $error, $this->instance->update_post_seo_data( [ 'post_id' => 42 ] ) );
 	}
 

--- a/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
+++ b/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
@@ -7,6 +7,7 @@ use Brain\Monkey;
 use Mockery;
 use WP_Error;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_Identifier_Resolver;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 use Yoast\WP\SEO\Builders\Indexable_Builder;
@@ -36,6 +37,13 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 	 * @var Mockery\MockInterface|Post_SEO_Field_Map
 	 */
 	private $field_map;
+
+	/**
+	 * The post access checker mock.
+	 *
+	 * @var Mockery\MockInterface|Post_Access_Checker
+	 */
+	private $post_access_checker;
 
 	/**
 	 * The indexable-to-postmeta helper mock.
@@ -78,12 +86,14 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 
 		$this->resolver              = Mockery::mock( Post_Identifier_Resolver::class );
 		$this->field_map             = Mockery::mock( Post_SEO_Field_Map::class );
+		$this->post_access_checker   = Mockery::mock( Post_Access_Checker::class );
 		$this->indexable_to_postmeta = Mockery::mock( Indexable_To_Postmeta_Helper::class );
 		$this->indexable_builder     = Mockery::mock( Indexable_Builder::class );
 
 		$this->instance = new Post_SEO_Data_Updater(
 			$this->resolver,
 			$this->field_map,
+			$this->post_access_checker,
 			$this->indexable_to_postmeta,
 			$this->indexable_builder,
 		);
@@ -113,6 +123,12 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->once()
 			->with( $input )
 			->andReturn( $indexable );
+
+		$this->post_access_checker
+			->expects( 'ensure_can_edit' )
+			->once()
+			->with( 42 )
+			->andReturn( true );
 
 		$this->field_map
 			->expects( 'apply_to_indexable' )
@@ -174,6 +190,32 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that a post the user may not edit is refused and nothing is written.
+	 *
+	 * @covers ::update_post_seo_data
+	 *
+	 * @return void
+	 */
+	public function test_update_post_seo_data_forbidden() {
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_id = 42;
+		$error                = Mockery::mock( WP_Error::class );
+
+		$this->resolver
+			->expects( 'resolve_one' )
+			->once()
+			->andReturn( $indexable );
+
+		$this->post_access_checker
+			->expects( 'ensure_can_edit' )
+			->once()
+			->with( 42 )
+			->andReturn( $error );
+
+		$this->assertSame( $error, $this->instance->update_post_seo_data( [ 'post_id' => 42 ] ) );
+	}
+
+	/**
 	 * Tests that a failed rebuild returns an error.
 	 *
 	 * @covers ::update_post_seo_data
@@ -188,6 +230,12 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->expects( 'resolve_one' )
 			->once()
 			->andReturn( $indexable );
+
+		$this->post_access_checker
+			->expects( 'ensure_can_edit' )
+			->once()
+			->with( 42 )
+			->andReturn( true );
 
 		$this->field_map
 			->expects( 'apply_to_indexable' )

--- a/tests/Unit/Abilities/Infrastructure/Post_Access_Checker_Test.php
+++ b/tests/Unit/Abilities/Infrastructure/Post_Access_Checker_Test.php
@@ -1,0 +1,121 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\Infrastructure;
+
+use Brain\Monkey;
+use Mockery;
+use WP_Error;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Post_Access_Checker class.
+ *
+ * @group abilities
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Abilities\Infrastructure\Post_Access_Checker
+ */
+final class Post_Access_Checker_Test extends TestCase {
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Post_Access_Checker
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		Mockery::mock( WP_Error::class );
+
+		Monkey\Functions\stubs(
+			[
+				'__' => static function ( $text ) {
+					return $text;
+				},
+			],
+		);
+
+		$this->instance = new Post_Access_Checker();
+	}
+
+	/**
+	 * Tests that ensure_can_edit passes for an editable post.
+	 *
+	 * @covers ::ensure_can_edit
+	 *
+	 * @return void
+	 */
+	public function test_ensure_can_edit_editable() {
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_post', 42 )
+			->andReturn( true );
+
+		$this->assertTrue( $this->instance->ensure_can_edit( 42 ) );
+	}
+
+	/**
+	 * Tests that ensure_can_edit refuses a post the user may not edit with a 403 error.
+	 *
+	 * @covers ::ensure_can_edit
+	 * @covers ::forbidden_error
+	 *
+	 * @return void
+	 */
+	public function test_ensure_can_edit_forbidden() {
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_post', 42 )
+			->andReturn( false );
+
+		// WP_Error is doubled as an empty class in unit context, so only the type is asserted.
+		$this->assertInstanceOf( WP_Error::class, $this->instance->ensure_can_edit( 42 ) );
+	}
+
+	/**
+	 * Tests that filter_editable keeps only the posts the user may edit.
+	 *
+	 * @covers ::filter_editable
+	 *
+	 * @return void
+	 */
+	public function test_filter_editable() {
+		$editable                = Mockery::mock( Indexable_Mock::class );
+		$editable->object_id     = 1;
+		$not_editable            = Mockery::mock( Indexable_Mock::class );
+		$not_editable->object_id = 2;
+
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_post', 1 )
+			->andReturn( true );
+		Monkey\Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'edit_post', 2 )
+			->andReturn( false );
+
+		$this->assertSame( [ $editable ], $this->instance->filter_editable( [ $editable, $not_editable ] ) );
+	}
+
+	/**
+	 * Tests that filter_editable returns an empty list untouched.
+	 *
+	 * @covers ::filter_editable
+	 *
+	 * @return void
+	 */
+	public function test_filter_editable_empty() {
+		Monkey\Functions\expect( 'current_user_can' )->never();
+
+		$this->assertSame( [], $this->instance->filter_editable( [] ) );
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -170,27 +170,6 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that can_edit_posts checks the edit posts capability and returns its result.
-	 *
-	 * @covers ::can_edit_posts
-	 *
-	 * @dataProvider provide_can_manage_seo
-	 *
-	 * @param bool $allowed Whether the capability is granted.
-	 *
-	 * @return void
-	 */
-	public function test_can_edit_posts( bool $allowed ) {
-		$this->capability_helper
-			->expects( 'current_user_can' )
-			->once()
-			->with( 'edit_posts' )
-			->andReturn( $allowed );
-
-		$this->assertSame( $allowed, $this->instance->can_edit_posts() );
-	}
-
-	/**
 	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
 	 *
 	 * @covers ::register_abilities
@@ -289,7 +268,7 @@ final class Abilities_Integration_Test extends TestCase {
 						'type'  => 'array',
 						'items' => $this->get_expected_output_schema(),
 					],
-					'permission_callback' => [ $this->instance, 'can_edit_posts' ],
+					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 					'meta'                => $this->get_read_meta(),
 				],
@@ -305,7 +284,7 @@ final class Abilities_Integration_Test extends TestCase {
 					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
 					'input_schema'        => $this->get_expected_update_input_schema(),
 					'output_schema'       => $this->get_expected_output_schema(),
-					'permission_callback' => [ $this->instance, 'can_edit_posts' ],
+					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => $this->get_write_meta(),
 				],

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -170,6 +170,27 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that can_edit_posts checks the edit posts capability and returns its result.
+	 *
+	 * @covers ::can_edit_posts
+	 *
+	 * @dataProvider provide_can_manage_seo
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_posts( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'edit_posts' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_edit_posts() );
+	}
+
+	/**
 	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
 	 *
 	 * @covers ::register_abilities
@@ -268,7 +289,7 @@ final class Abilities_Integration_Test extends TestCase {
 						'type'  => 'array',
 						'items' => $this->get_expected_output_schema(),
 					],
-					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
+					'permission_callback' => [ $this->instance, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 					'meta'                => $this->get_read_meta(),
 				],
@@ -284,7 +305,7 @@ final class Abilities_Integration_Test extends TestCase {
 					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
 					'input_schema'        => $this->get_expected_update_input_schema(),
 					'output_schema'       => $this->get_expected_output_schema(),
-					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
+					'permission_callback' => [ $this->instance, 'can_edit_posts' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => $this->get_write_meta(),
 				],

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -262,7 +262,7 @@ final class Abilities_Integration_Test extends TestCase {
 				[
 					'label'               => 'Get Post SEO Data',
 					'category'            => 'yoast-seo',
-					'description'         => 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required.',
+					'description'         => 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.',
 					'input_schema'        => $this->get_expected_identifier_input_schema(),
 					'output_schema'       => [
 						'type'  => 'array',
@@ -281,7 +281,7 @@ final class Abilities_Integration_Test extends TestCase {
 				[
 					'label'               => 'Update Post SEO Data',
 					'category'            => 'yoast-seo',
-					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field.',
+					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
 					'input_schema'        => $this->get_expected_update_input_schema(),
 					'output_schema'       => $this->get_expected_output_schema(),
 					'permission_callback' => [ $this->instance, 'can_manage_seo' ],

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -170,6 +170,27 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that can_edit_advanced_metadata checks the advanced metadata capability and returns its result.
+	 *
+	 * @covers ::can_edit_advanced_metadata
+	 *
+	 * @dataProvider provide_can_manage_seo
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_advanced_metadata( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_edit_advanced_metadata' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_edit_advanced_metadata() );
+	}
+
+	/**
 	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
 	 *
 	 * @covers ::register_abilities
@@ -268,7 +289,7 @@ final class Abilities_Integration_Test extends TestCase {
 						'type'  => 'array',
 						'items' => $this->get_expected_output_schema(),
 					],
-					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
+					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
 					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
 					'meta'                => $this->get_read_meta(),
 				],
@@ -284,7 +305,7 @@ final class Abilities_Integration_Test extends TestCase {
 					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
 					'input_schema'        => $this->get_expected_update_input_schema(),
 					'output_schema'       => $this->get_expected_output_schema(),
-					'permission_callback' => [ $this->instance, 'can_manage_seo' ],
+					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
 					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
 					'meta'                => $this->get_write_meta(),
 				],


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Prevent users that can't edit a post from using the new Abilities on that post.

## Relevant technical choices:

* We guard the abilities with the `wpseo_edit_advanced_metadata` capability, since it's the one that is required for stuff like the `noindex`, `canonical`, `schema_page_type`, and `schema_article_type` that are included in the abilities here. So, even if an author uses the ability to update one of it's own posts (which they can do), they will be restricted from doing so unless they also have the `wpseo_edit_advanced_metadata` capability.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

### Setup

* Use WordPress 6.9+ (the Abilities API must be in core) with this branch built (`composer install`, so the DI container includes the new `Post_Access_Checker`).
* You need three users:
  * `admin` — a regular administrator.
  * `author` — a user with the Author role, **with the `wpseo_edit_advanced_metadata` capability additionally granted** (e.g. `wp user add-cap author wpseo_edit_advanced_metadata`, or via a role editor plugin). This capability is the abilities' site-wide gate, so granting it lets this user reach the abilities while still lacking edit access to other users' posts — which is exactly what the per-post checks enforce.
  * `plain-author` — a second user with the plain Author role and no extra capabilities.
* Create two published posts: one authored by `author` (call it post A), one authored by `admin` (call it post B). Give both a recognisable title sharing a keyword, e.g. "Guide to apples" (A) and "Guide to oranges" (B).
* Create application passwords for `author` and `plain-author` and call the endpoints below as the indicated user (e.g. `curl -u author:APP_PASSWORD`).

### The capability gate — both post SEO data abilities

1. **User without the capability** — as `plain-author`, GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[post_id]=<ID of post A>` → a permission error from the Abilities API (403), even though post A is their own post: users who may not edit advanced SEO metadata cannot use these abilities at all.

### Reading — `yoast-seo/get-post-seo-data` (as `author`)

2. **Own post by ID** — GET the `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[post_id]=<ID of post A>` → 200 with post A's SEO data.
3. **Someone else's post by ID** — GET the `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[post_id]=<ID of post B>` → error `yoast_seo_cannot_edit_post` (status 403). ✳️ Before this PR any user passing the site-wide gate could read every post's SEO data regardless of edit access.
4. **Someone else's post by permalink** — GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[permalink]=<permalink to post B>` → same 403.
5. **Title search matching both posts** — GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[title]=Guide` → 200 with **only post A** in the results; post B is silently omitted.
6. **Title search matching only inaccessible posts** — GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[title]=oranges` (matches only post B) → 403 `yoast_seo_cannot_edit_post`.
7. **Paging past the last result** — GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[title]=Guide&input[page]=99` → 200 with an empty array (valid empty page, **not** a 403).

### Writing — `yoast-seo/update-post-seo-data` (as `author`)

8. **Own post** — POST to `/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run` with body `{ "input": { "post_id": <ID of post A>, "seo_title": "Updated by ability" } }` → 200 with the updated data; verify in the editor that post A's SEO title changed.
9. **Someone else's post by ID** — POST to `/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run` with body `{ "input": { "post_id": <ID of post B>, "seo_title": "Updated by ability" } }` → 403 `yoast_seo_cannot_edit_post`; verify post B's SEO title is **unchanged**. ✳️ Before this PR any user passing the site-wide gate could write to every post.
10. **Someone else's post by permalink** — POST to `/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run` with body `{ "input": { "permalink": <permalink of post B>, "seo_title": "Updated by ability" } }` →  same 403, nothing written.

### Regressions

11. **As `admin`**, repeat steps 3, 5, and 9 → everything is returned/updated as before (admins can edit others' posts, so nothing is filtered or refused).
12. **As a stock Editor-role user** (no extra capabilities), repeat step 2 on any post → 200: Editors hold `wpseo_edit_advanced_metadata` by default, so they can use both post SEO data abilities. ✳️ Before this PR Editors were refused at the gate (`wpseo_manage_options`).
13. The three score abilities (`get-seo-scores`, `get-readability-scores`, `get-inclusive-language-scores`) remain gated by `wpseo_manage_options` — as `author`, GET `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-seo-scores/run` → permission error; as `admin` → 200.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #

