### PR TITLE
Bulk editor needs-improvement scores on content type SEO controls

### DIFF
--- a/src/bulk-editor/user-interface/posts-route.php
+++ b/src/bulk-editor/user-interface/posts-route.php
@@ -13,6 +13,7 @@ use Yoast\WP\SEO\Bulk_Editor\Application\Posts\Posts_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Domain\Posts\Posts_Query;
 use Yoast\WP\SEO\Conditionals\No_Conditionals;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Main;
 use Yoast\WP\SEO\Routes\Route_Interface;
@@ -88,6 +89,13 @@ class Posts_Route implements Route_Interface {
 	private $options_helper;
 
 	/**
+	 * The post type helper.
+	 *
+	 * @var Post_Type_Helper
+	 */
+	private $post_type_helper;
+
+	/**
 	 * The constructor.
 	 *
 	 * @param Posts_Repository                      $posts_repository            The posts repository.
@@ -95,19 +103,22 @@ class Posts_Route implements Route_Interface {
 	 * @param Content_Type_Access_Checker_Interface $content_type_access_checker The content type access checker.
 	 * @param User_Helper                           $user_helper                 The user helper.
 	 * @param Options_Helper                        $options_helper              The options helper.
+	 * @param Post_Type_Helper                      $post_type_helper            The post type helper.
 	 */
 	public function __construct(
 		Posts_Repository $posts_repository,
 		Content_Types_Repository $content_types_repository,
 		Content_Type_Access_Checker_Interface $content_type_access_checker,
 		User_Helper $user_helper,
-		Options_Helper $options_helper
+		Options_Helper $options_helper,
+		Post_Type_Helper $post_type_helper
 	) {
 		$this->posts_repository            = $posts_repository;
 		$this->content_types_repository    = $content_types_repository;
 		$this->content_type_access_checker = $content_type_access_checker;
 		$this->user_helper                 = $user_helper;
 		$this->options_helper              = $options_helper;
+		$this->post_type_helper            = $post_type_helper;
 	}
 
 	/**
@@ -170,7 +181,7 @@ class Posts_Route implements Route_Interface {
 							'type' => 'string',
 							'enum' => Posts_Collector_Interface::NEEDS_IMPROVEMENT_FIELDS,
 						],
-						'description' => 'The fields to filter posts by; a field matches when it is empty, or (for search fields with SEO analysis enabled) when its score needs improvement.',
+						'description' => 'The fields to filter posts by; a field matches when it is empty, or (for search fields, while SEO analysis is enabled and the content type shows Yoast\'s controls and assessments) when its score needs improvement.',
 					],
 					'include'           => [
 						'required'    => false,
@@ -221,9 +232,11 @@ class Posts_Route implements Route_Interface {
 			$author_id = $this->user_helper->get_current_user_id();
 		}
 
-		// The per-field scores only back the filter while SEO analysis is on; otherwise they go stale and
-		// the filter falls back to the empty-field check.
-		$scores_enabled = $this->options_helper->get( 'keyword_analysis_active' ) === true;
+		// The per-field scores only back the filter while SEO analysis is on globally and the content type
+		// shows Yoast's controls and assessments; otherwise they go stale and the filter falls back to the
+		// empty-field check.
+		$scores_enabled = $this->options_helper->get( 'keyword_analysis_active' ) === true
+			&& $this->post_type_helper->has_metabox( $content_type );
 
 		// The schema already coerces the items to positive integers; deduplicate on top of that.
 		$include = \array_values( \array_unique( \array_map( 'intval', (array) $request->get_param( 'include' ) ) ) );

--- a/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Abstract_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Abstract_Test.php
@@ -10,6 +10,7 @@ use Yoast\WP\SEO\Bulk_Editor\Application\Content_Types\Content_Types_Repository;
 use Yoast\WP\SEO\Bulk_Editor\Application\Posts\Posts_Repository;
 use Yoast\WP\SEO\Bulk_Editor\User_Interface\Posts_Route;
 use Yoast\WP\SEO\Helpers\Options_Helper;
+use Yoast\WP\SEO\Helpers\Post_Type_Helper;
 use Yoast\WP\SEO\Helpers\User_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
@@ -63,6 +64,13 @@ abstract class Abstract_Test extends TestCase {
 	protected $options_helper;
 
 	/**
+	 * Holds the post type helper.
+	 *
+	 * @var Mockery\MockInterface|Post_Type_Helper
+	 */
+	protected $post_type_helper;
+
+	/**
 	 * Sets up the test fixtures.
 	 *
 	 * @return void
@@ -75,6 +83,7 @@ abstract class Abstract_Test extends TestCase {
 		$this->content_type_access_checker = Mockery::mock( Content_Type_Access_Checker_Interface::class );
 		$this->user_helper                 = Mockery::mock( User_Helper::class );
 		$this->options_helper              = Mockery::mock( Options_Helper::class );
+		$this->post_type_helper            = Mockery::mock( Post_Type_Helper::class );
 
 		$this->instance = new Posts_Route(
 			$this->posts_repository,
@@ -82,6 +91,7 @@ abstract class Abstract_Test extends TestCase {
 			$this->content_type_access_checker,
 			$this->user_helper,
 			$this->options_helper,
+			$this->post_type_helper,
 		);
 	}
 }

--- a/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Get_Posts_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Get_Posts_Test.php
@@ -37,6 +37,7 @@ final class Get_Posts_Test extends Abstract_Test {
 		$request->expects( 'get_param' )->with( 'needs_improvement' )->andReturn( [ 'seo_title' ] );
 		$request->expects( 'get_param' )->with( 'include' )->andReturn( [] );
 		$this->options_helper->expects( 'get' )->with( 'keyword_analysis_active' )->andReturn( true );
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnTrue();
 
 		$this->content_types_repository
 			->expects( 'get_content_types' )
@@ -130,6 +131,59 @@ final class Get_Posts_Test extends Abstract_Test {
 	}
 
 	/**
+	 * Tests that scoring is disabled in the query when the content type does not show Yoast's controls and
+	 * assessments, even while SEO analysis is active globally, so the filter falls back to the empty-field check.
+	 *
+	 * @return void
+	 */
+	public function test_get_posts_disables_scores_when_content_type_has_no_metabox() {
+		$request = Mockery::mock( WP_REST_Request::class );
+		$request->expects( 'get_param' )->with( 'content_type' )->andReturn( 'page' );
+		$request->expects( 'get_param' )->with( 'page' )->andReturn( 1 );
+		$request->expects( 'get_param' )->with( 'per_page' )->andReturn( 20 );
+		$request->expects( 'get_param' )->with( 'search' )->andReturn( '' );
+		$request->expects( 'get_param' )->with( 'status' )->andReturn( [ 'publish' ] );
+		$request->expects( 'get_param' )->with( 'needs_improvement' )->andReturn( [ 'seo_title' ] );
+		$request->expects( 'get_param' )->with( 'include' )->andReturn( [] );
+		$this->options_helper->expects( 'get' )->with( 'keyword_analysis_active' )->andReturn( true );
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnFalse();
+
+		$this->content_types_repository
+			->expects( 'get_content_types' )
+			->once()
+			->andReturn(
+				[
+					[
+						'name'  => 'page',
+						'label' => 'Pages',
+					],
+				],
+			);
+
+		$this->content_type_access_checker->expects( 'can_edit_others' )->with( 'page' )->andReturnTrue();
+
+		$posts_page = Mockery::mock( Posts_Page::class );
+		$posts_page->expects( 'to_array' )->once()->andReturn( [] );
+
+		$this->posts_repository
+			->expects( 'get_posts' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $query ) {
+						return $query instanceof Posts_Query
+							&& $query->are_scores_enabled() === false;
+					},
+				),
+			)
+			->andReturn( $posts_page );
+
+		Mockery::mock( 'overload:' . WP_REST_Response::class );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $this->instance->get_posts( $request ) );
+	}
+
+	/**
 	 * Tests that a user who cannot edit other authors' posts is restricted to their own.
 	 *
 	 * @return void
@@ -159,6 +213,7 @@ final class Get_Posts_Test extends Abstract_Test {
 		$this->content_type_access_checker->expects( 'can_edit_others' )->with( 'page' )->andReturnFalse();
 		$this->user_helper->expects( 'get_current_user_id' )->once()->andReturn( 5 );
 		$this->options_helper->expects( 'get' )->with( 'keyword_analysis_active' )->andReturn( true );
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnTrue();
 
 		$posts_page = Mockery::mock( Posts_Page::class );
 		$posts_page->expects( 'to_array' )->once()->andReturn( [] );
@@ -196,6 +251,7 @@ final class Get_Posts_Test extends Abstract_Test {
 		$request->expects( 'get_param' )->with( 'needs_improvement' )->andReturn( [] );
 		$request->expects( 'get_param' )->with( 'include' )->andReturn( [] );
 		$this->options_helper->expects( 'get' )->with( 'keyword_analysis_active' )->andReturn( true );
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnTrue();
 
 		$this->content_types_repository
 			->expects( 'get_content_types' )
@@ -247,6 +303,7 @@ final class Get_Posts_Test extends Abstract_Test {
 		$request->expects( 'get_param' )->with( 'needs_improvement' )->andReturn( [] );
 		$request->expects( 'get_param' )->with( 'include' )->andReturn( [ 5, '3', 3, 5 ] );
 		$this->options_helper->expects( 'get' )->with( 'keyword_analysis_active' )->andReturn( true );
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnTrue();
 
 		$this->content_types_repository
 			->expects( 'get_content_types' )

--- a/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Register_Routes_Test.php
+++ b/tests/Unit/Bulk_Editor/User_Interface/Posts_Route/Register_Routes_Test.php
@@ -79,7 +79,7 @@ final class Register_Routes_Test extends Abstract_Test {
 								'type' => 'string',
 								'enum' => Posts_Collector_Interface::NEEDS_IMPROVEMENT_FIELDS,
 							],
-							'description' => 'The fields to filter posts by; a field matches when it is empty, or (for search fields with SEO analysis enabled) when its score needs improvement.',
+							'description' => 'The fields to filter posts by; a field matches when it is empty, or (for search fields, while SEO analysis is enabled and the content type shows Yoast\'s controls and assessments) when its score needs improvement.',
 						],
 						'include'           => [
 							'required'    => false,


### PR DESCRIPTION
## Context

When a content type has *Enable SEO controls and assessments* turned off (*Yoast SEO > Settings > Content types > Posts > Additional settings*), the SEO analysis is hidden everywhere in the editor. But the Bulk editor's *Needs improvement* filters and the SEO title / meta description smart-select still evaluated the stored per-field assessment scores, so posts whose fields were filled but scored badly kept matching. `Posts_Route::get_posts()` derived `$scores_enabled` from the global `keyword_analysis_active` option only, ignoring the per-content-type `display-metabox-pt-<post_type>` setting. This PR gates the scores on that setting too, so the filter falls back to the empty-field check — the same behaviour already used when *Settings > Site features > SEO analysis* is off.

## Summary

* Fixes an unreleased bug where the Bulk editor *Needs improvement* filters and SEO title / meta description smart-select kept using the stored assessment scores when *Enable SEO controls and assessments* was off for the content type.

## Relevant technical choices

* **Gate on `Post_Type_Helper::has_metabox()`.** It reads the same `display-metabox-pt-<post_type>` option the editor uses to hide its controls, so the Bulk editor and the editor agree on when scores are meaningful.
* **Single choke point.** `$scores_enabled` flows through `Posts_Query` into both the filter WHERE clause and the per-post `needsImprovement` booleans the smart-select consumes, so one guard covers the filter and the smart-select — no JS change needed.

## Test instructions for the acceptance test before the PR gets merged

1. [x] Keep *Settings > Site features > SEO analysis* ON.
2. [x] Create **post A** with an SEO title and a meta description filled in that both score *needs improvement* (red/orange), and **post B** with an empty meta description.
3. [x] Go to *Yoast SEO > Settings > Content types > Posts > Additional settings*, turn OFF *Enable SEO controls and assessments*, and click *Save changes*.
4. [x] Open post A in the editor and confirm no Yoast analysis is shown.
5. [x] Go to *Yoast SEO > Bulk editor > Posts* (`/wp-admin/admin.php?page=wpseo_page_bulk_edit`), *Search appearance* tab.
6. [x] Open *Filters* and enable (check) *Needs improvement > Meta descriptions*; confirm post A (filled, bad score) is **not** listed and post B (empty) **is** listed.
7. [x] Open the *Select* dropdown and click *Meta descriptions*; confirm post A is **not** selected and post B **is**.
8. [x] Enable *Filters > Needs improvement > SEO titles*; confirm post A (filled, bad score) is **not** listed.

> [!NOTE]
> A field that has a default template configured (Posts ship a default *SEO title* template) never counts as "empty", so with SEO controls off no post matches the *SEO titles* filter — this mirrors the existing behaviour when *SEO analysis* is turned off globally. The *Meta description* field has no default template on Posts, so genuinely-empty meta descriptions still match.

### Regression — *Site features > SEO analysis* OFF

With *SEO analysis* off globally, scores must never back the filter regardless of the content-type setting (the global toggle first).

9. [x] Go to *Settings > Site features*, turn OFF *SEO analysis*, and click *Save changes*.
10. [x] With *Enable SEO controls and assessments* still OFF for Posts, reload the Bulk editor and confirm *Needs improvement > Meta descriptions* (filter and *Select > Meta descriptions*) matches only the empty post B — post A (filled, bad score) is not matched.
11. [x] Go to *Settings > Content types > Posts > Additional settings*, turn *Enable SEO controls and assessments* back ON, and click *Save changes*.
12. [x] Reload the Bulk editor and confirm the behaviour is unchanged — post A (bad score) still does not match, because scores stay disabled while *SEO analysis* is off.
13. [x] Turn *Settings > Site features > SEO analysis* back ON, now both post should be part of the SEO and Meta descriptions filters (bad score).

## Relevant test scenarios

- [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies

Verify with a content type that has *Enable SEO controls and assessments* on (scores still back the filter) and one where it is off (empty-field check only).

## Test instructions for QA when the code is in the RC

- [x] QA should use the same steps as above.

## Impact check

- The Bulk editor *Needs improvement* filters (`Posts_Route` / `Posts_Query` / posts collectors).
- The Bulk editor SEO title / meta description smart-select (consumes the `needsImprovement` booleans from the REST route).

## Other environments

- [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
- [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

- [ ] I have written documentation for this change.

## Quality assurance

- [x] I have tested this code to the best of my abilities.
- [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
- [x] I have added unit tests to verify the code works as intended.
- [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
- [x] I have written this PR in accordance with my team's definition of done.
- [x] I have checked that the base branch is correctly set.
- [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation

- [ ] No innovation project is applicable for this PR.
- [x] This PR falls under an innovation project. I have attached the innovation label.
- [x] I have added my hours to the WBSO document.

Fixes Yoast/plugins-automated-testing#3139

