### PR TITLE
Hide the social appearance modal help link when Open Graph is off

### DIFF
--- a/packages/js/src/components/modals/editorModals/SocialAppearanceModal.js
+++ b/packages/js/src/components/modals/editorModals/SocialAppearanceModal.js
@@ -46,7 +46,7 @@ const SocialAppearanceModal = ( props ) => {
 			id="yoast-social-appearance-modal"
 			shouldCloseOnClickOutside={ false }
 			SuffixHeroIcon={ <StyledHeroIcon className="yst-text-slate-500" { ...svgAriaProps } /> }
-			titleHelpLink={ <SocialPreviewsHelpLink /> }
+			titleHelpLink={ useOpenGraphData ? <SocialPreviewsHelpLink /> : null }
 		>
 			{ useOpenGraphData &&
 				<Fragment>

--- a/packages/js/tests/components/modals/editorModals/SocialAppearanceModal.test.js
+++ b/packages/js/tests/components/modals/editorModals/SocialAppearanceModal.test.js
@@ -1,8 +1,7 @@
 import { render, screen } from "../../../test-utils";
 import EditorModal from "../../../../src/components/modals/editorModals/EditorModal";
 import SocialAppearanceModal from "../../../../src/components/modals/editorModals/SocialAppearanceModal";
-
-const noop = () => {};
+import { noop } from "lodash";
 
 /**
  * Mocked EditorModal container.

--- a/packages/js/tests/components/modals/editorModals/SocialAppearanceModal.test.js
+++ b/packages/js/tests/components/modals/editorModals/SocialAppearanceModal.test.js
@@ -1,0 +1,60 @@
+import { render, screen } from "../../../test-utils";
+import EditorModal from "../../../../src/components/modals/editorModals/EditorModal";
+import SocialAppearanceModal from "../../../../src/components/modals/editorModals/SocialAppearanceModal";
+
+const noop = () => {};
+
+/**
+ * Mocked EditorModal container.
+ *
+ * Renders the modal open, without the WP data store the container normally reads from.
+ *
+ * @param {Object} props The props.
+ *
+ * @returns {JSX.Element} The element.
+ */
+const EditorModalMock = props => (
+	<EditorModal { ...props } postTypeName="post" isOpen={ true } open={ noop } close={ noop } />
+);
+
+jest.mock( "../../../../src/containers/EditorModal", () => EditorModalMock );
+
+// The editors are Redux containers; this suite is about the modal chrome around them.
+jest.mock( "../../../../src/containers/FacebookEditor", () => ( {
+	__esModule: true,
+	"default": () => "Facebook editor",
+} ) );
+jest.mock( "../../../../src/containers/TwitterEditor", () => ( {
+	__esModule: true,
+	"default": () => "X editor",
+} ) );
+
+describe( "SocialAppearanceModal", () => {
+	beforeEach( () => {
+		global.wpseoAdminL10n = {
+			"shortlinks.social_previews_info": "https://example.com/social-previews",
+		};
+	} );
+
+	it( "links the modal title to the social previews page when Open Graph is enabled", () => {
+		render( <SocialAppearanceModal useOpenGraphData={ true } useTwitterData={ true } /> );
+
+		const link = screen.getByRole( "link", { name: /Learn more about social previews/ } );
+
+		expect( link ).toHaveAttribute( "href", "https://example.com/social-previews" );
+	} );
+
+	it( "still offers the help link when X appearance is disabled", () => {
+		render( <SocialAppearanceModal useOpenGraphData={ true } useTwitterData={ false } /> );
+
+		expect( screen.getByRole( "link", { name: /Learn more about social previews/ } ) ).toBeInTheDocument();
+	} );
+
+	it( "does not offer the help link when Open Graph is disabled", () => {
+		// Only the X appearance editor remains, matching the metabox, which has no link in that case either.
+		render( <SocialAppearanceModal useOpenGraphData={ false } useTwitterData={ true } /> );
+
+		expect( screen.getByText( "X editor" ) ).toBeInTheDocument();
+		expect( screen.queryByRole( "link", { name: /Learn more about social previews/ } ) ).toBeNull();
+	} );
+} );

--- a/packages/js/tests/components/social/SocialMetadata.test.js
+++ b/packages/js/tests/components/social/SocialMetadata.test.js
@@ -50,4 +50,11 @@ describe( "SocialMetadata", () => {
 
 		expect( screen.getByRole( "link", { name: /Learn more about social previews/ } ) ).toBeInTheDocument();
 	} );
+
+	it( "does not offer the help link when Open Graph is disabled", () => {
+		// Only the X appearance section remains, and that one never carries the link.
+		render( <SocialMetadata useOpenGraphData={ false } useTwitterData={ true } /> );
+
+		expect( screen.queryByRole( "link", { name: /Learn more about social previews/ } ) ).toBeNull();
+	} );
 } );


### PR DESCRIPTION
## Context

#23560 added a `?` help link to the social appearance sections of the editor. In the metabox it only appears in the *Social media appearance* section, so with Open Graph data off and X card data on there is no link. The sidebar modal always rendered it, so the two disagreed in that setting. This PR makes the modal follow the metabox.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where the social previews help link would be shown in the *Social media appearance* modal when Open Graph data was disabled.

## Relevant technical choices:

* **The link is hidden in the modal rather than added to the metabox.** #23560 deliberately gave the *X appearance* section no help link, and the shortlink points at the social previews page.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged

1. [ ] Go to *Yoast SEO > Settings > Site features > Social sharing* and switch *Open Graph data* off while leaving *X card data* on.
2. [ ] Open a post in the block editor and open the *Social* tab of the Yoast SEO metabox; confirm there is no `?` icon.
3. [ ] Open the Yoast SEO sidebar and click *Social media appearance*; confirm the modal title has no `?` icon next to it.
4. [ ] Switch *Open Graph data* back on and reload the post; confirm the `?` icon is back next to *Social media appearance* in both the metabox and the modal title, and that clicking it opens the social previews page in a new tab.
5. [ ] Switch *X card data* off (Open Graph on) and reload the post; confirm the `?` icon is still shown in both the metabox and the modal title.
6. [ ] Run `yarn test tests/components/social tests/components/modals/editorModals` in `packages/js`; expect 2 suites and 8 tests passing.

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [x] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

Console: no React warnings when the modal opens without the help link. Editors: the modal is also used in Elementor's Yoast panel, so step 3 is worth repeating there.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The *Social media appearance* modal in the block editor sidebar and the Elementor panel. Only the help link in its title changes.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [x] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes Yoast/plugins-automated-testing#3154
