### PR TITLE
fix(a11y): add missing translator comments for screen-reader-only i18n calls

### DIFF
--- a/packages/js/src/ai-content-planner/components/feature-modal.js
+++ b/packages/js/src/ai-content-planner/components/feature-modal.js
@@ -119,7 +119,9 @@ export const FeatureModal = ( {
 							className="yst-no-underline"
 							target="_blank"
 							rel="noopener noreferrer"
-							aria-label={ __( "Learn more about AI (Opens in a new browser tab)", "wordpress-seo" ) }
+							aria-label={
+								/* translators: Hidden accessibility text. */
+								__( "Learn more about AI (Opens in a new browser tab)", "wordpress-seo" ) }
 						>
 							<QuestionMarkCircleIcon { ...svgAriaProps } className="yst-w-4 yst-h-4 yst-text-slate-500 yst-shrink-0" />
 						</Link>

--- a/packages/js/src/ai-content-planner/components/inline-banner.js
+++ b/packages/js/src/ai-content-planner/components/inline-banner.js
@@ -20,7 +20,13 @@ import { OutboundLink } from "../../shared-admin/components";
  */
 export const InlineBanner = ( { isPremium, onDismiss, onDismissPermanently, onClick, learnMoreLink } ) => {
 	const ariaProps = useSvgAria();
-	return <Root><div role="group" aria-label={ __( "Content suggestions banner", "wordpress-seo" ) } className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg">
+	return <Root><div
+		role="group"
+		aria-label={
+			/* translators: Hidden accessibility text. */
+			__( "Content suggestions banner", "wordpress-seo" ) }
+		className="yst-z-50 yst-relative yst-p-4 yst-ai-gradient-border yst-rounded-lg"
+	>
 		<DropdownMenu as="span" className="yst-absolute yst-top-4 yst-end-4">
 			<DropdownMenu.IconTrigger
 				screenReaderTriggerLabel={ __( "Open banner options", "wordpress-seo" ) }

--- a/packages/js/src/ai-content-planner/components/outline-modal-content.js
+++ b/packages/js/src/ai-content-planner/components/outline-modal-content.js
@@ -108,7 +108,9 @@ const LoadingOutlineModalContent = () => {
 			<hr className="yst-border-slate-200 yst-my-6" />
 			<StructureSectionHeader />
 			<ul
-				aria-label={ __( "Blog post structure", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text. */
+					__( "Blog post structure", "wordpress-seo" ) }
 				aria-busy={ true }
 				className="yst-list-none yst-p-0 yst-m-0 yst-flex yst-flex-col yst-gap-2"
 			>
@@ -299,7 +301,12 @@ export const OutlineModalContent = ( {
 							<StructureSectionHeader />
 							{ /* Live region announces keyboard reorder results to screen readers. */ }
 							<div aria-live="assertive" aria-atomic="true" className="yst-sr-only">{ reorderMessage }</div>
-							<ul aria-label={ __( "Blog post structure", "wordpress-seo" ) } className="yst-flex yst-flex-col yst-gap-2 yst-list-none yst-p-0 yst-m-0">
+							<ul
+								aria-label={
+									/* translators: Hidden accessibility text. */
+									__( "Blog post structure", "wordpress-seo" ) }
+								className="yst-flex yst-flex-col yst-gap-2 yst-list-none yst-p-0 yst-m-0"
+							>
 								{ structure.map( ( item, index ) => (
 									<StructureRow
 										key={ item.id }

--- a/packages/js/src/ai-content-planner/components/structure-row.js
+++ b/packages/js/src/ai-content-planner/components/structure-row.js
@@ -119,11 +119,16 @@ export const StructureRow = ( {
 	>
 		<span className="yst-font-medium yst-text-slate-500">H2</span>
 		<span className="yst-text-slate-600">{ heading }</span>
-		<span className="yst-sr-only">{ sprintf(
-			/* translators: 1: current position, 2: total items. */
-			__( "Position %1$d out of %2$d. Use Alt+Arrow Up/Down to reorder.", "wordpress-seo" ),
-			index + 1,
-			totalItems ) }</span>
+		<span className="yst-sr-only">
+			{
+				/* translators: Hidden accessibility text. */
+				sprintf(
+					/* translators: 1: current position, 2: total items. */
+					__( "Position %1$d out of %2$d. Use Alt+Arrow Up/Down to reorder.", "wordpress-seo" ),
+					index + 1,
+					totalItems )
+			}
+		</span>
 	</Row> );
 };
 

--- a/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
+++ b/packages/js/src/ai-generator/components/errors/site-unreachable-modal.js
@@ -62,8 +62,10 @@ const UnavailableBody = () => {
 					{ __( "Still need help?", "wordpress-seo" ) }
 					<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-4 yst-w-4 yst-text-slate-400 rtl:yst-rotate-[270deg]" { ...svgAriaProps } />
 					<span className="yst-sr-only">
-						{ /* translators: Hidden accessibility text. */ }
-						{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
 					</span>
 				</Button>
 				<Button as="a" href={ commonErrorsLink } target="_blank" rel="noopener noreferrer" variant="primary">
@@ -105,8 +107,10 @@ const resolveBody = ( { isAvailable, canConnect, connectUrl, learnMoreUrl }, onC
 						{ __( "Connect to MyYoast", "wordpress-seo" ) }
 						<ExternalLinkIcon className="yst--me-1 yst-ms-1 yst-h-4 yst-w-4 rtl:yst-rotate-[270deg]" { ...svgAriaProps } />
 						<span className="yst-sr-only">
-							{ /* translators: Hidden accessibility text. */ }
-							{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }
+							{
+								/* translators: Hidden accessibility text. */
+								__( "(Opens in a new browser tab)", "wordpress-seo" )
+							}
 						</span>
 					</Button>
 				</Actions>

--- a/packages/js/src/bulk-editor/app.js
+++ b/packages/js/src/bulk-editor/app.js
@@ -121,13 +121,19 @@ const App = ( { dataProvider, remoteDataProvider } ) => {
 				closeButtonId="button-close-bulk-editor-navigation-mobile"
 				openButtonScreenReaderText={ __( "Open bulk editor navigation", "wordpress-seo" ) }
 				closeButtonScreenReaderText={ __( "Close bulk editor navigation", "wordpress-seo" ) }
-				aria-label={ __( "Bulk editor navigation", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text. */
+					__( "Bulk editor navigation", "wordpress-seo" ) }
 			>
 				<BulkEditorNavMenu { ...menuProps } idSuffix="-mobile" />
 			</SidebarNavigation.Mobile>
 			<div className="yst-p-4 min-[783px]:yst-p-8 yst-flex yst-items-start yst-gap-6">
 				<aside className="yst-w-56 yst-shrink-0 yst-hidden min-[783px]:yst-block">
-					<SidebarNavigation.Sidebar aria-label={ __( "Bulk editor menu", "wordpress-seo" ) }>
+					<SidebarNavigation.Sidebar
+						aria-label={
+							/* translators: Hidden accessibility text. */
+							__( "Bulk editor menu", "wordpress-seo" ) }
+					>
 						<BulkEditorNavMenu { ...menuProps } />
 					</SidebarNavigation.Sidebar>
 				</aside>

--- a/packages/js/src/bulk-editor/components/bulk-action-bar.js
+++ b/packages/js/src/bulk-editor/components/bulk-action-bar.js
@@ -48,7 +48,9 @@ export const SelectionToolbar = ( { idSuffix = "", isAllSelected, isIndeterminat
 					id={ `bulk-editor-select-all${ idSuffix }` }
 					name={ `bulk-editor-select-all${ idSuffix }` }
 					value="all"
-					aria-label={ __( "Select all", "wordpress-seo" ) }
+					aria-label={
+						/* translators: Hidden accessibility text. */
+						__( "Select all", "wordpress-seo" ) }
 					checked={ isAllSelected }
 					onChange={ onToggleAll }
 				/>

--- a/packages/js/src/bulk-editor/components/bulk-editor-filters.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-filters.js
@@ -105,7 +105,9 @@ export const BulkEditorFilters = () => {
 				setIsVisible={ setIsOpen }
 				position="bottom-left"
 				className="before:yst-hidden !yst-top-full yst-mt-1 yst-py-0.5 yst-px-0 yst-shadow-lg"
-				aria-label={ __( "Filters", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text. */
+					__( "Filters", "wordpress-seo" ) }
 			>
 				{ overviewIds.length > 0 && (
 					<CheckboxGroup

--- a/packages/js/src/bulk-editor/components/bulk-editor-footer.js
+++ b/packages/js/src/bulk-editor/components/bulk-editor-footer.js
@@ -60,8 +60,9 @@ export const BulkEditorFooter = ( { total, totalPages, isPending } ) => {
 				// On mobile the pager fills the row: stretch the nav full width and let each button grow
 				// equally with slim padding so multi-digit page numbers fit. Desktop keeps the inline pill.
 				className="max-sm:yst-flex max-sm:yst-w-full max-sm:[&>*]:yst-flex-1 max-sm:[&_button]:yst-justify-center max-sm:[&_button]:!yst-px-1"
-				/* translators: Hidden accessibility label for the pagination navigation landmark. */
-				aria-label={ __( "Results pagination", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text, Hidden accessibility label for the pagination navigation landmark. */
+					__( "Results pagination", "wordpress-seo" ) }
 				current={ page }
 				total={ totalPages }
 				onNavigate={ onNavigate }

--- a/packages/js/src/bulk-editor/components/dismissible-alert.js
+++ b/packages/js/src/bulk-editor/components/dismissible-alert.js
@@ -35,7 +35,9 @@ export const DismissibleAlert = ( { variant = "info", role = "status", className
 				type="button"
 				className="yst-absolute yst-end-4 yst-top-4 yst-text-current hover:yst-opacity-75 yst-cursor-pointer"
 				onClick={ handleDismiss }
-				aria-label={ __( "Dismiss", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text. */
+					__( "Dismiss", "wordpress-seo" ) }
 			>
 				<SolidXIcon className="yst-h-5 yst-w-5" { ...svgAriaProps } />
 			</button>

--- a/packages/js/src/bulk-editor/components/table/preview-editable-field-cell.js
+++ b/packages/js/src/bulk-editor/components/table/preview-editable-field-cell.js
@@ -25,9 +25,9 @@ export const PreviewEditableFieldCell = ( { field, item, replacementVariables, r
 	return (
 		<Table.Cell key={ field.key } className="yst-bulk-editor-cell-value">
 			<span id={ `bulk-editor-preview-${ field.key }-${ item.id }` } className="yst-sr-only">
-				{ sprintf(
-					/* translators: %1$s expands to the field label, %2$s to the content item title. */
-					__( "%1$s for %2$s", "wordpress-seo" ), field.label, item.title ) }
+				{
+					/* translators: Hidden accessibility text, %1$s expands to the field label, %2$s to the content item title. */
+					sprintf( __( "%1$s for %2$s", "wordpress-seo" ), field.label, item.title ) }
 			</span>
 			<ReplacementVariableEditorStandalone
 				content={ item[ field.key ] || item[ `${ field.key }Fallback` ] || "" }

--- a/packages/js/src/bulk-editor/components/table/table-header.js
+++ b/packages/js/src/bulk-editor/components/table/table-header.js
@@ -39,7 +39,12 @@ export const BulkEditorHeader = ( { fields, columnCount, selectionToolbar, bulkA
 		) }
 		<Table.Row className="[&_th]:!yst-text-slate-800 [&_th]:!yst-py-3 [&_th]:!yst-leading-[19px]">
 			<Table.Header scope="col">
-				<span className="yst-sr-only">{ __( "Select", "wordpress-seo" ) }</span>
+				<span className="yst-sr-only">
+					{
+					/* translators: Hidden accessibility text. */
+						__( "Select", "wordpress-seo" )
+					}
+				</span>
 			</Table.Header>
 			<Table.Header scope="col">{ __( "Title", "wordpress-seo" ) }</Table.Header>
 			{ fields.map( ( field ) => (

--- a/packages/js/src/bulk-editor/components/table/table-row.js
+++ b/packages/js/src/bulk-editor/components/table/table-row.js
@@ -79,8 +79,9 @@ export const BulkEditorRow = ( {
 					name={ `bulk-editor-select-${ item.id }` }
 					value={ String( item.id ) }
 					className="yst-mt-0.5"
-					/* translators: %s expands to the content item title. */
-					aria-label={ sprintf( __( "Select %s", "wordpress-seo" ), item.title ) }
+					aria-label={
+						/* translators: Hidden accessibility text, %s expands to the content item title. */
+						sprintf( __( "Select %s", "wordpress-seo" ), item.title ) }
 					checked={ isSelected }
 					onChange={ handleToggle }
 					// A post the current user cannot edit is shown locked and cannot be selected for bulk editing.

--- a/packages/js/src/bulk-editor/components/update-modal.js
+++ b/packages/js/src/bulk-editor/components/update-modal.js
@@ -37,7 +37,12 @@ export const UpdateModal = ( { onClose, isOpen } ) => {
 					as="a"
 				>
 					{ __( "Update now", "wordpress-seo" ) }
-					<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+					<span className="yst-sr-only">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "(Opens in a new browser tab)", "wordpress-seo" )
+						}
+					</span>
 					<ArrowNarrowRightIcon className="yst-h-4 yst-w-4 rtl:yst-rotate-180 yst-shrink-0" { ...ariaProps } />
 				</Button> }
 			</Actions>

--- a/packages/js/src/bulk-editor/components/upsell-modal.js
+++ b/packages/js/src/bulk-editor/components/upsell-modal.js
@@ -56,7 +56,12 @@ export const UpsellModal = ( {
 					>
 						<LockClosedIcon className="yst--ms-1 yst-me-2 yst-h-5 yst-w-5" aria-hidden="true" />
 						{ upsellLabel }
-						<span className="yst-sr-only">{ __( "(Opens in a new browser tab)", "wordpress-seo" ) }</span>
+						<span className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "(Opens in a new browser tab)", "wordpress-seo" )
+							}
+						</span>
 					</Button>
 					{ learnMoreLink && (
 						<OutboundLink href={ learnMoreLink } variant="primary" className="yst-inline-flex yst-items-center yst-gap-1 yst-text-sm yst-font-medium yst-no-underline">

--- a/packages/js/src/components/BlackFridayPromotion.js
+++ b/packages/js/src/components/BlackFridayPromotion.js
@@ -56,7 +56,12 @@ export const BlackFridayPromotion = ( {
 					{ __( "BLACK FRIDAY", "wordpress-seo" ) } </Badge>
 				<button className="yst-absolute yst-top-4 yst-end-4" onClick={ onDismiss }>
 					<XIcon className="yst-w-4 yst-text-slate-400 yst-shrink-0 yst--mt-0.5" />
-					<div className="yst-sr-only">{ __( "Dismiss", "wordpress-seo" ) }</div>
+					<div className="yst-sr-only">
+						{
+							/* translators: Hidden accessibility text. */
+							__( "Dismiss", "wordpress-seo" )
+						}
+					</div>
 				</button>
 				<div
 					className={

--- a/packages/js/src/components/modals/UpsellModal.js
+++ b/packages/js/src/components/modals/UpsellModal.js
@@ -111,7 +111,12 @@ export const UpsellModal = ( {
 									__( "Explore %s", "wordpress-seo" ),
 									isWooAd && ! isWooSEOActive ? "Yoast WooCommerce SEO" : "Yoast SEO Premium"
 								) }
-								<span className="yst-sr-only">{ __( "Opens in a new tab", "wordpress-seo" ) }</span>
+								<span className="yst-sr-only">
+									{
+										/* translators: Hidden accessibility text. */
+										__( "Opens in a new tab", "wordpress-seo" )
+									}
+								</span>
 							</Button>
 							<div className="yst-italic yst-text-slate-500 yst-mt-1">{ note }</div>
 						</div>

--- a/packages/js/src/components/modals/WincherUpgradeCallout.js
+++ b/packages/js/src/components/modals/WincherUpgradeCallout.js
@@ -243,7 +243,13 @@ const WincherUpgradeCallout = ( { onClose = null, isTitleShortened = false, trac
 	return (
 		<CalloutContainer isTitleShortened={ isTitleShortened }>
 			{ onClose && (
-				<CloseButton type="button" aria-label={ __( "Close the upgrade callout", "wordpress-seo" ) } onClick={ onClose }>
+				<CloseButton
+					type="button"
+					aria-label={
+						/* translators: Hidden accessibility text. */
+						__( "Close the upgrade callout", "wordpress-seo" ) }
+					onClick={ onClose }
+				>
 					<SvgIcon icon="times-circle" color={ colors.$color_pink_dark } size="14px" />
 				</CloseButton>
 			) }

--- a/packages/js/src/general/app.js
+++ b/packages/js/src/general/app.js
@@ -113,7 +113,9 @@ const App = () => {
 					openButtonScreenReaderText={ __( "Open dashboard navigation", "wordpress-seo" ) }
 					/* translators: Hidden accessibility text. */
 					closeButtonScreenReaderText={ __( "Close dashboard navigation", "wordpress-seo" ) }
-					aria-label={ __( "Dashboard navigation", "wordpress-seo" ) }
+					aria-label={
+						/* translators: Hidden accessibility text. */
+						__( "Dashboard navigation", "wordpress-seo" ) }
 				>
 					<Menu idSuffix="-mobile" />
 				</SidebarNavigation.Mobile>

--- a/packages/js/src/general/components/bulk-editor-tour-notification.js
+++ b/packages/js/src/general/components/bulk-editor-tour-notification.js
@@ -91,7 +91,9 @@ export const BulkEditorTourNotification = () => {
 		onClose={ onClose }
 		className={ classNames( "yst-z-[9999]", positionClass ) }
 		position={ isRtl ? "bottom-right" : "bottom-left" }
-		aria-label={ __( "New: Work faster with bulk updates", "wordpress-seo" ) }
+		aria-label={
+			/* translators: Hidden accessibility text. */
+			__( "New: Work faster with bulk updates", "wordpress-seo" ) }
 	>
 		<ModalNotification.Panel className="yst-w-96">
 			<div className="yst-flex yst-gap-3">

--- a/packages/js/src/general/components/notice.js
+++ b/packages/js/src/general/components/notice.js
@@ -33,7 +33,12 @@ export function Notice( { title, id, isDismissable, children, className = "" } )
 				{ title && <div className="yst-text-sm yst-font-medium" dangerouslySetInnerHTML={ { __html: title } } /> }
 				{ isDismissable && (
 					<button type="button" className="notice-dismiss" onClick={ handleDismiss }>
-						<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+						<span className="yst-sr-only">
+							{
+								/* translators: Hidden accessibility text. */
+								__( "Close", "wordpress-seo" )
+							}
+						</span>
 					</button>
 				) }
 			</div>

--- a/packages/js/src/insights/components/prominent-words.js
+++ b/packages/js/src/insights/components/prominent-words.js
@@ -102,7 +102,9 @@ const ProminentWords = ( { location } ) => { // eslint-disable-line complexity
 					/* translators: Hidden accessibility text; %d expands to the number of occurrences. */
 					__( "%d occurrences", "wordpress-seo" )
 				}
-				aria-label={ __( "Prominent words", "wordpress-seo" ) }
+				aria-label={
+					/* translators: Hidden accessibility text. */
+					__( "Prominent words", "wordpress-seo" ) }
 				className={ shouldUpsell ? "yoast-data-model--upsell" : null }
 			/>
 		</div>

--- a/packages/js/src/redirects/app.js
+++ b/packages/js/src/redirects/app.js
@@ -22,7 +22,9 @@ const App = () => {
 					openButtonScreenReaderText={ __( "Open redirects navigation", "wordpress-seo" ) }
 					/* translators: Hidden accessibility text. */
 					closeButtonScreenReaderText={ __( "Close redirects navigation", "wordpress-seo" ) }
-					aria-label={ __( "Redirects navigation", "wordpress-seo" ) }
+					aria-label={
+						/* translators: Hidden accessibility text. */
+						__( "Redirects navigation", "wordpress-seo" ) }
 				>
 					<Menu idSuffix="-mobile" />
 				</SidebarNavigation.Mobile>

--- a/packages/js/src/redirects/routes/redirects.js
+++ b/packages/js/src/redirects/routes/redirects.js
@@ -143,7 +143,9 @@ export const Redirects = () => {
 									<Checkbox
 										id="yst-select-all-redirects"
 										name="selectAllRedirects"
-										aria-label={ __( "Select all", "wordpress-seo" ) }
+										aria-label={
+											/* translators: Hidden accessibility text. */
+											__( "Select all", "wordpress-seo" ) }
 										disabled={ true }
 										value="dummy-value"
 									/>

--- a/packages/js/src/settings/app.js
+++ b/packages/js/src/settings/app.js
@@ -172,7 +172,9 @@ const App = () => {
 					openButtonScreenReaderText={ __( "Open settings navigation", "wordpress-seo" ) }
 					/* translators: Hidden accessibility text. */
 					closeButtonScreenReaderText={ __( "Close settings navigation", "wordpress-seo" ) }
-					aria-label={ __( "Settings navigation", "wordpress-seo" ) }
+					aria-label={
+						/* translators: Hidden accessibility text. */
+						__( "Settings navigation", "wordpress-seo" ) }
 				>
 					<Menu idSuffix="-mobile" postTypes={ postTypes } taxonomies={ taxonomies } />
 				</SidebarNavigation.Mobile>

--- a/packages/js/src/settings/components/search.js
+++ b/packages/js/src/settings/components/search.js
@@ -231,7 +231,9 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 			isOpen={ isOpen }
 			initialFocus={ inputRef }
 			position="top-center"
-			aria-label={ __( "Search", "wordpress-seo" ) }
+			aria-label={
+				/* translators: Hidden accessibility text. */
+				__( "Search", "wordpress-seo" ) }
 		>
 			<Modal.Panel hasCloseButton={ false }>
 				<LiveAnnouncer>
@@ -247,7 +249,9 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 							ref={ inputRef }
 							id="input-search"
 							placeholder={ __( "Search…", "wordpress-seo" ) }
-							aria-label={ __( "Search", "wordpress-seo" ) }
+							aria-label={
+								/* translators: Hidden accessibility text. */
+								__( "Search", "wordpress-seo" ) }
 							value={ query }
 							onChange={ handleQueryChange }
 							className="yst-h-12 yst-w-full yst-border-0 yst-rounded-lg sm:yst-text-sm yst-bg-transparent yst-px-11 yst-text-slate-800 yst-placeholder-slate-500 focus:yst-outline-none focus:yst-ring-inset focus:yst-ring-2 focus:yst-ring-primary-500 focus:yst-border-primary-500"
@@ -259,7 +263,12 @@ const Search = ( { buttonId = "button-search", modalId = "modal-search" } ) => {
 								onClick={ setClose }
 								className="yst-modal__close-button"
 							>
-								<span className="yst-sr-only">{ __( "Close", "wordpress-seo" ) }</span>
+								<span className="yst-sr-only">
+									{
+										/* translators: Hidden accessibility text. */
+										__( "Close", "wordpress-seo" )
+									}
+								</span>
 								<XIcon className="yst-h-6 yst-w-6" { ...ariaSvgProps } />
 							</button>
 						</div>

--- a/packages/js/src/settings/routes/llms-txt.js
+++ b/packages/js/src/settings/routes/llms-txt.js
@@ -328,8 +328,9 @@ const LlmTxt = () => {
 														// eslint-disable-next-line react/jsx-no-bind
 														onClick={ arrayHelpers.remove.bind( null, index ) }
 														className={ classNames( "yst-p-2.5", index === 0 && "yst-mt-7" ) }
-														// translators: %1$s expands to array index + 1.
-														aria-label={ sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
+														aria-label={
+															/* translators: Hidden accessibility text, %1$s expands to array index + 1. */
+															sprintf( __( "Remove page %1$s", "wordpress-seo" ), index + 1 ) }
 														disabled={ ! activeManualSelection }
 													>
 														<TrashIcon className="yst-h-5 yst-w-5" />

--- a/packages/js/src/settings/routes/site-representation.js
+++ b/packages/js/src/settings/routes/site-representation.js
@@ -305,8 +305,9 @@ const SiteRepresentation = () => {
 															// eslint-disable-next-line react/jsx-no-bind
 															onClick={ arrayHelpers.remove.bind( null, index ) }
 															className="yst-mt-7 yst-p-2.5"
-															// translators: %1$s expands to array index + 1.
-															aria-label={ sprintf( __( "Remove Other profile %1$s", "wordpress-seo" ), index + 1 ) }
+															aria-label={
+																/* translators: Hidden accessibility text, %1$s expands to array index + 1. */
+																sprintf( __( "Remove Other profile %1$s", "wordpress-seo" ), index + 1 ) }
 														>
 															<TrashIcon className="yst-h-5 yst-w-5" />
 														</Button>


### PR DESCRIPTION
## Context

Strings inside `yst-sr-only` elements and `aria-label` attributes are only ever read by screen readers — they have no visual context. Translators working on these strings need a comment explaining this, otherwise the string appears with no context and may be translated incorrectly.

This PR adds the standard `/* translators: Hidden accessibility text. */` comment (or a combined comment such as `/* translators: Hidden accessibility text, %s expands to the post title. */` where a format specifier is also present) before each such i18n call across `packages/js`.

This rule will be updated in https://github.com/Yoast/eslint-config.

## Summary
This PR can be summarized in the following changelog entry:

* Adds missing `/* translators: Hidden accessibility text. */` comments before i18n calls in screen-reader-only contexts (`yst-sr-only` elements and `aria-label` attributes).

## Relevant technical choices:

* The comment is placed directly inside the JSX expression container, immediately above the i18n call — e.g. `aria-label={\n\t/* translators: Hidden accessibility text. */\n\t__( "...", "wordpress-seo" ) }`. This mirrors the existing pattern used elsewhere in the codebase (e.g. `packages/js/src/bulk-editor/app.js`).
* Where a translator comment already existed to describe format specifiers (e.g. `%s expands to the post title`), the two are combined: `/* translators: Hidden accessibility text, %s expands to the post title. */`.
* Where the existing comment used the wrong keyword (`Hidden accessibility label` instead of `text`), it was corrected and moved inside the expression.
* 28 files are touched; all changes are mechanical comment additions with no logic changes.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Add the patch [accessibility-comments.patch](https://github.com/user-attachments/files/31554659/accessibility-comments.patch)
* Run `yarn lint` inside `packages/js` and confirm zero errors and zero new errors related to `yoast/require-sr-only-translator-comment`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* No functional change — QA can confirm by running `yarn lint` inside `packages/js` and verifying no new errors appear.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* JS source files only — no PHP, no built assets, no user-facing behaviour changes.
* Affected areas: bulk editor, settings pages, redirects, insights, general dashboard, AI content planner, AI generator modals, upsell modals, Black Friday promotion, Wincher upgrade callout.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).