### PR TITLE
GH Actions: fix flagnames in "Coveralls finish" workflow

### DIFF
--- a/.github/workflows/finish-coveralls.yml
+++ b/.github/workflows/finish-coveralls.yml
@@ -105,5 +105,5 @@ jobs:
           COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # Connect all builds together.
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          carryforward: "unit-php-7.4,unit-php-8.3,php-7.4-wp-6.8-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-yoastseo"
+          carryforward: "unit-php-7.4,unit-php-8.3,php-7.4-wp-6.8,php-7.4-wp-6.8-ms,php-8.3-wp-latest,php-8.3-wp-latest-ms,package-analysis-report,package-browserslist-config,package-components,package-dashboard-frontend,package-feature-flag,package-helpers,package-js,package-replacement-variable-editor,package-search-metadata-previews,package-social-metadata-forms,package-social-metadata-previews,package-ui-library,package-yoastseo"
           parallel-finished: true

--- a/.github/workflows/jstest.yml
+++ b/.github/workflows/jstest.yml
@@ -60,6 +60,8 @@ jobs:
       # As these packages are all unique, don't stop the workflow when the test run of one package fails.
       fail-fast: false
       matrix:
+        # IMPORTANT: when these are updated, make sure to also update the `carryforward` flag names
+        #            in the `finish-coveralls.yml` workflow!
         package:
           - 'analysis-report'
           - 'browserslist-config'
@@ -141,6 +143,8 @@ jobs:
       # As these packages are all unique, don't stop the workflow when the test run of one package fails.
       fail-fast: false
       matrix:
+        # IMPORTANT: when these are updated, make sure to also update the `carryforward` flag names
+        #            in the `finish-coveralls.yml` workflow!
         include:
           - package:              'yoastseo'
             needs_premium_config: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
         coverage: [false]
 
         # Run code coverage only on high/low PHP.
+        # IMPORTANT: when these are updated, make sure to also update the `carryforward` flag names
+        #            in the `finish-coveralls.yml` workflow!
         include:
         - php_version: 7.4
           coverage: true
@@ -141,6 +143,8 @@ jobs:
 
     strategy:
       matrix:
+        # IMPORTANT: when these are updated, make sure to also update the `carryforward` flag names
+        #            in the `finish-coveralls.yml` workflow!
         include:
           - php_version: "7.4"
             wp_version: "6.8"


### PR DESCRIPTION
## Context

* Improve CI

## Summary

This PR can be summarized in the following changelog entry:

* Improve CI

## Relevant technical choices:

The flag names in the `carryforward` key in the `finish-coveralls.yml` workflow were out of date and incomplete.

Let's see if the changes in this commit improve things.

I've also added a comment now to alert GH Action maintainers to update the flags in the `finish-coveralls.yml` workflow when they update test matrices. Hopefully this will help going forward.


## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* _N/A_