### PR TITLE
Reinstate get/set SEO data abilities

### DIFF
--- a/src/abilities/infrastructure/post-seo-field-map.php
+++ b/src/abilities/infrastructure/post-seo-field-map.php
@@ -4,6 +4,7 @@
 namespace Yoast\WP\SEO\Abilities\Infrastructure;
 
 use WPSEO_Rank;
+use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Models\Indexable;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Surfaces\Values\Meta;
@@ -14,7 +15,8 @@ use Yoast\WP\SEO\Surfaces\Values\Meta;
  * This is the single source of truth for the field contract shared by the read
  * (collector) and write (updater) abilities. The write path applies the input
  * onto an indexable; persistence to post meta is delegated to
- * Indexable_To_Postmeta_Helper so the encodings live in one place.
+ * Indexable_To_Postmeta_Helper so the encodings live in one place. The same definitions 
+ * drive both the ability input schema and the write.
  */
 class Post_SEO_Field_Map {
 
@@ -33,24 +35,6 @@ class Post_SEO_Field_Map {
 		'open_graph_description' => 'open_graph_description',
 		'twitter_title'          => 'twitter_title',
 		'twitter_description'    => 'twitter_description',
-	];
-
-	/**
-	 * Maps the string input fields to the indexable column they write to.
-	 *
-	 * @var array<string, string>
-	 */
-	private const STRING_FIELDS = [
-		'seo_title'              => 'title',
-		'meta_description'       => 'description',
-		'focus_keyphrase'        => 'primary_focus_keyword',
-		'canonical'              => 'canonical',
-		'open_graph_title'       => 'open_graph_title',
-		'open_graph_description' => 'open_graph_description',
-		'twitter_title'          => 'twitter_title',
-		'twitter_description'    => 'twitter_description',
-		'schema_page_type'       => 'schema_page_type',
-		'schema_article_type'    => 'schema_article_type',
 	];
 
 	/**
@@ -84,6 +68,129 @@ class Post_SEO_Field_Map {
 	public function __construct( Meta_Surface $meta_surface ) {
 		$this->meta_surface = $meta_surface;
 	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the string fields editable through the update post SEO data ability.
+	 *
+	 * Each definition maps the ability input field name to the indexable column the
+	 * value is written to and the JSON-schema fragment describing the field in the
+	 * ability input schema. Keeping both in one definition means a field is only
+	 * accepted by the input schema when the write path also knows how to apply it,
+	 * so the two cannot drift apart.
+	 *
+	 * @return array<string, array<string, mixed>> The field definitions, keyed by input field name.
+	 */
+	public function get_editable_string_fields(): array {
+		$fields = [
+			'canonical'           => [
+				'column' => 'canonical',
+				'schema' => [ 'type' => [ 'string', 'null' ] ],
+			],
+			'schema_page_type'    => [
+				'column' => 'schema_page_type',
+				'schema' => $this->nullable_enum_schema(
+					\array_keys( Schema_Types::PAGE_TYPES ),
+					\__( 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
+				),
+			],
+			'schema_article_type' => [
+				'column' => 'schema_article_type',
+				'schema' => $this->nullable_enum_schema(
+					$this->get_schema_article_types(),
+					\__( 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
+				),
+			],
+		];
+
+		/**
+		 * Filter: 'wpseo_editable_post_seo_data_string_fields' - Allows adding string fields to the
+		 * ones editable through the update post SEO data ability.
+		 *
+		 * Each entry is keyed by the ability input field name and defines both the indexable column
+		 * the value is written to ('column') and the JSON-schema fragment describing the field in
+		 * the ability input schema ('schema'). Entries missing either part, or keyed by a reserved
+		 * input field name, are discarded.
+		 *
+		 * @param array<string, array<string, mixed>> $fields The editable string field definitions.
+		 */
+		$filtered = \apply_filters( 'wpseo_editable_post_seo_data_string_fields', $fields );
+
+		if ( ! \is_array( $filtered ) ) {
+			return $fields;
+		}
+
+		return \array_filter( $filtered, [ $this, 'is_valid_string_field' ], \ARRAY_FILTER_USE_BOTH );
+	}
+
+	/**
+	 * Checks whether a filtered field definition is usable.
+	 *
+	 * Guards the schema and write paths against malformed filter additions: an entry is
+	 * only kept when it targets a non-reserved input field and defines both the indexable
+	 * column and the schema fragment.
+	 *
+	 * @param mixed $field     The field definition to check.
+	 * @param mixed $input_key The input field name the definition is keyed by.
+	 *
+	 * @return bool Whether the definition is usable.
+	 */
+	private function is_valid_string_field( $field, $input_key ): bool {
+		if ( ! \is_string( $input_key ) || $input_key === '' ) {
+			return false;
+		}
+
+		// Never let a filtered definition hijack the post identifiers or the non-string fields.
+		$reserved = \array_merge( [ 'post_id', 'permalink', 'noindex' ], \array_keys( self::BOOLEAN_FIELDS ) );
+		if ( \in_array( $input_key, $reserved, true ) ) {
+			return false;
+		}
+
+		return \is_array( $field )
+			&& isset( $field['column'] ) && \is_string( $field['column'] ) && $field['column'] !== ''
+			&& isset( $field['schema'] ) && \is_array( $field['schema'] ) && $field['schema'] !== [];
+	}
+
+	/**
+	 * Returns the allowed Schema.org article type values.
+	 *
+	 * Mirrors the validation in WPSEO_Option_Titles so the ability accepts exactly the
+	 * article types the editor does, including any registered through the filter.
+	 *
+	 * @return array<int, string> The allowed article type values.
+	 */
+	private function get_schema_article_types(): array {
+		/**
+		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
+		 *
+		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
+		 *
+		 * @param array $schema_article_types The available schema article types.
+		 */
+		return \array_keys( \apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES ) );
+	}
+
+	/**
+	 * Returns a nullable-string input schema constrained to a fixed set of allowed values.
+	 *
+	 * Null and the empty string are always allowed on top of the enum so the field can be
+	 * cleared, matching the patch-clear semantics of the other write fields.
+	 *
+	 * @param array<int, string> $allowed_values The allowed string values.
+	 * @param string             $description    The field description.
+	 *
+	 * @return array<string, mixed> The input schema fragment.
+	 */
+	private function nullable_enum_schema( array $allowed_values, string $description ): array {
+		return [
+			'type'        => [ 'string', 'null' ],
+			'description' => $description,
+			'enum'        => \array_merge( $allowed_values, [ '', null ] ),
+		];
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
 
 	/**
 	 * Builds the post SEO data array from an indexable.
@@ -200,9 +307,10 @@ class Post_SEO_Field_Map {
 	public function apply_to_indexable( array $input, Indexable $indexable ): array {
 		$changed_columns = [];
 
-		foreach ( self::STRING_FIELDS as $input_key => $column ) {
+		foreach ( $this->get_editable_string_fields() as $input_key => $field ) {
 			if ( \array_key_exists( $input_key, $input ) ) {
 				$value                = $input[ $input_key ];
+				$column               = $field['column'];
 				$indexable->{$column} = ( $value === null || $value === '' ) ? null : (string) $value;
 				$changed_columns[]    = $column;
 			}

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -6,9 +6,9 @@ namespace Yoast\WP\SEO\Abilities\User_Interface;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
 use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 use Yoast\WP\SEO\Conditionals\Abilities_API_Conditional;
 use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
-use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
 use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
 use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
@@ -57,6 +57,13 @@ class Abilities_Integration implements Integration_Interface {
 	private $post_seo_data_updater;
 
 	/**
+	 * The post SEO field map.
+	 *
+	 * @var Post_SEO_Field_Map
+	 */
+	private $post_seo_field_map;
+
+	/**
 	 * Returns the conditionals based on which this loadable should be active.
 	 *
 	 * @return array<string> The conditionals.
@@ -76,19 +83,22 @@ class Abilities_Integration implements Integration_Interface {
 	 * @param Enabled_Analysis_Features_Repository $enabled_analysis_features_repository The enabled analysis features repository.
 	 * @param Post_SEO_Data_Collector              $post_seo_data_collector              The post SEO data collector.
 	 * @param Post_SEO_Data_Updater                $post_seo_data_updater                The post SEO data updater.
+	 * @param Post_SEO_Field_Map                   $post_seo_field_map                   The post SEO field map.
 	 */
 	public function __construct(
 		Score_Retriever $score_retriever,
 		Capability_Helper $capability_helper,
 		Enabled_Analysis_Features_Repository $enabled_analysis_features_repository,
 		Post_SEO_Data_Collector $post_seo_data_collector,
-		Post_SEO_Data_Updater $post_seo_data_updater
+		Post_SEO_Data_Updater $post_seo_data_updater,
+		Post_SEO_Field_Map $post_seo_field_map
 	) {
 		$this->score_retriever                      = $score_retriever;
 		$this->capability_helper                    = $capability_helper;
 		$this->enabled_analysis_features_repository = $enabled_analysis_features_repository;
 		$this->post_seo_data_collector              = $post_seo_data_collector;
 		$this->post_seo_data_updater                = $post_seo_data_updater;
+		$this->post_seo_field_map                   = $post_seo_field_map;
 	}
 
 	/**
@@ -125,6 +135,10 @@ class Abilities_Integration implements Integration_Interface {
 		if ( $enabled_features[ Inclusive_Language_Analysis::NAME ] === true ) {
 			$this->register_inclusive_language_scores_ability();
 		}
+
+		// Metadata read/write is independent of which analysis features are enabled.
+		$this->register_get_post_seo_data_ability();
+		$this->register_update_post_seo_data_ability();
 	}
 
 	/**
@@ -404,88 +418,42 @@ class Abilities_Integration implements Integration_Interface {
 	/**
 	 * Returns the input schema for updating a post's SEO data (write path).
 	 *
+	 * The string field properties come from the field map's editable field
+	 * definitions, so the schema always matches what the write path applies.
+	 *
 	 * @return array<string, mixed> The input schema.
 	 */
 	private function get_update_post_seo_data_input_schema(): array {
-		$nullable_string = [ 'type' => [ 'string', 'null' ] ];
+		$properties = [
+			'post_id'   => [
+				'type'        => 'integer',
+				'description' => \__( 'The ID of the post to update.', 'wordpress-seo' ),
+				'minimum'     => 1,
+			],
+			'permalink' => [
+				'type'        => 'string',
+				'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
+			],
+		];
+
+		foreach ( $this->post_seo_field_map->get_editable_string_fields() as $field_name => $field ) {
+			$properties[ $field_name ] = $field['schema'];
+		}
+
+		$properties['is_cornerstone'] = [ 'type' => 'boolean' ];
+		$properties['noindex']        = [
+			'type'        => [ 'boolean', 'null' ],
+			'description' => \__( 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.', 'wordpress-seo' ),
+		];
+		$properties['nofollow']       = [ 'type' => 'boolean' ];
+		$properties['noimageindex']   = [ 'type' => 'boolean' ];
+		$properties['noarchive']      = [ 'type' => 'boolean' ];
+		$properties['nosnippet']      = [ 'type' => 'boolean' ];
 
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,
-			'properties'           => [
-				'post_id'                => [
-					'type'        => 'integer',
-					'description' => \__( 'The ID of the post to update.', 'wordpress-seo' ),
-					'minimum'     => 1,
-				],
-				'permalink'              => [
-					'type'        => 'string',
-					'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
-				],
-				'seo_title'              => $nullable_string,
-				'meta_description'       => $nullable_string,
-				'focus_keyphrase'        => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
-				'canonical'              => $nullable_string,
-				'is_cornerstone'         => [ 'type' => 'boolean' ],
-				'noindex'                => [
-					'type'        => [ 'boolean', 'null' ],
-					'description' => \__( 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.', 'wordpress-seo' ),
-				],
-				'nofollow'               => [ 'type' => 'boolean' ],
-				'noimageindex'           => [ 'type' => 'boolean' ],
-				'noarchive'              => [ 'type' => 'boolean' ],
-				'nosnippet'              => [ 'type' => 'boolean' ],
-				'open_graph_title'       => $nullable_string,
-				'open_graph_description' => $nullable_string,
-				'twitter_title'          => $nullable_string,
-				'twitter_description'    => $nullable_string,
-				'schema_page_type'       => $this->nullable_enum_schema(
-					\array_keys( Schema_Types::PAGE_TYPES ),
-					\__( 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
-				),
-				'schema_article_type'    => $this->nullable_enum_schema(
-					$this->get_schema_article_types(),
-					\__( 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
-				),
-			],
-		];
-	}
-
-	/**
-	 * Returns the allowed Schema.org article type values.
-	 *
-	 * Mirrors the validation in WPSEO_Option_Titles so the ability accepts exactly the
-	 * article types the editor does, including any registered through the filter.
-	 *
-	 * @return array<int, string> The allowed article type values.
-	 */
-	private function get_schema_article_types(): array {
-		/**
-		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
-		 *
-		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
-		 *
-		 * @param array $schema_article_types The available schema article types.
-		 */
-		return \array_keys( \apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES ) );
-	}
-
-	/**
-	 * Returns a nullable-string input schema constrained to a fixed set of allowed values.
-	 *
-	 * Null and the empty string are always allowed on top of the enum so the field can be
-	 * cleared, matching the patch-clear semantics of the other write fields.
-	 *
-	 * @param array<int, string> $allowed_values The allowed string values.
-	 * @param string             $description    The field description.
-	 *
-	 * @return array<string, mixed> The input schema fragment.
-	 */
-	private function nullable_enum_schema( array $allowed_values, string $description ): array {
-		return [
-			'type'        => [ 'string', 'null' ],
-			'description' => $description,
-			'enum'        => \array_merge( $allowed_values, [ '', null ] ),
+			'properties'           => $properties,
 		];
 	}
 

--- a/tests/Unit/Abilities/Infrastructure/Post_SEO_Field_Map_Test.php
+++ b/tests/Unit/Abilities/Infrastructure/Post_SEO_Field_Map_Test.php
@@ -6,6 +6,7 @@ namespace Yoast\WP\SEO\Tests\Unit\Abilities\Infrastructure;
 use Brain\Monkey;
 use Mockery;
 use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
+use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Surfaces\Values\Meta;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
@@ -41,6 +42,11 @@ final class Post_SEO_Field_Map_Test extends TestCase {
 	 */
 	protected function set_up() {
 		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		// The editable-fields and article-type enums are built from documented filters; return the defaults unfiltered.
+		Monkey\Functions\when( 'apply_filters' )->returnArg( 2 );
 
 		$this->meta_surface = Mockery::mock( Meta_Surface::class );
 		$this->instance     = new Post_SEO_Field_Map( $this->meta_surface );
@@ -213,6 +219,7 @@ final class Post_SEO_Field_Map_Test extends TestCase {
 	 * Tests that string fields are set from their value and cleared to null when emptied.
 	 *
 	 * @covers ::apply_to_indexable
+	 * @covers ::get_editable_string_fields
 	 *
 	 * @return void
 	 */
@@ -221,20 +228,178 @@ final class Post_SEO_Field_Map_Test extends TestCase {
 
 		$changed = $this->instance->apply_to_indexable(
 			[
-				'seo_title'        => 'New title',
-				'meta_description' => '',
-				'canonical'        => null,
-				'focus_keyphrase'  => 'a phrase',
+				'canonical'           => 'https://example.com/canonical/',
+				'schema_page_type'    => '',
+				'schema_article_type' => null,
 			],
 			$indexable,
 		);
 
+		$this->assertSame( 'https://example.com/canonical/', $indexable->canonical );
+		$this->assertNull( $indexable->schema_page_type );
+		$this->assertNull( $indexable->schema_article_type );
+		// The order follows the field declaration order, not the input order.
+		$this->assertSame( [ 'canonical', 'schema_page_type', 'schema_article_type' ], $changed );
+	}
+
+	/**
+	 * Tests that string fields outside the default editable set are not applied.
+	 *
+	 * The title, description, Open Graph, and Twitter fields are only editable when a
+	 * plugin (Premium) adds them through the editable-fields filter, and the focus
+	 * keyphrase is not editable at all.
+	 *
+	 * @covers ::apply_to_indexable
+	 * @covers ::get_editable_string_fields
+	 *
+	 * @return void
+	 */
+	public function test_apply_to_indexable_ignores_non_default_string_fields() {
+		$indexable = Mockery::mock( Indexable_Mock::class );
+
+		$changed = $this->instance->apply_to_indexable(
+			[
+				'seo_title'              => 'New title',
+				'meta_description'       => 'New description',
+				'focus_keyphrase'        => 'a phrase',
+				'open_graph_title'       => 'New OG title',
+				'open_graph_description' => 'New OG description',
+				'twitter_title'          => 'New Twitter title',
+				'twitter_description'    => 'New Twitter description',
+			],
+			$indexable,
+		);
+
+		$this->assertSame( [], $changed );
+	}
+
+	/**
+	 * Tests the default editable string field definitions: each maps to its indexable
+	 * column and carries the input-schema fragment the ability exposes.
+	 *
+	 * @covers ::get_editable_string_fields
+	 * @covers ::nullable_enum_schema
+	 * @covers ::get_schema_article_types
+	 *
+	 * @return void
+	 */
+	public function test_get_editable_string_fields_defaults() {
+		$fields = $this->instance->get_editable_string_fields();
+
+		$this->assertSame( [ 'canonical', 'schema_page_type', 'schema_article_type' ], \array_keys( $fields ) );
+		$this->assertSame( 'canonical', $fields['canonical']['column'] );
+		$this->assertSame( [ 'type' => [ 'string', 'null' ] ], $fields['canonical']['schema'] );
+		$this->assertSame( 'schema_page_type', $fields['schema_page_type']['column'] );
+		$this->assertSame(
+			\array_merge( \array_keys( Schema_Types::PAGE_TYPES ), [ '', null ] ),
+			$fields['schema_page_type']['schema']['enum'],
+		);
+		$this->assertSame( 'schema_article_type', $fields['schema_article_type']['column'] );
+		$this->assertSame(
+			\array_merge( \array_keys( Schema_Types::ARTICLE_TYPES ), [ '', null ] ),
+			$fields['schema_article_type']['schema']['enum'],
+		);
+	}
+
+	/**
+	 * Tests that a string field added through the editable-fields filter is applied to
+	 * the indexable like a default field.
+	 *
+	 * This is the extension point Premium uses to make its fields editable.
+	 *
+	 * @covers ::apply_to_indexable
+	 * @covers ::get_editable_string_fields
+	 * @covers ::is_valid_string_field
+	 *
+	 * @return void
+	 */
+	public function test_apply_to_indexable_applies_filtered_fields() {
+		Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( $hook_name, $value ) {
+				if ( $hook_name === 'wpseo_editable_post_seo_data_string_fields' ) {
+					$value['seo_title'] = [
+						'column' => 'title',
+						'schema' => [ 'type' => [ 'string', 'null' ] ],
+					];
+				}
+
+				return $value;
+			},
+		);
+
+		$indexable = Mockery::mock( Indexable_Mock::class );
+
+		$changed = $this->instance->apply_to_indexable( [ 'seo_title' => 'New title' ], $indexable );
+
 		$this->assertSame( 'New title', $indexable->title );
-		$this->assertNull( $indexable->description );
-		$this->assertNull( $indexable->canonical );
-		$this->assertSame( 'a phrase', $indexable->primary_focus_keyword );
-		// The order follows the STRING_FIELDS declaration order, not the input order.
-		$this->assertSame( [ 'title', 'description', 'primary_focus_keyword', 'canonical' ], $changed );
+		$this->assertSame( [ 'title' ], $changed );
+	}
+
+	/**
+	 * Tests that malformed or reserved filtered field definitions are discarded.
+	 *
+	 * @covers ::get_editable_string_fields
+	 * @covers ::is_valid_string_field
+	 *
+	 * @return void
+	 */
+	public function test_get_editable_string_fields_discards_invalid_definitions() {
+		$hijack_definition = [
+			'column' => 'title',
+			'schema' => [ 'type' => [ 'string', 'null' ] ],
+		];
+		$invalid_fields    = [
+			'no_column'    => [ 'schema' => [ 'type' => [ 'string', 'null' ] ] ],
+			'no_schema'    => [ 'column' => 'title' ],
+			'empty_column' => [
+				'column' => '',
+				'schema' => [ 'type' => [ 'string', 'null' ] ],
+			],
+			'not_an_array' => 'title',
+			// Reserved input fields cannot be hijacked into string writes.
+			'post_id'      => $hijack_definition,
+			'noindex'      => $hijack_definition,
+			'nofollow'     => $hijack_definition,
+		];
+
+		Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( $hook_name, $value ) use ( $invalid_fields ) {
+				if ( $hook_name === 'wpseo_editable_post_seo_data_string_fields' ) {
+					return \array_merge( $value, $invalid_fields );
+				}
+
+				return $value;
+			},
+		);
+
+		$this->assertSame(
+			[ 'canonical', 'schema_page_type', 'schema_article_type' ],
+			\array_keys( $this->instance->get_editable_string_fields() ),
+		);
+	}
+
+	/**
+	 * Tests that the default definitions are kept when the filter does not return an array.
+	 *
+	 * @covers ::get_editable_string_fields
+	 *
+	 * @return void
+	 */
+	public function test_get_editable_string_fields_falls_back_on_broken_filter() {
+		Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( $hook_name, $value ) {
+				if ( $hook_name === 'wpseo_editable_post_seo_data_string_fields' ) {
+					return null;
+				}
+
+				return $value;
+			},
+		);
+
+		$this->assertSame(
+			[ 'canonical', 'schema_page_type', 'schema_article_type' ],
+			\array_keys( $this->instance->get_editable_string_fields() ),
+		);
 	}
 
 	/**

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -8,15 +8,21 @@ use Mockery;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
 use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
 use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 use Yoast\WP\SEO\Abilities\User_Interface\Abilities_Integration;
 use Yoast\WP\SEO\Conditionals\Abilities_API_Conditional;
 use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
 use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
 use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
 use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
 use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Meta_Helper;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -64,6 +70,13 @@ final class Abilities_Integration_Test extends TestCase {
 	private $post_seo_data_updater;
 
 	/**
+	 * The post SEO field map.
+	 *
+	 * @var Post_SEO_Field_Map
+	 */
+	private $post_seo_field_map;
+
+	/**
 	 * The instance under test.
 	 *
 	 * @var Abilities_Integration
@@ -80,11 +93,16 @@ final class Abilities_Integration_Test extends TestCase {
 
 		$this->stubTranslationFunctions();
 
+		// The editable-fields and article-type enums are built from documented filters; return the defaults unfiltered.
+		Monkey\Functions\when( 'apply_filters' )->returnArg( 2 );
+
 		$this->score_retriever                      = Mockery::mock( Score_Retriever::class );
 		$this->capability_helper                    = Mockery::mock( Capability_Helper::class );
 		$this->enabled_analysis_features_repository = Mockery::mock( Enabled_Analysis_Features_Repository::class );
 		$this->post_seo_data_collector              = Mockery::mock( Post_SEO_Data_Collector::class );
 		$this->post_seo_data_updater                = Mockery::mock( Post_SEO_Data_Updater::class );
+		// A real field map, so these tests exercise the actual field contract the ability registers with.
+		$this->post_seo_field_map = new Post_SEO_Field_Map( Mockery::mock( Meta_Surface::class ) );
 
 		$this->instance = new Abilities_Integration(
 			$this->score_retriever,
@@ -92,6 +110,7 @@ final class Abilities_Integration_Test extends TestCase {
 			$this->enabled_analysis_features_repository,
 			$this->post_seo_data_collector,
 			$this->post_seo_data_updater,
+			$this->post_seo_field_map,
 		);
 	}
 
@@ -182,7 +201,7 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that register_abilities registers all score abilities when all analyses are enabled.
+	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -200,12 +219,14 @@ final class Abilities_Integration_Test extends TestCase {
 		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
 		$this->expect_score_ability( 'yoast-seo/get-readability-scores' );
 		$this->expect_score_ability( 'yoast-seo/get-inclusive-language-scores' );
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
 	}
 
 	/**
-	 * Tests that no abilities are registered when all analysis features are disabled.
+	 * Tests that the score abilities are not registered when their analysis features are disabled,
+	 * but the metadata abilities always are.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -220,13 +241,13 @@ final class Abilities_Integration_Test extends TestCase {
 			],
 		);
 
-		Monkey\Functions\expect( 'wp_register_ability' )->never();
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
 	}
 
 	/**
-	 * Tests that only the keyphrase score ability registers when only that analysis is enabled.
+	 * Tests that only the keyphrase score ability registers alongside the metadata abilities.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -242,8 +263,227 @@ final class Abilities_Integration_Test extends TestCase {
 		);
 
 		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
+	}
+
+	/**
+	 * Tests that the get and update post SEO data abilities register with the expected definition.
+	 *
+	 * @covers ::register_abilities
+	 * @covers ::register_get_post_seo_data_ability
+	 * @covers ::register_update_post_seo_data_ability
+	 * @covers ::get_update_post_seo_data_input_schema
+	 *
+	 * @return void
+	 */
+	public function test_register_post_seo_data_abilities_definition() {
+		$this->mock_enabled_features(
+			[
+				Keyphrase_Analysis::NAME          => false,
+				Readability_Analysis::NAME        => false,
+				Inclusive_Language_Analysis::NAME => false,
+			],
+		);
+
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'yoast-seo/get-post-seo-data',
+				[
+					'label'               => 'Get Post SEO Data',
+					'category'            => 'yoast-seo',
+					'description'         => 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.',
+					'input_schema'        => $this->get_expected_identifier_input_schema(),
+					'output_schema'       => [
+						'type'  => 'array',
+						'items' => $this->get_expected_output_schema(),
+					],
+					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
+					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
+					'meta'                => $this->get_read_meta(),
+				],
+			);
+
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'yoast-seo/update-post-seo-data',
+				[
+					'label'               => 'Update Post SEO Data',
+					'category'            => 'yoast-seo',
+					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
+					'input_schema'        => $this->get_expected_update_input_schema(),
+					'output_schema'       => $this->get_expected_output_schema(),
+					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
+					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
+					'meta'                => $this->get_write_meta(),
+				],
+			);
+
+		$this->instance->register_abilities();
+	}
+
+	/**
+	 * Tests that a string field added through the editable-fields filter is exposed in the
+	 * update ability input schema, alongside the unchanged default fields.
+	 *
+	 * This is the extension point Premium uses to add its editable fields, so the schema
+	 * must pick up filtered definitions without any change to the defaults.
+	 *
+	 * @covers ::register_update_post_seo_data_ability
+	 * @covers ::get_update_post_seo_data_input_schema
+	 *
+	 * @return void
+	 */
+	public function test_update_input_schema_includes_filtered_fields() {
+		Monkey\Functions\when( 'apply_filters' )->alias(
+			static function ( $hook_name, $value ) {
+				if ( $hook_name === 'wpseo_editable_post_seo_data_string_fields' ) {
+					$value['seo_title'] = [
+						'column' => 'title',
+						'schema' => [ 'type' => [ 'string', 'null' ] ],
+					];
+				}
+
+				return $value;
+			},
+		);
+
+		$properties = $this->get_registered_update_ability_args()['input_schema']['properties'];
+
+		$this->assertSame( [ 'type' => [ 'string', 'null' ] ], $properties['seo_title'] );
+
+		// The default fields are still present alongside the filtered addition.
+		foreach ( [ 'canonical', 'schema_page_type', 'schema_article_type', 'is_cornerstone', 'noindex' ] as $default_field ) {
+			$this->assertArrayHasKey( $default_field, $properties );
+		}
+	}
+
+	/**
+	 * Tests that every writable field in the update input schema is applied by the
+	 * field map and cascades to a post meta write.
+	 *
+	 * The field contract is spread over hand-maintained structures (the input schema,
+	 * Post_SEO_Field_Map, Indexable_To_Postmeta_Helper) which fail silently when they
+	 * drift: a schema field missing from the field map is validated and accepted but
+	 * never applied, and an indexable column missing from the postmeta map is skipped
+	 * by the cascade and then reverted by the indexable rebuild. This test turns both
+	 * drift paths into a failure.
+	 *
+	 * @covers ::register_abilities
+	 * @covers ::register_update_post_seo_data_ability
+	 * @covers ::get_update_post_seo_data_input_schema
+	 *
+	 * @return void
+	 */
+	public function test_every_writable_input_field_cascades_to_post_meta() {
+		$input_schema = $this->get_registered_update_ability_args()['input_schema'];
+
+		$writable_fields = \array_diff_key(
+			$input_schema['properties'],
+			[
+				'post_id'   => true,
+				'permalink' => true,
+			],
+		);
+
+		$field_map            = new Post_SEO_Field_Map( Mockery::mock( Meta_Surface::class ) );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_id = 42;
+
+		$changed_columns = [];
+		foreach ( $writable_fields as $field => $field_schema ) {
+			// A truthy value for every type, so each mapped column performs a meta write below.
+			$value   = ( \in_array( 'boolean', (array) $field_schema['type'], true ) ) ? true : 'a value';
+			$changed = $field_map->apply_to_indexable( [ $field => $value ], $indexable );
+
+			$this->assertNotEmpty(
+				$changed,
+				"Input field `{$field}` is accepted by the update input schema but not applied by Post_SEO_Field_Map, so writes to it are silently dropped.",
+			);
+
+			$changed_columns[] = $changed;
+		}
+
+		$meta_writes = 0;
+		$meta_helper = Mockery::mock( Meta_Helper::class );
+		$meta_helper->shouldReceive( 'set_value', 'delete' )->andReturnUsing(
+			static function () use ( &$meta_writes ) {
+				++$meta_writes;
+
+				return true;
+			},
+		);
+		$postmeta_helper = new Indexable_To_Postmeta_Helper( $meta_helper );
+
+		foreach ( \array_unique( \array_merge( ...$changed_columns ) ) as $column ) {
+			$writes_before = $meta_writes;
+			$postmeta_helper->map_column_to_postmeta( $indexable, $column, true );
+
+			$this->assertGreaterThan(
+				$writes_before,
+				$meta_writes,
+				"Indexable column `{$column}` has no Indexable_To_Postmeta_Helper mapping, so writes to it are silently discarded and reverted by the indexable rebuild.",
+			);
+		}
+	}
+
+	/**
+	 * Tests that the SEO data array built by the field map exposes exactly the
+	 * properties documented in the output schema.
+	 *
+	 * @covers ::register_abilities
+	 * @covers ::register_update_post_seo_data_ability
+	 * @covers ::get_post_seo_data_output_schema
+	 *
+	 * @return void
+	 */
+	public function test_output_schema_matches_field_map_output() {
+		$output_schema = $this->get_registered_update_ability_args()['output_schema'];
+
+		$meta_surface = Mockery::mock( Meta_Surface::class );
+		$meta_surface->expects( 'for_indexable' )->andReturnFalse();
+		$field_map = new Post_SEO_Field_Map( $meta_surface );
+
+		$schema_properties = \array_keys( $output_schema['properties'] );
+		$output_fields     = \array_keys( $field_map->to_seo_array( Mockery::mock( Indexable_Mock::class ) ) );
+		\sort( $schema_properties );
+		\sort( $output_fields );
+
+		$this->assertSame(
+			$schema_properties,
+			$output_fields,
+			'The output schema and Post_SEO_Field_Map::to_seo_array() must describe the same set of fields.',
+		);
+	}
+
+	/**
+	 * Registers the abilities against a capturing stub and returns the arguments the
+	 * update ability was registered with.
+	 *
+	 * @return array<string, mixed> The update ability registration arguments.
+	 */
+	private function get_registered_update_ability_args(): array {
+		$this->mock_enabled_features(
+			[
+				Keyphrase_Analysis::NAME          => false,
+				Readability_Analysis::NAME        => false,
+				Inclusive_Language_Analysis::NAME => false,
+			],
+		);
+
+		$captured = [];
+		Monkey\Functions\when( 'wp_register_ability' )->alias(
+			static function ( $name, $args ) use ( &$captured ) {
+				$captured[ $name ] = $args;
+			},
+		);
+
+		$this->instance->register_abilities();
+
+		return $captured['yoast-seo/update-post-seo-data'];
 	}
 
 	/**
@@ -257,6 +497,206 @@ final class Abilities_Integration_Test extends TestCase {
 		Monkey\Functions\expect( 'wp_register_ability' )
 			->once()
 			->with( $slug, Mockery::type( 'array' ) );
+	}
+
+	/**
+	 * Registers loose expectations for the two metadata abilities.
+	 *
+	 * @return void
+	 */
+	private function expect_post_seo_data_abilities(): void {
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with( 'yoast-seo/get-post-seo-data', Mockery::type( 'array' ) );
+
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with( 'yoast-seo/update-post-seo-data', Mockery::type( 'array' ) );
+	}
+
+	/**
+	 * Returns the read meta (read-only annotations).
+	 *
+	 * @return array<string, mixed> The meta.
+	 */
+	private function get_read_meta(): array {
+		return [
+			'show_in_rest' => true,
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'mcp'          => [
+				'public' => true,
+			],
+		];
+	}
+
+	/**
+	 * Returns the write meta (non-read-only annotations).
+	 *
+	 * @return array<string, mixed> The meta.
+	 */
+	private function get_write_meta(): array {
+		return [
+			'show_in_rest' => true,
+			'annotations'  => [
+				'readonly'    => false,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'mcp'          => [
+				'public' => true,
+			],
+		];
+	}
+
+	/**
+	 * Returns the expected identifier input schema for the read ability.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_identifier_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'   => [
+					'type'        => 'integer',
+					'description' => 'The ID of the post to retrieve.',
+					'minimum'     => 1,
+				],
+				'permalink' => [
+					'type'        => 'string',
+					'description' => 'The permalink (URL) of the post to retrieve.',
+				],
+				'title'     => [
+					'type'        => 'string',
+					'description' => 'Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter.',
+				],
+				'page'      => [
+					'type'        => 'integer',
+					'description' => 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.',
+					'minimum'     => 1,
+					'default'     => 1,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the expected update input schema: the Free-editable fields only.
+	 *
+	 * The title, description, Open Graph, and Twitter fields are Premium additions
+	 * through the editable-fields filter, and the focus keyphrase is not editable at all.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_update_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'             => [
+					'type'        => 'integer',
+					'description' => 'The ID of the post to update.',
+					'minimum'     => 1,
+				],
+				'permalink'           => [
+					'type'        => 'string',
+					'description' => 'The permalink (URL) of the post to update.',
+				],
+				'canonical'           => [ 'type' => [ 'string', 'null' ] ],
+				'schema_page_type'    => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::PAGE_TYPES ), [ '', null ] ),
+				],
+				'schema_article_type' => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::ARTICLE_TYPES ), [ '', null ] ),
+				],
+				'is_cornerstone'      => [ 'type' => 'boolean' ],
+				'noindex'             => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.',
+				],
+				'nofollow'            => [ 'type' => 'boolean' ],
+				'noimageindex'        => [ 'type' => 'boolean' ],
+				'noarchive'           => [ 'type' => 'boolean' ],
+				'nosnippet'           => [ 'type' => 'boolean' ],
+			],
+		];
+	}
+
+	/**
+	 * Returns the expected post SEO data output schema.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_output_schema(): array {
+		$nullable_string = [ 'type' => [ 'string', 'null' ] ];
+		$score           = static function ( $analysis ) {
+			return [
+				'type'        => 'string',
+				'enum'        => [ 'na', 'bad', 'ok', 'good' ],
+				'description' => \sprintf(
+					'The result of the %s that ran on the post when it was last saved.',
+					$analysis,
+				),
+			];
+		};
+		$rendered        = static function ( $field ) {
+			return [
+				'type'        => [ 'string', 'null' ],
+				'description' => \sprintf(
+					'The %s as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output.',
+					$field,
+				),
+			];
+		};
+
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'post_id'                         => [ 'type' => 'integer' ],
+				'post_title'                      => $nullable_string,
+				'permalink'                       => $nullable_string,
+				'post_type'                       => [ 'type' => 'string' ],
+				'post_status'                     => $nullable_string,
+				'seo_title'                       => $nullable_string,
+				'seo_title_rendered'              => $rendered( 'SEO title' ),
+				'meta_description'                => $nullable_string,
+				'meta_description_rendered'       => $rendered( 'meta description' ),
+				'focus_keyphrase'                 => $nullable_string,
+				'canonical'                       => $nullable_string,
+				'canonical_rendered'              => $rendered( 'canonical URL' ),
+				'is_cornerstone'                  => [ 'type' => 'boolean' ],
+				'noindex'                         => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => 'Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies.',
+				],
+				'nofollow'                        => [ 'type' => 'boolean' ],
+				'noimageindex'                    => [ 'type' => 'boolean' ],
+				'noarchive'                       => [ 'type' => 'boolean' ],
+				'nosnippet'                       => [ 'type' => 'boolean' ],
+				'open_graph_title'                => $nullable_string,
+				'open_graph_title_rendered'       => $rendered( 'Open Graph title' ),
+				'open_graph_description'          => $nullable_string,
+				'open_graph_description_rendered' => $rendered( 'Open Graph description' ),
+				'twitter_title'                   => $nullable_string,
+				'twitter_title_rendered'          => $rendered( 'Twitter title' ),
+				'twitter_description'             => $nullable_string,
+				'twitter_description_rendered'    => $rendered( 'Twitter description' ),
+				'schema_page_type'                => $nullable_string,
+				'schema_article_type'             => $nullable_string,
+				'seo_score'                       => $score( 'SEO analysis' ),
+				'readability_score'               => $score( 'readability analysis' ),
+				'inclusive_language_score'        => $score( 'inclusive language analysis' ),
+			],
+		];
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

*

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Introduces two new Yoast SEO abilities to get and set SEO data for specified posts.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Declaration of the abilities
<details>

<summary>The GET SEO data ability</summary>


**Note for testers**:
Throughout the testing process, to perform GET requests do the following:
* Open a post in the Block editor
* Open the browser's console and execute the following snippet:
```js
pathToTest = '/wp-abilities/v1/abilities';
response = await wp.apiFetch( { path: pathToTest } );
console.log( response );
```
* The example above performs a GET request to ``http://YOUR-BLOG-URL/wp-json/wp-abilities/v1/abilities``; make sure to adapt the `pathToTest` value accordingly to what you're testing
---
* Do a GET request to WP's `http://example.com/wp-json/wp-abilities/v1/abilities` endpoint and confirm that you see the `yoast-seo/get-post-seo-data` ability we added and that it looks like this:

```
    {
        "name": "yoast-seo/get-post-seo-data",
        "label": "Get Post SEO Data",
        "description": "Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.",
        "category": "yoast-seo",
        "input_schema": {
            "type": "object",
            "additionalProperties": false,
            "properties": {
                "post_id": {
                    "type": "integer",
                    "description": "The ID of the post to retrieve.",
                    "minimum": 1
                },
                "permalink": {
                    "type": "string",
                    "description": "The permalink (URL) of the post to retrieve."
                },
                "title": {
                    "type": "string",
                    "description": "Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter."
                },
                "page": {
                    "type": "integer",
                    "description": "The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.",
                    "minimum": 1,
                    "default": 1
                }
            }
        },
        "output_schema": {
            "type": "array",
            "items": {
                "type": "object",
                "properties": {
                    "post_id": {
                        "type": "integer"
                    },
                    "post_title": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "permalink": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "post_type": {
                        "type": "string"
                    },
                    "post_status": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "seo_title": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "seo_title_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The SEO title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "meta_description": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "meta_description_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The meta description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "focus_keyphrase": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "canonical": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "canonical_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The canonical URL as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "is_cornerstone": {
                        "type": "boolean"
                    },
                    "noindex": {
                        "type": [
                            "boolean",
                            "null"
                        ],
                        "description": "Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies."
                    },
                    "nofollow": {
                        "type": "boolean"
                    },
                    "noimageindex": {
                        "type": "boolean"
                    },
                    "noarchive": {
                        "type": "boolean"
                    },
                    "nosnippet": {
                        "type": "boolean"
                    },
                    "open_graph_title": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "open_graph_title_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The Open Graph title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "open_graph_description": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "open_graph_description_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The Open Graph description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "twitter_title": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "twitter_title_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The Twitter title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "twitter_description": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "twitter_description_rendered": {
                        "type": [
                            "string",
                            "null"
                        ],
                        "description": "The Twitter description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                    },
                    "schema_page_type": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "schema_article_type": {
                        "type": [
                            "string",
                            "null"
                        ]
                    },
                    "seo_score": {
                        "type": "string",
                        "enum": [
                            "na",
                            "bad",
                            "ok",
                            "good"
                        ],
                        "description": "The result of the SEO analysis that ran on the post when it was last saved."
                    },
                    "readability_score": {
                        "type": "string",
                        "enum": [
                            "na",
                            "bad",
                            "ok",
                            "good"
                        ],
                        "description": "The result of the readability analysis that ran on the post when it was last saved."
                    },
                    "inclusive_language_score": {
                        "type": "string",
                        "enum": [
                            "na",
                            "bad",
                            "ok",
                            "good"
                        ],
                        "description": "The result of the inclusive language analysis that ran on the post when it was last saved."
                    }
                }
            }
        },
        "meta": {
            "annotations": {
                "readonly": true,
                "destructive": false,
                "idempotent": true
            },
            "show_in_rest": true,
            "mcp": {
                "public": true
            }
        },
        "_links": {
            "self": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data",
                    "targetHints": {
                        "allow": [
                            "GET"
                        ]
                    }
                }
            ],
            "collection": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities"
                }
            ],
            "wp:action-run": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run"
                }
            ]
        }
    }
```
</details>
<details>

<summary>The SET SEO data ability</summary>

* Do a GET request to WP's `http://example.com/wp-json/wp-abilities/v1/abilities` endpoint and confirm that you see the `yoast-seo/update-post-seo-data` ability we added and that it looks like this:

```
    {
        "name": "yoast-seo/update-post-seo-data",
        "label": "Update Post SEO Data",
        "description": "Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.",
        "category": "yoast-seo",
        "input_schema": {
            "type": "object",
            "additionalProperties": false,
            "properties": {
                "post_id": {
                    "type": "integer",
                    "description": "The ID of the post to update.",
                    "minimum": 1
                },
                "permalink": {
                    "type": "string",
                    "description": "The permalink (URL) of the post to update."
                },
                "canonical": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "schema_page_type": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.",
                    "enum": [
                        "WebPage",
                        "ItemPage",
                        "AboutPage",
                        "FAQPage",
                        "QAPage",
                        "ProfilePage",
                        "ContactPage",
                        "MedicalWebPage",
                        "CollectionPage",
                        "CheckoutPage",
                        "RealEstateListing",
                        "SearchResultsPage",
                        "",
                        null
                    ]
                },
                "schema_article_type": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.",
                    "enum": [
                        "Article",
                        "BlogPosting",
                        "SocialMediaPosting",
                        "NewsArticle",
                        "AdvertiserContentArticle",
                        "SatiricalArticle",
                        "ScholarlyArticle",
                        "TechArticle",
                        "Report",
                        "None",
                        "",
                        null
                    ]
                },
                "is_cornerstone": {
                    "type": "boolean"
                },
                "noindex": {
                    "type": [
                        "boolean",
                        "null"
                    ],
                    "description": "Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default."
                },
                "nofollow": {
                    "type": "boolean"
                },
                "noimageindex": {
                    "type": "boolean"
                },
                "noarchive": {
                    "type": "boolean"
                },
                "nosnippet": {
                    "type": "boolean"
                }
            }
        },
        "output_schema": {
            "type": "object",
            "properties": {
                "post_id": {
                    "type": "integer"
                },
                "post_title": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "permalink": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "post_type": {
                    "type": "string"
                },
                "post_status": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "seo_title": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "seo_title_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The SEO title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "meta_description": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "meta_description_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The meta description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "focus_keyphrase": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "canonical": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "canonical_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The canonical URL as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "is_cornerstone": {
                    "type": "boolean"
                },
                "noindex": {
                    "type": [
                        "boolean",
                        "null"
                    ],
                    "description": "Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies."
                },
                "nofollow": {
                    "type": "boolean"
                },
                "noimageindex": {
                    "type": "boolean"
                },
                "noarchive": {
                    "type": "boolean"
                },
                "nosnippet": {
                    "type": "boolean"
                },
                "open_graph_title": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "open_graph_title_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Open Graph title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "open_graph_description": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "open_graph_description_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Open Graph description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "twitter_title": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "twitter_title_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Twitter title as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "twitter_description": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "twitter_description_rendered": {
                    "type": [
                        "string",
                        "null"
                    ],
                    "description": "The Twitter description as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output."
                },
                "schema_page_type": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "schema_article_type": {
                    "type": [
                        "string",
                        "null"
                    ]
                },
                "seo_score": {
                    "type": "string",
                    "enum": [
                        "na",
                        "bad",
                        "ok",
                        "good"
                    ],
                    "description": "The result of the SEO analysis that ran on the post when it was last saved."
                },
                "readability_score": {
                    "type": "string",
                    "enum": [
                        "na",
                        "bad",
                        "ok",
                        "good"
                    ],
                    "description": "The result of the readability analysis that ran on the post when it was last saved."
                },
                "inclusive_language_score": {
                    "type": "string",
                    "enum": [
                        "na",
                        "bad",
                        "ok",
                        "good"
                    ],
                    "description": "The result of the inclusive language analysis that ran on the post when it was last saved."
                }
            }
        },
        "meta": {
            "annotations": {
                "readonly": false,
                "destructive": false,
                "idempotent": true
            },
            "show_in_rest": true,
            "mcp": {
                "public": true
            }
        },
        "_links": {
            "self": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data",
                    "targetHints": {
                        "allow": [
                            "GET"
                        ]
                    }
                }
            ],
            "collection": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities"
                }
            ],
            "wp:action-run": [
                {
                    "href": "https://basic.wordpress.test/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run"
                }
            ]
        }
    }
```
* Confirm that the above declarations and their descriptions make sense and help agents understand what's possible.
* Confirm that you dont see `seo_title`, `meta_description`, `open_graph_title`, `twitter_title`, `open_graph_description` and `twitter_description` in the input schema, unless you have Premium active too
* Activated Premium, repeat the request and confirm that you see `seo_title`, `meta_description`, `open_graph_title`, `twitter_title`, `open_graph_description` in the input schema now
* Confirm that you dont see `focus_keyphrase` in the input schema, regardless whether you have Premium enabled or not
* Now disable the indexables (using the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` filter) and confirm that you can't find the above abilities
</details>

#### Usage of the new abilities

* Create a post with meaningful content and set its SEO data (title, meta description, social title, robots, SEO/readability score, etc.)

<details>

<summary>Using the REST API</summary>

<details>
<summary>Using our `getting SEO data` ability</summary>

* You can smoke test the respective steps in [the original PR](https://github.com/Yoast/wordpress-seo/pull/23369) to ensure no regressions, they should be working exactly the same
</details>


<details>
<summary>Using our `setting SEO data` ability</summary>

* You can smoke test the respective steps in [the original PR](https://github.com/Yoast/wordpress-seo/pull/23369) to ensure no regressions, but there are some differences listed below:
* With Premium not active: trying to set either one of `seo_title`, `meta_description`, `open_graph_title`, `twitter_title`, `open_graph_description` and `twitter_description` and `focus_keyphrase`, you will get a `400 - ability_invalid_input` error code
  * Make sure that indeed the relevant indexable data did NOT change after that 
  * For any other field, you should get the same behavior described in the original PR
* With Premium active: trying to set either one of `seo_title`, `meta_description`, `open_graph_title`, `twitter_title`, `open_graph_description` and `twitter_description`, now works like seamlessly. Not for `focus_keyphrase` though, because this is not editable at all now.
  * Make sure that indeed the relevant indexable data DID change after that
</details>


</details>
<details>

<summary>Using an AI agent</summary>

* Follow [the documentation on how to test WP Abilities](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/4975198209/Set+up+an+MCP+server+to+test+WP+Abilities)
* **To use the GET SEO data ability**,
* You can smoke test the respective steps in [the original PR](https://github.com/Yoast/wordpress-seo/pull/23369) to ensure no regressions, they should be working exactly the same
* **To use the SET SEO data ability**,
* You can smoke test the respective steps in [the original PR](https://github.com/Yoast/wordpress-seo/pull/23369) to ensure no regressions, but there should be some differences: 
  * With Premium not active: telling the agent to set either one of SEO Title, Meta description, OG title/description or Twitter title/description, it will not be possible for it to do it
    * Make sure that indeed the relevant indexable data did NOT change after that 
    * For any other data, you should get the same behavior described in the original PR
  * With Premium active: telling the agent to set either one of SEO Title, Meta description, OG title/description or Twitter title/description, it will now be possible for it to do it
    * Make sure that indeed the relevant indexable data DID change after that 
</details>

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
