### PR TITLE
Reinstate ability to set SEO data

### DIFF
--- a/src/abilities/infrastructure/post-seo-field-map.php
+++ b/src/abilities/infrastructure/post-seo-field-map.php
@@ -11,10 +11,12 @@ use Yoast\WP\SEO\Surfaces\Values\Meta;
 /**
  * Translates between the ability input, an indexable, and the post SEO data value object.
  *
- * This is the single source of truth for the field contract shared by the read
- * (collector) and write (updater) abilities. The write path applies the input
- * onto an indexable; persistence to post meta is delegated to
- * Indexable_To_Postmeta_Helper so the encodings live in one place.
+ * The read path (collector) maps every readable field onto the output array. The
+ * write path (updater) applies whatever validated input it receives onto an
+ * indexable; which fields are exposed for writing is decided by the ability's
+ * input schema, so the writable set may be narrower than the fields known here.
+ * Persistence to post meta is delegated to Indexable_To_Postmeta_Helper so the
+ * encodings live in one place.
  */
 class Post_SEO_Field_Map {
 
@@ -43,7 +45,6 @@ class Post_SEO_Field_Map {
 	private const STRING_FIELDS = [
 		'seo_title'              => 'title',
 		'meta_description'       => 'description',
-		'focus_keyphrase'        => 'primary_focus_keyword',
 		'canonical'              => 'canonical',
 		'open_graph_title'       => 'open_graph_title',
 		'open_graph_description' => 'open_graph_description',

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -127,6 +127,7 @@ class Abilities_Integration implements Integration_Interface {
 		}
 
 		$this->register_get_post_seo_data_ability();
+		$this->register_update_post_seo_data_ability();
 	}
 
 	/**
@@ -415,37 +416,31 @@ class Abilities_Integration implements Integration_Interface {
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'properties'           => [
-				'post_id'                => [
+				'post_id'             => [
 					'type'        => 'integer',
 					'description' => \__( 'The ID of the post to update.', 'wordpress-seo' ),
 					'minimum'     => 1,
 				],
-				'permalink'              => [
+				'permalink'           => [
 					'type'        => 'string',
 					'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
 				],
-				'seo_title'              => $nullable_string,
-				'meta_description'       => $nullable_string,
-				'focus_keyphrase'        => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
-				'canonical'              => $nullable_string,
-				'is_cornerstone'         => [ 'type' => 'boolean' ],
-				'noindex'                => [
+				'focus_keyphrase'     => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
+				'canonical'           => $nullable_string,
+				'is_cornerstone'      => [ 'type' => 'boolean' ],
+				'noindex'             => [
 					'type'        => [ 'boolean', 'null' ],
 					'description' => \__( 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.', 'wordpress-seo' ),
 				],
-				'nofollow'               => [ 'type' => 'boolean' ],
-				'noimageindex'           => [ 'type' => 'boolean' ],
-				'noarchive'              => [ 'type' => 'boolean' ],
-				'nosnippet'              => [ 'type' => 'boolean' ],
-				'open_graph_title'       => $nullable_string,
-				'open_graph_description' => $nullable_string,
-				'twitter_title'          => $nullable_string,
-				'twitter_description'    => $nullable_string,
-				'schema_page_type'       => $this->nullable_enum_schema(
+				'nofollow'            => [ 'type' => 'boolean' ],
+				'noimageindex'        => [ 'type' => 'boolean' ],
+				'noarchive'           => [ 'type' => 'boolean' ],
+				'nosnippet'           => [ 'type' => 'boolean' ],
+				'schema_page_type'    => $this->nullable_enum_schema(
 					\array_keys( Schema_Types::PAGE_TYPES ),
 					\__( 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
 				),
-				'schema_article_type'    => $this->nullable_enum_schema(
+				'schema_article_type' => $this->nullable_enum_schema(
 					$this->get_schema_article_types(),
 					\__( 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
 				),

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -425,7 +425,6 @@ class Abilities_Integration implements Integration_Interface {
 					'type'        => 'string',
 					'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
 				],
-				'focus_keyphrase'     => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
 				'canonical'           => $nullable_string,
 				'is_cornerstone'      => [ 'type' => 'boolean' ],
 				'noindex'             => [

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -273,7 +273,8 @@ class Abilities_Integration implements Integration_Interface {
 						'show_in_rest' => true,
 						'annotations'  => [
 							'readonly'    => false,
-							'destructive' => false,
+							// We can't claim this is truly non-destructive because technically there can be data deletions.
+							'destructive' => null,
 							'idempotent'  => true,
 						],
 						'mcp'          => [

--- a/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
+++ b/tests/Unit/Abilities/Application/Post_SEO_Data_Updater_Test.php
@@ -110,9 +110,9 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 	 */
 	public function test_update_post_seo_data() {
 		$input                = [
-			'post_id'          => 42,
-			'meta_description' => 'New description',
-			'noindex'          => true,
+			'post_id'   => 42,
+			'canonical' => 'https://example.com/canonical',
+			'noindex'   => true,
 		];
 		$indexable            = Mockery::mock( Indexable_Mock::class );
 		$indexable->object_id = 42;
@@ -134,12 +134,12 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->expects( 'apply_to_indexable' )
 			->once()
 			->with( $input, $indexable )
-			->andReturn( [ 'description', 'is_robots_noindex' ] );
+			->andReturn( [ 'canonical', 'is_robots_noindex' ] );
 
 		$this->indexable_to_postmeta
 			->expects( 'map_column_to_postmeta' )
 			->once()
-			->with( $indexable, 'description', true );
+			->with( $indexable, 'canonical', true );
 		$this->indexable_to_postmeta
 			->expects( 'map_column_to_postmeta' )
 			->once()
@@ -157,15 +157,15 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->with( $rebuilt )
 			->andReturn(
 				[
-					'post_id'          => 42,
-					'meta_description' => 'New description',
+					'post_id'   => 42,
+					'canonical' => 'https://example.com/canonical',
 				],
 			);
 
 		$this->assertSame(
 			[
-				'post_id'          => 42,
-				'meta_description' => 'New description',
+				'post_id'   => 42,
+				'canonical' => 'https://example.com/canonical',
 			],
 			$this->instance->update_post_seo_data( $input ),
 		);
@@ -246,12 +246,12 @@ final class Post_SEO_Data_Updater_Test extends TestCase {
 			->expects( 'apply_to_indexable' )
 			->once()
 			->with( [ 'post_id' => 42 ], $indexable )
-			->andReturn( [ 'description' ] );
+			->andReturn( [ 'canonical' ] );
 
 		$this->indexable_to_postmeta
 			->expects( 'map_column_to_postmeta' )
 			->once()
-			->with( $indexable, 'description', true );
+			->with( $indexable, 'canonical', true );
 
 		$this->indexable_builder
 			->expects( 'build_for_id_and_type' )

--- a/tests/Unit/Abilities/Infrastructure/Post_SEO_Field_Map_Test.php
+++ b/tests/Unit/Abilities/Infrastructure/Post_SEO_Field_Map_Test.php
@@ -224,7 +224,6 @@ final class Post_SEO_Field_Map_Test extends TestCase {
 				'seo_title'        => 'New title',
 				'meta_description' => '',
 				'canonical'        => null,
-				'focus_keyphrase'  => 'a phrase',
 			],
 			$indexable,
 		);
@@ -232,9 +231,8 @@ final class Post_SEO_Field_Map_Test extends TestCase {
 		$this->assertSame( 'New title', $indexable->title );
 		$this->assertNull( $indexable->description );
 		$this->assertNull( $indexable->canonical );
-		$this->assertSame( 'a phrase', $indexable->primary_focus_keyword );
 		// The order follows the STRING_FIELDS declaration order, not the input order.
-		$this->assertSame( [ 'title', 'description', 'primary_focus_keyword', 'canonical' ], $changed );
+		$this->assertSame( [ 'title', 'description', 'canonical' ], $changed );
 	}
 
 	/**

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -12,12 +12,15 @@ use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
 use Yoast\WP\SEO\Abilities\User_Interface\Abilities_Integration;
 use Yoast\WP\SEO\Conditionals\Abilities_API_Conditional;
 use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Config\Schema_Types;
 use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
 use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
 use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
 use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
 use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
 use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Meta_Helper;
 use Yoast\WP\SEO\Surfaces\Meta_Surface;
 use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
@@ -82,6 +85,9 @@ final class Abilities_Integration_Test extends TestCase {
 		parent::set_up();
 
 		$this->stubTranslationFunctions();
+
+		// The article-type enum is built from the documented filter; return the default unfiltered.
+		Monkey\Functions\when( 'apply_filters' )->returnArg( 2 );
 
 		$this->score_retriever                      = Mockery::mock( Score_Retriever::class );
 		$this->capability_helper                    = Mockery::mock( Capability_Helper::class );
@@ -185,7 +191,7 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that register_abilities registers all score abilities plus the get post SEO data ability.
+	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -203,14 +209,14 @@ final class Abilities_Integration_Test extends TestCase {
 		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
 		$this->expect_score_ability( 'yoast-seo/get-readability-scores' );
 		$this->expect_score_ability( 'yoast-seo/get-inclusive-language-scores' );
-		$this->expect_get_post_seo_data_ability();
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
 	}
 
 	/**
 	 * Tests that the score abilities are not registered when their analysis features are disabled,
-	 * but the get post SEO data ability always is.
+	 * but the metadata abilities always are.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -225,13 +231,13 @@ final class Abilities_Integration_Test extends TestCase {
 			],
 		);
 
-		$this->expect_get_post_seo_data_ability();
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
 	}
 
 	/**
-	 * Tests that only the keyphrase score ability registers alongside the get post SEO data ability.
+	 * Tests that only the keyphrase score ability registers alongside the metadata abilities.
 	 *
 	 * @covers ::register_abilities
 	 *
@@ -247,20 +253,21 @@ final class Abilities_Integration_Test extends TestCase {
 		);
 
 		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
-		$this->expect_get_post_seo_data_ability();
+		$this->expect_post_seo_data_abilities();
 
 		$this->instance->register_abilities();
 	}
 
 	/**
-	 * Tests that the get post SEO data ability registers with the expected definition.
+	 * Tests that the get and update post SEO data abilities register with the expected definition.
 	 *
 	 * @covers ::register_abilities
 	 * @covers ::register_get_post_seo_data_ability
+	 * @covers ::register_update_post_seo_data_ability
 	 *
 	 * @return void
 	 */
-	public function test_register_get_post_seo_data_ability_definition() {
+	public function test_register_post_seo_data_abilities_definition() {
 		$this->mock_enabled_features(
 			[
 				Keyphrase_Analysis::NAME          => false,
@@ -288,7 +295,92 @@ final class Abilities_Integration_Test extends TestCase {
 				],
 			);
 
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with(
+				'yoast-seo/update-post-seo-data',
+				[
+					'label'               => 'Update Post SEO Data',
+					'category'            => 'yoast-seo',
+					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
+					'input_schema'        => $this->get_expected_update_input_schema(),
+					'output_schema'       => $this->get_expected_output_schema(),
+					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
+					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
+					'meta'                => $this->get_write_meta(),
+				],
+			);
+
 		$this->instance->register_abilities();
+	}
+
+	/**
+	 * Tests that every writable field in the update input schema is applied by the
+	 * field map and cascades to a post meta write.
+	 *
+	 * The field contract is spread over hand-maintained structures (the input schema,
+	 * Post_SEO_Field_Map, Indexable_To_Postmeta_Helper) which fail silently when they
+	 * drift: a schema field missing from the field map is validated and accepted but
+	 * never applied, and an indexable column missing from the postmeta map is skipped
+	 * by the cascade and then reverted by the indexable rebuild. This test turns both
+	 * drift paths into a failure.
+	 *
+	 * @covers ::register_abilities
+	 * @covers ::register_update_post_seo_data_ability
+	 * @covers ::get_update_post_seo_data_input_schema
+	 *
+	 * @return void
+	 */
+	public function test_every_writable_input_field_cascades_to_post_meta() {
+		$input_schema = $this->get_registered_ability_args( 'yoast-seo/update-post-seo-data' )['input_schema'];
+
+		$writable_fields = \array_diff_key(
+			$input_schema['properties'],
+			[
+				'post_id'   => true,
+				'permalink' => true,
+			],
+		);
+
+		$field_map            = new Post_SEO_Field_Map( Mockery::mock( Meta_Surface::class ) );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_id = 42;
+
+		$changed_columns = [];
+		foreach ( $writable_fields as $field => $field_schema ) {
+			// A truthy value for every type, so each mapped column performs a meta write below.
+			$value   = ( \in_array( 'boolean', (array) $field_schema['type'], true ) ) ? true : 'a value';
+			$changed = $field_map->apply_to_indexable( [ $field => $value ], $indexable );
+
+			$this->assertNotEmpty(
+				$changed,
+				"Input field `{$field}` is accepted by the update input schema but not applied by Post_SEO_Field_Map, so writes to it are silently dropped.",
+			);
+
+			$changed_columns[] = $changed;
+		}
+
+		$meta_writes = 0;
+		$meta_helper = Mockery::mock( Meta_Helper::class );
+		$meta_helper->shouldReceive( 'set_value', 'delete' )->andReturnUsing(
+			static function () use ( &$meta_writes ) {
+				++$meta_writes;
+
+				return true;
+			},
+		);
+		$postmeta_helper = new Indexable_To_Postmeta_Helper( $meta_helper );
+
+		foreach ( \array_unique( \array_merge( ...$changed_columns ) ) as $column ) {
+			$writes_before = $meta_writes;
+			$postmeta_helper->map_column_to_postmeta( $indexable, $column, true );
+
+			$this->assertGreaterThan(
+				$writes_before,
+				$meta_writes,
+				"Indexable column `{$column}` has no Indexable_To_Postmeta_Helper mapping, so writes to it are silently discarded and reverted by the indexable rebuild.",
+			);
+		}
 	}
 
 	/**
@@ -307,7 +399,7 @@ final class Abilities_Integration_Test extends TestCase {
 	 * @return void
 	 */
 	public function test_output_schema_matches_field_map_output() {
-		$output_schema = $this->get_registered_get_ability_args()['output_schema']['items'];
+		$output_schema = $this->get_registered_ability_args( 'yoast-seo/get-post-seo-data' )['output_schema']['items'];
 
 		$meta_surface = Mockery::mock( Meta_Surface::class );
 		$meta_surface->expects( 'for_indexable' )->andReturnFalse();
@@ -327,11 +419,13 @@ final class Abilities_Integration_Test extends TestCase {
 
 	/**
 	 * Registers the abilities against a capturing stub and returns the arguments the
-	 * get post SEO data ability was registered with.
+	 * given ability was registered with.
 	 *
-	 * @return array<string, mixed> The get ability registration arguments.
+	 * @param string $slug The ability slug to return the registration arguments for.
+	 *
+	 * @return array<string, mixed> The ability registration arguments.
 	 */
-	private function get_registered_get_ability_args(): array {
+	private function get_registered_ability_args( string $slug ): array {
 		$this->mock_enabled_features(
 			[
 				Keyphrase_Analysis::NAME          => false,
@@ -349,7 +443,7 @@ final class Abilities_Integration_Test extends TestCase {
 
 		$this->instance->register_abilities();
 
-		return $captured['yoast-seo/get-post-seo-data'];
+		return $captured[ $slug ];
 	}
 
 	/**
@@ -366,14 +460,18 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Registers a loose expectation for the get post SEO data ability registration.
+	 * Registers loose expectations for the post SEO data ability registrations.
 	 *
 	 * @return void
 	 */
-	private function expect_get_post_seo_data_ability(): void {
+	private function expect_post_seo_data_abilities(): void {
 		Monkey\Functions\expect( 'wp_register_ability' )
 			->once()
 			->with( 'yoast-seo/get-post-seo-data', Mockery::type( 'array' ) );
+
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with( 'yoast-seo/update-post-seo-data', Mockery::type( 'array' ) );
 	}
 
 	/**
@@ -386,6 +484,25 @@ final class Abilities_Integration_Test extends TestCase {
 			'show_in_rest' => true,
 			'annotations'  => [
 				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'mcp'          => [
+				'public' => true,
+			],
+		];
+	}
+
+	/**
+	 * Returns the write meta (non-read-only annotations).
+	 *
+	 * @return array<string, mixed> The meta.
+	 */
+	private function get_write_meta(): array {
+		return [
+			'show_in_rest' => true,
+			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => false,
 				'idempotent'  => true,
 			],
@@ -423,6 +540,52 @@ final class Abilities_Integration_Test extends TestCase {
 					'description' => 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.',
 					'minimum'     => 1,
 					'default'     => 1,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the expected update input schema.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_update_input_schema(): array {
+		$nullable_string = [ 'type' => [ 'string', 'null' ] ];
+
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'             => [
+					'type'        => 'integer',
+					'description' => 'The ID of the post to update.',
+					'minimum'     => 1,
+				],
+				'permalink'           => [
+					'type'        => 'string',
+					'description' => 'The permalink (URL) of the post to update.',
+				],
+				'focus_keyphrase'     => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
+				'canonical'           => $nullable_string,
+				'is_cornerstone'      => [ 'type' => 'boolean' ],
+				'noindex'             => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.',
+				],
+				'nofollow'            => [ 'type' => 'boolean' ],
+				'noimageindex'        => [ 'type' => 'boolean' ],
+				'noarchive'           => [ 'type' => 'boolean' ],
+				'nosnippet'           => [ 'type' => 'boolean' ],
+				'schema_page_type'    => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::PAGE_TYPES ), [ '', null ] ),
+				],
+				'schema_article_type' => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::ARTICLE_TYPES ), [ '', null ] ),
 				],
 			],
 		];

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -566,7 +566,6 @@ final class Abilities_Integration_Test extends TestCase {
 					'type'        => 'string',
 					'description' => 'The permalink (URL) of the post to update.',
 				],
-				'focus_keyphrase'     => \array_merge( $nullable_string, [ 'maxLength' => 191 ] ),
 				'canonical'           => $nullable_string,
 				'is_cornerstone'      => [ 'type' => 'boolean' ],
 				'noindex'             => [


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* This re-instates most the `update-post-seo-data` part of [the original PR](https://github.com/Yoast/wordpress-seo/pull/23369), that was reverted [here](https://github.com/Yoast/wordpress-seo/pull/23515). More details, in [the relevant task](https://github.com/Yoast/reserved-tasks/issues/1436).

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adds a Yoast SEO Ability for updating SEO data for posts.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Because the original PR was thoroughly tested and this change is a simple change, let's focus on some quick smoke tests:
  * Perform a GET request to `/wp-json/wp-abilities/v1/abilities` and confirm that you see the `update-post-seo-data` ability
    * Make sure there's no `focus_keyphrase`, `seo_title`, `meta_description`, `open_graph_title`, `open_graph_description`, `twitter_title` and `twitter_description` fields in the `input_schema` this time.
  * Run a POST request to `/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run`
    * you need to add the following body: `{"input":{"post_id":<POST_ID>,"is_cornerstone":true}}`
    * or use the post's permalink to find it (but not the title), by adding this body: `{"input":{"permalink":"<POST_PERMALINK>","is_cornerstone":true}}`
    * and instead of `is_cornerstone`, you can set any of the attributes that were listed in the ability declaration you saw in the above section. 
    * Go to the post itself and confirm that what you changed actually changed.
  * Instead of `is_cornerstone`, try to change any one of the `focus_keyphrase`, `seo_title`, `meta_description`, `open_graph_title`, `open_graph_description`, `twitter_title` and `twitter_description` fields
    * Confirm that you get an error in the response and that the data didnt change actually.
  * For the next steps, follow [the documentation on how to test WP Abilities](https://yoast.atlassian.net/wiki/spaces/PLUGIN/pages/4975198209/Set+up+an+MCP+server+to+test+WP+Abilities)
  * In Claude incognito window, ask the agent to set any of the above SEO data. We will try using ID and permalink 
    * Ask the agent something like "For the post with ID 5, set its canonical to be the current permalink but with "bla_bla" appended"
    * or "Noindex the `https://basic.wordpress.test/test-post` post"
    * Check the frontend of the post and confirm that the attribute has changed
    * Repeat the test using invalid SEO data, for example use a schema page type that doesn't exist. eg. "for the post with ID 5, set its schema page type to `FooPage`. Confirm that the agent wont do that.
    * Repeat the test using  SEO data representing the `focus_keyphrase`, `seo_title`, `meta_description`, `open_graph_title`, `open_graph_description`, `twitter_title` and `twitter_description` fields that we haven't added support for. Confirm that the agent can't do that.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

*

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
