### PR TITLE
fix: reject a non-string AUTH_KEY during encryption key derivation

### DIFF
--- a/src/myyoast-client/infrastructure/crypto/encryption.php
+++ b/src/myyoast-client/infrastructure/crypto/encryption.php
@@ -113,7 +113,7 @@ class Encryption {
 			throw new Encryption_Exception( 'The sodium PHP extension is required but not available.' );
 		}
 
-		if ( ! \defined( 'AUTH_KEY' ) || \AUTH_KEY === '' || \AUTH_KEY === 'put your unique phrase here' ) {
+		if ( ! \defined( 'AUTH_KEY' ) || ! \is_string( \AUTH_KEY ) || \AUTH_KEY === '' || \AUTH_KEY === 'put your unique phrase here' ) {
 			throw new Encryption_Exception( 'AUTH_KEY is not configured. Please set a unique AUTH_KEY in wp-config.php.' );
 		}
 

--- a/tests/Unit/MyYoast_Client/Infrastructure/Crypto/Encryption_Invalid_Key_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Crypto/Encryption_Invalid_Key_Test.php
@@ -1,0 +1,106 @@
+<?php
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+
+namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Infrastructure\Crypto;
+
+use stdClass;
+use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
+use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption_Exception;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests that the Encryption class rejects a non-string AUTH_KEY.
+ *
+ * AUTH_KEY can only be defined once per PHP process, so these tests live in
+ * their own class with process isolation rather than in Encryption_Test, which
+ * defines AUTH_KEY as a valid string.
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class Encryption_Invalid_Key_Test extends TestCase {
+
+	/**
+	 * The test instance.
+	 *
+	 * @var Encryption
+	 */
+	private $instance;
+
+	/**
+	 * Set up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->instance = new Encryption();
+	}
+
+	/**
+	 * Provides the non-string AUTH_KEY values that define() accepts.
+	 *
+	 * @return array<string, array<mixed>>
+	 */
+	public static function provide_non_string_auth_keys() {
+		return [
+			'null'    => [ null ],
+			'false'   => [ false ],
+			'true'    => [ true ],
+			'integer' => [ 123 ],
+			'float'   => [ 1.5 ],
+			'array'   => [ [ 'key' ] ],
+			'object'  => [ new stdClass() ],
+		];
+	}
+
+	/**
+	 * Tests that encrypting with a non-string AUTH_KEY throws instead of reaching hash_hkdf().
+	 *
+	 * Without the is_string() guard, a null AUTH_KEY makes hash_hkdf() raise a
+	 * deprecation notice and then a ValueError, which callers do not expect to handle.
+	 *
+	 * @covers ::encrypt
+	 * @covers ::derive_key
+	 *
+	 * @dataProvider provide_non_string_auth_keys
+	 *
+	 * @param mixed $auth_key The non-string AUTH_KEY value to define.
+	 *
+	 * @return void
+	 */
+	public function test_encrypt_with_non_string_auth_key_throws( $auth_key ) {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WordPress core constant.
+		\define( 'AUTH_KEY', $auth_key );
+
+		$this->expectException( Encryption_Exception::class );
+		$this->expectExceptionMessage( 'AUTH_KEY is not configured. Please set a unique AUTH_KEY in wp-config.php.' );
+
+		$this->instance->encrypt( 'secret', 'test-context' );
+	}
+
+	/**
+	 * Tests that decrypting with a non-string AUTH_KEY throws instead of reaching hash_hkdf().
+	 *
+	 * @covers ::decrypt
+	 * @covers ::derive_key
+	 *
+	 * @dataProvider provide_non_string_auth_keys
+	 *
+	 * @param mixed $auth_key The non-string AUTH_KEY value to define.
+	 *
+	 * @return void
+	 */
+	public function test_decrypt_with_non_string_auth_key_throws( $auth_key ) {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- WordPress core constant.
+		\define( 'AUTH_KEY', $auth_key );
+
+		$this->expectException( Encryption_Exception::class );
+		$this->expectExceptionMessage( 'AUTH_KEY is not configured. Please set a unique AUTH_KEY in wp-config.php.' );
+
+		$this->instance->decrypt( 'irrelevant', 'test-context' );
+	}
+}

--- a/tests/Unit/MyYoast_Client/Infrastructure/Crypto/Encryption_Invalid_Key_Test.php
+++ b/tests/Unit/MyYoast_Client/Infrastructure/Crypto/Encryption_Invalid_Key_Test.php
@@ -3,7 +3,6 @@
 
 namespace Yoast\WP\SEO\Tests\Unit\MyYoast_Client\Infrastructure\Crypto;
 
-use stdClass;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption;
 use Yoast\WP\SEO\MyYoast_Client\Infrastructure\Crypto\Encryption_Exception;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -43,6 +42,9 @@ final class Encryption_Invalid_Key_Test extends TestCase {
 	/**
 	 * Provides the non-string AUTH_KEY values that define() accepts.
 	 *
+	 * Objects are omitted: define() only accepts them as of PHP 8.1, so an object
+	 * AUTH_KEY cannot occur on the oldest PHP versions this plugin supports.
+	 *
 	 * @return array<string, array<mixed>>
 	 */
 	public static function provide_non_string_auth_keys() {
@@ -53,7 +55,6 @@ final class Encryption_Invalid_Key_Test extends TestCase {
 			'integer' => [ 123 ],
 			'float'   => [ 1.5 ],
 			'array'   => [ [ 'key' ] ],
-			'object'  => [ new stdClass() ],
 		];
 	}
 


### PR DESCRIPTION
## Context
If WordPress salts are defined as `NULL` (misconfiguration error), you'd get a fatal error when using the MyYoast connection on sites with PHP >= 8. `Fatal error: Uncaught ValueError: hash_hkdf(): Argument #2 ($key) cannot be empty in ...`.
`Encryption::derive_key()` only verified that `AUTH_KEY` was defined, non-empty string, and not the wp-config.php placeholder — so a `NULL` salt passed the guard and was handed to `hash_hkdf()`, producing a PHP deprecation notice and an uncaught `ValueError`. Because every caller catches `Encryption_Exception` specifically, the unexpected exception type escaped up the stack and surfaced as an uncaught error that broke keyphrase analysis in the editor.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where an uncaught fatal error was thrown in the post editor on sites using the oAuth connection to MyYoast, when the `AUTH_KEY` salt in wp-config.php was set to a non-string value.

## Relevant technical choices:

* Added `! is_string( AUTH_KEY )` to the existing guard in `Encryption::derive_key()`, so every non-string value `define()` accepts (`null`, bool, int, float, array, object) now throws the intended `Encryption_Exception` instead of reaching `hash_hkdf()`.
* The test lives in its own class, `Encryption_Invalid_Key_Test`, because `AUTH_KEY` is a process-wide constant that the existing `Encryption_Test` already defines as a valid string. It uses `@runTestsInSeparateProcesses` + `@preserveGlobalState disabled` with a data provider, following the pattern already established in `Management_Route_Test`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* First, reproduce the bug on the current release branch (without this PR's changes):
  1. Enable the MyYoast connection feature flag by adding to the wp-config.php: `define( "YOAST_SEO_MYYOAST_CONNECTION", true);`
  1. Open the integrations settings and connect to MyYoast.
  1. Open your site's `wp-config.php` file in a text editor.
  1. Find the line that starts with `define( 'AUTH_KEY',` . Comment it out, and add a new line with `define( 'AUTH_KEY', null );`. Save the file.
  1. In the WordPress admin, create a new post using the default (block) editor.
  1. See either a white page or an error on screen (depending on your config)

* Now check out this PR's branch and open the editor again
* No error should appear and the editor should be responsive as usual.
* Finally, restore your original `AUTH_KEY` line in `wp-config.php` and confirm that everything still works normally — connecting to MyYoast in particular.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Repeat https://yoast.slack.com/archives/C03KU0EHCNQ/p1785309743783109

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The MyYoast client's encryption helper, which derives its key from `AUTH_KEY`. Its callers are token storage, user token storage, client registration, and the DPoP handler — so connecting to MyYoast and anything relying on a stored MyYoast token is worth a regression check on a site with a normal, valid `AUTH_KEY`.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3106
