### PR TITLE
Refactor the way we detect whether we're on a block editor

### DIFF
--- a/admin/metabox/class-metabox.php
+++ b/admin/metabox/class-metabox.php
@@ -358,8 +358,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 			echo new Meta_Fields_Presenter( $this->get_metabox_post(), 'social' );
 		}
 
-		$screen          = WP_Screen::get();
-		$is_block_editor = $screen && $screen->is_block_editor();
+		$is_block_editor = YoastSEO()->helpers->current_page->is_block_editor();
 		if ( $is_block_editor && $this->get_metabox_post()->post_type === 'post' ) {
 			/**
 			 * Filter: 'wpseo_enable_ai_content_planner_inline_banner' - Allows hiding the AI Content Planner inline banner site-wide.
@@ -862,7 +861,7 @@ class WPSEO_Metabox extends WPSEO_Meta {
 		$asset_manager->enqueue_style( 'ai-generator' );
 		$asset_manager->enqueue_style( 'ai-fix-assessments' );
 
-		$is_block_editor  = WP_Screen::get()->is_block_editor();
+		$is_block_editor  = YoastSEO()->helpers->current_page->is_block_editor();
 		$post_edit_handle = 'post-edit';
 		if ( ! $is_block_editor ) {
 			$post_edit_handle = 'post-edit-classic';

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -399,6 +399,25 @@ class Current_Page_Helper {
 	}
 
 	/**
+	 * Determines whether the current admin screen is the block editor.
+	 *
+	 * Deliberately uses get_current_screen() and not WP_Screen::get(): the latter re-applies
+	 * the replace_editor filter on every call, which is a render hook with side effects
+	 * (e.g. it breaks the WooCommerce block email editor).
+	 *
+	 * @return bool Whether the current screen is the block editor.
+	 */
+	public function is_block_editor() {
+		if ( ! \function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		$screen = \get_current_screen();
+
+		return $screen !== null && $screen->is_block_editor();
+	}
+
+	/**
 	 * Check if the current opened page is a Yoast SEO page.
 	 *
 	 * @return bool True when current page is a yoast seo plugin page.

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -405,7 +405,7 @@ class Current_Page_Helper {
 	 * the replace_editor filter on every call, which is a render hook with side effects
 	 * (e.g. it breaks the WooCommerce block email editor).
 	 *
-	 * Only reliable after set_current_screen() has run (during admin page load, before
+	 * Only reliable after set_current_screen() has run (during admin page load, after
 	 * admin_init); earlier calls return false.
 	 *
 	 * @return bool Whether the current screen is the block editor.

--- a/src/helpers/current-page-helper.php
+++ b/src/helpers/current-page-helper.php
@@ -405,6 +405,9 @@ class Current_Page_Helper {
 	 * the replace_editor filter on every call, which is a render hook with side effects
 	 * (e.g. it breaks the WooCommerce block email editor).
 	 *
+	 * Only reliable after set_current_screen() has run (during admin page load, before
+	 * admin_init); earlier calls return false.
+	 *
 	 * @return bool Whether the current screen is the block editor.
 	 */
 	public function is_block_editor() {

--- a/src/integrations/admin/fix-news-dependencies-integration.php
+++ b/src/integrations/admin/fix-news-dependencies-integration.php
@@ -2,16 +2,32 @@
 
 namespace Yoast\WP\SEO\Integrations\Admin;
 
-use WP_Screen;
 use WPSEO_Admin_Asset_Manager;
 use Yoast\WP\SEO\Conditionals\Admin_Conditional;
 use Yoast\WP\SEO\Conditionals\News_Conditional;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
  * Fix_News_Dependencies_Integration class.
  */
 class Fix_News_Dependencies_Integration implements Integration_Interface {
+
+	/**
+	 * Holds the current page helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
+
+	/**
+	 * Constructs the integration.
+	 *
+	 * @param Current_Page_Helper $current_page_helper The current page helper.
+	 */
+	public function __construct( Current_Page_Helper $current_page_helper ) {
+		$this->current_page_helper = $current_page_helper;
+	}
 
 	/**
 	 * Returns the conditionals based in which this loadable should be active.
@@ -51,7 +67,7 @@ class Fix_News_Dependencies_Integration implements Integration_Interface {
 			return;
 		}
 
-		$is_block_editor  = WP_Screen::get()->is_block_editor();
+		$is_block_editor  = $this->current_page_helper->is_block_editor();
 		$post_edit_handle = 'post-edit';
 		if ( ! $is_block_editor ) {
 			$post_edit_handle = 'post-edit-classic';

--- a/src/integrations/third-party/elementor.php
+++ b/src/integrations/third-party/elementor.php
@@ -4,7 +4,6 @@ namespace Yoast\WP\SEO\Integrations\Third_Party;
 
 use Elementor\Plugin;
 use WP_Post;
-use WP_Screen;
 use WPSEO_Admin_Asset_Manager;
 use WPSEO_Admin_Recommended_Replace_Vars;
 use WPSEO_Meta;
@@ -19,6 +18,7 @@ use Yoast\WP\SEO\Conditionals\Third_Party\Elementor_Edit_Conditional;
 use Yoast\WP\SEO\Editors\Application\Site\Website_Information_Repository;
 use Yoast\WP\SEO\Elementor\Infrastructure\Request_Post;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Helpers\Options_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 use Yoast\WP\SEO\Presenters\Admin\Meta_Fields_Presenter;
@@ -63,6 +63,13 @@ class Elementor implements Integration_Interface {
 	 * @var Request_Post
 	 */
 	private $request_post;
+
+	/**
+	 * Holds the current page helper.
+	 *
+	 * @var Current_Page_Helper
+	 */
+	private $current_page_helper;
 
 	/**
 	 * Holds whether the socials are enabled.
@@ -118,21 +125,24 @@ class Elementor implements Integration_Interface {
 	/**
 	 * Constructor.
 	 *
-	 * @param WPSEO_Admin_Asset_Manager $asset_manager The asset manager.
-	 * @param Options_Helper            $options       The options helper.
-	 * @param Capability_Helper         $capability    The capability helper.
-	 * @param Request_Post              $request_post  The Request_Post.
+	 * @param WPSEO_Admin_Asset_Manager $asset_manager       The asset manager.
+	 * @param Options_Helper            $options             The options helper.
+	 * @param Capability_Helper         $capability          The capability helper.
+	 * @param Request_Post              $request_post        The Request_Post.
+	 * @param Current_Page_Helper       $current_page_helper The current page helper.
 	 */
 	public function __construct(
 		WPSEO_Admin_Asset_Manager $asset_manager,
 		Options_Helper $options,
 		Capability_Helper $capability,
-		Request_Post $request_post
+		Request_Post $request_post,
+		Current_Page_Helper $current_page_helper
 	) {
-		$this->asset_manager = $asset_manager;
-		$this->options       = $options;
-		$this->capability    = $capability;
-		$this->request_post  = $request_post;
+		$this->asset_manager       = $asset_manager;
+		$this->options             = $options;
+		$this->capability          = $capability;
+		$this->request_post        = $request_post;
+		$this->current_page_helper = $current_page_helper;
 
 		$this->seo_analysis                 = new WPSEO_Metabox_Analysis_SEO();
 		$this->readability_analysis         = new WPSEO_Metabox_Analysis_Readability();
@@ -463,7 +473,7 @@ class Elementor implements Integration_Interface {
 		$script_data = [
 			'metabox'                   => $this->get_metabox_script_data( $permalink ),
 			'isPost'                    => true,
-			'isBlockEditor'             => WP_Screen::get()->is_block_editor(),
+			'isBlockEditor'             => $this->current_page_helper->is_block_editor(),
 			'isElementorEditor'         => true,
 			'isAlwaysIntroductionV2'    => $this->is_elementor_version_compatible_with_introduction_v2(),
 			'isElementorV4Atomic'       => $is_v4_atomic,

--- a/tests/Unit/Helpers/Current_Page_Helper_Test.php
+++ b/tests/Unit/Helpers/Current_Page_Helper_Test.php
@@ -6,6 +6,7 @@ use Brain\Monkey;
 use Mockery;
 use WP_Post;
 use WP_Query;
+use WP_Screen;
 use Yoast\WP\SEO\Helpers\Current_Page_Helper;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 use Yoast\WP\SEO\Wrappers\WP_Query_Wrapper;
@@ -934,5 +935,66 @@ final class Current_Page_Helper_Test extends TestCase {
 	 */
 	public function test_is_trash_overview_without_status() {
 		$this->assertFalse( $this->instance->is_trash_overview() );
+	}
+
+	/**
+	 * Test is_block_editor function when get_current_screen() is not available.
+	 *
+	 * @covers ::is_block_editor
+	 *
+	 * @return void
+	 */
+	public function test_is_block_editor_without_get_current_screen_function() {
+		// A previously mocked get_current_screen() persists for the rest of the process, making the guard untestable.
+		if ( \function_exists( 'get_current_screen' ) ) {
+			$this->markTestSkipped( 'get_current_screen() has already been defined by another test.' );
+		}
+
+		$this->assertFalse( $this->instance->is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor function when there is no current screen.
+	 *
+	 * @covers ::is_block_editor
+	 *
+	 * @return void
+	 */
+	public function test_is_block_editor_without_screen() {
+		Monkey\Functions\expect( 'get_current_screen' )->once()->andReturn( null );
+
+		$this->assertFalse( $this->instance->is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor function when the current screen is the block editor.
+	 *
+	 * @covers ::is_block_editor
+	 *
+	 * @return void
+	 */
+	public function test_is_block_editor_on_block_editor_screen() {
+		$screen = Mockery::mock( WP_Screen::class );
+		$screen->expects( 'is_block_editor' )->once()->andReturn( true );
+
+		Monkey\Functions\expect( 'get_current_screen' )->once()->andReturn( $screen );
+
+		$this->assertTrue( $this->instance->is_block_editor() );
+	}
+
+	/**
+	 * Test is_block_editor function when the current screen is not the block editor.
+	 *
+	 * @covers ::is_block_editor
+	 *
+	 * @return void
+	 */
+	public function test_is_block_editor_on_classic_editor_screen() {
+		$screen = Mockery::mock( WP_Screen::class );
+		$screen->expects( 'is_block_editor' )->once()->andReturn( false );
+
+		Monkey\Functions\expect( 'get_current_screen' )->once()->andReturn( $screen );
+
+		$this->assertFalse( $this->instance->is_block_editor() );
 	}
 }

--- a/tests/Unit/Helpers/Current_Page_Helper_Test.php
+++ b/tests/Unit/Helpers/Current_Page_Helper_Test.php
@@ -938,22 +938,6 @@ final class Current_Page_Helper_Test extends TestCase {
 	}
 
 	/**
-	 * Test is_block_editor function when get_current_screen() is not available.
-	 *
-	 * @covers ::is_block_editor
-	 *
-	 * @return void
-	 */
-	public function test_is_block_editor_without_get_current_screen_function() {
-		// A previously mocked get_current_screen() persists for the rest of the process, making the guard untestable.
-		if ( \function_exists( 'get_current_screen' ) ) {
-			$this->markTestSkipped( 'get_current_screen() has already been defined by another test.' );
-		}
-
-		$this->assertFalse( $this->instance->is_block_editor() );
-	}
-
-	/**
 	 * Test is_block_editor function when there is no current screen.
 	 *
 	 * @covers ::is_block_editor


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Sets up [Premium's PR](https://github.com/Yoast/wordpress-seo-premium/pull/5064).

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the way we detect whether we're on a block editor. To be used to fix a Premium bug.

## Relevant technical choices:

* The new `Current_Page_Helper::is_block_editor()` returns `false` when no screen is set, and its `function_exists( 'get_current_screen' )` guard does the same in non-admin contexts. This only diverges from the old `WP_Screen::get()` behavior in cases where that behavior was the problem:
  * All current call sites run at `admin_enqueue_scripts` or later ( after `set_current_screen()` is called), so no actual change in behavior here
  * Before the screen is set, `WP_Screen::get()` computed the flag on `post.php`/`post-new.php` by re-firing `replace_editor` and in non-admin contexts it fataled (the `WP_Screen` class isn't loaded there). Returning `false` (the classic-editor fallback) is the intended, safe default in both cases. 
  * The one caveat for future callers of this now-public API (`YoastSEO()->helpers->current_page`): don't call it before `set_current_screen()` has run. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

#### Fix the Premium bug (with [the respective Premium PR](https://github.com/Yoast/wordpress-seo-premium/pull/5064))
- WooCommerce ≥ 11.0.1 and go to WooCommerce → Settings → Advanced → Features → enable the experimental block email editor.)
- Use a freshly created admin user (or one that has never seen any introductions) (or delete the `_yoast_wpseo_introductions` usermeta for an existing user)
- Go to **WooCommerce → Settings → Emails** and open any transactional email for editing (this edits a `woo_email` post in the block email editor)
**Without this fix**:
- Confirm the editor is dead and clicking in the email content doesnt do anything. 
- Deactivate Premium, reload and the editor works again. Reactivate Premium
**With this fix**:
- The editor must be fully interactive: click blocks in the canvas, open sidebar panels, use toolbar buttons, and save the email

#### Free regression tests

##### Woo email without Premium
- Without Premium, open a WooCommerce email for editing. 
- The editor must be fully interactive and this should work before *and* after the fix. 

##### News script dependency (`Fix_News_Dependencies_Integration`)**
Preconditions: News SEO active.
1. Block editor → edit a post: News SEO's editor integration (Google News analysis in the Yoast sidebar) loads with no JS console errors.
2. Classic editor → same check. News features in the metabox work, no console errors.

##### Metabox script handle (`WPSEO_Metabox::enqueue()`)**
* Block editor → edit a post: the Yoast sidebar and the Yoast metabox below the editor load and run analysis (`yoast-seo-post-edit` bundle in the Network tab).
  * Also run `document.getElementById( 'yoast-seo-post-edit-js' )` & `document.getElementById( 'yoast-seo-post-edit-classic-js' )` in the console
  * The first one should get you an element, the second one should get you null
* Classic editor → edit a post: the Yoast metabox loads and runs analysis (`yoast-seo-post-edit-classic` bundle). Snippet editor, focus keyphrase, and analysis all functional.
  * Also run `document.getElementById( 'yoast-seo-post-edit-js' )` & `document.getElementById( 'yoast-seo-post-edit-classic-js' )` in the console
  * The first one should get you null, the second one should get you an element

##### Content planner hidden fields (`WPSEO_Metabox::render_hidden_fields()`)**
* Block editor → edit a **post** (post type `post` specifically): the AI Content Planner inline banner behavior is unchanged. A quick way to ensure that:
  * check the page source in the Inspector and confirm you find the `yoast_wpseo_is_content_planner_banner_rendered` and `yoast_wpseo_is_content_planner_banner_dismissed` fields.
* Classic editor and non-`post` post types (e.g. a page): 
  * those hidden fields are **not** rendered. 
  * Changing a Yoast meta field (eg. focus keyphrase) and saving a post still persists the change

##### Elementor script data (`elementor.php`)**
Preconditions: Elementor active.
1. Edit a post with Elementor: the Yoast SEO panel inside the Elementor editor loads and analysis runs.
2. In the browser console of the Elementor editor page, `wpseoScriptData.isBlockEditor` is an empty string.
3. Saving from Elementor persists Yoast meta (title/description survive a reload).

#### Premium regression tests
##### AI Optimize introduction (`AI_Optimize_Classic_Introduction`)**
Preconditions: AI features enabled, fresh admin user (introduction not yet seen).
* Classic editor → edit a post: 
  * Run `wpseoIntroductions`
  * Confirm that you see a `ai-optimize-classic` entry
  * No console errors
* Block editor → edit a post (another fresh user, or reset the introduction): 
  * Run `wpseoIntroductions`
  * Confirm no `ai-optimize-classic` entry (or if no introductions available, you get a `Uncaught ReferenceError: wpseoIntroductions is not defined` message)
  * No console errors
* Elementor editor → edit a post (another fresh user, or reset the introduction):   
  * Run `wpseoIntroductions`
  * Confirm no `ai-optimize-classic` entry (or if no introductions available, you get a `Uncaught ReferenceError: wpseoIntroductions is not defined` message)
  * No console errors

##### Link suggestions metabox (`WPSEO_Metabox_Link_Suggestions`)**
Preconditions: Premium with link suggestions enabled (**Yoast SEO → Settings → Site features → Link suggestions**), post type supported by prominent words.
1. Classic editor → edit a post: the **"Yoast internal linking"** metabox appears in the sidebar (side, low position) and populates with suggestions.
2. Block editor → edit a post: that standalone metabox is **absent** (link suggestions live inside the Yoast sidebar instead).

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Added in the test instructions

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #

