### PR TITLE
fix: prevent oEmbed data leaking between posts on nested calls

### DIFF
--- a/src/integrations/front-end/open-graph-oembed.php
+++ b/src/integrations/front-end/open-graph-oembed.php
@@ -21,27 +21,6 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	private $meta;
 
 	/**
-	 * The oEmbed data.
-	 *
-	 * @var array
-	 */
-	private $data;
-
-	/**
-	 * The post ID for the current post.
-	 *
-	 * @var int
-	 */
-	private $post_id;
-
-	/**
-	 * The post meta.
-	 *
-	 * @var Meta|false
-	 */
-	private $post_meta;
-
-	/**
 	 * Returns the conditionals based in which this loadable should be active.
 	 *
 	 * @return array
@@ -84,72 +63,84 @@ class Open_Graph_OEmbed implements Integration_Interface {
 	 * @return array An array of oEmbed data with modified values where appropriate.
 	 */
 	public function set_oembed_data( $data, $post ) {
-		// Data to be returned.
-		$this->data      = $data;
-		$this->post_id   = $post->ID;
-		$this->post_meta = $this->meta->for_post( $this->post_id );
+		$post_meta = $this->meta->for_post( $post->ID );
 
-		if ( ! empty( $this->post_meta ) ) {
-			$this->set_title();
-			$this->set_description();
-			$this->set_image();
+		if ( ! empty( $post_meta ) ) {
+			$data = $this->set_title( $data, $post_meta );
+			$data = $this->set_description( $data, $post_meta );
+			$data = $this->set_image( $data, $post_meta );
 		}
 
-		return $this->data;
+		return $data;
 	}
 
 	/**
 	 * Sets the OpenGraph title if configured.
 	 *
-	 * @return void
+	 * @param array $data      The oEmbed data.
+	 * @param Meta  $post_meta The post meta to read the title from.
+	 *
+	 * @return array The oEmbed data with the title set where appropriate.
 	 */
-	protected function set_title() {
-		$opengraph_title = $this->post_meta->open_graph_title;
+	protected function set_title( $data, $post_meta ) {
+		$opengraph_title = $post_meta->open_graph_title;
 
 		if ( ! empty( $opengraph_title ) ) {
-			$this->data['title'] = $opengraph_title;
+			$data['title'] = $opengraph_title;
 		}
+
+		return $data;
 	}
 
 	/**
 	 * Sets the OpenGraph description if configured.
 	 *
-	 * @return void
+	 * @param array $data      The oEmbed data.
+	 * @param Meta  $post_meta The post meta to read the description from.
+	 *
+	 * @return array The oEmbed data with the description set where appropriate.
 	 */
-	protected function set_description() {
-		$opengraph_description = $this->post_meta->open_graph_description;
+	protected function set_description( $data, $post_meta ) {
+		$opengraph_description = $post_meta->open_graph_description;
 
 		if ( ! empty( $opengraph_description ) ) {
-			$this->data['description'] = $opengraph_description;
+			$data['description'] = $opengraph_description;
 		}
+
+		return $data;
 	}
 
 	/**
 	 * Sets the image if it has been configured.
 	 *
-	 * @return void
+	 * @param array $data      The oEmbed data.
+	 * @param Meta  $post_meta The post meta to read the image from.
+	 *
+	 * @return array The oEmbed data with the image set where appropriate.
 	 */
-	protected function set_image() {
-		$images = $this->post_meta->open_graph_images;
+	protected function set_image( $data, $post_meta ) {
+		$images = $post_meta->open_graph_images;
 
 		if ( ! \is_array( $images ) ) {
-			return;
+			return $data;
 		}
 
 		$image = \reset( $images );
 
 		if ( empty( $image ) || ! isset( $image['url'] ) ) {
-			return;
+			return $data;
 		}
 
-		$this->data['thumbnail_url'] = $image['url'];
+		$data['thumbnail_url'] = $image['url'];
 
 		if ( isset( $image['width'] ) ) {
-			$this->data['thumbnail_width'] = $image['width'];
+			$data['thumbnail_width'] = $image['width'];
 		}
 
 		if ( isset( $image['height'] ) ) {
-			$this->data['thumbnail_height'] = $image['height'];
+			$data['thumbnail_height'] = $image['height'];
 		}
+
+		return $data;
 	}
 }

--- a/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
+++ b/tests/Unit/Integrations/Front_End/Open_Graph_OEmbed_Test.php
@@ -115,6 +115,68 @@ final class Open_Graph_OEmbed_Test extends TestCase {
 	}
 
 	/**
+	 * Tests that a nested/re-entrant call to set_oembed_data for a different post -- e.g. a
+	 * theme building an excerpt by re-running the_content filters while the outer oEmbed
+	 * response for another post is still being assembled -- does not leak its data into the
+	 * outer, still in-progress call.
+	 *
+	 * @covers ::set_oembed_data
+	 * @covers ::set_title
+	 * @covers ::set_description
+	 *
+	 * @return void
+	 */
+	public function test_set_oembed_data_is_reentrant_safe() {
+		$post_a = (object) [ 'ID' => 1 ];
+		$post_b = (object) [ 'ID' => 2 ];
+
+		$meta_a = (object) [
+			'open_graph_title'       => 'title-a',
+			'open_graph_description' => 'description-a',
+			'open_graph_images'      => [],
+		];
+		$meta_b = (object) [
+			'open_graph_title'       => 'title-b',
+			'open_graph_description' => 'description-b',
+			'open_graph_images'      => [],
+		];
+
+		$this->meta
+			->expects( 'for_post' )
+			->once()
+			->with( 1 )
+			->andReturnUsing(
+				function () use ( $post_b, $meta_b ) {
+					// Simulate a nested oEmbed call for a different post firing while the
+					// outer call for post A is still in progress.
+					$this->meta->expects( 'for_post' )->once()->with( 2 )->andReturn( $meta_b );
+
+					$nested = $this->instance->set_oembed_data( [], $post_b );
+
+					$this->assertEquals(
+						[
+							'title'       => 'title-b',
+							'description' => 'description-b',
+						],
+						$nested
+					);
+
+					return $meta_a;
+				}
+			);
+
+		$result = $this->instance->set_oembed_data( [], $post_a );
+
+		$this->assertEquals(
+			[
+				'title'       => 'title-a',
+				'description' => 'description-a',
+			],
+			$result
+		);
+	}
+
+	/**
 	 * Returns the data to test with.
 	 *
 	 * @return array


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

`Open_Graph_OEmbed::set_oembed_data()` stored the oEmbed data, the post ID, and the post meta it was working with on shared instance properties (`$this->data`, `$this->post_id`, `$this->post_meta`) instead of local variables. If the `oembed_response_data` filter fires re-entrantly within the same request — for example a theme rebuilding an excerpt by re-running content filters for a different post while the outer oEmbed response is still being assembled — the inner call overwrites that shared state. By the time the outer call resumes and runs `set_title()`/`set_description()`/`set_image()`, it operates on the wrong post's meta and returns the wrong post's title/description/image. WordPress then caches that wrong result indefinitely in the original post's `_oembed_*` postmeta, so the bug outlives the request that caused it.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the oEmbed response for a post could contain another post's Open Graph title, description, or image when the `oembed_response_data` filter fired more than once in the same request.

## Relevant technical choices:

* `set_oembed_data()` and its three helpers (`set_title`, `set_description`, `set_image`) now thread `$data` and `$post_meta` through as parameters and return values instead of reading/writing instance state. This makes a single call self-contained regardless of any nested call that happens inside it.
* Removed the `$data`, `$post_id`, and `$post_meta` instance properties entirely rather than keeping them alongside the new parameters — confirmed via GitHub code search (`Open_Graph_OEmbed` across the repo) that nothing outside this class reads them, so they were purely internal, now-redundant state.
* Added `test_set_oembed_data_is_reentrant_safe()`, which mocks `Meta_Surface::for_post()` for post A to trigger a nested `set_oembed_data()` call for post B before returning post A's meta — reproducing the exact re-entrancy scenario. It fails against the pre-fix code (post A's result contains post B's title/description) and passes against this fix.
* **Disclosure**: no PHP/Composer toolchain is available in the environment this PR was prepared in, so `composer check-branch-cs` and the PHPUnit run could not be executed locally. The new test was hand-traced line-by-line against both the old and new implementations instead of run. The existing `test_set_oembed_data_with_no_data_set` cases were re-traced the same way and are unaffected by the signature change from the caller's perspective (`set_oembed_data()`'s public signature is unchanged). Please let CI run the full suite before merge.

## Test instructions
<!--
Please provide step-by-step instructions on how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Set an Open Graph title/description/image on two different posts (Post A and Post B) via the Yoast SEO metabox.
* Embed Post A inside Post B's content (or in a way that causes both posts' oEmbed data to be requested within the same page load, e.g. both posts appearing on an archive/listing page that themes/plugins often filter through `the_content` more than once).
* Request the oEmbed endpoint for each post (`/wp-json/oembed/1.0/embed?url=<post-url>`) and confirm each response's `title`/`description`/`thumbnail_url` matches that post's own Open Graph settings, not the other post's.
* Run the automated test suite (`Open_Graph_OEmbed_Test`), in particular the new `test_set_oembed_data_is_reentrant_safe` case.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC
* [x] QA should use the same steps as above.

QA can test this PR by following these steps:

* Same steps as the acceptance test above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* The oEmbed response (`oembed_response_data` filter) for any post with Open Graph title/description/image set — this is the only integration touched.

## Other environments

* [ ] This PR also affects Shopify.
* [ ] This PR also affects Yoast SEO for Google Docs.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.

Fixes #23527

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
