### PR TITLE
feat(bulk-editor): supply post images through a filter

### DIFF
--- a/src/bulk-editor/domain/posts/post.php
+++ b/src/bulk-editor/domain/posts/post.php
@@ -79,6 +79,13 @@ class Post {
 	private $editable;
 
 	/**
+	 * The images and their variations for this post.
+	 *
+	 * @var array<string, int|string>
+	 */
+	private $images;
+
+	/**
 	 * Whether each field needs improvement, keyed by field param (e.g. `seo_title`). Empty for a post whose
 	 * fields are not editable.
 	 *
@@ -117,21 +124,22 @@ class Post {
 	/**
 	 * The constructor.
 	 *
-	 * @param int                 $id                          The post ID.
-	 * @param string              $title                       The post title.
-	 * @param string              $status                      The post status.
-	 * @param string              $edit_link                   The URL to edit the post.
-	 * @param string              $focus_keyphrase             The focus keyphrase.
-	 * @param string              $seo_title                   The raw stored SEO title.
-	 * @param string              $meta_description            The raw stored meta description.
-	 * @param string              $social_title                The raw stored social title.
-	 * @param string              $social_description          The raw stored social description.
-	 * @param bool                $editable                    Whether the current user may edit this post.
-	 * @param array<string, bool> $needs_improvement           Whether each field needs improvement, keyed by field param.
-	 * @param string              $seo_title_fallback          The post type's SEO title template (empty when stored value is set).
-	 * @param string              $meta_description_fallback   The post type's meta description template (empty when stored value is set).
-	 * @param string              $social_title_fallback       The post type's social title template (empty when stored value is set).
-	 * @param string              $social_description_fallback The post type's social description template (empty when stored value is set).
+	 * @param int                       $id                          The post ID.
+	 * @param string                    $title                       The post title.
+	 * @param string                    $status                      The post status.
+	 * @param string                    $edit_link                   The URL to edit the post.
+	 * @param string                    $focus_keyphrase             The focus keyphrase.
+	 * @param string                    $seo_title                   The raw stored SEO title.
+	 * @param string                    $meta_description            The raw stored meta description.
+	 * @param string                    $social_title                The raw stored social title.
+	 * @param string                    $social_description          The raw stored social description.
+	 * @param bool                      $editable                    Whether the current user may edit this post.
+	 * @param array<string, bool>       $needs_improvement           Whether each field needs improvement, keyed by field param.
+	 * @param string                    $seo_title_fallback          The post type's SEO title template (empty when stored value is set).
+	 * @param string                    $meta_description_fallback   The post type's meta description template (empty when stored value is set).
+	 * @param string                    $social_title_fallback       The post type's social title template (empty when stored value is set).
+	 * @param string                    $social_description_fallback The post type's social description template (empty when stored value is set).
+	 * @param array<string, int|string> $images                      The images and their variations for this post.
 	 */
 	public function __construct(
 		int $id,
@@ -148,7 +156,8 @@ class Post {
 		string $seo_title_fallback = '',
 		string $meta_description_fallback = '',
 		string $social_title_fallback = '',
-		string $social_description_fallback = ''
+		string $social_description_fallback = '',
+		array $images = []
 	) {
 		$this->id                          = $id;
 		$this->title                       = $title;
@@ -165,6 +174,7 @@ class Post {
 		$this->meta_description_fallback   = $meta_description_fallback;
 		$this->social_title_fallback       = $social_title_fallback;
 		$this->social_description_fallback = $social_description_fallback;
+		$this->images                      = $images;
 	}
 
 	/**
@@ -197,6 +207,7 @@ class Post {
 				],
 				$this->needs_improvement,
 			),
+			'images'                      => $this->images,
 		];
 	}
 }

--- a/src/bulk-editor/infrastructure/posts/indexable-posts-collector.php
+++ b/src/bulk-editor/infrastructure/posts/indexable-posts-collector.php
@@ -19,6 +19,7 @@ use Yoast\WP\SEO\Repositories\Indexable_Repository;
  */
 class Indexable_Posts_Collector implements Posts_Collector_Interface {
 
+	use Post_Images_Trait;
 	use Post_Title_Trait;
 	use Searchable_Fields_Trait;
 
@@ -285,9 +286,10 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 	private function build_post( Indexable $indexable, bool $editable, bool $scores_enabled ): Post {
 		$object_id = (int) $indexable->object_id;
 		$title     = $this->get_normalized_title( $object_id );
+		$images    = $this->get_post_images( $object_id, (string) $indexable->object_sub_type );
 
 		if ( ! $editable ) {
-			return new Post( $object_id, $title, (string) $indexable->post_status, '', '', '', '', '', '', false );
+			return new Post( $object_id, $title, (string) $indexable->post_status, '', '', '', '', '', '', false, [], '', '', '', '', $images );
 		}
 
 		$post_type = (string) $indexable->object_sub_type;
@@ -321,6 +323,7 @@ class Indexable_Posts_Collector implements Posts_Collector_Interface {
 			( $raw_meta_description === '' ) ? $resolved_values['meta_description'] : '',
 			( $raw_social_title === '' ) ? $resolved_values['social_title'] : '',
 			( $raw_social_description === '' ) ? $resolved_values['social_description'] : '',
+			$images,
 		);
 	}
 

--- a/src/bulk-editor/infrastructure/posts/post-images-trait.php
+++ b/src/bulk-editor/infrastructure/posts/post-images-trait.php
@@ -1,0 +1,35 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts;
+
+/**
+ * Collects the images shown for a post, shared by both post collectors.
+ */
+trait Post_Images_Trait {
+
+	/**
+	 * Returns the images to show for a post in the bulk editor.
+	 *
+	 * Yoast SEO itself has no images to show, so the list is empty unless an add-on supplies one.
+	 *
+	 * @param int    $post_id      The post ID.
+	 * @param string $content_type The post type.
+	 *
+	 * @return array<string, int|string> The images.
+	 */
+	protected function get_post_images( int $post_id, string $content_type ): array {
+		/**
+		 * Filter: 'wpseo_bulk_editor_post_images' - Allows add-ons to supply the images shown for a post.
+		 *
+		 * @internal
+		 *
+		 * @param array<string, int|string> $images       The images, empty by default.
+		 * @param int                       $post_id      The post ID.
+		 * @param string                    $content_type The post type.
+		 */
+		$images = \apply_filters( 'wpseo_bulk_editor_post_images', [], $post_id, $content_type );
+
+		return \is_array( $images ) ? $images : [];
+	}
+}

--- a/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
+++ b/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
@@ -17,6 +17,7 @@ use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
  */
 class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 
+	use Post_Images_Trait;
 	use Post_Title_Trait;
 	use Searchable_Fields_Trait;
 
@@ -114,7 +115,7 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 
 		$posts_list = new Posts_List();
 		foreach ( $post_ids as $post_id ) {
-			$posts_list->add( $this->build_post( $post_id, ( $editability[ $post_id ] ?? false ), $query->are_scores_enabled() ) );
+			$posts_list->add( $this->build_post( $post_id, ( $editability[ $post_id ] ?? false ), $query->are_scores_enabled(), $query->get_content_type() ) );
 		}
 
 		return new Posts_Page( $posts_list, (int) $wp_query->found_posts, $query->get_page(), $query->get_per_page() );
@@ -214,20 +215,22 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 	 * The SEO data and edit link of a post the current user cannot edit are withheld, so the post is
 	 * shown in the list but stays locked and does not expose its metadata.
 	 *
-	 * @param int  $post_id        The post ID.
-	 * @param bool $editable       Whether the current user may edit the post.
-	 * @param bool $scores_enabled Whether the per-field scores may back the needs-improvement verdict.
+	 * @param int    $post_id        The post ID.
+	 * @param bool   $editable       Whether the current user may edit the post.
+	 * @param bool   $scores_enabled Whether the per-field scores may back the needs-improvement verdict.
+	 * @param string $content_type   The post type of the collected page.
 	 *
 	 * @return Post The post.
 	 */
-	private function build_post( int $post_id, bool $editable, bool $scores_enabled ): Post {
+	private function build_post( int $post_id, bool $editable, bool $scores_enabled, string $content_type ): Post {
 		$post      = \get_post( $post_id );
 		$status    = ( $post !== null ) ? (string) $post->post_status : '';
 		$post_type = ( $post !== null ) ? (string) $post->post_type : '';
 		$title     = $this->get_normalized_title( $post_id );
+		$images    = $this->get_post_images( $post_id, $content_type );
 
 		if ( ! $editable ) {
-			return new Post( $post_id, $title, $status, '', '', '', '', '', '', false );
+			return new Post( $post_id, $title, $status, '', '', '', '', '', '', false, $images );
 		}
 
 		// Read each field's value once from its meta suffix, keyed by field param, so the values can be reused for
@@ -264,6 +267,7 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 			( $raw_meta_description === '' ) ? $fields['meta_description'] : '',
 			( $raw_social_title === '' ) ? $fields['social_title'] : '',
 			( $raw_social_description === '' ) ? $fields['social_description'] : '',
+			$images,
 		);
 	}
 

--- a/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
+++ b/src/bulk-editor/infrastructure/posts/post-meta-posts-collector.php
@@ -230,7 +230,7 @@ class Post_Meta_Posts_Collector implements Posts_Collector_Interface {
 		$images    = $this->get_post_images( $post_id, $content_type );
 
 		if ( ! $editable ) {
-			return new Post( $post_id, $title, $status, '', '', '', '', '', '', false, $images );
+			return new Post( $post_id, $title, $status, '', '', '', '', '', '', false, [], '', '', '', '', $images );
 		}
 
 		// Read each field's value once from its meta suffix, keyed by field param, so the values can be reused for

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Post_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Post_Test.php
@@ -67,9 +67,48 @@ final class Post_Test extends TestCase {
 					'social_title'       => false,
 					'social_description' => true,
 				],
+				'images'                      => [],
 			],
 			$instance->to_array(),
 		);
+	}
+
+	/**
+	 * Tests that the images passed to the post are exposed as they were given.
+	 *
+	 * @return void
+	 */
+	public function test_to_array_with_images() {
+		$images = [
+			'thumbnail' => 'https://example.com/product.jpg',
+			'count'     => 3,
+		];
+
+		$instance = new Post(
+			7,
+			'Hello world',
+			'draft',
+			'',
+			'',
+			'',
+			'',
+			'',
+			'',
+			true,
+			[
+				'seo_title'          => false,
+				'meta_description'   => true,
+				'social_title'       => false,
+				'social_description' => true,
+			],
+			'',
+			'',
+			'',
+			'',
+			$images,
+		);
+
+		$this->assertSame( $images, $instance->to_array()['images'] );
 	}
 
 	/**
@@ -102,6 +141,7 @@ final class Post_Test extends TestCase {
 					'social_title'       => false,
 					'social_description' => false,
 				],
+				'images'                      => [],
 			],
 			$instance->to_array(),
 		);

--- a/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Page_Test.php
+++ b/tests/Unit/Bulk_Editor/Domain/Posts/Posts_Page_Test.php
@@ -53,6 +53,7 @@ final class Posts_Page_Test extends TestCase {
 							'social_title'       => false,
 							'social_description' => false,
 						],
+						'images'                      => [],
 					],
 				],
 				'total'       => 45,

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Indexable_Posts_Collector/Get_Posts_Test.php
@@ -4,6 +4,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector;
 
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
 use Yoast\WP\Lib\ORM;
@@ -13,7 +14,7 @@ use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 /**
  * Tests get_posts.
  *
- * @group bulk-editor
+ * @group  bulk-editor
  *
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::get_posts
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Indexable_Posts_Collector::resolve_total
@@ -83,6 +84,7 @@ final class Get_Posts_Test extends Abstract_Test {
 							'social_title'       => false,
 							'social_description' => false,
 						],
+						'images'                      => [],
 					],
 				],
 				'total'       => 1,
@@ -229,9 +231,68 @@ final class Get_Posts_Test extends Abstract_Test {
 					'social_title'       => false,
 					'social_description' => false,
 				],
+				'images'                      => [],
 			],
 			$result['posts'][0],
 		);
+	}
+
+	/**
+	 * Tests that the images an add-on supplies for the post are added to it.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_adds_filtered_images() {
+		$indexable                  = new Indexable_Mock();
+		$indexable->object_id       = 7;
+		$indexable->object_sub_type = 'product';
+
+		$query = $this->stub_page_query( [ $indexable ] );
+		$query->allows( 'count' );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
+
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'Hello world' );
+		Functions\expect( 'get_edit_post_link' )->once()->andReturn( 'edit' );
+
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->with( [], 7, 'product' )
+			->andReturn( [ 'thumbnail' => 'https://example.com/product.jpg' ] );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'product', 1, 20, '', self::STATUSES ) )->to_array();
+
+		$this->assertSame( [ 'thumbnail' => 'https://example.com/product.jpg' ], $result['posts'][0]['images'] );
+	}
+
+	/**
+	 * Tests that a non-editable post still gets its images, since they are shown rather than withheld.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_adds_filtered_images_to_non_editable_post() {
+		$indexable                  = new Indexable_Mock();
+		$indexable->object_id       = 7;
+		$indexable->object_sub_type = 'product';
+
+		$query = $this->stub_page_query( [ $indexable ] );
+		$query->allows( 'count' );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => false ] );
+
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'Secret product' );
+		Functions\expect( 'get_edit_post_link' )->never();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->with( [], 7, 'product' )
+			->andReturn( [ 'thumbnail' => 'https://example.com/product1.jpg' ] );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'product', 1, 20, '', self::STATUSES ) )->to_array();
+
+		$this->assertSame( [ 'thumbnail' => 'https://example.com/product1.jpg' ], $result['posts'][0]['images'] );
+		// The SEO data stays withheld, so the images are the only data a locked post exposes.
+		$this->assertSame( '', $result['posts'][0]['seo_title'] );
 	}
 
 	/**
@@ -379,7 +440,22 @@ final class Get_Posts_Test extends Abstract_Test {
 		Functions\expect( 'get_the_title' )->once()->with( 5 )->andReturn( 'Hello world' );
 		Functions\expect( 'get_edit_post_link' )->once()->with( 5, 'raw' )->andReturn( 'edit' );
 
-		$result = $this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES, null, [], true, [ 5, 3 ] ) )->to_array();
+		$result = $this->instance->get_posts(
+			new Posts_Query(
+				'page',
+				1,
+				20,
+				'',
+				self::STATUSES,
+				null,
+				[],
+				true,
+				[
+					5,
+					3,
+				],
+			),
+		)->to_array();
 
 		$this->assertSame( 5, $result['posts'][0]['id'] );
 		$this->assertSame( 1, $result['total'] );
@@ -546,7 +622,20 @@ final class Get_Posts_Test extends Abstract_Test {
 		$this->indexable_repository->allows( 'query' )->andReturn( $query );
 		$this->post_editability_resolver->allows( 'resolve' )->andReturn( [] );
 
-		$this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES, null, [ 'seo_title', 'meta_description' ] ) );
+		$this->instance->get_posts(
+			new Posts_Query(
+				'page',
+				1,
+				20,
+				'',
+				self::STATUSES,
+				null,
+				[
+					'seo_title',
+					'meta_description',
+				],
+			),
+		);
 
 		$this->assertStringContainsString( 'title IS NULL', $captured[0] );
 		$this->assertStringContainsString( 'seo_title_score BETWEEN %d AND %d', $captured[0] );
@@ -587,7 +676,20 @@ final class Get_Posts_Test extends Abstract_Test {
 		$this->indexable_repository->allows( 'query' )->andReturn( $query );
 		$this->post_editability_resolver->allows( 'resolve' )->andReturn( [] );
 
-		$this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES, null, [ 'social_title', 'social_description' ] ) );
+		$this->instance->get_posts(
+			new Posts_Query(
+				'page',
+				1,
+				20,
+				'',
+				self::STATUSES,
+				null,
+				[
+					'social_title',
+					'social_description',
+				],
+			),
+		);
 
 		$this->assertStringContainsString( 'open_graph_title IS NULL', $captured[0] );
 		$this->assertStringContainsString( 'open_graph_description IS NULL', $captured[0] );
@@ -629,7 +731,21 @@ final class Get_Posts_Test extends Abstract_Test {
 		$this->indexable_repository->allows( 'query' )->andReturn( $query );
 		$this->post_editability_resolver->allows( 'resolve' )->andReturn( [] );
 
-		$this->instance->get_posts( new Posts_Query( 'page', 1, 20, '', self::STATUSES, null, [ 'seo_title', 'meta_description' ], false ) );
+		$this->instance->get_posts(
+			new Posts_Query(
+				'page',
+				1,
+				20,
+				'',
+				self::STATUSES,
+				null,
+				[
+					'seo_title',
+					'meta_description',
+				],
+				false,
+			),
+		);
 
 		$this->assertStringContainsString( 'title IS NULL', $captured[0] );
 		$this->assertStringNotContainsString( 'BETWEEN', $captured[0] );

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Images_Trait/Get_Post_Images_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Images_Trait/Get_Post_Images_Test.php
@@ -1,0 +1,62 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+// phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
+namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Images_Trait;
+
+use Brain\Monkey\Filters;
+use Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Images_Trait;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests get_post_images.
+ *
+ * @group bulk-editor
+ *
+ * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Images_Trait::get_post_images
+ */
+final class Get_Post_Images_Test extends TestCase {
+
+	use Post_Images_Trait;
+
+	/**
+	 * Tests that the post and its content type are offered to the filter and that its images are returned.
+	 *
+	 * @return void
+	 */
+	public function test_returns_the_filtered_images() {
+		$images = [
+			'thumbnail' => 'https://example.com/product.jpg',
+			'count'     => 3,
+		];
+
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->with( [], 7, 'product' )
+			->andReturn( $images );
+
+		$this->assertSame( $images, $this->get_post_images( 7, 'product' ) );
+	}
+
+	/**
+	 * Tests that no images are returned when the filter returns a non-array.
+	 *
+	 * @return void
+	 */
+	public function test_falls_back_to_no_images_when_the_filter_returns_a_non_array() {
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->andReturn( 'not-an-array' );
+
+		$this->assertSame( [], $this->get_post_images( 7, 'product' ) );
+	}
+
+	/**
+	 * Tests that no images are returned when no add-on hooks into the filter.
+	 *
+	 * @return void
+	 */
+	public function test_returns_no_images_by_default() {
+		$this->assertSame( [], $this->get_post_images( 7, 'post' ) );
+	}
+}

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
@@ -207,6 +207,48 @@ final class Get_Posts_Test extends Abstract_Test {
 	}
 
 	/**
+	 * Tests that the images an add-on supplies are added to a post the current user cannot edit.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_adds_filtered_images_to_non_editable_post() {
+		$this->stub_run_query( [ 7 ], 1 );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => false ] );
+
+		Functions\expect( 'get_post' )->once()->with( 7 )->andReturn(
+			(object) [
+				'post_status' => 'publish',
+				'post_type'   => 'product',
+			],
+		);
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'Secret product' );
+		Functions\expect( 'get_edit_post_link' )->never();
+		Functions\expect( 'get_post_meta' )->never();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->with( [], 7, 'product' )
+			->andReturn( [ 'thumbnail' => 'https://example.com/product1.jpg' ] );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'product', 1, 20, '', self::STATUSES ) )->to_array();
+
+		$this->assertSame( [ 'thumbnail' => 'https://example.com/product1.jpg' ], $result['posts'][0]['images'] );
+		// The SEO data stays withheld, so the images are the only data a locked post exposes.
+		$this->assertSame( '', $result['posts'][0]['seo_title'] );
+		// The images must not end up in the needs-improvement verdict, which sits in the constructor slot before them.
+		$this->assertSame(
+			[
+				'seo_title'          => false,
+				'meta_description'   => false,
+				'social_title'       => false,
+				'social_description' => false,
+			],
+			$result['posts'][0]['needs_improvement'],
+		);
+	}
+
+	/**
 	 * Tests that the SEO title and meta description fall back to the resolved template when the stored
 	 * values are empty, and that the post is not flagged as needing improvement.
 	 *

--- a/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Posts/Post_Meta_Posts_Collector/Get_Posts_Test.php
@@ -4,6 +4,7 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.MaxExceeded
 namespace Yoast\WP\SEO\Tests\Unit\Bulk_Editor\Infrastructure\Posts\Post_Meta_Posts_Collector;
 
+use Brain\Monkey\Filters;
 use Brain\Monkey\Functions;
 use Mockery;
 use WP_Query;
@@ -12,7 +13,7 @@ use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
 /**
  * Tests get_posts.
  *
- * @group bulk-editor
+ * @group  bulk-editor
  *
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Meta_Posts_Collector::get_posts
  * @covers Yoast\WP\SEO\Bulk_Editor\Infrastructure\Posts\Post_Meta_Posts_Collector::build_needs_improvement
@@ -86,6 +87,7 @@ final class Get_Posts_Test extends Abstract_Test {
 							'social_title'       => false,
 							'social_description' => false,
 						],
+						'images'                      => [],
 					],
 				],
 				'total'       => 1,
@@ -142,6 +144,7 @@ final class Get_Posts_Test extends Abstract_Test {
 					'social_title'       => false,
 					'social_description' => false,
 				],
+				'images'                      => [],
 			],
 			$result['posts'][0],
 		);
@@ -171,6 +174,36 @@ final class Get_Posts_Test extends Abstract_Test {
 
 		$this->assertSame( 42, $result['total'] );
 		$this->assertSame( 3, $result['total_pages'] );
+	}
+
+	/**
+	 * Tests that the images an add-on supplies for the post are added to it, with the queried content type.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_adds_filtered_images() {
+		$this->stub_run_query( [ 7 ], 1 );
+
+		$this->post_editability_resolver->expects( 'resolve' )->with( [ 7 ] )->andReturn( [ 7 => true ] );
+
+		Functions\expect( 'get_post' )->once()->andReturn(
+			(object) [
+				'post_status' => 'publish',
+				'post_type'   => 'page',
+			],
+		);
+		Functions\expect( 'get_the_title' )->once()->andReturn( 'A product' );
+		Functions\expect( 'get_edit_post_link' )->once()->andReturn( 'edit' );
+		Functions\expect( 'get_post_meta' )->times( 7 )->andReturn( '' );
+
+		Filters\expectApplied( 'wpseo_bulk_editor_post_images' )
+			->once()
+			->with( [], 7, 'product' )
+			->andReturn( [ 'thumbnail' => 'https://example.com/product.jpg' ] );
+
+		$result = $this->instance->get_posts( new Posts_Query( 'product', 1, 20, '', self::STATUSES ) )->to_array();
+
+		$this->assertSame( [ 'thumbnail' => 'https://example.com/product.jpg' ], $result['posts'][0]['images'] );
 	}
 
 	/**
@@ -324,6 +357,9 @@ final class Get_Posts_Test extends Abstract_Test {
 		$wp_query->posts       = $post_ids;
 		$wp_query->found_posts = $found_posts;
 
-		$this->instance->expects( 'run_query' )->once()->with( Mockery::type( Posts_Query::class ) )->andReturn( $wp_query );
+		$this->instance->expects( 'run_query' )
+			->once()
+			->with( Mockery::type( Posts_Query::class ) )
+			->andReturn( $wp_query );
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* The bulk editor table needs to show images for the content it lists, but Yoast SEO Free has no images of its own to show — a product image and its variations are Woo-specific knowledge that lives in Woo SEO.
* This PR adds the extension point Free is missing: an `images` field on the bulk editor post, filled through a new filter, so an add-on can supply the images per post without Free knowing anything about products.
* Free itself supplies nothing, so this changes no behaviour on its own; it is the groundwork the Woo SEO bulk editor integration hooks into.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds an internal filter that lets add-ons supply the images shown for a post in the bulk editor.

## Relevant technical choices:


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Check out this branch and make sure Yoast SEO is active.
* Go to *Yoast SEO → Bulk editor* and confirm the table still loads, lists your posts, and that searching, filtering by content type and paging all still work exactly as before. Nothing visible should have changed.
* Open a post from the table with the *Edit* link and confirm it still opens the right post.
* To confirm the new extension point actually works, add this snippet to a plugin or to your theme's `functions.php`, then reload the bulk editor and check the browser's network tab: the `posts` response should carry an `images` value of `{"thumbnail": "test"}` for every row.

```php
add_filter(
	'wpseo_bulk_editor_post_images',
	static function ( $images, $post_id, $content_type ) {
		return [ 'thumbnail' => 'test' ];
	},
	10,
	3
);
```

* Repeat the previous step with the indexables switched off, so the fallback collector is used, and confirm the `images` value is still present. Indexables can be disabled by adding `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` alongside the snippet.
* Finally, remove the snippet again and confirm the `images` value falls back to an empty object with no PHP notices in the log.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

* Console/network: the change alters the shape of the bulk editor's posts response, so the response payload is where the new field is visible and where a PHP notice would surface.
* Content types: the filter receives the content type as its third argument, so it is worth checking the bulk editor for more than one post type — a regular post type and a custom one — to confirm the right value arrives.

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:



## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The bulk editor's posts endpoint: every row in its response gains an `images` key, so any consumer that asserts on the exact response shape is affected.
* Both bulk editor post collectors — the indexable one and the post meta fallback — since both now run the new filter once per post in the page.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

<!-- The filter is documented in a docblock at its call site in Post_Images_Trait, and the reasoning behind the shared trait and the locked-post choice is in Relevant technical choices above. It is marked @internal, so it is deliberately not published on the developer portal. -->

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [x] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

<!-- The first two and the definition-of-done boxes are left for the author: this branch has been verified with the automated checks only, so the manual pass with the integration plugins active still has to happen. No images or SVGs are touched by this PR. -->

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
