### PR TITLE
Fix keyphrase in slug assessment when keyphrase contains a period

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/url/parseSlugSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/url/parseSlugSpec.js
@@ -5,7 +5,15 @@ describe( "A test to parse slug", () => {
 		expect( parseSlug( "cats-color-types" ) ).toBe( "cats color types" );
 	} );
 
-	it( "parses slug", () => {
+	it( "parses slug with empty string", () => {
 		expect( parseSlug( "" ) ).toBe( "" );
+	} );
+
+	it( "parses slug with periods", () => {
+		expect( parseSlug( "ubuntu-26.04-available" ) ).toBe( "ubuntu 26 04 available" );
+	} );
+
+	it( "parses slug with underscores and periods", () => {
+		expect( parseSlug( "ubuntu_26.04_available" ) ).toBe( "ubuntu 26 04 available" );
 	} );
 } );

--- a/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/researches/keywordCountInUrlSpec.js
@@ -292,6 +292,20 @@ describe( "test to check slug for keyword", function() {
 		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 2, percentWordMatches: 100 } );
 	} );
 
+	it( "returns matches when keyphrase contains a period and slug uses hyphens", function() {
+		const paper = new Paper( "", { slug: "ubuntu-26-04-available-for-vps", keyword: "Ubuntu 26.04 available" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
+
+	it( "returns matches when keyphrase contains a period and slug uses periods", function() {
+		const paper = new Paper( "", { slug: "ubuntu-26.04-available", keyword: "Ubuntu 26.04 available" } );
+		const researcher = new EnglishResearcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		expect( slugKeyword( paper, researcher ) ).toEqual( { keyphraseLength: 3, percentWordMatches: 100 } );
+	} );
+
 	it( "works with different forms of a hyphenated keyphrase in Indonesian that's not a reduplication", function() {
 		const paper = new Paper( "", { slug: "pontang-panting", keyword: "berpontang-panting" } );
 		const researcher = new IndonesianResearcher( paper );

--- a/packages/yoastseo/src/languageProcessing/helpers/match/matchTextWithTransliteration.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/match/matchTextWithTransliteration.js
@@ -9,13 +9,25 @@ import { getLanguage } from "../../index";
 /**
  * Creates a regex from the keyword with included wordboundaries.
  *
+ * Escaped periods (e.g. `\.` from version numbers like "26.04") are replaced with a pattern
+ * that matches either a literal period or a space. This ensures that keyphrase words
+ * containing periods can still match against slugs, where periods are converted to spaces
+ * by `parseSlug`.
+ *
  * @param {string} keyword  The keyword to create a regex from.
  * @param {string} language The language used to determine the word boundary.
  *
  * @returns {RegExp} Regular expression of the keyword with word boundaries.
  */
 const toRegex = function( keyword, language ) {
-	keyword = addWordBoundary( keyword, false, "", language );
+	/*
+	 * Replace escaped periods with a character class that matches either a literal period
+	 * or a space. This allows keyphrase words like "26.04" to match against slugs where
+	 * the period has been converted to a space (e.g. "26 04").
+	 */
+	const keywordWithPeriodAsWordBoundary = keyword.replace( /\\\./g, "[.\\u0020]" );
+
+	keyword = addWordBoundary( keywordWithPeriodAsWordBoundary, false, "", language );
 	return new RegExp( keyword, "ig" );
 };
 

--- a/packages/yoastseo/src/languageProcessing/helpers/url/parseSlug.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/url/parseSlug.js
@@ -1,10 +1,10 @@
 /**
- * Parses the slug by transforming hyphens and underscores into white space.
+ * Parses the slug by transforming hyphens, underscores, and periods into white space.
  *
  * @param {string} slug The slug to parse
  *
  * @returns {string} The parsed slug.
  */
 export default function( slug ) {
-	return slug.replace( /[-_]/ig, " " );
+	return slug.replace( /[-_.]/ig, " " );
 }


### PR DESCRIPTION
## Context

Fixes the keyphrase in slug assessment showing a false negative when the focus keyphrase contains a period (e.g. "Ubuntu 26.04 available"). The slug parsing now treats periods as word boundaries, and the regex building now matches escaped periods against spaces.

## Summary

This PR can be summarized in the following changelog entry:

* [@yoast/yoastseo] Fixes a bug where the keyphrase in slug assessment showed a false negative when the focus keyphrase contained a period.

## Relevant technical choices:

* Modified `parseSlug` to convert periods to spaces alongside hyphens and underscores.
* Modified `toRegex` in `matchTextWithTransliteration` to replace escaped periods with a character class that matches either a literal period or a space.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

This PR can be acceptance tested by following these steps:

1. Create a new post and set the focus keyphrase to "Ubuntu 26.04 available"
2. Set the slug to "ubuntu-26-04-available-for-vps"
3. Verify that the keyphrase in slug assessment shows green (100% match)

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have added unit tests to verify the code works as intended.

Fixes #23222