### PR TITLE
Change toggle's title and description

### DIFF
--- a/packages/js/src/settings/helpers/search.js
+++ b/packages/js/src/settings/helpers/search.js
@@ -993,7 +993,7 @@ export const createSearchIndex = ( postTypes, taxonomies, { userLocale } = {} ) 
 			route: "/breadcrumbs",
 			routeLabel: __( "Breadcrumbs", "wordpress-seo" ),
 			fieldId: "input-wpseo_titles-breadcrumbs-enable",
-			fieldLabel: __( "Enable breadcrumbs for your theme", "wordpress-seo" ),
+			fieldLabel: __( "Enable breadcrumbs inserted in your theme's template", "wordpress-seo" ),
 			keywords: [],
 		},
 		...reduce( postTypes, ( acc, postType ) => {

--- a/packages/js/src/settings/routes/breadcrumbs.js
+++ b/packages/js/src/settings/routes/breadcrumbs.js
@@ -153,14 +153,18 @@ const Breadcrumbs = () => {
 							) }
 						</p>
 						<p>
-							{ __( "You can always choose to enable/disable them for your theme below. This setting will not apply to breadcrumbs inserted through a widget, a block or a shortcode.", "wordpress-seo" ) }
+							{ sprintf(
+								/* translators: %1$s expands to "Yoast SEO". */
+								__( "This setting only controls breadcrumbs added to your theme's template files with the %1$s PHP function. It doesn't affect breadcrumbs inserted through a block, widget, or shortcode, or the breadcrumbs structured data in your page source.", "wordpress-seo" ),
+								"Yoast SEO"
+							) }
 						</p>
 						<FormikValueChangeField
 							as={ ToggleField }
 							type="checkbox"
 							name="wpseo_titles.breadcrumbs-enable"
 							id="input-wpseo_titles-breadcrumbs-enable"
-							label={ __( "Enable breadcrumbs for your theme", "wordpress-seo" ) }
+							label={ __( "Enable breadcrumbs inserted in your theme's template", "wordpress-seo" ) }
 							className="yst-max-w-sm"
 						/>
 					</FieldsetLayout>


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* We want to make more clear the intended behaviour/usage of the `Settings` -> `Advanced` -> `Breadcrumbs` -> `Enable breadcrumbs` toggle.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Adjust the name and description of the setting's toggle controlling the breadcrumbs' rendering to state clearly its intended behaviour.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Navigate to `Settings` -> `Advanced` -> `Breadcrumbs`
  * Make sure in the section named `How to insert breadcrumbs in your theme` you see a toggle named: `Enable breadcrumbs inserted in your theme's template`
  *  Make sure the paragraph above the toggle reads: `This setting only controls breadcrumbs added to your theme's template files with the Yoast SEO PHP function. It doesn't affect breadcrumbs inserted through a block, widget, or shortcode, or the breadcrumbs structured data in your page source.`

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [X] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* This PR implements just a copy change, nothing changes in the toggle implementation.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [X] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [X] I have written this PR in accordance with my team's definition of done.
* [X] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/wordpress-seo/issues/22922
