### PR TITLE
Fix: use target user_id in map_meta_cap_for_seo_manager to prevent circular recursion

### DIFF
--- a/admin/capabilities/class-register-capabilities.php
+++ b/admin/capabilities/class-register-capabilities.php
@@ -25,7 +25,7 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 		/**
 		 * Maybe add manage_privacy_options capability for wpseo_manager user role.
 		 */
-		add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 2 );
+		add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 3 );
 	}
 
 	/**
@@ -83,20 +83,21 @@ class WPSEO_Register_Capabilities implements WPSEO_WordPress_Integration {
 	/**
 	 * Maybe add manage_privacy_options capability for wpseo_manager user role.
 	 *
-	 * @param string[] $caps Primitive capabilities required of the user.
-	 * @param string[] $cap  Capability being checked.
+	 * @param string[] $caps    Primitive capabilities required of the user.
+	 * @param string   $cap     Capability being checked.
+	 * @param int      $user_id The user ID.
 	 *
 	 * @return string[] Filtered primitive capabilities required of the user.
 	 */
-	public function map_meta_cap_for_seo_manager( $caps, $cap ) {
-		$user = wp_get_current_user();
-
+	public function map_meta_cap_for_seo_manager( $caps, $cap, $user_id = 0 ) {
 		// No multisite support.
 		if ( is_multisite() ) {
 			return $caps;
 		}
 
-		if ( ! is_array( $user->roles ) ) {
+		$user = $user_id ? get_userdata( $user_id ) : wp_get_current_user();
+
+		if ( ! $user instanceof WP_User || ! is_array( $user->roles ) ) {
 			return $caps;
 		}
 


### PR DESCRIPTION
## Context

In `WPSEO_Register_Capabilities::map_meta_cap_for_seo_manager`, the method is hooked into the WordPress `map_meta_cap` filter:
```php
add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 2 );
```
Inside the callback, it calls `wp_get_current_user()` directly:
```php
public function map_meta_cap_for_seo_manager( $caps, $cap ) {
    $user = wp_get_current_user();
```

This presents two problems:
1. `map_meta_cap` passes 4 arguments: `$caps, $cap, $user_id, $args`. By not accepting `$user_id` and calling `wp_get_current_user()`, capability checks for arbitrary users (`user_can( $user_id, ... )`) evaluate against the currently logged-in user rather than the user being checked.
2. If capability checks run during authentication before global `$current_user` is populated (e.g. during Application Password validation or `determine_current_user` filters), `wp_get_current_user()` triggers `_wp_get_current_user()`, which re-fires `determine_current_user`. This causes an infinite recursion loop until PHP exhausts memory and throws a fatal 500 error.

## Summary

This PR can be summarized in the following changelog entry:

* Fixes a bug where `map_meta_cap_for_seo_manager` called `wp_get_current_user()` instead of using the passed `$user_id`, causing circular authentication recursion and out-of-memory errors during early capability checks.

## Relevant technical choices:

* Updated `add_filter( 'map_meta_cap', [ $this, 'map_meta_cap_for_seo_manager' ], 10, 3 );` to accept 3 parameters.
* Updated `map_meta_cap_for_seo_manager( $caps, $cap, $user_id = 0 )` to accept `$user_id`.
* Used `$user = $user_id ? get_userdata( $user_id ) : wp_get_current_user();`. When `$user_id` is supplied by `map_meta_cap`, the user object is fetched directly without calling `wp_get_current_user()`, avoiding re-entrant authentication. When `$user_id` is not present, it safely falls back to `wp_get_current_user()`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

1. Add a test filter to a plugin or theme:
   ```php
   add_filter( 'wp_is_application_passwords_available_for_user', function ( $available, $user ) {
       if ( user_can( $user, 'manage_options' ) ) {
           return $available;
       }
       return false;
   }, 10, 2 );
   ```
2. Send an authenticated REST API request using an Application Password:
   ```bash
   curl -i -u "admin:app_password" https://example.com/wp-json/wp/v2/users/me
   ```
3. Verify that the request succeeds with HTTP 200 rather than failing with a 500 Out of Memory error.
4. Verify that users with the `wpseo_manager` role still properly have `manage_options` stripped from required primitive caps when checking `manage_privacy_options`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

QA can test this PR by following these steps:
* Same as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:
* `WPSEO_Register_Capabilities` capability filtering for the `wpseo_manager` role on `manage_privacy_options`.

Fixes #23595
