### PR TITLE
Version increase @yoast/ui-library: 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@yoast/postcss-preset": "^1.2.1",
     "@yoast/related-keyphrase-suggestions": "^0.4.0",
     "@yoast/tailwindcss-preset": "^2.6.0",
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "colors": "1.4.0",
     "copy-webpack-plugin": "^12.0.2",
     "core-js": "^2.6.12",

--- a/packages/dashboard-frontend/package.json
+++ b/packages/dashboard-frontend/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@wordpress/element": "^6.0.1",
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "chart.js": "^4.2.1",
     "react": "^18",
     "react-chartjs-2": "^5.2.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -44,7 +44,7 @@
     "@yoast/search-metadata-previews": "^3.0.0",
     "@yoast/social-metadata-forms": "^2.0.0",
     "@yoast/style-guide": "^0.14.0-alpha.1",
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "a11y-speak": "git+https://github.com/Yoast/a11y-speak.git#main",
     "babel-polyfill": "^6.26.0",
     "bowser": "^2.11.0",

--- a/packages/related-keyphrase-suggestions/package.json
+++ b/packages/related-keyphrase-suggestions/package.json
@@ -75,7 +75,7 @@
     "prop-types": "^15.8.1"
   },
   "peerDependencies": {
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/replacement-variable-editor/package.json
+++ b/packages/replacement-variable-editor/package.json
@@ -63,6 +63,6 @@
   "peerDependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
     "draft-js": "^0.11.7",
-	"@yoast/ui-library": "^4.5.0"
+	"@yoast/ui-library": "^4.6.0"
   }
 }

--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -58,7 +58,7 @@
   "peerDependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
     "@heroicons/react": "^1.0.6",
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "draft-js": "^0.11.7"
   },
   "publishConfig": {

--- a/packages/social-metadata-forms/package.json
+++ b/packages/social-metadata-forms/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@draft-js-plugins/mention": "^5.0.0",
-    "@yoast/ui-library": "^4.5.0",
+    "@yoast/ui-library": "^4.6.0",
     "draft-js": "^0.11.7"
   }
 }

--- a/packages/ui-library/changelog.md
+++ b/packages/ui-library/changelog.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 4.6.0
+
+### Enhancements:
+
+* Exposes the sparkles gradient icon and decouples the gradient border styling. [#23205](https://github.com/Yoast/wordpress-seo/pull/23205)
+* Adds `yst-mt-2` spacing to the `TextField` description. [#23233](https://github.com/Yoast/wordpress-seo/pull/23233)
+* Adds a `Divider` element and a `SidebarNavigation.MenuItemWithLimiter` component. [#23343](https://github.com/Yoast/wordpress-seo/pull/23343)
+* Adds support for using the `TextareaField` without a label. [#23534](https://github.com/Yoast/wordpress-seo/pull/23534)
+
+### Bugfixes:
+
+* Fixes a bug where a table's row separator was not rendered next to a taller cell in Firefox. [#23387](https://github.com/Yoast/wordpress-seo/pull/23387)
+* Fixes a bug where the text color of the `ai-primary` and `ai-secondary` button variants would change to the browser's default visited-link color when the button was rendered as a link. [#23567](https://github.com/Yoast/wordpress-seo/pull/23567)
+
+### Other:
+
+* Improves the tooltip arrow styling to avoid conflicting style sheets. [#23205](https://github.com/Yoast/wordpress-seo/pull/23205)
+
+### Non user facing:
+
+* Switches Heroicons imports to individual ESM paths, to reduce the plugin bundle size. [#23292](https://github.com/Yoast/wordpress-seo/pull/23292)
+* Replaces deprecated `defaultProps` with ES6 default parameters across components, for React 19 compatibility. [#23317](https://github.com/Yoast/wordpress-seo/pull/23317)
+* Adds a React render smoke test that mounts every component, run in CI on React 18.3 and 19.2. [#23320](https://github.com/Yoast/wordpress-seo/pull/23320)
+* Makes `SidebarNavigation.Sidebar` pass extra props to the `nav` element, so the navigation landmark can be named via `aria-label`. [#23333](https://github.com/Yoast/wordpress-seo/pull/23333)
+
 ## 4.5.0
 
 ### Enhancements:

--- a/packages/ui-library/changelog.md
+++ b/packages/ui-library/changelog.md
@@ -22,7 +22,7 @@
 
 * Switches Heroicons imports to individual ESM paths, to reduce the plugin bundle size. [#23292](https://github.com/Yoast/wordpress-seo/pull/23292)
 * Replaces deprecated `defaultProps` with ES6 default parameters across components, for React 19 compatibility. [#23317](https://github.com/Yoast/wordpress-seo/pull/23317)
-* Adds a React render smoke test that mounts every component, run in CI on React 18.3 and 19.2. [#23320](https://github.com/Yoast/wordpress-seo/pull/23320)
+* Adds a React render smoke test that mounts every component, runs in CI on React 18.3 and 19.2. [#23320](https://github.com/Yoast/wordpress-seo/pull/23320)
 * Makes `SidebarNavigation.Sidebar` pass extra props to the `nav` element, so the navigation landmark can be named via `aria-label`. [#23333](https://github.com/Yoast/wordpress-seo/pull/23333)
 
 ## 4.5.0

--- a/packages/ui-library/package.json
+++ b/packages/ui-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yoast/ui-library",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Yoast UI library",
   "main": "build/index.js",
   "style": "build/css/style.css",


### PR DESCRIPTION
- @yoast/ui-library: 4.6.0

## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* `@yoast/ui-library` has accumulated ten changelog-tagged changes on `trunk` since it was last published as `4.5.0` in #23045, including the AI button visited-link fix from #23567. This releases them as `4.6.0` so consumers (Premium, the add-ons, Shopify) can pick them up.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Release of yoast packages: @yoast/ui-library.

## Relevant technical choices:

* **Minor bump**: all ten changes are additive, and `packages/ui-library/package.json` gained no `peerDependencies`, `engines`, `main` or `exports` changes since `4.5.0`.
* **Dependent ranges bumped in lockstep**: the seven `package.json` files declaring `@yoast/ui-library` move from `^4.5.0` to `^4.6.0`, matching #22971 and #23045, even though the caret already resolved to `4.6.0`.
* **No dependent is released here**: those seven packages have no unreleased changes of their own, so they get no version bump and no changelog entry.
* **Changelog assembled from the PR bodies**: each entry comes from its PR's `[@yoast/ui-library …]` bullet. Two were edited — a typo fix in #23534's ("suppot" → "support") and a shortened clause in #23317's. The #23292 entry was written from that PR's description, as it carried no tagged bullet.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. [x] Confirm the **Pre publish NPM Packages** check on this PR is green, and that its log reports `Packages to release: @yoast/ui-library`.
2. [x] Download the `npm-pack-dry-run` artifact from that run and confirm it holds a single `ui-library-yoast-ui-library-4.6.0.tgz`.
3. [x] Confirm the tarball contains only the `build/` output (no `src/`, no `tests/`), per the package's `files` field.
4. [x] Confirm `packages/ui-library/changelog.md` lists a `## 4.6.0` section whose entries match the linked PRs.
5. [x] Confirm no `package.json` in the repo still references `@yoast/ui-library` at `^4.5.0`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [ ] QA should use the same steps as above.

<!--
If the above checkbox has not been checked, write down all steps QA should take to test this PR, not only the difference with the acceptance test steps. If QA should use the test instructions specified on the epic, paste a link to the relevant comment on the epic.
-->
QA can test this PR by following these steps:

* Not applicable — this PR only bumps a version and a changelog. The underlying changes were tested in their own PRs.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Nothing in the plugin itself changes — no source file is touched, only versions and the changelog.
* On merge, the **Publish NPM packages** workflow publishes `@yoast/ui-library@4.6.0` to npm, so anything installing the package from the registry is affected.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
