### PR TITLE
Fix: Publish NPM packages workflow broken by setup-node v7

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -25,6 +25,8 @@ jobs:
       id-token: write
       contents: read
       pull-requests: read
+    env:
+      NODE_AUTH_TOKEN: ''
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Context
A Dependabot auto-merge bumped `actions/setup-node` from v6.4.0 to v7.0.0 (commit `aabcc19`). In v7, the action runs `yarn cache dir` to locate the Yarn cache **before** it exports `NODE_AUTH_TOKEN` to the runner environment. Yarn v1 reads `.npmrc` synchronously during that probe and fails immediately when it finds the unresolved `${NODE_AUTH_TOKEN}` placeholder that `setup-node` writes when `registry-url` is set. The v6 action did not exhibit this ordering issue.

## Summary
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Publish NPM Packages workflow crashed on startup because `actions/setup-node` v7 (introduced by Dependabot) ran `yarn cache dir` before `NODE_AUTH_TOKEN` was defined in the runner environment.

## Relevant technical choices:

* Declaring `NODE_AUTH_TOKEN: ''` at the job level ensures the variable is always defined when the setup-node cache probe runs, without affecting the OIDC-based publish step that follows (which sets its own value and does not rely on a static token).

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* After merge, go to https://github.com/Yoast/wordpress-seo/actions/workflows/publish-npm-packages.yml and click on `Run workflow`, add the PR number `23570` and check the workflow is passing. 
* Go to https://www.npmjs.com/package/@yoast/ui-library and check version increased to 4.6.0 

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* CI-only change — no QA steps required.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* GitHub Actions CI only — no plugin code is changed.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).