### PR TITLE
Add ImageCell sub-component to the ui-library Table

### DIFF
--- a/packages/ui-library/src/elements/table/docs/index.js
+++ b/packages/ui-library/src/elements/table/docs/index.js
@@ -3,5 +3,6 @@ export { default as tableBody } from "./table-body.md";
 export { default as tableCell } from "./table-cell.md";
 export { default as tableHead } from "./table-head.md";
 export { default as tableHeader } from "./table-header.md";
+export { default as tableImageCell } from "./table-image-cell.md";
 export { default as tableRow } from "./table-row.md";
 export { default as minimal } from "./table-variant-minimal.md";

--- a/packages/ui-library/src/elements/table/docs/table-image-cell.md
+++ b/packages/ui-library/src/elements/table/docs/table-image-cell.md
@@ -1,1 +1,3 @@
-The sub component `Table.ImageCell`. It renders a thumbnail for the given `src`, and falls back to a placeholder when no `src` is passed.
+The sub component `Table.ImageCell`. It renders a thumbnail for the given `src`, and falls back to a placeholder icon when no `src` is passed.
+
+The `placeholderAlt` prop controls the accessible label announced by screen readers for the placeholder. It defaults to `"No image available"`. Pass a custom string to provide context-specific text (e.g. `"No product image"`).

--- a/packages/ui-library/src/elements/table/docs/table-image-cell.md
+++ b/packages/ui-library/src/elements/table/docs/table-image-cell.md
@@ -1,0 +1,1 @@
+The sub component `Table.ImageCell`. It renders a thumbnail for the given `src`, and falls back to a placeholder when no `src` is passed.

