### PR TITLE
fix: remove core title tag renderers after block template resolution

### DIFF
--- a/src/integrations/front-end-integration.php
+++ b/src/integrations/front-end-integration.php
@@ -269,6 +269,30 @@ class Front_End_Integration implements Integration_Interface {
 		\remove_action( 'wp_head', 'start_post_rel_link' );
 		\remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head' );
 		\remove_action( 'wp_head', 'noindex', 1 );
+
+		$this->remove_core_title_tag_renderers();
+
+		/*
+		 * Block themes re-register `_block_template_render_title_tag` on `wp_head` during block
+		 * template resolution -- see `locate_block_template()` in wp-includes/block-template.php,
+		 * which runs on `template_include`, long after `init`. The call above therefore cannot
+		 * catch it, leaving a duplicate `<title>` alongside ours. Repeat the removal on `wp_head`
+		 * at a priority lower than the 1 those renderers use.
+		 */
+		\add_action( 'wp_head', [ $this, 'remove_core_title_tag_renderers' ], 0 );
+	}
+
+	/**
+	 * Removes WordPress core's (and the Gutenberg plugin's) title tag renderers.
+	 * Only does this when our own Title presenter is actually going to be output.
+	 *
+	 * @return void
+	 */
+	public function remove_core_title_tag_renderers() {
+		if ( $this->should_title_presenter_be_removed() ) {
+			return;
+		}
+
 		\remove_action( 'wp_head', '_wp_render_title_tag', 1 );
 		\remove_action( 'wp_head', '_block_template_render_title_tag', 1 );
 		\remove_action( 'wp_head', 'gutenberg_render_title_tag', 1 );

--- a/tests/Unit/Integrations/Front_End_Integration_Test.php
+++ b/tests/Unit/Integrations/Front_End_Integration_Test.php
@@ -148,6 +148,11 @@ final class Front_End_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_register_hooks() {
+		Monkey\Functions\expect( 'get_theme_support' )
+			->once()
+			->with( 'title-tag' )
+			->andReturn( true );
+
 		$this->instance->register_hooks();
 
 		$this->assertNotFalse( \has_action( 'wp_head', [ $this->instance, 'call_wpseo_head' ] ), 'Does not have expected wp_head action' );
@@ -155,6 +160,56 @@ final class Front_End_Integration_Test extends TestCase {
 		$this->assertNotFalse( \has_filter( 'wp_title', [ $this->instance, 'filter_title' ] ), 'Does not have expected wp_title filter' );
 		$this->assertNotFalse( \has_filter( 'wpseo_frontend_presenter_classes', [ $this->instance, 'filter_robots_presenter' ] ), 'Does not have expected wpseo_frontend_presenter_classes filter' );
 		$this->assertNotFalse( \has_filter( 'render_block', [ $this->instance, 'query_loop_next_prev' ] ), 'Filter for checking query loop block' );
+		$this->assertSame( 0, \has_action( 'wp_head', [ $this->instance, 'remove_core_title_tag_renderers' ] ), 'Does not have expected wp_head action at priority 0' );
+	}
+
+	/**
+	 * Tests that core's and Gutenberg's title tag renderers are removed.
+	 *
+	 * @covers ::remove_core_title_tag_renderers
+	 *
+	 * @return void
+	 */
+	public function test_remove_core_title_tag_renderers() {
+		Monkey\Functions\expect( 'get_theme_support' )
+			->once()
+			->with( 'title-tag' )
+			->andReturn( true );
+
+		\add_action( 'wp_head', '_wp_render_title_tag', 1 );
+		\add_action( 'wp_head', '_block_template_render_title_tag', 1 );
+		\add_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
+
+		$this->instance->remove_core_title_tag_renderers();
+
+		$this->assertFalse( \has_action( 'wp_head', '_wp_render_title_tag' ), 'Core title tag renderer was not removed' );
+		$this->assertFalse( \has_action( 'wp_head', '_block_template_render_title_tag' ), 'Block template title tag renderer was not removed' );
+		$this->assertFalse( \has_action( 'wp_head', 'gutenberg_render_title_tag' ), 'Gutenberg title tag renderer was not removed' );
+	}
+
+	/**
+	 * Tests that core's title tag renderers are kept when our own title presenter is removed.
+	 *
+	 * @covers ::remove_core_title_tag_renderers
+	 *
+	 * @return void
+	 */
+	public function test_remove_core_title_tag_renderers_keeps_renderers_when_presenter_is_removed() {
+		Monkey\Functions\expect( 'get_theme_support' )
+			->once()
+			->with( 'title-tag' )
+			->andReturn( false );
+
+		$this->options
+			->expects( 'get' )
+			->with( 'forcerewritetitle', false )
+			->andReturn( false );
+
+		\add_action( 'wp_head', '_block_template_render_title_tag', 1 );
+
+		$this->instance->remove_core_title_tag_renderers();
+
+		$this->assertSame( 1, \has_action( 'wp_head', '_block_template_render_title_tag' ), 'Renderer should be kept so the page still has a title' );
 	}
 
 	/**


### PR DESCRIPTION
## Context

Issue #23313 reports a duplicate `<title>` tag on block (FSE) themes. The cause is hook timing: core registers its block template title renderer after this integration has already tried to remove it.

`Front_End_Integration::register_hooks()` runs on `init` (it is invoked from `Loader::load_integrations()`, hooked to `init`). Among its cleanups it removes three title tag renderers:

```php
\remove_action( 'wp_head', '_wp_render_title_tag', 1 );
\remove_action( 'wp_head', '_block_template_render_title_tag', 1 );
\remove_action( 'wp_head', 'gutenberg_render_title_tag', 1 );
```

At `init`, only `_wp_render_title_tag` is actually registered — it comes from `wp-includes/default-filters.php`. The other two have not been added yet, so those two calls are no-ops.

Core registers its block template renderer later, inside `locate_block_template()` (`wp-includes/block-template.php`):

```php
remove_action( 'wp_head', '_wp_render_title_tag', 1 );    // Remove conditional title tag rendering...
add_action( 'wp_head', '_block_template_render_title_tag', 1 ); // ...and make it unconditional.
```

`locate_block_template()` is called from `get_query_template()` during template loading, which happens well after `init`. So core adds a title renderer *after* this integration has finished removing them, and nothing removes the new one.

Whether that produces a duplicate depends on `should_title_presenter_be_removed()`:

| Configuration | `should_title_presenter_be_removed()` | Our `Title` presenter | Core renderer | Result |
| --- | --- | --- | --- | --- |
| Block theme, no `title-tag` support | `true` | removed | renders | one `<title>` |
| Block theme, with `title-tag` support | `false` | kept | renders | **two `<title>` tags** |

So the duplicate occurs when `title-tag` support is present — declared by the theme itself or by another plugin. Worth noting for the issue report: core does **not** auto-register `title-tag` for block themes. `_add_default_theme_supports()` adds `post-thumbnails`, `responsive-embeds`, `editor-styles`, `html5` and `automatic-feed-links`, but not `title-tag`. That is exactly why core's block renderer is documented as rendering "regardless of whether theme has title-tag support".

Classic themes are unaffected, since `locate_block_template()` does not run for them.

Note on the issue report: #23313 states that `add_theme_support( 'title-tag' )` is not present in the theme's `functions.php`. The duplicate does require that support to be registered, so on that site it is most likely added by the theme outside `functions.php` (a parent theme or an included file) or by another active plugin. The fix behaves correctly either way, since it only removes core's renderer when our own `Title` presenter is actually being output.

The same root cause was described in #22446, which was closed for inactivity before it could be investigated.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where a duplicate `<title>` tag was output when using a block theme.

Changelog label: `changelog: bugfix` — I don't have permission to attach labels to this repository, so this needs to be applied by a maintainer.

## Relevant technical choices:

* The three `remove_action()` calls move into a new `remove_core_title_tag_renderers()` method, which is called directly from `register_hooks()` and hooked again to `wp_head` at priority `0`. A single method means the list of renderer names lives in one place and cannot drift between the two call sites.

* `wp_head` priority `0` is the earliest point that reliably works. It runs after template resolution has registered `_block_template_render_title_tag`, and before priority `1`, where all three renderers fire.

* The method returns early when `should_title_presenter_be_removed()` is true. In that case `maybe_remove_title_presenter()` has already dropped our own `Title` presenter, so core's renderer is the only thing left producing a title — removing it too would leave the page with no `<title>` at all. This mirrors the existing presenter logic rather than introducing a second, separate notion of when we own the title.

* Not `template_include`: it is a filter, not an action, so a callback hooked there must return the template path. A removal-only callback would return `null` and break template loading.

* Not the same priority as the renderers: `WP_Hook::do_action()` iterates the callbacks of a priority with `foreach`, which operates on a copy of that bucket. Removing a callback from the priority currently being executed is therefore not reliable, whereas removing one from a priority not yet reached is.

* Because the guard also applies to the `init`-time call, `_wp_render_title_tag` now stays registered on themes without `title-tag` support where it was previously removed. This does not change any output: `_wp_render_title_tag()` itself returns early unless `current_theme_supports( 'title-tag' )`, so it emits nothing in exactly the cases where it is now left in place.

* Disclosure: this patch was written with the assistance of an AI coding agent (Claude, by Anthropic), operated and reviewed by the PR author. Regarding the licensing note in the contribution guidelines: the change relocates existing `remove_action()` calls into a method and defers them to a later hook, with tests modelled on patterns already used elsewhere in this repository's test suite — no external code was copied.

* `composer test-wp-env` was not run — Docker was not available in the development environment. `composer test`, `composer lint-branch` and `composer check-cs-thresholds` all pass locally. `composer check-branch-cs` reports one error and one warning in `Front_End_Integration_Test.php`, both pre-existing on lines this PR does not touch (a data provider `@return` annotation and an unused variable); the threshold check is unchanged at 2366 errors / 254 warnings.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Set up a WordPress site with Yoast SEO active and a **block theme** (for example Twenty Twenty-Four or Twenty Twenty-Five).
2. Add `add_theme_support( 'title-tag' );` inside an `after_setup_theme` callback in the theme's `functions.php`. This is the configuration that triggers the bug.
3. Open any page on the public side of the site (not the admin).
4. Right-click the page and choose "View page source", then search the source for `<title`.
5. **On `trunk` (before this PR):** the page contains two `<title>` tags.
6. **With this PR:** the page contains exactly one `<title>` tag, generated by Yoast SEO. The title text itself should be unchanged.
7. Now remove the `add_theme_support( 'title-tag' );` line added in step 2 and reload the page. There should still be exactly **one** `<title>` tag — this checks that the fix does not remove the last remaining title.
8. Switch to a **classic theme** (for example Twenty Twenty-One) and repeat steps 3–4. There should still be exactly one `<title>` tag, as before this change.
9. If you have the **Gutenberg** plugin available, activate it, switch back to the block theme, and repeat steps 2–6.

#### Relevant test scenarios

* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies

The title tag is emitted for every front-end request, so it is worth confirming on a singular post, a page, an archive and the homepage. The change is not editor-specific and involves no JavaScript, so no console output is expected.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same as the acceptance test steps above. Step 7 is the important regression check: a page must never end up with zero `<title>` tags.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* Front-end `<title>` tag output, on both block and classic themes.
* The `wp_head` hook registrations made by `Front_End_Integration`. No other head output (canonical, robots, Open Graph, schema) is touched.
* `should_title_presenter_be_removed()` gains a second caller. Its behaviour is unchanged, but it is now also consulted during `init` and on `wp_head`, which means `get_theme_support()` and the `forcerewritetitle` option are read slightly earlier than before.
* `remove_core_title_tag_renderers()` is a new public method on `Front_End_Integration`. As a side effect it gives site owners an escape hatch: `remove_action( 'wp_head', [ $integration, 'remove_core_title_tag_renderers' ], 0 )` restores core's renderer.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #23313
