### PR TITLE
1426 hide post type when seo controls off

### DIFF
--- a/src/bulk-editor/infrastructure/content-types/content-types-collector.php
+++ b/src/bulk-editor/infrastructure/content-types/content-types-collector.php
@@ -52,7 +52,12 @@ class Content_Types_Collector {
 		$excluded_post_types = $this->get_excluded_post_types();
 
 		foreach ( $post_types as $post_type_object ) {
-			if ( \in_array( $post_type_object->name, $excluded_post_types, true ) ) {
+			$post_type_name = $post_type_object->name;
+
+			if ( \in_array( $post_type_name, $excluded_post_types, true ) ) {
+				continue;
+			}
+			if ( ! $this->post_type_helper->has_metabox( $post_type_name ) ) {
 				continue;
 			}
 			if ( $post_type_object->show_ui === false ) {
@@ -60,10 +65,10 @@ class Content_Types_Collector {
 			}
 			// Offer the type when the user can edit at least one of its posts; the per-post edit
 			// permission is enforced when the posts themselves are collected.
-			if ( ! $this->access_checker->can_edit_any( $post_type_object->name ) ) {
+			if ( ! $this->access_checker->can_edit_any( $post_type_name ) ) {
 				continue;
 			}
-			$content_type = new Content_Type( $post_type_object->name, $post_type_object->label, $post_type_object->labels->singular_name );
+			$content_type = new Content_Type( $post_type_name, $post_type_object->label, $post_type_object->labels->singular_name );
 			$content_types_list->add( $content_type );
 		}
 

--- a/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
+++ b/tests/Unit/Bulk_Editor/Infrastructure/Content_Types/Content_Types_Collector/Get_Content_Types_Test.php
@@ -32,6 +32,8 @@ final class Get_Content_Types_Test extends Abstract_Test {
 			->once()
 			->andReturn( $indexable_post_type_objects );
 
+		$this->post_type_helper->allows( 'has_metabox' )->andReturnTrue();
+
 		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
 
 		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
@@ -43,6 +45,54 @@ final class Get_Content_Types_Test extends Abstract_Test {
 
 		$this->assertInstanceOf( Content_Types_List::class, $content_types_list );
 		$this->assertSame( $expected, $content_types_list->to_array() );
+	}
+
+	/**
+	 * Tests that content types with the Yoast metabox disabled are excluded.
+	 *
+	 * @return void
+	 */
+	public function test_get_content_types_excludes_types_with_the_metabox_disabled() {
+		$this->post_type_helper
+			->expects( 'get_indexable_post_type_objects' )
+			->once()
+			->andReturn(
+				[
+					(object) [
+						'name'    => 'post',
+						'label'   => 'Posts',
+						'labels'  => (object) [ 'singular_name' => 'Post' ],
+						'show_ui' => true,
+					],
+					(object) [
+						'name'    => 'page',
+						'label'   => 'Pages',
+						'labels'  => (object) [ 'singular_name' => 'Page' ],
+						'show_ui' => true,
+					],
+				],
+			);
+
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'post' )->andReturnTrue();
+		$this->post_type_helper->expects( 'has_metabox' )->with( 'page' )->andReturnFalse();
+
+		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
+
+		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
+			->once()
+			->with( [ 'attachment' ] )
+			->andReturnFirstArg();
+
+		$this->assertSame(
+			[
+				[
+					'name'          => 'post',
+					'label'         => 'Posts',
+					'singularLabel' => 'Post',
+				],
+			],
+			$this->instance->get_content_types()->to_array(),
+		);
 	}
 
 	/**
@@ -70,6 +120,8 @@ final class Get_Content_Types_Test extends Abstract_Test {
 					],
 				],
 			);
+
+		$this->post_type_helper->allows( 'has_metabox' )->andReturnTrue();
 
 		$this->access_checker->expects( 'can_edit_any' )->with( 'post' )->andReturnTrue();
 		$this->access_checker->expects( 'can_edit_any' )->with( 'page' )->andReturnFalse();
@@ -117,6 +169,8 @@ final class Get_Content_Types_Test extends Abstract_Test {
 				],
 			);
 
+		$this->post_type_helper->allows( 'has_metabox' )->andReturnTrue();
+
 		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
 
 		Filters\expectApplied( 'wpseo_bulk_editor_excluded_post_types' )
@@ -161,6 +215,8 @@ final class Get_Content_Types_Test extends Abstract_Test {
 					],
 				],
 			);
+
+		$this->post_type_helper->allows( 'has_metabox' )->andReturnTrue();
 
 		$this->access_checker->allows( 'can_edit_any' )->andReturnTrue();
 


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* N/A

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Don't show a post type in the Bulk editor if `Enable SEO controls and assessments` is turned off for that post type.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

<details>

<summary>Prerequisites</summary>

* Have a site with a few published `posts` and `pages`
* Log in as an `Administrator`
* Have at least one custom post type available, either:
  * by activating `WooCommerce` and having a couple of `Products`, or
  * by registering your own, e.g. a `Books` post type with `'public' => true`

</details>

<details>

<summary>Test the fix on the default content types</summary>

* Go to `Yoast SEO` -> `Bulk editor`
  * Make sure you see `Posts` and `Pages` among the content types
* Go to `Yoast SEO` -> `Settings` -> `Content types` -> `Posts`
  * Scroll down to `Additional settings`
  * Turn `Enable SEO controls and assessments` off and save
* Go back to `Yoast SEO` -> `Bulk editor`
  * Verify `Posts` is gone, and that `Pages` is still there and still works
* Turn `Enable SEO controls and assessments` back on for `Posts` and save
  * Verify `Posts` is offered again in the bulk editor
* Repeat the same steps for `Pages`

</details>

<details>

<summary>Test the fix on a custom post type</summary>

* Go to `Yoast SEO` -> `Bulk editor`
  * Make sure your custom post type (e.g. `Products`) is offered as a content type
* Go to `Yoast SEO` -> `Settings` -> `Content types` -> `Products`
  * In `Additional settings`, turn `Enable SEO controls and assessments` off and save
* Go back to `Yoast SEO` -> `Bulk editor`
  * Verify `Products` is gone, while `Posts` and `Pages` are untouched
* Turn the toggle back on for `Products` and save
  * Verify `Products` is offered again

</details>

<details>

<summary>Test the entry in the content overview</summary>

* With `Enable SEO controls and assessments` off for `Posts`, go to `Posts` -> `All Posts`
  * Open the `Bulk actions` dropdown and verify the `Yoast SEO` group with `Bulk edit` is **not** there
* Turn the toggle back on and reload `Posts` -> `All Posts`
  * Verify the `Yoast SEO` group with `Bulk edit` is back
* Do the same check on your custom post type's overview (e.g. `Products` -> `All Products`)

</details>

<details>

<summary>Counter-checks</summary>

* Turn `Enable SEO controls and assessments` off for **all** content types
  * Verify the bulk editor still loads and simply offers no content types, instead of erroring or showing a blank page
  * Check this with the browser console open: there should be no errors
* Make sure the toggle keeps doing what it always did: with it off, the Yoast SEO metabox and sidebar are hidden when you edit a post of that type
* Make sure a content type that still has the toggle on can be selected, edited and saved in the bulk editor exactly as before

</details>

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* N/A

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes https://github.com/Yoast/reserved-tasks/issues/1426