--- a/packages/ui-library/src/elements/table/image-cell.js
+++ b/packages/ui-library/src/elements/table/image-cell.js
@@ -1,0 +1,33 @@
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
+import PropTypes from "prop-types";
+import React from "react";
+import classNames from "classnames";
+
+/**
+ * The ImageCell component is a specialized table cell that displays an image or a placeholder.
+ *
+ * @param {Object} [props] Optional cell props.
+ * @param {string} [src] The image source. When empty, fallback to a placeholder.
+ * @param {string} [alt] The image alt text. Defaults to empty.
+ * @param {string} [className] Optional class name.
+ * @param {string} [placeholderAlt] Optional alt text for the placeholder image. Defaults to "No image available".
+ * @returns {JSX.Element} The element.
+ */
+export const ImageCell = ( { src = "", alt = "", className = "", placeholderAlt = "No image available", ...props } ) => {
+	return (
+		<td className={ classNames( "yst-table-cell", className ) } { ...props }>
+			<div className="yst-table-image-cell">
+				{ src
+					? <img src={ src } alt={ alt } className="yst-table-image-cell-image" />
+					: <PhotographIcon className="yst-table-image-cell-placeholder" aria-hidden={ false } aria-label={ placeholderAlt } role="img" />  }
+			</div>
+		</td>
+	);
+};
+
+ImageCell.propTypes = {
+	src: PropTypes.string,
+	alt: PropTypes.string,
+	className: PropTypes.string,
+	placeholderAlt: PropTypes.string,
+};

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -1,7 +1,7 @@
-import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
+import { ImageCell } from "./image-cell";
 
 const rowClassNameMap = {
 	variant: {
@@ -25,35 +25,6 @@ const Cell = ( { children, className = "", ...props } ) => (
 Cell.propTypes = {
 	children: PropTypes.node.isRequired,
 	className: PropTypes.string,
-};
-
-/**
- * The ImageCell component is a specialized table cell that displays an image or a placeholder.
- *
- * @param {Object} [props] Optional cell props.
- * @param {string} [src] The image source. When empty, fallback to a placeholder.
- * @param {string} [alt] The image alt text. Defaults to empty.
- * @param {string} [className] Optional class name.
- * @param {string} [placeholderAlt] Optional alt text for the placeholder image. Defaults to "No image available".
- * @returns {JSX.Element} The element.
- */
-const ImageCell = ( { src = "", alt = "", className = "", placeholderAlt = "No image available", ...props } ) => {
-	return (
-		<Cell className={ className } { ...props }>
-			<div className="yst-table-image-cell">
-				{ src
-					? <img src={ src } alt={ alt } className="yst-table-image-cell-image" />
-					: <PhotographIcon className="yst-table-image-cell-placeholder" aria-hidden={ false } aria-label={ placeholderAlt } role="img" />  }
-			</div>
-		</Cell>
-	);
-};
-
-ImageCell.propTypes = {
-	src: PropTypes.string,
-	alt: PropTypes.string,
-	className: PropTypes.string,
-	placeholderAlt: PropTypes.string,
 };
 
 /**

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -2,7 +2,6 @@ import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
-import { useSvgAria } from "../../hooks";
 
 const rowClassNameMap = {
 	variant: {
@@ -29,21 +28,22 @@ Cell.propTypes = {
 };
 
 /**
+ * The ImageCell component is a specialized table cell that displays an image or a placeholder.
+ *
+ * @param {Object} [props] Optional cell props.
  * @param {string} [src] The image source. When empty, fallback to a placeholder.
  * @param {string} [alt] The image alt text. Defaults to empty.
  * @param {string} [className] Optional class name.
- * @param {Object} [props] Optional cell props.
+ * @param {string} [placeholderAlt] Optional alt text for the placeholder image. Defaults to "No image available".
  * @returns {JSX.Element} The element.
  */
-const ImageCell = ( { src = "", alt = "", className = "", ...props } ) => {
-	const svgAriaProps = useSvgAria();
-
+const ImageCell = ( { src = "", alt = "", className = "", placeholderAlt = "No image available", ...props } ) => {
 	return (
 		<Cell className={ className } { ...props }>
 			<div className="yst-table-image-cell">
 				{ src
 					? <img src={ src } alt={ alt } className="yst-table-image-cell-image" />
-					: <PhotographIcon className="yst-table-image-cell-placeholder" { ...svgAriaProps } /> }
+					: <PhotographIcon className="yst-table-image-cell-placeholder" aria-hidden={ false } aria-label={ placeholderAlt } role="img" />  }
 			</div>
 		</Cell>
 	);
@@ -53,6 +53,7 @@ ImageCell.propTypes = {
 	src: PropTypes.string,
 	alt: PropTypes.string,
 	className: PropTypes.string,
+	placeholderAlt: PropTypes.string,
 };
 
 /**

--- a/packages/ui-library/src/elements/table/index.js
+++ b/packages/ui-library/src/elements/table/index.js
@@ -1,6 +1,8 @@
+import PhotographIcon from "@heroicons/react/outline/PhotographIcon";
 import classNames from "classnames";
 import PropTypes from "prop-types";
 import React, { forwardRef } from "react";
+import { useSvgAria } from "../../hooks";
 
 const rowClassNameMap = {
 	variant: {
@@ -23,6 +25,33 @@ const Cell = ( { children, className = "", ...props } ) => (
 
 Cell.propTypes = {
 	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
+};
+
+/**
+ * @param {string} [src] The image source. When empty, fallback to a placeholder.
+ * @param {string} [alt] The image alt text. Defaults to empty.
+ * @param {string} [className] Optional class name.
+ * @param {Object} [props] Optional cell props.
+ * @returns {JSX.Element} The element.
+ */
+const ImageCell = ( { src = "", alt = "", className = "", ...props } ) => {
+	const svgAriaProps = useSvgAria();
+
+	return (
+		<Cell className={ className } { ...props }>
+			<div className="yst-table-image-cell">
+				{ src
+					? <img src={ src } alt={ alt } className="yst-table-image-cell-image" />
+					: <PhotographIcon className="yst-table-image-cell-placeholder" { ...svgAriaProps } /> }
+			</div>
+		</Cell>
+	);
+};
+
+ImageCell.propTypes = {
+	src: PropTypes.string,
+	alt: PropTypes.string,
 	className: PropTypes.string,
 };
 
@@ -132,5 +161,7 @@ Table.Row = Row;
 Table.Row.displayName = "Table.Row";
 Table.Cell = Cell;
 Table.Cell.displayName = "Table.Cell";
+Table.ImageCell = ImageCell;
+Table.ImageCell.displayName = "Table.ImageCell";
 
 export default Table;

--- a/packages/ui-library/src/elements/table/stories.js
+++ b/packages/ui-library/src/elements/table/stories.js
@@ -1,7 +1,10 @@
 import React from "react";
 import Table from ".";
 import { InteractiveDocsPage } from "../../../.storybook/interactive-docs-page";
-import { component, tableBody, tableCell, tableHead, tableHeader, tableRow, minimal } from "./docs";
+import { component, tableBody, tableCell, tableHead, tableHeader, tableImageCell, tableRow, minimal } from "./docs";
+
+// A stand-in thumbnail, so the story does not depend on a remote image.
+const sampleImage = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 160 100'%3E%3Crect width='160' height='100' fill='%23e2e8f0'/%3E%3Ccircle cx='124' cy='28' r='14' fill='%23fbbf24'/%3E%3Cpath d='M0 100 L52 40 L104 100 Z' fill='%2394a3b8'/%3E%3Cpath d='M78 100 L118 58 L160 100 Z' fill='%23cbd5e1'/%3E%3C/svg%3E";
 
 export const Factory = {
 	parameters: {
@@ -270,6 +273,36 @@ export const MinimalVariant = {
 	},
 };
 
+export const TableImageCell = {
+	name: "Table image cell",
+	parameters: {
+		controls: { disable: false },
+		docs: { description: { story: tableImageCell } },
+	},
+	args: {
+		children: (
+			<>
+				<Table.Head>
+					<Table.Row>
+						<Table.Header>Image</Table.Header>
+						<Table.Header>Header 2</Table.Header>
+					</Table.Row>
+				</Table.Head>
+				<Table.Body>
+					<Table.Row>
+						<Table.ImageCell src={ sampleImage } alt="" />
+						<Table.Cell>With an image</Table.Cell>
+					</Table.Row>
+					<Table.Row>
+						<Table.ImageCell />
+						<Table.Cell>Without an image, so a placeholder is shown</Table.Cell>
+					</Table.Row>
+				</Table.Body>
+			</>
+		),
+	},
+};
+
 export default {
 	title: "1) Elements/Table",
 	component: Table,
@@ -290,6 +323,7 @@ export default {
 					TableHeader,
 					TableBody,
 					TableCell,
+					TableImageCell,
 					MinimalVariant,
 				] }
 			/>,

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -11,6 +11,33 @@
 				.yst-table-cell {
 					@apply yst-px-3 yst-py-4 yst-text-sm yst-text-slate-600;
 				}
+
+				.yst-table-image-cell {
+					@apply
+					yst-flex
+					yst-items-center
+					yst-justify-center
+					yst-w-16 yst-h-16
+					yst-overflow-hidden
+					yst-rounded
+					yst-border
+					yst-border-slate-300
+					yst-bg-white;
+				}
+
+				.yst-table-image-cell-image {
+					@apply
+					yst-w-full
+					yst-h-full
+					yst-object-cover
+					yst-object-center;
+				}
+
+				.yst-table-image-cell-placeholder {
+					@apply
+					yst-w-5 yst-h-5
+					yst-text-slate-400;
+				}
 			}
 		}
 

--- a/packages/ui-library/tests/react-render-smoke.test.js
+++ b/packages/ui-library/tests/react-render-smoke.test.js
@@ -148,6 +148,11 @@ const cases = [
 		Component: Table,
 		props: { children: <Table.Body><Table.Row><Table.Cell>Cell</Table.Cell></Table.Row></Table.Body> },
 	},
+	{
+		name: "Table with image cell",
+		Component: Table,
+		props: { children: <Table.Body><Table.Row><Table.ImageCell /></Table.Row></Table.Body> },
+	},
 	{ name: "TagInput", Component: TagInput, props: {} },
 	{
 		name: "TagInput.Tag",


### PR DESCRIPTION
## Context
Adds an `ImageCell` sub-component to the `@yoast/ui-library` `Table`: a table cell that renders a
thumbnail for a given `src`, and falls back to a placeholder box when there is none. It is the cell
used by the image column in the AI alt text bulk editor, where a media item may have no thumbnail
available.

## Summary
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library enhancement 0.1.0] Adds a `Table.ImageCell` sub-component that renders a thumbnail, and a placeholder when no image source is given.

## Relevant technical choices:
* **A separate `Table.ImageCell` rather than a `variant` on `Table.Cell`.** `variant` elsewhere in this file only swaps class names; an image cell changes the prop contract, so folding it in would mean relaxing `Cell`'s required `children` for every consumer.
* **`ImageCell` keeps the `yst-table-cell` class, so it inherits cell padding, the last-row corner rounding in the default variant, and the minimal variant's edge padding.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. [ ] Run `yarn workspace @yoast/ui-library storybook` and open `http://localhost:6006`.
2. [ ] Open *1) Elements > Table > Docs* and scroll to the *Table image cell* story.
3. [ ] Confirm the first row renders the thumbnail cropped to fill a 64x64 box with rounded corners and a light grey (`#CBD5E1`) border.
4. [ ] Confirm the second row renders the placeholder in that same box: a centered grey photo icon, matching the [designs](https://www.figma.com/design/DxCMTut7yLqPYJMUCba14d/AI-Image-Alt-Text-Generator?node-id=380-6154).
5. [ ] In the story's Controls, switch *variant* to `minimal`; confirm both image cells keep their box and lose the outer table border and the leading/trailing cell padding, like the neighbouring text cells.
6. [ ] Use the *Direction* toolbar addon to switch to RTL; confirm the image column moves to the right and the cells stay aligned.
7. [ ] Run `yarn workspace @yoast/ui-library test` and confirm all 62 tests pass, including `Table with image cell mounts with only required props`.
8. [ ] Run `yarn workspace @yoast/ui-library build` and confirm it completes with no errors.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open

### Test instructions for QA when the code is in the RC
* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Not applicable — this only adds a component to `@yoast/ui-library` and is not wired into any plugin screen yet.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* Only `@yoast/ui-library`'s `Table` (`packages/ui-library/src/elements/table/`) and its Storybook stories. Existing `Table` sub-components are untouched, and nothing in the plugin UI consumes `Table.ImageCell` yet.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [x] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to the WBSO document.

Fixes [#1429](https://github.com/Yoast/reserved-tasks/issues/1429)
