### PR TITLE
Shorten test files and classes names

### DIFF
--- a/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Abstract_TestCase.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Abstract_TestCase.php
@@ -13,10 +13,8 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
  * Base class for the WooCommerce_Product_Type_Change_Listener_Integration tests.
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-abstract class Abstract_WooCommerce_Product_Type_Change_Listener_Integration_TestCase extends TestCase {
+abstract class Abstract_TestCase extends TestCase {
 
 	/**
 	 * Holds the instance.

--- a/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Get_Conditionals_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Get_Conditionals_Test.php
@@ -13,10 +13,8 @@ use Yoast\WP\SEO\Schema_Aggregator\Infrastructure\Schema_Aggregator_Conditional;
  * @group WooCommerce_Product_Type_Change_Listener_Integration
  *
  * @covers Yoast\WP\SEO\Schema_Aggregator\User_Interface\Cache\WooCommerce_Product_Type_Change_Listener_Integration::get_conditionals
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-final class WooCommerce_Product_Type_Change_Listener_Integration_Get_Conditionals_Test extends Abstract_WooCommerce_Product_Type_Change_Listener_Integration_TestCase {
+final class Get_Conditionals_Test extends Abstract_TestCase {
 
 	/**
 	 * Tests that get_conditionals returns the expected conditionals.

--- a/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Register_Hooks_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Register_Hooks_Test.php
@@ -12,10 +12,8 @@ use Brain\Monkey;
  * @group WooCommerce_Product_Type_Change_Listener_Integration
  *
  * @covers Yoast\WP\SEO\Schema_Aggregator\User_Interface\Cache\WooCommerce_Product_Type_Change_Listener_Integration::register_hooks
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-final class WooCommerce_Product_Type_Change_Listener_Integration_Register_Hooks_Test extends Abstract_WooCommerce_Product_Type_Change_Listener_Integration_TestCase {
+final class Register_Hooks_Test extends Abstract_TestCase {
 
 	/**
 	 * Tests the registration of the hooks.

--- a/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Reset_Cache_Test.php
+++ b/tests/Unit/Schema_Aggregator/User_Interface/Cache/WooCommerce_Product_Type_Change_Listener_Integration/Reset_Cache_Test.php
@@ -13,10 +13,8 @@ use Mockery;
  * @group WooCommerce_Product_Type_Change_Listener_Integration
  *
  * @covers Yoast\WP\SEO\Schema_Aggregator\User_Interface\Cache\WooCommerce_Product_Type_Change_Listener_Integration::reset_cache
- *
- * @phpcs:disable Yoast.NamingConventions.ObjectNameDepth.MaxExceeded
  */
-final class WooCommerce_Product_Type_Change_Listener_Integration_Reset_Cache_Test extends Abstract_WooCommerce_Product_Type_Change_Listener_Integration_TestCase {
+final class Reset_Cache_Test extends Abstract_TestCase {
 
 	/**
 	 * Data provider for product ID is empty scenarios.


### PR DESCRIPTION
Long paths can cause issues in Windows dev envs

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* N/A

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Shortens some file names as they can cause issues in Windows-based development environments.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* No tests needed, this is just unit tests.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Only test files.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/23518
