### PR TITLE
Restructure abilities registration to an ability-per-class basis

### DIFF
--- a/src/abilities/domain/ability-interface.php
+++ b/src/abilities/domain/ability-interface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoast\WP\SEO\Abilities\Domain;
+
+/**
+ * Describes an ability that can be registered with the WordPress Abilities API.
+ */
+interface Ability_Interface {
+
+	/**
+	 * Returns the full name of the ability, including the category prefix.
+	 *
+	 * @return string The ability name, e.g. `yoast-seo/get-seo-scores`.
+	 */
+	public function get_name(): string;
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The registration arguments are heterogeneous by nature.
+
+	/**
+	 * Returns the arguments to register the ability with.
+	 *
+	 * @return array<string, mixed> The ability registration arguments.
+	 */
+	public function get_args(): array;
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+
+	/**
+	 * Returns whether the ability should be registered at all.
+	 *
+	 * @return bool Whether the ability is available.
+	 */
+	public function is_available(): bool;
+}

--- a/src/abilities/user-interface/abilities-integration.php
+++ b/src/abilities/user-interface/abilities-integration.php
@@ -3,17 +3,8 @@
 // phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
 namespace Yoast\WP\SEO\Abilities\User_Interface;
 
-use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
-use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
-use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
+use Yoast\WP\SEO\Abilities\Domain\Ability_Interface;
 use Yoast\WP\SEO\Conditionals\Abilities_API_Conditional;
-use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
-use Yoast\WP\SEO\Config\Schema_Types;
-use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
-use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
-use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
-use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
-use Yoast\WP\SEO\Helpers\Capability_Helper;
 use Yoast\WP\SEO\Integrations\Integration_Interface;
 
 /**
@@ -22,39 +13,11 @@ use Yoast\WP\SEO\Integrations\Integration_Interface;
 class Abilities_Integration implements Integration_Interface {
 
 	/**
-	 * The score retriever.
+	 * The abilities to register.
 	 *
-	 * @var Score_Retriever
+	 * @var Ability_Interface[]
 	 */
-	private $score_retriever;
-
-	/**
-	 * The capability helper.
-	 *
-	 * @var Capability_Helper
-	 */
-	private $capability_helper;
-
-	/**
-	 * The enabled analysis features repository.
-	 *
-	 * @var Enabled_Analysis_Features_Repository
-	 */
-	private $enabled_analysis_features_repository;
-
-	/**
-	 * The post SEO data collector.
-	 *
-	 * @var Post_SEO_Data_Collector
-	 */
-	private $post_seo_data_collector;
-
-	/**
-	 * The post SEO data updater.
-	 *
-	 * @var Post_SEO_Data_Updater
-	 */
-	private $post_seo_data_updater;
+	private $abilities;
 
 	/**
 	 * Returns the conditionals based on which this loadable should be active.
@@ -62,33 +25,16 @@ class Abilities_Integration implements Integration_Interface {
 	 * @return array<string> The conditionals.
 	 */
 	public static function get_conditionals() {
-		return [
-			Abilities_API_Conditional::class,
-			Should_Index_Indexables_Conditional::class,
-		];
+		return [ Abilities_API_Conditional::class ];
 	}
 
 	/**
 	 * Constructor.
 	 *
-	 * @param Score_Retriever                      $score_retriever                      The score retriever.
-	 * @param Capability_Helper                    $capability_helper                    The capability helper.
-	 * @param Enabled_Analysis_Features_Repository $enabled_analysis_features_repository The enabled analysis features repository.
-	 * @param Post_SEO_Data_Collector              $post_seo_data_collector              The post SEO data collector.
-	 * @param Post_SEO_Data_Updater                $post_seo_data_updater                The post SEO data updater.
+	 * @param Ability_Interface ...$abilities The abilities to register.
 	 */
-	public function __construct(
-		Score_Retriever $score_retriever,
-		Capability_Helper $capability_helper,
-		Enabled_Analysis_Features_Repository $enabled_analysis_features_repository,
-		Post_SEO_Data_Collector $post_seo_data_collector,
-		Post_SEO_Data_Updater $post_seo_data_updater
-	) {
-		$this->score_retriever                      = $score_retriever;
-		$this->capability_helper                    = $capability_helper;
-		$this->enabled_analysis_features_repository = $enabled_analysis_features_repository;
-		$this->post_seo_data_collector              = $post_seo_data_collector;
-		$this->post_seo_data_updater                = $post_seo_data_updater;
+	public function __construct( Ability_Interface ...$abilities ) {
+		$this->abilities = $abilities;
 	}
 
 	/**
@@ -101,58 +47,46 @@ class Abilities_Integration implements Integration_Interface {
 	}
 
 	/**
-	 * Registers the Yoast SEO abilities.
+	 * Registers the available Yoast SEO abilities.
 	 *
 	 * @return void
 	 */
 	public function register_abilities() {
-		$enabled_features = $this->enabled_analysis_features_repository->get_features_by_keys(
-			[
-				Keyphrase_Analysis::NAME,
-				Readability_Analysis::NAME,
-				Inclusive_Language_Analysis::NAME,
-			],
-		)->to_array();
+		foreach ( $this->abilities as $ability ) {
+			if ( ! $ability->is_available() ) {
+				continue;
+			}
 
-		if ( $enabled_features[ Keyphrase_Analysis::NAME ] === true ) {
-			$this->register_seo_scores_ability();
+			\wp_register_ability( $ability->get_name(), $ability->get_args() );
 		}
-
-		if ( $enabled_features[ Readability_Analysis::NAME ] === true ) {
-			$this->register_readability_scores_ability();
-		}
-
-		if ( $enabled_features[ Inclusive_Language_Analysis::NAME ] === true ) {
-			$this->register_inclusive_language_scores_ability();
-		}
-
-		$this->register_get_post_seo_data_ability();
-		$this->register_update_post_seo_data_ability();
 	}
 
 	/**
 	 * Checks whether the current user can manage Yoast SEO.
 	 *
-	 * Gates the score abilities behind the Yoast SEO management capability.
+	 * @deprecated 28.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool Whether the current user can manage Yoast SEO.
 	 */
 	public function can_manage_seo(): bool {
-		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.6', 'Abstract_Score_Ability::can_manage_seo' );
+
+		return \YoastSEO()->helpers->capability->current_user_can( 'wpseo_manage_options' );
 	}
 
 	/**
 	 * Checks whether the current user can edit advanced SEO metadata.
 	 *
-	 * Gates the post SEO data abilities on the same capability that gates the advanced
-	 * and schema fields in the editors, so the abilities can never grant a field the
-	 * editor UI denies. The capability helper also passes wpseo_manage_options holders.
-	 * Per-post edit access is enforced on top, in the execute callbacks.
+	 * @deprecated 28.6
+	 * @codeCoverageIgnore
 	 *
 	 * @return bool Whether the current user can edit advanced SEO metadata.
 	 */
 	public function can_edit_advanced_metadata(): bool {
-		return $this->capability_helper->current_user_can( 'wpseo_edit_advanced_metadata' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.6', 'Abstract_Post_SEO_Data_Ability::can_edit_advanced_metadata' );
+
+		return \YoastSEO()->helpers->capability->current_user_can( 'wpseo_edit_advanced_metadata' );
 	}
 
 	/**
@@ -164,441 +98,8 @@ class Abilities_Integration implements Integration_Interface {
 	 * @return bool Whether the current user can read scores.
 	 */
 	public function can_read_scores(): bool {
-		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Use can_manage_seo() instead.' );
+		\_deprecated_function( __METHOD__, 'Yoast SEO 28.2', 'Abstract_Score_Ability::can_manage_seo' );
 
-		return $this->can_manage_seo();
+		return \YoastSEO()->helpers->capability->current_user_can( 'wpseo_manage_options' );
 	}
-
-	/**
-	 * Registers the SEO scores ability.
-	 *
-	 * @return void
-	 */
-	private function register_seo_scores_ability(): void {
-		$output_schema                                  = $this->get_score_output_schema();
-		$output_schema['properties']['focus_keyphrase'] = [
-			'type'        => [ 'string', 'null' ],
-			'description' => \__( 'The focus keyphrase for the post, or null if not set.', 'wordpress-seo' ),
-		];
-
-		\wp_register_ability(
-			Ability_Categories_Integration::CATEGORY_SLUG . '/get-seo-scores',
-			$this->get_shared_ability_args(
-				[
-					'label'            => \__( 'Get SEO Scores', 'wordpress-seo' ),
-					'description'      => \__( 'Get the SEO scores for the most recently modified posts.', 'wordpress-seo' ),
-					'output_schema'    => $this->wrap_in_array_schema( $output_schema ),
-					'execute_callback' => [ $this->score_retriever, 'get_seo_scores' ],
-				],
-			),
-		);
-	}
-
-	/**
-	 * Registers the readability scores ability.
-	 *
-	 * @return void
-	 */
-	private function register_readability_scores_ability(): void {
-		\wp_register_ability(
-			Ability_Categories_Integration::CATEGORY_SLUG . '/get-readability-scores',
-			$this->get_shared_ability_args(
-				[
-					'label'            => \__( 'Get Readability Scores', 'wordpress-seo' ),
-					'description'      => \__( 'Get the readability scores for the most recently modified posts.', 'wordpress-seo' ),
-					'output_schema'    => $this->wrap_in_array_schema( $this->get_score_output_schema() ),
-					'execute_callback' => [ $this->score_retriever, 'get_readability_scores' ],
-				],
-			),
-		);
-	}
-
-	/**
-	 * Registers the inclusive language scores ability.
-	 *
-	 * @return void
-	 */
-	private function register_inclusive_language_scores_ability(): void {
-		\wp_register_ability(
-			Ability_Categories_Integration::CATEGORY_SLUG . '/get-inclusive-language-scores',
-			$this->get_shared_ability_args(
-				[
-					'label'            => \__( 'Get Inclusive Language Scores', 'wordpress-seo' ),
-					'description'      => \__( 'Get the inclusive language scores for the most recently modified posts.', 'wordpress-seo' ),
-					'output_schema'    => $this->wrap_in_array_schema( $this->get_score_output_schema() ),
-					'execute_callback' => [ $this->score_retriever, 'get_inclusive_language_scores' ],
-				],
-			),
-		);
-	}
-
-	/**
-	 * Registers the get post SEO data ability.
-	 *
-	 * @return void
-	 */
-	private function register_get_post_seo_data_ability(): void {
-		\wp_register_ability(
-			Ability_Categories_Integration::CATEGORY_SLUG . '/get-post-seo-data',
-			$this->get_shared_ability_args(
-				[
-					'label'               => \__( 'Get Post SEO Data', 'wordpress-seo' ),
-					'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
-					'input_schema'        => $this->get_post_identifier_input_schema(),
-					'output_schema'       => $this->wrap_in_array_schema( $this->get_post_seo_data_output_schema() ),
-					'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
-					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
-				],
-			),
-		);
-	}
-
-	/**
-	 * Registers the update post SEO data ability.
-	 *
-	 * @return void
-	 */
-	private function register_update_post_seo_data_ability(): void {
-		\wp_register_ability(
-			Ability_Categories_Integration::CATEGORY_SLUG . '/update-post-seo-data',
-			$this->get_shared_ability_args(
-				[
-					'label'               => \__( 'Update Post SEO Data', 'wordpress-seo' ),
-					'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
-					'input_schema'        => $this->get_update_post_seo_data_input_schema(),
-					'output_schema'       => $this->get_post_seo_data_output_schema(),
-					'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
-					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
-					'meta'                => [
-						'show_in_rest' => true,
-						'annotations'  => [
-							'readonly'    => false,
-							// We can't claim this is truly non-destructive because technically there can be data deletions.
-							'destructive' => null,
-							'idempotent'  => true,
-						],
-						'mcp'          => [
-							'public' => true,
-						],
-					],
-				],
-			),
-		);
-	}
-
-	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- Too complicated of a param declaration for this case.
-
-	/**
-	 * Returns the shared ability arguments merged with ability-specific arguments.
-	 *
-	 * @param array<string, mixed> $ability_specific_args The ability-specific arguments.
-	 *
-	 * @return array<string, mixed> The merged ability arguments.
-	 */
-	private function get_shared_ability_args( array $ability_specific_args ): array {
-	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
-		return \array_merge(
-			[
-				'category'            => Ability_Categories_Integration::CATEGORY_SLUG,
-				'input_schema'        => [
-					'type'                 => 'object',
-					'additionalProperties' => false,
-					'properties'           => [
-						'number_of_posts' => [
-							'type'        => 'integer',
-							'description' => \__( 'The number of recently modified posts to retrieve scores for. Defaults to 10.', 'wordpress-seo' ),
-							'minimum'     => 1,
-							'maximum'     => 100,
-							'default'     => 10,
-						],
-					],
-				],
-				'permission_callback' => [ $this, 'can_manage_seo' ],
-				'meta'                => [
-					'show_in_rest' => true,
-					'annotations'  => [
-						'readonly'    => true,
-						'destructive' => false,
-						'idempotent'  => true,
-					],
-					'mcp'          => [
-						'public' => true,
-					],
-				],
-			],
-			$ability_specific_args,
-		);
-	}
-
-	/**
-	 * Wraps an item schema in an array schema.
-	 *
-	 * @param array<string, array<string, string>> $item_schema The item schema.
-	 *
-	 * @return array<string, array<string, string>> The array schema.
-	 */
-	private function wrap_in_array_schema( array $item_schema ): array {
-		return [
-			'type'  => 'array',
-			'items' => $item_schema,
-		];
-	}
-
-	/**
-	 * Returns the score output schema, including the title property.
-	 *
-	 * @return array<string, array<string, string>> The score output schema.
-	 */
-	private function get_score_output_schema(): array {
-		return [
-			'type'       => 'object',
-			'properties' => [
-				'title' => [
-					'type'        => 'string',
-					'description' => \__( 'The post title.', 'wordpress-seo' ),
-				],
-				'score' => [
-					'type'        => 'string',
-					'enum'        => [ 'na', 'bad', 'ok', 'good' ],
-					'description' => \__( 'The score slug.', 'wordpress-seo' ),
-				],
-				'label' => [
-					'type'        => 'string',
-					'description' => \__( 'A human-readable label for the score.', 'wordpress-seo' ),
-				],
-			],
-		];
-	}
-
-	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
-
-	/**
-	 * Returns the input schema for identifying a post (read path).
-	 *
-	 * @return array<string, mixed> The input schema.
-	 */
-	private function get_post_identifier_input_schema(): array {
-		return [
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => [
-				'post_id'   => [
-					'type'        => 'integer',
-					'description' => \__( 'The ID of the post to retrieve.', 'wordpress-seo' ),
-					'minimum'     => 1,
-				],
-				'permalink' => [
-					'type'        => 'string',
-					'description' => \__( 'The permalink (URL) of the post to retrieve.', 'wordpress-seo' ),
-				],
-				'title'     => [
-					'type'        => 'string',
-					'description' => \__( 'Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter.', 'wordpress-seo' ),
-				],
-				'page'      => [
-					'type'        => 'integer',
-					'description' => \__( 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.', 'wordpress-seo' ),
-					'minimum'     => 1,
-					'default'     => 1,
-				],
-			],
-		];
-	}
-
-	/**
-	 * Returns the input schema for updating a post's SEO data (write path).
-	 *
-	 * @return array<string, mixed> The input schema.
-	 */
-	private function get_update_post_seo_data_input_schema(): array {
-		return [
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => [
-				'post_id'             => [
-					'type'        => 'integer',
-					'description' => \__( 'The ID of the post to update.', 'wordpress-seo' ),
-					'minimum'     => 1,
-				],
-				'permalink'           => [
-					'type'        => 'string',
-					'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
-				],
-				'canonical'           => [
-					'type'        => [ 'string', 'null' ],
-					'description' => \__( 'The custom canonical URL for the post. Use null or an empty string to remove it and fall back to the default canonical.', 'wordpress-seo' ),
-				],
-				'is_cornerstone'      => [
-					'type'        => 'boolean',
-					'description' => \__( 'Whether the post is marked as cornerstone content.', 'wordpress-seo' ),
-				],
-				'noindex'             => [
-					'type'        => [ 'boolean', 'null' ],
-					'description' => \__( 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.', 'wordpress-seo' ),
-				],
-				'nofollow'            => [
-					'type'        => 'boolean',
-					'description' => \__( 'Whether search engines should be told not to follow the links on this post.', 'wordpress-seo' ),
-				],
-				'noimageindex'        => [
-					'type'        => 'boolean',
-					'description' => \__( 'Whether search engines should be told not to index the images on this post.', 'wordpress-seo' ),
-				],
-				'noarchive'           => [
-					'type'        => 'boolean',
-					'description' => \__( 'Whether search engines should be told not to show a cached copy of this post.', 'wordpress-seo' ),
-				],
-				'nosnippet'           => [
-					'type'        => 'boolean',
-					'description' => \__( 'Whether search engines should be told not to show a snippet of this post in the search results.', 'wordpress-seo' ),
-				],
-				'schema_page_type'    => $this->nullable_enum_schema(
-					\array_keys( Schema_Types::PAGE_TYPES ),
-					\__( 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
-				),
-				'schema_article_type' => $this->nullable_enum_schema(
-					$this->get_schema_article_types(),
-					\__( 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
-				),
-			],
-		];
-	}
-
-	/**
-	 * Returns the allowed Schema.org article type values.
-	 *
-	 * Mirrors the validation in WPSEO_Option_Titles so the ability accepts exactly the
-	 * article types the editor does, including any registered through the filter.
-	 *
-	 * @return array<int, string> The allowed article type values.
-	 */
-	private function get_schema_article_types(): array {
-		/**
-		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
-		 *
-		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
-		 *
-		 * @param array $schema_article_types The available schema article types.
-		 */
-		return \array_keys( \apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES ) );
-	}
-
-	/**
-	 * Returns a nullable-string input schema constrained to a fixed set of allowed values.
-	 *
-	 * Null and the empty string are always allowed on top of the enum so the field can be
-	 * cleared, matching the patch-clear semantics of the other write fields.
-	 *
-	 * @param array<int, string> $allowed_values The allowed string values.
-	 * @param string             $description    The field description.
-	 *
-	 * @return array<string, mixed> The input schema fragment.
-	 */
-	private function nullable_enum_schema( array $allowed_values, string $description ): array {
-		return [
-			'type'        => [ 'string', 'null' ],
-			'description' => $description,
-			'enum'        => \array_merge( $allowed_values, [ '', null ] ),
-		];
-	}
-
-	/**
-	 * Returns the output schema describing a post's SEO data.
-	 *
-	 * @return array<string, mixed> The output schema.
-	 */
-	private function get_post_seo_data_output_schema(): array {
-		$nullable_string = [
-			'type' => [ 'string', 'null' ],
-		];
-		$score           = static function ( $analysis ) {
-			return [
-				'type'        => 'string',
-				'enum'        => [ 'na', 'bad', 'ok', 'good' ],
-				'description' => \sprintf(
-					/* translators: %s expands to the name of the analysis, e.g. "SEO analysis". */
-					\__( 'The result of the %s that ran on the post when it was last saved.', 'wordpress-seo' ),
-					$analysis,
-				),
-			];
-		};
-
-		// The rendered companion of a field carries the value as actually output on the front end: the global default template applied where no custom value is set, with replacement variables expanded.
-		$rendered = static function ( $field ) {
-			return [
-				'type'        => [ 'string', 'null' ],
-				'description' => \sprintf(
-					/* translators: %s expands to the name of the SEO field, e.g. "SEO title". */
-					\__( 'The %s as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output.', 'wordpress-seo' ),
-					$field,
-				),
-			];
-		};
-
-		// The raw side of a rendered pair carries the stored per-post value; null means "no custom value set", not "nothing is output".
-		$raw = static function ( $field ) {
-			return [
-				'type'        => [ 'string', 'null' ],
-				'description' => \sprintf(
-					/* translators: %s expands to the name of the SEO field, e.g. "SEO title". */
-					\__( 'The custom %s as stored for the post, which may contain unexpanded replacement variables. Null when no custom value is set; the rendered companion field carries what is actually output.', 'wordpress-seo' ),
-					$field,
-				),
-			];
-		};
-
-		return [
-			'type'       => 'object',
-			'properties' => [
-				'post_id'                         => [ 'type' => 'integer' ],
-				'post_title'                      => $nullable_string,
-				'permalink'                       => $nullable_string,
-				'post_type'                       => [ 'type' => 'string' ],
-				'post_status'                     => $nullable_string,
-				'seo_title'                       => $raw( \__( 'SEO title', 'wordpress-seo' ) ),
-				'seo_title_rendered'              => $rendered( \__( 'SEO title', 'wordpress-seo' ) ),
-				'meta_description'                => $raw( \__( 'meta description', 'wordpress-seo' ) ),
-				'meta_description_rendered'       => $rendered( \__( 'meta description', 'wordpress-seo' ) ),
-				'focus_keyphrase'                 => $nullable_string,
-				'canonical'                       => [
-					'type'        => [ 'string', 'null' ],
-					'description' => \__( 'The custom canonical URL as stored for the post. Null when no custom value is set; the rendered companion field carries what is actually output.', 'wordpress-seo' ),
-				],
-				'canonical_rendered'              => [
-					'type'        => [ 'string', 'null' ],
-					'description' => \__( 'The canonical URL as output on the front end: the custom value when set, otherwise the permalink of the post. Null when nothing is output.', 'wordpress-seo' ),
-				],
-				'is_cornerstone'                  => [ 'type' => 'boolean' ],
-				'noindex'                         => [
-					'type'        => [ 'boolean', 'null' ],
-					'description' => \__( 'Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies.', 'wordpress-seo' ),
-				],
-				'nofollow'                        => [ 'type' => 'boolean' ],
-				'noimageindex'                    => [ 'type' => 'boolean' ],
-				'noarchive'                       => [ 'type' => 'boolean' ],
-				'nosnippet'                       => [ 'type' => 'boolean' ],
-				'open_graph_title'                => $raw( \__( 'Open Graph title', 'wordpress-seo' ) ),
-				'open_graph_title_rendered'       => $rendered( \__( 'Open Graph title', 'wordpress-seo' ) ),
-				'open_graph_description'          => $raw( \__( 'Open Graph description', 'wordpress-seo' ) ),
-				'open_graph_description_rendered' => $rendered( \__( 'Open Graph description', 'wordpress-seo' ) ),
-				'twitter_title'                   => $raw( \__( 'X title', 'wordpress-seo' ) ),
-				'twitter_title_rendered'          => $rendered( \__( 'X title', 'wordpress-seo' ) ),
-				'twitter_description'             => $raw( \__( 'X description', 'wordpress-seo' ) ),
-				'twitter_description_rendered'    => $rendered( \__( 'X description', 'wordpress-seo' ) ),
-				'schema_page_type'                => [
-					'type'        => [ 'string', 'null' ],
-					'description' => \__( 'The Schema.org page type stored for the post. Null means no override is set and the default for the post type applies.', 'wordpress-seo' ),
-				],
-				'schema_article_type'             => [
-					'type'        => [ 'string', 'null' ],
-					'description' => \__( 'The Schema.org article type stored for the post. Null means no override is set and the default for the post type applies.', 'wordpress-seo' ),
-				],
-				'seo_score'                       => $score( \__( 'SEO analysis', 'wordpress-seo' ) ),
-				'readability_score'               => $score( \__( 'readability analysis', 'wordpress-seo' ) ),
-				'inclusive_language_score'        => $score( \__( 'inclusive language analysis', 'wordpress-seo' ) ),
-			],
-		];
-	}
-
-	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
 }

--- a/src/abilities/user-interface/abilities/abstract-post-seo-data-ability.php
+++ b/src/abilities/user-interface/abilities/abstract-post-seo-data-ability.php
@@ -1,0 +1,168 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\Domain\Ability_Interface;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+
+/**
+ * Base class for the abilities that read or write the SEO data of a post.
+ */
+abstract class Abstract_Post_SEO_Data_Ability implements Ability_Interface {
+
+	/**
+	 * The capability helper.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * The should index indexables conditional.
+	 *
+	 * @var Should_Index_Indexables_Conditional
+	 */
+	private $should_index_indexables_conditional;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Capability_Helper                   $capability_helper                   The capability helper.
+	 * @param Should_Index_Indexables_Conditional $should_index_indexables_conditional The should index indexables conditional.
+	 */
+	public function __construct(
+		Capability_Helper $capability_helper,
+		Should_Index_Indexables_Conditional $should_index_indexables_conditional
+	) {
+		$this->capability_helper                   = $capability_helper;
+		$this->should_index_indexables_conditional = $should_index_indexables_conditional;
+	}
+
+	/**
+	 * Returns whether the ability is available: the SEO data is read from and written to the
+	 * indexables, so they must be built.
+	 *
+	 * @return bool Whether the ability is available.
+	 */
+	public function is_available(): bool {
+		return $this->should_index_indexables_conditional->is_met();
+	}
+
+	/**
+	 * Checks whether the current user can edit advanced SEO metadata.
+	 *
+	 * Gates the post SEO data abilities on the same capability that gates the advanced
+	 * and schema fields in the editors, so the abilities can never grant a field the
+	 * editor UI denies. The capability helper also passes wpseo_manage_options holders.
+	 * Per-post edit access is enforced on top, in the execute callbacks.
+	 *
+	 * @return bool Whether the current user can edit advanced SEO metadata.
+	 */
+	public function can_edit_advanced_metadata(): bool {
+		return $this->capability_helper->current_user_can( 'wpseo_edit_advanced_metadata' );
+	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the output schema describing a post's SEO data.
+	 *
+	 * @return array<string, mixed> The output schema.
+	 */
+	protected function get_post_seo_data_output_schema(): array {
+		$nullable_string = [
+			'type' => [ 'string', 'null' ],
+		];
+		$score           = static function ( $analysis ) {
+			return [
+				'type'        => 'string',
+				'enum'        => [ 'na', 'bad', 'ok', 'good' ],
+				'description' => \sprintf(
+					/* translators: %s expands to the name of the analysis, e.g. "SEO analysis". */
+					\__( 'The result of the %s that ran on the post when it was last saved.', 'wordpress-seo' ),
+					$analysis,
+				),
+			];
+		};
+
+		// The rendered companion of a field carries the value as actually output on the front end: the global default template applied where no custom value is set, with replacement variables expanded.
+		$rendered = static function ( $field ) {
+			return [
+				'type'        => [ 'string', 'null' ],
+				'description' => \sprintf(
+					/* translators: %s expands to the name of the SEO field, e.g. "SEO title". */
+					\__( 'The %s as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output.', 'wordpress-seo' ),
+					$field,
+				),
+			];
+		};
+
+		// The raw side of a rendered pair carries the stored per-post value; null means "no custom value set", not "nothing is output".
+		$raw = static function ( $field ) {
+			return [
+				'type'        => [ 'string', 'null' ],
+				'description' => \sprintf(
+					/* translators: %s expands to the name of the SEO field, e.g. "SEO title". */
+					\__( 'The custom %s as stored for the post, which may contain unexpanded replacement variables. Null when no custom value is set; the rendered companion field carries what is actually output.', 'wordpress-seo' ),
+					$field,
+				),
+			];
+		};
+
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'post_id'                         => [ 'type' => 'integer' ],
+				'post_title'                      => $nullable_string,
+				'permalink'                       => $nullable_string,
+				'post_type'                       => [ 'type' => 'string' ],
+				'post_status'                     => $nullable_string,
+				'seo_title'                       => $raw( \__( 'SEO title', 'wordpress-seo' ) ),
+				'seo_title_rendered'              => $rendered( \__( 'SEO title', 'wordpress-seo' ) ),
+				'meta_description'                => $raw( \__( 'meta description', 'wordpress-seo' ) ),
+				'meta_description_rendered'       => $rendered( \__( 'meta description', 'wordpress-seo' ) ),
+				'focus_keyphrase'                 => $nullable_string,
+				'canonical'                       => [
+					'type'        => [ 'string', 'null' ],
+					'description' => \__( 'The custom canonical URL as stored for the post. Null when no custom value is set; the rendered companion field carries what is actually output.', 'wordpress-seo' ),
+				],
+				'canonical_rendered'              => [
+					'type'        => [ 'string', 'null' ],
+					'description' => \__( 'The canonical URL as output on the front end: the custom value when set, otherwise the permalink of the post. Null when nothing is output.', 'wordpress-seo' ),
+				],
+				'is_cornerstone'                  => [ 'type' => 'boolean' ],
+				'noindex'                         => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => \__( 'Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies.', 'wordpress-seo' ),
+				],
+				'nofollow'                        => [ 'type' => 'boolean' ],
+				'noimageindex'                    => [ 'type' => 'boolean' ],
+				'noarchive'                       => [ 'type' => 'boolean' ],
+				'nosnippet'                       => [ 'type' => 'boolean' ],
+				'open_graph_title'                => $raw( \__( 'Open Graph title', 'wordpress-seo' ) ),
+				'open_graph_title_rendered'       => $rendered( \__( 'Open Graph title', 'wordpress-seo' ) ),
+				'open_graph_description'          => $raw( \__( 'Open Graph description', 'wordpress-seo' ) ),
+				'open_graph_description_rendered' => $rendered( \__( 'Open Graph description', 'wordpress-seo' ) ),
+				'twitter_title'                   => $raw( \__( 'X title', 'wordpress-seo' ) ),
+				'twitter_title_rendered'          => $rendered( \__( 'X title', 'wordpress-seo' ) ),
+				'twitter_description'             => $raw( \__( 'X description', 'wordpress-seo' ) ),
+				'twitter_description_rendered'    => $rendered( \__( 'X description', 'wordpress-seo' ) ),
+				'schema_page_type'                => [
+					'type'        => [ 'string', 'null' ],
+					'description' => \__( 'The Schema.org page type stored for the post. Null means no override is set and the default for the post type applies.', 'wordpress-seo' ),
+				],
+				'schema_article_type'             => [
+					'type'        => [ 'string', 'null' ],
+					'description' => \__( 'The Schema.org article type stored for the post. Null means no override is set and the default for the post type applies.', 'wordpress-seo' ),
+				],
+				'seo_score'                       => $score( \__( 'SEO analysis', 'wordpress-seo' ) ),
+				'readability_score'               => $score( \__( 'readability analysis', 'wordpress-seo' ) ),
+				'inclusive_language_score'        => $score( \__( 'inclusive language analysis', 'wordpress-seo' ) ),
+			],
+		];
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+}

--- a/src/abilities/user-interface/abilities/abstract-score-ability.php
+++ b/src/abilities/user-interface/abilities/abstract-score-ability.php
@@ -1,0 +1,214 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
+use Yoast\WP\SEO\Abilities\Domain\Ability_Interface;
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+
+/**
+ * Base class for the abilities that return the analysis scores of the most recently modified posts.
+ */
+abstract class Abstract_Score_Ability implements Ability_Interface {
+
+	/**
+	 * The score retriever.
+	 *
+	 * @var Score_Retriever
+	 */
+	protected $score_retriever;
+
+	/**
+	 * The capability helper.
+	 *
+	 * @var Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * The enabled analysis features repository.
+	 *
+	 * @var Enabled_Analysis_Features_Repository
+	 */
+	private $enabled_analysis_features_repository;
+
+	/**
+	 * The should index indexables conditional.
+	 *
+	 * @var Should_Index_Indexables_Conditional
+	 */
+	private $should_index_indexables_conditional;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Score_Retriever                      $score_retriever                      The score retriever.
+	 * @param Capability_Helper                    $capability_helper                    The capability helper.
+	 * @param Enabled_Analysis_Features_Repository $enabled_analysis_features_repository The enabled analysis features repository.
+	 * @param Should_Index_Indexables_Conditional  $should_index_indexables_conditional  The should index indexables conditional.
+	 */
+	public function __construct(
+		Score_Retriever $score_retriever,
+		Capability_Helper $capability_helper,
+		Enabled_Analysis_Features_Repository $enabled_analysis_features_repository,
+		Should_Index_Indexables_Conditional $should_index_indexables_conditional
+	) {
+		$this->score_retriever                      = $score_retriever;
+		$this->capability_helper                    = $capability_helper;
+		$this->enabled_analysis_features_repository = $enabled_analysis_features_repository;
+		$this->should_index_indexables_conditional  = $should_index_indexables_conditional;
+	}
+
+	/**
+	 * Returns the name of the analysis feature the ability depends on.
+	 *
+	 * @return string The analysis feature name.
+	 */
+	abstract protected function get_feature_name(): string;
+
+	/**
+	 * Returns the label of the ability.
+	 *
+	 * @return string The label.
+	 */
+	abstract protected function get_label(): string;
+
+	/**
+	 * Returns the description of the ability.
+	 *
+	 * @return string The description.
+	 */
+	abstract protected function get_description(): string;
+
+	/**
+	 * Returns the callback that executes the ability.
+	 *
+	 * @return array<int, object|string> The execute callback.
+	 */
+	abstract protected function get_execute_callback(): array;
+
+	/**
+	 * Returns whether the ability is available: the scores are read from the indexables, so
+	 * they must be built, and the analysis feature the ability depends on must be enabled.
+	 *
+	 * @return bool Whether the ability is available.
+	 */
+	public function is_available(): bool {
+		if ( ! $this->should_index_indexables_conditional->is_met() ) {
+			return false;
+		}
+
+		$feature_name     = $this->get_feature_name();
+		$enabled_features = $this->enabled_analysis_features_repository->get_features_by_keys( [ $feature_name ] )->to_array();
+
+		return isset( $enabled_features[ $feature_name ] ) && $enabled_features[ $feature_name ] === true;
+	}
+
+	/**
+	 * Checks whether the current user can manage Yoast SEO.
+	 *
+	 * Gates the score abilities behind the Yoast SEO management capability.
+	 *
+	 * @return bool Whether the current user can manage Yoast SEO.
+	 */
+	public function can_manage_seo(): bool {
+		return $this->capability_helper->current_user_can( 'wpseo_manage_options' );
+	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the arguments to register the ability with.
+	 *
+	 * @return array<string, mixed> The ability registration arguments.
+	 */
+	public function get_args(): array {
+		return [
+			'label'               => $this->get_label(),
+			'description'         => $this->get_description(),
+			'category'            => Ability_Categories_Integration::CATEGORY_SLUG,
+			'input_schema'        => [
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'number_of_posts' => [
+						'type'        => 'integer',
+						'description' => \__( 'The number of recently modified posts to retrieve scores for. Defaults to 10.', 'wordpress-seo' ),
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'default'     => 10,
+					],
+				],
+			],
+			'output_schema'       => $this->get_output_schema(),
+			'permission_callback' => [ $this, 'can_manage_seo' ],
+			'execute_callback'    => $this->get_execute_callback(),
+			'meta'                => [
+				'show_in_rest' => true,
+				'annotations'  => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the output schema: an array of score items.
+	 *
+	 * @return array<string, mixed> The output schema.
+	 */
+	protected function get_output_schema(): array {
+		return $this->wrap_in_array_schema( $this->get_score_output_schema() );
+	}
+
+	/**
+	 * Wraps an item schema in an array schema.
+	 *
+	 * @param array<string, mixed> $item_schema The item schema.
+	 *
+	 * @return array<string, mixed> The array schema.
+	 */
+	protected function wrap_in_array_schema( array $item_schema ): array {
+		return [
+			'type'  => 'array',
+			'items' => $item_schema,
+		];
+	}
+
+	/**
+	 * Returns the score output schema, including the title property.
+	 *
+	 * @return array<string, mixed> The score output schema.
+	 */
+	protected function get_score_output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'title' => [
+					'type'        => 'string',
+					'description' => \__( 'The post title.', 'wordpress-seo' ),
+				],
+				'score' => [
+					'type'        => 'string',
+					'enum'        => [ 'na', 'bad', 'ok', 'good' ],
+					'description' => \__( 'The score slug.', 'wordpress-seo' ),
+				],
+				'label' => [
+					'type'        => 'string',
+					'description' => \__( 'A human-readable label for the score.', 'wordpress-seo' ),
+				],
+			],
+		];
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+}

--- a/src/abilities/user-interface/abilities/get-inclusive-language-scores-ability.php
+++ b/src/abilities/user-interface/abilities/get-inclusive-language-scores-ability.php
@@ -1,0 +1,58 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
+
+/**
+ * The ability that returns the inclusive language scores of the most recently modified posts.
+ */
+class Get_Inclusive_Language_Scores_Ability extends Abstract_Score_Ability {
+
+	/**
+	 * Returns the full name of the ability.
+	 *
+	 * @return string The ability name.
+	 */
+	public function get_name(): string {
+		return Ability_Categories_Integration::CATEGORY_SLUG . '/get-inclusive-language-scores';
+	}
+
+	/**
+	 * Returns the name of the analysis feature the ability depends on.
+	 *
+	 * @return string The analysis feature name.
+	 */
+	protected function get_feature_name(): string {
+		return Inclusive_Language_Analysis::NAME;
+	}
+
+	/**
+	 * Returns the label of the ability.
+	 *
+	 * @return string The label.
+	 */
+	protected function get_label(): string {
+		return \__( 'Get Inclusive Language Scores', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the description of the ability.
+	 *
+	 * @return string The description.
+	 */
+	protected function get_description(): string {
+		return \__( 'Get the inclusive language scores for the most recently modified posts.', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the callback that executes the ability.
+	 *
+	 * @return array<int, object|string> The execute callback.
+	 */
+	protected function get_execute_callback(): array {
+		return [ $this->score_retriever, 'get_inclusive_language_scores' ];
+	}
+}

--- a/src/abilities/user-interface/abilities/get-post-seo-data-ability.php
+++ b/src/abilities/user-interface/abilities/get-post-seo-data-ability.php
@@ -1,0 +1,116 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+
+/**
+ * The ability that returns the SEO data of one or more posts.
+ */
+class Get_Post_SEO_Data_Ability extends Abstract_Post_SEO_Data_Ability {
+
+	/**
+	 * The post SEO data collector.
+	 *
+	 * @var Post_SEO_Data_Collector
+	 */
+	private $post_seo_data_collector;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Capability_Helper                   $capability_helper                   The capability helper.
+	 * @param Should_Index_Indexables_Conditional $should_index_indexables_conditional The should index indexables conditional.
+	 * @param Post_SEO_Data_Collector             $post_seo_data_collector             The post SEO data collector.
+	 */
+	public function __construct(
+		Capability_Helper $capability_helper,
+		Should_Index_Indexables_Conditional $should_index_indexables_conditional,
+		Post_SEO_Data_Collector $post_seo_data_collector
+	) {
+		parent::__construct( $capability_helper, $should_index_indexables_conditional );
+
+		$this->post_seo_data_collector = $post_seo_data_collector;
+	}
+
+	/**
+	 * Returns the full name of the ability.
+	 *
+	 * @return string The ability name.
+	 */
+	public function get_name(): string {
+		return Ability_Categories_Integration::CATEGORY_SLUG . '/get-post-seo-data';
+	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the arguments to register the ability with.
+	 *
+	 * @return array<string, mixed> The ability registration arguments.
+	 */
+	public function get_args(): array {
+		return [
+			'label'               => \__( 'Get Post SEO Data', 'wordpress-seo' ),
+			'description'         => \__( 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.', 'wordpress-seo' ),
+			'category'            => Ability_Categories_Integration::CATEGORY_SLUG,
+			'input_schema'        => $this->get_post_identifier_input_schema(),
+			'output_schema'       => [
+				'type'  => 'array',
+				'items' => $this->get_post_seo_data_output_schema(),
+			],
+			'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
+			'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
+			'meta'                => [
+				'show_in_rest' => true,
+				'annotations'  => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the input schema for identifying a post (read path).
+	 *
+	 * @return array<string, mixed> The input schema.
+	 */
+	private function get_post_identifier_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'   => [
+					'type'        => 'integer',
+					'description' => \__( 'The ID of the post to retrieve.', 'wordpress-seo' ),
+					'minimum'     => 1,
+				],
+				'permalink' => [
+					'type'        => 'string',
+					'description' => \__( 'The permalink (URL) of the post to retrieve.', 'wordpress-seo' ),
+				],
+				'title'     => [
+					'type'        => 'string',
+					'description' => \__( 'Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter.', 'wordpress-seo' ),
+				],
+				'page'      => [
+					'type'        => 'integer',
+					'description' => \__( 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.', 'wordpress-seo' ),
+					'minimum'     => 1,
+					'default'     => 1,
+				],
+			],
+		];
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+}

--- a/src/abilities/user-interface/abilities/get-readability-scores-ability.php
+++ b/src/abilities/user-interface/abilities/get-readability-scores-ability.php
@@ -1,0 +1,58 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
+
+/**
+ * The ability that returns the readability scores of the most recently modified posts.
+ */
+class Get_Readability_Scores_Ability extends Abstract_Score_Ability {
+
+	/**
+	 * Returns the full name of the ability.
+	 *
+	 * @return string The ability name.
+	 */
+	public function get_name(): string {
+		return Ability_Categories_Integration::CATEGORY_SLUG . '/get-readability-scores';
+	}
+
+	/**
+	 * Returns the name of the analysis feature the ability depends on.
+	 *
+	 * @return string The analysis feature name.
+	 */
+	protected function get_feature_name(): string {
+		return Readability_Analysis::NAME;
+	}
+
+	/**
+	 * Returns the label of the ability.
+	 *
+	 * @return string The label.
+	 */
+	protected function get_label(): string {
+		return \__( 'Get Readability Scores', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the description of the ability.
+	 *
+	 * @return string The description.
+	 */
+	protected function get_description(): string {
+		return \__( 'Get the readability scores for the most recently modified posts.', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the callback that executes the ability.
+	 *
+	 * @return array<int, object|string> The execute callback.
+	 */
+	protected function get_execute_callback(): array {
+		return [ $this->score_retriever, 'get_readability_scores' ];
+	}
+}

--- a/src/abilities/user-interface/abilities/get-seo-scores-ability.php
+++ b/src/abilities/user-interface/abilities/get-seo-scores-ability.php
@@ -1,0 +1,77 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
+
+/**
+ * The ability that returns the SEO scores of the most recently modified posts.
+ */
+class Get_SEO_Scores_Ability extends Abstract_Score_Ability {
+
+	/**
+	 * Returns the full name of the ability.
+	 *
+	 * @return string The ability name.
+	 */
+	public function get_name(): string {
+		return Ability_Categories_Integration::CATEGORY_SLUG . '/get-seo-scores';
+	}
+
+	/**
+	 * Returns the name of the analysis feature the ability depends on.
+	 *
+	 * @return string The analysis feature name.
+	 */
+	protected function get_feature_name(): string {
+		return Keyphrase_Analysis::NAME;
+	}
+
+	/**
+	 * Returns the label of the ability.
+	 *
+	 * @return string The label.
+	 */
+	protected function get_label(): string {
+		return \__( 'Get SEO Scores', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the description of the ability.
+	 *
+	 * @return string The description.
+	 */
+	protected function get_description(): string {
+		return \__( 'Get the SEO scores for the most recently modified posts.', 'wordpress-seo' );
+	}
+
+	/**
+	 * Returns the callback that executes the ability.
+	 *
+	 * @return array<int, object|string> The execute callback.
+	 */
+	protected function get_execute_callback(): array {
+		return [ $this->score_retriever, 'get_seo_scores' ];
+	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the output schema: an array of score items, each including the focus keyphrase.
+	 *
+	 * @return array<string, mixed> The output schema.
+	 */
+	protected function get_output_schema(): array {
+		$output_schema                                  = $this->get_score_output_schema();
+		$output_schema['properties']['focus_keyphrase'] = [
+			'type'        => [ 'string', 'null' ],
+			'description' => \__( 'The focus keyphrase for the post, or null if not set.', 'wordpress-seo' ),
+		];
+
+		return $this->wrap_in_array_schema( $output_schema );
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+}

--- a/src/abilities/user-interface/abilities/update-post-seo-data-ability.php
+++ b/src/abilities/user-interface/abilities/update-post-seo-data-ability.php
@@ -1,0 +1,179 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
+use Yoast\WP\SEO\Abilities\User_Interface\Ability_Categories_Integration;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+
+/**
+ * The ability that updates the SEO data of a single post.
+ */
+class Update_Post_SEO_Data_Ability extends Abstract_Post_SEO_Data_Ability {
+
+	/**
+	 * The post SEO data updater.
+	 *
+	 * @var Post_SEO_Data_Updater
+	 */
+	private $post_seo_data_updater;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Capability_Helper                   $capability_helper                   The capability helper.
+	 * @param Should_Index_Indexables_Conditional $should_index_indexables_conditional The should index indexables conditional.
+	 * @param Post_SEO_Data_Updater               $post_seo_data_updater               The post SEO data updater.
+	 */
+	public function __construct(
+		Capability_Helper $capability_helper,
+		Should_Index_Indexables_Conditional $should_index_indexables_conditional,
+		Post_SEO_Data_Updater $post_seo_data_updater
+	) {
+		parent::__construct( $capability_helper, $should_index_indexables_conditional );
+
+		$this->post_seo_data_updater = $post_seo_data_updater;
+	}
+
+	/**
+	 * Returns the full name of the ability.
+	 *
+	 * @return string The ability name.
+	 */
+	public function get_name(): string {
+		return Ability_Categories_Integration::CATEGORY_SLUG . '/update-post-seo-data';
+	}
+
+	// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint -- The JSON schema arrays are heterogeneous by nature.
+
+	/**
+	 * Returns the arguments to register the ability with.
+	 *
+	 * @return array<string, mixed> The ability registration arguments.
+	 */
+	public function get_args(): array {
+		return [
+			'label'               => \__( 'Update Post SEO Data', 'wordpress-seo' ),
+			'description'         => \__( 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.', 'wordpress-seo' ),
+			'category'            => Ability_Categories_Integration::CATEGORY_SLUG,
+			'input_schema'        => $this->get_update_post_seo_data_input_schema(),
+			'output_schema'       => $this->get_post_seo_data_output_schema(),
+			'permission_callback' => [ $this, 'can_edit_advanced_metadata' ],
+			'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
+			'meta'                => [
+				'show_in_rest' => true,
+				'annotations'  => [
+					'readonly'    => false,
+					// We can't claim this is truly non-destructive because technically there can be data deletions.
+					'destructive' => null,
+					'idempotent'  => true,
+				],
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the input schema for updating a post's SEO data (write path).
+	 *
+	 * @return array<string, mixed> The input schema.
+	 */
+	private function get_update_post_seo_data_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'             => [
+					'type'        => 'integer',
+					'description' => \__( 'The ID of the post to update.', 'wordpress-seo' ),
+					'minimum'     => 1,
+				],
+				'permalink'           => [
+					'type'        => 'string',
+					'description' => \__( 'The permalink (URL) of the post to update.', 'wordpress-seo' ),
+				],
+				'canonical'           => [
+					'type'        => [ 'string', 'null' ],
+					'description' => \__( 'The custom canonical URL for the post. Use null or an empty string to remove it and fall back to the default canonical.', 'wordpress-seo' ),
+				],
+				'is_cornerstone'      => [
+					'type'        => 'boolean',
+					'description' => \__( 'Whether the post is marked as cornerstone content.', 'wordpress-seo' ),
+				],
+				'noindex'             => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => \__( 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.', 'wordpress-seo' ),
+				],
+				'nofollow'            => [
+					'type'        => 'boolean',
+					'description' => \__( 'Whether search engines should be told not to follow the links on this post.', 'wordpress-seo' ),
+				],
+				'noimageindex'        => [
+					'type'        => 'boolean',
+					'description' => \__( 'Whether search engines should be told not to index the images on this post.', 'wordpress-seo' ),
+				],
+				'noarchive'           => [
+					'type'        => 'boolean',
+					'description' => \__( 'Whether search engines should be told not to show a cached copy of this post.', 'wordpress-seo' ),
+				],
+				'nosnippet'           => [
+					'type'        => 'boolean',
+					'description' => \__( 'Whether search engines should be told not to show a snippet of this post in the search results.', 'wordpress-seo' ),
+				],
+				'schema_page_type'    => $this->nullable_enum_schema(
+					\array_keys( Schema_Types::PAGE_TYPES ),
+					\__( 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
+				),
+				'schema_article_type' => $this->nullable_enum_schema(
+					$this->get_schema_article_types(),
+					\__( 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.', 'wordpress-seo' ),
+				),
+			],
+		];
+	}
+
+	/**
+	 * Returns the allowed Schema.org article type values.
+	 *
+	 * Mirrors the validation in WPSEO_Option_Titles so the ability accepts exactly the
+	 * article types the editor does, including any registered through the filter.
+	 *
+	 * @return array<int, string> The allowed article type values.
+	 */
+	private function get_schema_article_types(): array {
+		/**
+		 * Filter: 'wpseo_schema_article_types' - Allow developers to filter the available article types.
+		 *
+		 * Make sure when you filter this to also filter `wpseo_schema_article_types_labels`.
+		 *
+		 * @param array $schema_article_types The available schema article types.
+		 */
+		return \array_keys( \apply_filters( 'wpseo_schema_article_types', Schema_Types::ARTICLE_TYPES ) );
+	}
+
+	/**
+	 * Returns a nullable-string input schema constrained to a fixed set of allowed values.
+	 *
+	 * Null and the empty string are always allowed on top of the enum so the field can be
+	 * cleared, matching the patch-clear semantics of the other write fields.
+	 *
+	 * @param array<int, string> $allowed_values The allowed string values.
+	 * @param string             $description    The field description.
+	 *
+	 * @return array<string, mixed> The input schema fragment.
+	 */
+	private function nullable_enum_schema( array $allowed_values, string $description ): array {
+		return [
+			'type'        => [ 'string', 'null' ],
+			'description' => $description,
+			'enum'        => \array_merge( $allowed_values, [ '', null ] ),
+		];
+	}
+
+	// phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Abstract_Score_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Abstract_Score_Ability_Test.php
@@ -1,0 +1,185 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Mockery;
+use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
+use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Base class for the score ability tests.
+ */
+abstract class Abstract_Score_Ability_Test extends TestCase {
+
+	/**
+	 * The score retriever mock.
+	 *
+	 * @var Mockery\MockInterface|Score_Retriever
+	 */
+	protected $score_retriever;
+
+	/**
+	 * The capability helper mock.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	protected $capability_helper;
+
+	/**
+	 * The enabled analysis features repository mock.
+	 *
+	 * @var Mockery\MockInterface|Enabled_Analysis_Features_Repository
+	 */
+	protected $enabled_analysis_features_repository;
+
+	/**
+	 * The should index indexables conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Should_Index_Indexables_Conditional
+	 */
+	protected $should_index_indexables_conditional;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Abstract_Score_Ability
+	 */
+	protected $instance;
+
+	/**
+	 * Creates the instance under test.
+	 *
+	 * @return Abstract_Score_Ability The instance under test.
+	 */
+	abstract protected function create_instance(): Abstract_Score_Ability;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		$this->score_retriever                      = Mockery::mock( Score_Retriever::class );
+		$this->capability_helper                    = Mockery::mock( Capability_Helper::class );
+		$this->enabled_analysis_features_repository = Mockery::mock( Enabled_Analysis_Features_Repository::class );
+		$this->should_index_indexables_conditional  = Mockery::mock( Should_Index_Indexables_Conditional::class );
+
+		$this->instance = $this->create_instance();
+	}
+
+	/**
+	 * Data provider for the boolean outcome tests.
+	 *
+	 * @return array<string, array<bool>> The outcomes.
+	 */
+	public static function provide_boolean_outcomes(): array {
+		return [
+			'true'  => [ true ],
+			'false' => [ false ],
+		];
+	}
+
+	/**
+	 * Mocks the indexables as being built and the given analysis feature state.
+	 *
+	 * @param string              $feature_name The analysis feature name the ability should ask for.
+	 * @param array<string, bool> $features     The feature states the repository returns.
+	 *
+	 * @return void
+	 */
+	protected function mock_available_features( string $feature_name, array $features ): void {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturnTrue();
+
+		$features_list = Mockery::mock( Analysis_Features_List::class );
+		$features_list
+			->expects( 'to_array' )
+			->once()
+			->andReturn( $features );
+
+		$this->enabled_analysis_features_repository
+			->expects( 'get_features_by_keys' )
+			->once()
+			->with( [ $feature_name ] )
+			->andReturn( $features_list );
+	}
+
+	/**
+	 * Returns the registration arguments shared by all score abilities.
+	 *
+	 * @param string               $execute_method The Score_Retriever method the ability executes.
+	 * @param array<string, mixed> $item_schema    The expected output item schema.
+	 *
+	 * @return array<string, mixed> The expected arguments, without label and description.
+	 */
+	protected function get_expected_shared_args( string $execute_method, array $item_schema ): array {
+		return [
+			'category'            => 'yoast-seo',
+			'input_schema'        => [
+				'type'                 => 'object',
+				'additionalProperties' => false,
+				'properties'           => [
+					'number_of_posts' => [
+						'type'        => 'integer',
+						'description' => 'The number of recently modified posts to retrieve scores for. Defaults to 10.',
+						'minimum'     => 1,
+						'maximum'     => 100,
+						'default'     => 10,
+					],
+				],
+			],
+			'output_schema'       => [
+				'type'  => 'array',
+				'items' => $item_schema,
+			],
+			'permission_callback' => [ $this->instance, 'can_manage_seo' ],
+			'execute_callback'    => [ $this->score_retriever, $execute_method ],
+			'meta'                => [
+				'show_in_rest' => true,
+				'annotations'  => [
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				],
+				'mcp'          => [
+					'public' => true,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Returns the expected output item schema shared by all score abilities.
+	 *
+	 * @return array<string, mixed> The item schema.
+	 */
+	protected function get_expected_item_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'title' => [
+					'type'        => 'string',
+					'description' => 'The post title.',
+				],
+				'score' => [
+					'type'        => 'string',
+					'enum'        => [ 'na', 'bad', 'ok', 'good' ],
+					'description' => 'The score slug.',
+				],
+				'label' => [
+					'type'        => 'string',
+					'description' => 'A human-readable label for the score.',
+				],
+			],
+		];
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Get_Inclusive_Language_Scores_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Get_Inclusive_Language_Scores_Ability_Test.php
@@ -1,0 +1,117 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Inclusive_Language_Scores_Ability;
+use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
+
+/**
+ * Tests the Get_Inclusive_Language_Scores_Ability class.
+ *
+ * @group abilities
+ *
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Inclusive_Language_Scores_Ability
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability
+ */
+final class Get_Inclusive_Language_Scores_Ability_Test extends Abstract_Score_Ability_Test {
+
+	/**
+	 * Creates the instance under test.
+	 *
+	 * @return Abstract_Score_Ability The instance under test.
+	 */
+	protected function create_instance(): Abstract_Score_Ability {
+		return new Get_Inclusive_Language_Scores_Ability(
+			$this->score_retriever,
+			$this->capability_helper,
+			$this->enabled_analysis_features_repository,
+			$this->should_index_indexables_conditional,
+		);
+	}
+
+	/**
+	 * Tests that get_name returns the prefixed ability name.
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'yoast-seo/get-inclusive-language-scores', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests that is_available is false when the indexables are not being built, without consulting the analysis features.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_when_indexables_are_not_indexed() {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturnFalse();
+		$this->enabled_analysis_features_repository->expects( 'get_features_by_keys' )->never();
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available follows the enabled state of the inclusive language analysis when the indexables are being built.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $enabled Whether the inclusive language analysis is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_is_available( bool $enabled ) {
+		$this->mock_available_features( Inclusive_Language_Analysis::NAME, [ Inclusive_Language_Analysis::NAME => $enabled ] );
+
+		$this->assertSame( $enabled, $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available returns false when the inclusive language analysis is unknown to the repository.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_with_unknown_feature() {
+		$this->mock_available_features( Inclusive_Language_Analysis::NAME, [] );
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that can_manage_seo checks the manage options capability and returns its result.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_manage_seo( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_manage_seo() );
+	}
+
+	/**
+	 * Tests that get_args returns the expected registration arguments.
+	 *
+	 * @return void
+	 */
+	public function test_get_args() {
+		$this->assertSame(
+			\array_merge(
+				[
+					'label'       => 'Get Inclusive Language Scores',
+					'description' => 'Get the inclusive language scores for the most recently modified posts.',
+				],
+				$this->get_expected_shared_args( 'get_inclusive_language_scores', $this->get_expected_item_schema() ),
+			),
+			$this->instance->get_args(),
+		);
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Get_Post_SEO_Data_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Get_Post_SEO_Data_Ability_Test.php
@@ -1,0 +1,221 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Mockery;
+use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Post_SEO_Data_Ability;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Get_Post_SEO_Data_Ability class.
+ *
+ * @group abilities
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Post_SEO_Data_Ability
+ */
+final class Get_Post_SEO_Data_Ability_Test extends TestCase {
+
+	use Post_SEO_Data_Schema_Trait;
+
+	/**
+	 * The capability helper mock.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * The should index indexables conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Should_Index_Indexables_Conditional
+	 */
+	private $should_index_indexables_conditional;
+
+	/**
+	 * The post SEO data collector mock.
+	 *
+	 * @var Mockery\MockInterface|Post_SEO_Data_Collector
+	 */
+	private $post_seo_data_collector;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Get_Post_SEO_Data_Ability
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		$this->capability_helper                   = Mockery::mock( Capability_Helper::class );
+		$this->should_index_indexables_conditional = Mockery::mock( Should_Index_Indexables_Conditional::class );
+		$this->post_seo_data_collector             = Mockery::mock( Post_SEO_Data_Collector::class );
+
+		$this->instance = new Get_Post_SEO_Data_Ability(
+			$this->capability_helper,
+			$this->should_index_indexables_conditional,
+			$this->post_seo_data_collector,
+		);
+	}
+
+	/**
+	 * Tests that get_name returns the prefixed ability name.
+	 *
+	 * @covers ::get_name
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'yoast-seo/get-post-seo-data', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests that is_available follows whether the indexables are being built.
+	 *
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::is_available
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $is_met Whether the indexables are being built.
+	 *
+	 * @return void
+	 */
+	public function test_is_available( bool $is_met ) {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturn( $is_met );
+
+		$this->assertSame( $is_met, $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that can_edit_advanced_metadata checks the advanced metadata capability and returns its result.
+	 *
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::__construct
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::can_edit_advanced_metadata
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_advanced_metadata( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_edit_advanced_metadata' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_edit_advanced_metadata() );
+	}
+
+	/**
+	 * Tests that get_args returns the expected registration arguments.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_args
+	 * @covers ::get_post_identifier_input_schema
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::get_post_seo_data_output_schema
+	 *
+	 * @return void
+	 */
+	public function test_get_args() {
+		$this->assertSame(
+			[
+				'label'               => 'Get Post SEO Data',
+				'description'         => 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.',
+				'category'            => 'yoast-seo',
+				'input_schema'        => [
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => [
+						'post_id'   => [
+							'type'        => 'integer',
+							'description' => 'The ID of the post to retrieve.',
+							'minimum'     => 1,
+						],
+						'permalink' => [
+							'type'        => 'string',
+							'description' => 'The permalink (URL) of the post to retrieve.',
+						],
+						'title'     => [
+							'type'        => 'string',
+							'description' => 'Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter.',
+						],
+						'page'      => [
+							'type'        => 'integer',
+							'description' => 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.',
+							'minimum'     => 1,
+							'default'     => 1,
+						],
+					],
+				],
+				'output_schema'       => [
+					'type'  => 'array',
+					'items' => $this->get_expected_output_schema(),
+				],
+				'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
+				'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			],
+			$this->instance->get_args(),
+		);
+	}
+
+	/**
+	 * Tests that the SEO data array built by the field map exposes exactly the
+	 * properties documented in the output schema.
+	 *
+	 * The field contract is spread over hand-maintained structures (the output schema
+	 * and Post_SEO_Field_Map) which fail silently when they drift: a field missing from
+	 * either side is simply never surfaced to the ability's consumers. This test turns
+	 * that drift into a failure.
+	 *
+	 * @covers ::get_args
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::get_post_seo_data_output_schema
+	 *
+	 * @return void
+	 */
+	public function test_output_schema_matches_field_map_output() {
+		$output_schema = $this->instance->get_args()['output_schema']['items'];
+
+		$meta_surface = Mockery::mock( Meta_Surface::class );
+		$meta_surface->expects( 'for_indexable' )->andReturnFalse();
+		$field_map = new Post_SEO_Field_Map( $meta_surface );
+
+		$schema_properties = \array_keys( $output_schema['properties'] );
+		$output_fields     = \array_keys( $field_map->to_seo_array( Mockery::mock( Indexable_Mock::class ) ) );
+		\sort( $schema_properties );
+		\sort( $output_fields );
+
+		$this->assertSame(
+			$schema_properties,
+			$output_fields,
+			'The output schema and Post_SEO_Field_Map::to_seo_array() must describe the same set of fields.',
+		);
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Get_Readability_Scores_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Get_Readability_Scores_Ability_Test.php
@@ -1,0 +1,117 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Readability_Scores_Ability;
+use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
+
+/**
+ * Tests the Get_Readability_Scores_Ability class.
+ *
+ * @group abilities
+ *
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_Readability_Scores_Ability
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability
+ */
+final class Get_Readability_Scores_Ability_Test extends Abstract_Score_Ability_Test {
+
+	/**
+	 * Creates the instance under test.
+	 *
+	 * @return Abstract_Score_Ability The instance under test.
+	 */
+	protected function create_instance(): Abstract_Score_Ability {
+		return new Get_Readability_Scores_Ability(
+			$this->score_retriever,
+			$this->capability_helper,
+			$this->enabled_analysis_features_repository,
+			$this->should_index_indexables_conditional,
+		);
+	}
+
+	/**
+	 * Tests that get_name returns the prefixed ability name.
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'yoast-seo/get-readability-scores', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests that is_available is false when the indexables are not being built, without consulting the analysis features.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_when_indexables_are_not_indexed() {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturnFalse();
+		$this->enabled_analysis_features_repository->expects( 'get_features_by_keys' )->never();
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available follows the enabled state of the readability analysis when the indexables are being built.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $enabled Whether the readability analysis is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_is_available( bool $enabled ) {
+		$this->mock_available_features( Readability_Analysis::NAME, [ Readability_Analysis::NAME => $enabled ] );
+
+		$this->assertSame( $enabled, $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available returns false when the readability analysis is unknown to the repository.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_with_unknown_feature() {
+		$this->mock_available_features( Readability_Analysis::NAME, [] );
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that can_manage_seo checks the manage options capability and returns its result.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_manage_seo( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_manage_seo() );
+	}
+
+	/**
+	 * Tests that get_args returns the expected registration arguments.
+	 *
+	 * @return void
+	 */
+	public function test_get_args() {
+		$this->assertSame(
+			\array_merge(
+				[
+					'label'       => 'Get Readability Scores',
+					'description' => 'Get the readability scores for the most recently modified posts.',
+				],
+				$this->get_expected_shared_args( 'get_readability_scores', $this->get_expected_item_schema() ),
+			),
+			$this->instance->get_args(),
+		);
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Get_SEO_Scores_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Get_SEO_Scores_Ability_Test.php
@@ -1,0 +1,123 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_SEO_Scores_Ability;
+use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
+
+/**
+ * Tests the Get_SEO_Scores_Ability class.
+ *
+ * @group abilities
+ *
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Get_SEO_Scores_Ability
+ * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Score_Ability
+ */
+final class Get_SEO_Scores_Ability_Test extends Abstract_Score_Ability_Test {
+
+	/**
+	 * Creates the instance under test.
+	 *
+	 * @return Abstract_Score_Ability The instance under test.
+	 */
+	protected function create_instance(): Abstract_Score_Ability {
+		return new Get_SEO_Scores_Ability(
+			$this->score_retriever,
+			$this->capability_helper,
+			$this->enabled_analysis_features_repository,
+			$this->should_index_indexables_conditional,
+		);
+	}
+
+	/**
+	 * Tests that get_name returns the prefixed ability name.
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'yoast-seo/get-seo-scores', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests that is_available is false when the indexables are not being built, without consulting the analysis features.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_when_indexables_are_not_indexed() {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturnFalse();
+		$this->enabled_analysis_features_repository->expects( 'get_features_by_keys' )->never();
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available follows the enabled state of the keyphrase analysis when the indexables are being built.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $enabled Whether the keyphrase analysis is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_is_available( bool $enabled ) {
+		$this->mock_available_features( Keyphrase_Analysis::NAME, [ Keyphrase_Analysis::NAME => $enabled ] );
+
+		$this->assertSame( $enabled, $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that is_available returns false when the keyphrase analysis is unknown to the repository.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_with_unknown_feature() {
+		$this->mock_available_features( Keyphrase_Analysis::NAME, [] );
+
+		$this->assertFalse( $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that can_manage_seo checks the manage options capability and returns its result.
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_manage_seo( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_manage_options' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_manage_seo() );
+	}
+
+	/**
+	 * Tests that get_args returns the expected registration arguments, with the focus keyphrase in the output schema.
+	 *
+	 * @return void
+	 */
+	public function test_get_args() {
+		$item_schema                                  = $this->get_expected_item_schema();
+		$item_schema['properties']['focus_keyphrase'] = [
+			'type'        => [ 'string', 'null' ],
+			'description' => 'The focus keyphrase for the post, or null if not set.',
+		];
+
+		$this->assertSame(
+			\array_merge(
+				[
+					'label'       => 'Get SEO Scores',
+					'description' => 'Get the SEO scores for the most recently modified posts.',
+				],
+				$this->get_expected_shared_args( 'get_seo_scores', $item_schema ),
+			),
+			$this->instance->get_args(),
+		);
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Post_SEO_Data_Schema_Trait.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Post_SEO_Data_Schema_Trait.php
@@ -1,0 +1,111 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+/**
+ * Shares the expectations of the post SEO data abilities between their tests.
+ */
+trait Post_SEO_Data_Schema_Trait {
+
+	/**
+	 * Data provider for the boolean outcome tests.
+	 *
+	 * @return array<string, array<bool>> The outcomes.
+	 */
+	public static function provide_boolean_outcomes(): array {
+		return [
+			'true'  => [ true ],
+			'false' => [ false ],
+		];
+	}
+
+	/**
+	 * Returns the expected post SEO data output schema.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_output_schema(): array {
+		$nullable_string = [ 'type' => [ 'string', 'null' ] ];
+		$score           = static function ( $analysis ) {
+			return [
+				'type'        => 'string',
+				'enum'        => [ 'na', 'bad', 'ok', 'good' ],
+				'description' => \sprintf(
+					'The result of the %s that ran on the post when it was last saved.',
+					$analysis,
+				),
+			];
+		};
+		$rendered        = static function ( $field ) {
+			return [
+				'type'        => [ 'string', 'null' ],
+				'description' => \sprintf(
+					'The %s as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output.',
+					$field,
+				),
+			];
+		};
+		$raw             = static function ( $field ) {
+			return [
+				'type'        => [ 'string', 'null' ],
+				'description' => \sprintf(
+					'The custom %s as stored for the post, which may contain unexpanded replacement variables. Null when no custom value is set; the rendered companion field carries what is actually output.',
+					$field,
+				),
+			];
+		};
+
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'post_id'                         => [ 'type' => 'integer' ],
+				'post_title'                      => $nullable_string,
+				'permalink'                       => $nullable_string,
+				'post_type'                       => [ 'type' => 'string' ],
+				'post_status'                     => $nullable_string,
+				'seo_title'                       => $raw( 'SEO title' ),
+				'seo_title_rendered'              => $rendered( 'SEO title' ),
+				'meta_description'                => $raw( 'meta description' ),
+				'meta_description_rendered'       => $rendered( 'meta description' ),
+				'focus_keyphrase'                 => $nullable_string,
+				'canonical'                       => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The custom canonical URL as stored for the post. Null when no custom value is set; the rendered companion field carries what is actually output.',
+				],
+				'canonical_rendered'              => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The canonical URL as output on the front end: the custom value when set, otherwise the permalink of the post. Null when nothing is output.',
+				],
+				'is_cornerstone'                  => [ 'type' => 'boolean' ],
+				'noindex'                         => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => 'Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies.',
+				],
+				'nofollow'                        => [ 'type' => 'boolean' ],
+				'noimageindex'                    => [ 'type' => 'boolean' ],
+				'noarchive'                       => [ 'type' => 'boolean' ],
+				'nosnippet'                       => [ 'type' => 'boolean' ],
+				'open_graph_title'                => $raw( 'Open Graph title' ),
+				'open_graph_title_rendered'       => $rendered( 'Open Graph title' ),
+				'open_graph_description'          => $raw( 'Open Graph description' ),
+				'open_graph_description_rendered' => $rendered( 'Open Graph description' ),
+				'twitter_title'                   => $raw( 'X title' ),
+				'twitter_title_rendered'          => $rendered( 'X title' ),
+				'twitter_description'             => $raw( 'X description' ),
+				'twitter_description_rendered'    => $rendered( 'X description' ),
+				'schema_page_type'                => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org page type stored for the post. Null means no override is set and the default for the post type applies.',
+				],
+				'schema_article_type'             => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org article type stored for the post. Null means no override is set and the default for the post type applies.',
+				],
+				'seo_score'                       => $score( 'SEO analysis' ),
+				'readability_score'               => $score( 'readability analysis' ),
+				'inclusive_language_score'        => $score( 'inclusive language analysis' ),
+			],
+		];
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities/Update_Post_SEO_Data_Ability_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities/Update_Post_SEO_Data_Ability_Test.php
@@ -1,0 +1,299 @@
+<?php
+
+// phpcs:disable Yoast.NamingConventions.NamespaceName.TooLong -- Needed in the folder structure.
+namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface\Abilities;
+
+use Brain\Monkey;
+use Mockery;
+use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
+use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
+use Yoast\WP\SEO\Abilities\User_Interface\Abilities\Update_Post_SEO_Data_Ability;
+use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
+use Yoast\WP\SEO\Config\Schema_Types;
+use Yoast\WP\SEO\Helpers\Capability_Helper;
+use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
+use Yoast\WP\SEO\Helpers\Meta_Helper;
+use Yoast\WP\SEO\Surfaces\Meta_Surface;
+use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
+use Yoast\WP\SEO\Tests\Unit\TestCase;
+
+/**
+ * Tests the Update_Post_SEO_Data_Ability class.
+ *
+ * @group abilities
+ *
+ * @coversDefaultClass \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Update_Post_SEO_Data_Ability
+ */
+final class Update_Post_SEO_Data_Ability_Test extends TestCase {
+
+	use Post_SEO_Data_Schema_Trait;
+
+	/**
+	 * The capability helper mock.
+	 *
+	 * @var Mockery\MockInterface|Capability_Helper
+	 */
+	private $capability_helper;
+
+	/**
+	 * The should index indexables conditional mock.
+	 *
+	 * @var Mockery\MockInterface|Should_Index_Indexables_Conditional
+	 */
+	private $should_index_indexables_conditional;
+
+	/**
+	 * The post SEO data updater mock.
+	 *
+	 * @var Mockery\MockInterface|Post_SEO_Data_Updater
+	 */
+	private $post_seo_data_updater;
+
+	/**
+	 * The instance under test.
+	 *
+	 * @var Update_Post_SEO_Data_Ability
+	 */
+	private $instance;
+
+	/**
+	 * Sets up the test fixtures.
+	 *
+	 * @return void
+	 */
+	protected function set_up() {
+		parent::set_up();
+
+		$this->stubTranslationFunctions();
+
+		// The article-type enum is built from the documented filter; return the default unfiltered.
+		Monkey\Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		$this->capability_helper                   = Mockery::mock( Capability_Helper::class );
+		$this->should_index_indexables_conditional = Mockery::mock( Should_Index_Indexables_Conditional::class );
+		$this->post_seo_data_updater               = Mockery::mock( Post_SEO_Data_Updater::class );
+
+		$this->instance = new Update_Post_SEO_Data_Ability(
+			$this->capability_helper,
+			$this->should_index_indexables_conditional,
+			$this->post_seo_data_updater,
+		);
+	}
+
+	/**
+	 * Tests that get_name returns the prefixed ability name.
+	 *
+	 * @covers ::get_name
+	 *
+	 * @return void
+	 */
+	public function test_get_name() {
+		$this->assertSame( 'yoast-seo/update-post-seo-data', $this->instance->get_name() );
+	}
+
+	/**
+	 * Tests that is_available follows whether the indexables are being built.
+	 *
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::is_available
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $is_met Whether the indexables are being built.
+	 *
+	 * @return void
+	 */
+	public function test_is_available( bool $is_met ) {
+		$this->should_index_indexables_conditional->expects( 'is_met' )->once()->andReturn( $is_met );
+
+		$this->assertSame( $is_met, $this->instance->is_available() );
+	}
+
+	/**
+	 * Tests that can_edit_advanced_metadata checks the advanced metadata capability and returns its result.
+	 *
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::__construct
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::can_edit_advanced_metadata
+	 *
+	 * @dataProvider provide_boolean_outcomes
+	 *
+	 * @param bool $allowed Whether the capability is granted.
+	 *
+	 * @return void
+	 */
+	public function test_can_edit_advanced_metadata( bool $allowed ) {
+		$this->capability_helper
+			->expects( 'current_user_can' )
+			->once()
+			->with( 'wpseo_edit_advanced_metadata' )
+			->andReturn( $allowed );
+
+		$this->assertSame( $allowed, $this->instance->can_edit_advanced_metadata() );
+	}
+
+	/**
+	 * Tests that get_args returns the expected registration arguments.
+	 *
+	 * @covers ::__construct
+	 * @covers ::get_args
+	 * @covers ::get_update_post_seo_data_input_schema
+	 * @covers ::get_schema_article_types
+	 * @covers ::nullable_enum_schema
+	 * @covers \Yoast\WP\SEO\Abilities\User_Interface\Abilities\Abstract_Post_SEO_Data_Ability::get_post_seo_data_output_schema
+	 *
+	 * @return void
+	 */
+	public function test_get_args() {
+		$this->assertSame(
+			[
+				'label'               => 'Update Post SEO Data',
+				'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
+				'category'            => 'yoast-seo',
+				'input_schema'        => $this->get_expected_update_input_schema(),
+				'output_schema'       => $this->get_expected_output_schema(),
+				'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
+				'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
+				'meta'                => [
+					'show_in_rest' => true,
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => null,
+						'idempotent'  => true,
+					],
+					'mcp'          => [
+						'public' => true,
+					],
+				],
+			],
+			$this->instance->get_args(),
+		);
+	}
+
+	/**
+	 * Tests that every writable field in the update input schema is applied by the
+	 * field map and cascades to a post meta write.
+	 *
+	 * The field contract is spread over hand-maintained structures (the input schema,
+	 * Post_SEO_Field_Map, Indexable_To_Postmeta_Helper) which fail silently when they
+	 * drift: a schema field missing from the field map is validated and accepted but
+	 * never applied, and an indexable column missing from the postmeta map is skipped
+	 * by the cascade and then reverted by the indexable rebuild. This test turns both
+	 * drift paths into a failure.
+	 *
+	 * @covers ::get_args
+	 * @covers ::get_update_post_seo_data_input_schema
+	 *
+	 * @return void
+	 */
+	public function test_every_writable_input_field_cascades_to_post_meta() {
+		$input_schema = $this->instance->get_args()['input_schema'];
+
+		$writable_fields = \array_diff_key(
+			$input_schema['properties'],
+			[
+				'post_id'   => true,
+				'permalink' => true,
+			],
+		);
+
+		$field_map            = new Post_SEO_Field_Map( Mockery::mock( Meta_Surface::class ) );
+		$indexable            = Mockery::mock( Indexable_Mock::class );
+		$indexable->object_id = 42;
+
+		$changed_columns = [];
+		foreach ( $writable_fields as $field => $field_schema ) {
+			// A truthy value for every type, so each mapped column performs a meta write below.
+			$value   = ( \in_array( 'boolean', (array) $field_schema['type'], true ) ) ? true : 'a value';
+			$changed = $field_map->apply_to_indexable( [ $field => $value ], $indexable );
+
+			$this->assertNotEmpty(
+				$changed,
+				"Input field `{$field}` is accepted by the update input schema but not applied by Post_SEO_Field_Map, so writes to it are silently dropped.",
+			);
+
+			$changed_columns[] = $changed;
+		}
+
+		$meta_writes = 0;
+		$meta_helper = Mockery::mock( Meta_Helper::class );
+		$meta_helper->shouldReceive( 'set_value', 'delete' )->andReturnUsing(
+			static function () use ( &$meta_writes ) {
+				++$meta_writes;
+
+				return true;
+			},
+		);
+		$postmeta_helper = new Indexable_To_Postmeta_Helper( $meta_helper );
+
+		foreach ( \array_unique( \array_merge( ...$changed_columns ) ) as $column ) {
+			$writes_before = $meta_writes;
+			$postmeta_helper->map_column_to_postmeta( $indexable, $column, true );
+
+			$this->assertGreaterThan(
+				$writes_before,
+				$meta_writes,
+				"Indexable column `{$column}` has no Indexable_To_Postmeta_Helper mapping, so writes to it are silently discarded and reverted by the indexable rebuild.",
+			);
+		}
+	}
+
+	/**
+	 * Returns the expected update input schema.
+	 *
+	 * @return array<string, mixed> The schema.
+	 */
+	private function get_expected_update_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'post_id'             => [
+					'type'        => 'integer',
+					'description' => 'The ID of the post to update.',
+					'minimum'     => 1,
+				],
+				'permalink'           => [
+					'type'        => 'string',
+					'description' => 'The permalink (URL) of the post to update.',
+				],
+				'canonical'           => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The custom canonical URL for the post. Use null or an empty string to remove it and fall back to the default canonical.',
+				],
+				'is_cornerstone'      => [
+					'type'        => 'boolean',
+					'description' => 'Whether the post is marked as cornerstone content.',
+				],
+				'noindex'             => [
+					'type'        => [ 'boolean', 'null' ],
+					'description' => 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.',
+				],
+				'nofollow'            => [
+					'type'        => 'boolean',
+					'description' => 'Whether search engines should be told not to follow the links on this post.',
+				],
+				'noimageindex'        => [
+					'type'        => 'boolean',
+					'description' => 'Whether search engines should be told not to index the images on this post.',
+				],
+				'noarchive'           => [
+					'type'        => 'boolean',
+					'description' => 'Whether search engines should be told not to show a cached copy of this post.',
+				],
+				'nosnippet'           => [
+					'type'        => 'boolean',
+					'description' => 'Whether search engines should be told not to show a snippet of this post in the search results.',
+				],
+				'schema_page_type'    => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::PAGE_TYPES ), [ '', null ] ),
+				],
+				'schema_article_type' => [
+					'type'        => [ 'string', 'null' ],
+					'description' => 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.',
+					'enum'        => \array_merge( \array_keys( Schema_Types::ARTICLE_TYPES ), [ '', null ] ),
+				],
+			],
+		];
+	}
+}

--- a/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
+++ b/tests/Unit/Abilities/User_Interface/Abilities_Integration_Test.php
@@ -5,24 +5,9 @@ namespace Yoast\WP\SEO\Tests\Unit\Abilities\User_Interface;
 
 use Brain\Monkey;
 use Mockery;
-use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Collector;
-use Yoast\WP\SEO\Abilities\Application\Post_SEO_Data_Updater;
-use Yoast\WP\SEO\Abilities\Application\Score_Retriever;
-use Yoast\WP\SEO\Abilities\Infrastructure\Post_SEO_Field_Map;
+use Yoast\WP\SEO\Abilities\Domain\Ability_Interface;
 use Yoast\WP\SEO\Abilities\User_Interface\Abilities_Integration;
 use Yoast\WP\SEO\Conditionals\Abilities_API_Conditional;
-use Yoast\WP\SEO\Conditionals\Should_Index_Indexables_Conditional;
-use Yoast\WP\SEO\Config\Schema_Types;
-use Yoast\WP\SEO\Editors\Application\Analysis_Features\Enabled_Analysis_Features_Repository;
-use Yoast\WP\SEO\Editors\Domain\Analysis_Features\Analysis_Features_List;
-use Yoast\WP\SEO\Editors\Framework\Inclusive_Language_Analysis;
-use Yoast\WP\SEO\Editors\Framework\Keyphrase_Analysis;
-use Yoast\WP\SEO\Editors\Framework\Readability_Analysis;
-use Yoast\WP\SEO\Helpers\Capability_Helper;
-use Yoast\WP\SEO\Helpers\Indexable_To_Postmeta_Helper;
-use Yoast\WP\SEO\Helpers\Meta_Helper;
-use Yoast\WP\SEO\Surfaces\Meta_Surface;
-use Yoast\WP\SEO\Tests\Unit\Doubles\Models\Indexable_Mock;
 use Yoast\WP\SEO\Tests\Unit\TestCase;
 
 /**
@@ -35,39 +20,18 @@ use Yoast\WP\SEO\Tests\Unit\TestCase;
 final class Abilities_Integration_Test extends TestCase {
 
 	/**
-	 * The score retriever mock.
+	 * An ability that is available.
 	 *
-	 * @var Mockery\MockInterface|Score_Retriever
+	 * @var Mockery\MockInterface|Ability_Interface
 	 */
-	private $score_retriever;
+	private $available_ability;
 
 	/**
-	 * The capability helper mock.
+	 * An ability that is not available.
 	 *
-	 * @var Mockery\MockInterface|Capability_Helper
+	 * @var Mockery\MockInterface|Ability_Interface
 	 */
-	private $capability_helper;
-
-	/**
-	 * The enabled analysis features repository mock.
-	 *
-	 * @var Mockery\MockInterface|Enabled_Analysis_Features_Repository
-	 */
-	private $enabled_analysis_features_repository;
-
-	/**
-	 * The post SEO data collector mock.
-	 *
-	 * @var Mockery\MockInterface|Post_SEO_Data_Collector
-	 */
-	private $post_seo_data_collector;
-
-	/**
-	 * The post SEO data updater mock.
-	 *
-	 * @var Mockery\MockInterface|Post_SEO_Data_Updater
-	 */
-	private $post_seo_data_updater;
+	private $unavailable_ability;
 
 	/**
 	 * The instance under test.
@@ -84,41 +48,21 @@ final class Abilities_Integration_Test extends TestCase {
 	protected function set_up() {
 		parent::set_up();
 
-		$this->stubTranslationFunctions();
+		$this->available_ability   = Mockery::mock( Ability_Interface::class );
+		$this->unavailable_ability = Mockery::mock( Ability_Interface::class );
 
-		// The article-type enum is built from the documented filter; return the default unfiltered.
-		Monkey\Functions\when( 'apply_filters' )->returnArg( 2 );
-
-		$this->score_retriever                      = Mockery::mock( Score_Retriever::class );
-		$this->capability_helper                    = Mockery::mock( Capability_Helper::class );
-		$this->enabled_analysis_features_repository = Mockery::mock( Enabled_Analysis_Features_Repository::class );
-		$this->post_seo_data_collector              = Mockery::mock( Post_SEO_Data_Collector::class );
-		$this->post_seo_data_updater                = Mockery::mock( Post_SEO_Data_Updater::class );
-
-		$this->instance = new Abilities_Integration(
-			$this->score_retriever,
-			$this->capability_helper,
-			$this->enabled_analysis_features_repository,
-			$this->post_seo_data_collector,
-			$this->post_seo_data_updater,
-		);
+		$this->instance = new Abilities_Integration( $this->available_ability, $this->unavailable_ability );
 	}
 
 	/**
-	 * Tests that get_conditionals returns the Abilities API and indexables conditionals.
+	 * Tests that get_conditionals returns the Abilities API conditional.
 	 *
 	 * @covers ::get_conditionals
 	 *
 	 * @return void
 	 */
 	public function test_get_conditionals() {
-		$this->assertSame(
-			[
-				Abilities_API_Conditional::class,
-				Should_Index_Indexables_Conditional::class,
-			],
-			Abilities_Integration::get_conditionals(),
-		);
+		$this->assertSame( [ Abilities_API_Conditional::class ], Abilities_Integration::get_conditionals() );
 	}
 
 	/**
@@ -137,589 +81,42 @@ final class Abilities_Integration_Test extends TestCase {
 	}
 
 	/**
-	 * Tests that can_manage_seo checks the manage options capability and returns its result.
+	 * Tests that register_abilities registers the available abilities and skips the unavailable ones.
 	 *
-	 * @covers ::can_manage_seo
-	 *
-	 * @dataProvider provide_can_manage_seo
-	 *
-	 * @param bool $allowed Whether the capability is granted.
-	 *
-	 * @return void
-	 */
-	public function test_can_manage_seo( bool $allowed ) {
-		$this->capability_helper
-			->expects( 'current_user_can' )
-			->once()
-			->with( 'wpseo_manage_options' )
-			->andReturn( $allowed );
-
-		$this->assertSame( $allowed, $this->instance->can_manage_seo() );
-	}
-
-	/**
-	 * Data provider for test_can_manage_seo.
-	 *
-	 * @return array<string, array<bool>> The capability outcomes.
-	 */
-	public static function provide_can_manage_seo(): array {
-		return [
-			'capability granted' => [ true ],
-			'capability denied'  => [ false ],
-		];
-	}
-
-	/**
-	 * Tests that can_edit_advanced_metadata checks the advanced metadata capability and returns its result.
-	 *
-	 * @covers ::can_edit_advanced_metadata
-	 *
-	 * @dataProvider provide_can_manage_seo
-	 *
-	 * @param bool $allowed Whether the capability is granted.
-	 *
-	 * @return void
-	 */
-	public function test_can_edit_advanced_metadata( bool $allowed ) {
-		$this->capability_helper
-			->expects( 'current_user_can' )
-			->once()
-			->with( 'wpseo_edit_advanced_metadata' )
-			->andReturn( $allowed );
-
-		$this->assertSame( $allowed, $this->instance->can_edit_advanced_metadata() );
-	}
-
-	/**
-	 * Tests that register_abilities registers all score abilities plus the metadata abilities.
-	 *
+	 * @covers ::__construct
 	 * @covers ::register_abilities
 	 *
 	 * @return void
 	 */
-	public function test_register_abilities_with_inclusive_language_enabled() {
-		$this->mock_enabled_features(
-			[
-				Keyphrase_Analysis::NAME          => true,
-				Readability_Analysis::NAME        => true,
-				Inclusive_Language_Analysis::NAME => true,
-			],
-		);
+	public function test_register_abilities() {
+		$args = [ 'label' => 'An available ability' ];
 
-		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
-		$this->expect_score_ability( 'yoast-seo/get-readability-scores' );
-		$this->expect_score_ability( 'yoast-seo/get-inclusive-language-scores' );
-		$this->expect_post_seo_data_abilities();
+		$this->available_ability->expects( 'is_available' )->once()->andReturnTrue();
+		$this->available_ability->expects( 'get_name' )->once()->andReturn( 'yoast-seo/available' );
+		$this->available_ability->expects( 'get_args' )->once()->andReturn( $args );
+
+		$this->unavailable_ability->expects( 'is_available' )->once()->andReturnFalse();
+		$this->unavailable_ability->expects( 'get_name' )->never();
+		$this->unavailable_ability->expects( 'get_args' )->never();
+
+		Monkey\Functions\expect( 'wp_register_ability' )
+			->once()
+			->with( 'yoast-seo/available', $args );
 
 		$this->instance->register_abilities();
 	}
 
 	/**
-	 * Tests that the score abilities are not registered when their analysis features are disabled,
-	 * but the metadata abilities always are.
+	 * Tests that register_abilities registers nothing when no abilities were injected.
 	 *
+	 * @covers ::__construct
 	 * @covers ::register_abilities
 	 *
 	 * @return void
 	 */
-	public function test_register_abilities_with_all_analysis_disabled() {
-		$this->mock_enabled_features(
-			[
-				Keyphrase_Analysis::NAME          => false,
-				Readability_Analysis::NAME        => false,
-				Inclusive_Language_Analysis::NAME => false,
-			],
-		);
+	public function test_register_abilities_without_abilities() {
+		Monkey\Functions\expect( 'wp_register_ability' )->never();
 
-		$this->expect_post_seo_data_abilities();
-
-		$this->instance->register_abilities();
-	}
-
-	/**
-	 * Tests that only the keyphrase score ability registers alongside the metadata abilities.
-	 *
-	 * @covers ::register_abilities
-	 *
-	 * @return void
-	 */
-	public function test_register_abilities_with_only_keyphrase_enabled() {
-		$this->mock_enabled_features(
-			[
-				Keyphrase_Analysis::NAME          => true,
-				Readability_Analysis::NAME        => false,
-				Inclusive_Language_Analysis::NAME => false,
-			],
-		);
-
-		$this->expect_score_ability( 'yoast-seo/get-seo-scores' );
-		$this->expect_post_seo_data_abilities();
-
-		$this->instance->register_abilities();
-	}
-
-	/**
-	 * Tests that the get and update post SEO data abilities register with the expected definition.
-	 *
-	 * @covers ::register_abilities
-	 * @covers ::register_get_post_seo_data_ability
-	 * @covers ::register_update_post_seo_data_ability
-	 *
-	 * @return void
-	 */
-	public function test_register_post_seo_data_abilities_definition() {
-		$this->mock_enabled_features(
-			[
-				Keyphrase_Analysis::NAME          => false,
-				Readability_Analysis::NAME        => false,
-				Inclusive_Language_Analysis::NAME => false,
-			],
-		);
-
-		Monkey\Functions\expect( 'wp_register_ability' )
-			->once()
-			->with(
-				'yoast-seo/get-post-seo-data',
-				[
-					'label'               => 'Get Post SEO Data',
-					'category'            => 'yoast-seo',
-					'description'         => 'Get the SEO data for a post. Identify the post by post_id, by permalink (URL), or by title keywords; the title may be a comma-separated list and returns the SEO data for every post matching any of the values, paginated most recently modified first (use the page parameter to reach older matches). At least one identifier is required. Only posts the current user is allowed to edit are returned.',
-					'input_schema'        => $this->get_expected_identifier_input_schema(),
-					'output_schema'       => [
-						'type'  => 'array',
-						'items' => $this->get_expected_output_schema(),
-					],
-					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
-					'execute_callback'    => [ $this->post_seo_data_collector, 'get_post_seo_data' ],
-					'meta'                => $this->get_read_meta(),
-				],
-			);
-
-		Monkey\Functions\expect( 'wp_register_ability' )
-			->once()
-			->with(
-				'yoast-seo/update-post-seo-data',
-				[
-					'label'               => 'Update Post SEO Data',
-					'category'            => 'yoast-seo',
-					'description'         => 'Update the SEO data for a single post. Identify the post by post_id or by permalink (URL). Only the fields you provide are changed; a provided empty value clears that field. Only posts the current user is allowed to edit can be updated.',
-					'input_schema'        => $this->get_expected_update_input_schema(),
-					'output_schema'       => $this->get_expected_output_schema(),
-					'permission_callback' => [ $this->instance, 'can_edit_advanced_metadata' ],
-					'execute_callback'    => [ $this->post_seo_data_updater, 'update_post_seo_data' ],
-					'meta'                => $this->get_write_meta(),
-				],
-			);
-
-		$this->instance->register_abilities();
-	}
-
-	/**
-	 * Tests that every writable field in the update input schema is applied by the
-	 * field map and cascades to a post meta write.
-	 *
-	 * The field contract is spread over hand-maintained structures (the input schema,
-	 * Post_SEO_Field_Map, Indexable_To_Postmeta_Helper) which fail silently when they
-	 * drift: a schema field missing from the field map is validated and accepted but
-	 * never applied, and an indexable column missing from the postmeta map is skipped
-	 * by the cascade and then reverted by the indexable rebuild. This test turns both
-	 * drift paths into a failure.
-	 *
-	 * @covers ::register_abilities
-	 * @covers ::register_update_post_seo_data_ability
-	 * @covers ::get_update_post_seo_data_input_schema
-	 *
-	 * @return void
-	 */
-	public function test_every_writable_input_field_cascades_to_post_meta() {
-		$input_schema = $this->get_registered_ability_args( 'yoast-seo/update-post-seo-data' )['input_schema'];
-
-		$writable_fields = \array_diff_key(
-			$input_schema['properties'],
-			[
-				'post_id'   => true,
-				'permalink' => true,
-			],
-		);
-
-		$field_map            = new Post_SEO_Field_Map( Mockery::mock( Meta_Surface::class ) );
-		$indexable            = Mockery::mock( Indexable_Mock::class );
-		$indexable->object_id = 42;
-
-		$changed_columns = [];
-		foreach ( $writable_fields as $field => $field_schema ) {
-			// A truthy value for every type, so each mapped column performs a meta write below.
-			$value   = ( \in_array( 'boolean', (array) $field_schema['type'], true ) ) ? true : 'a value';
-			$changed = $field_map->apply_to_indexable( [ $field => $value ], $indexable );
-
-			$this->assertNotEmpty(
-				$changed,
-				"Input field `{$field}` is accepted by the update input schema but not applied by Post_SEO_Field_Map, so writes to it are silently dropped.",
-			);
-
-			$changed_columns[] = $changed;
-		}
-
-		$meta_writes = 0;
-		$meta_helper = Mockery::mock( Meta_Helper::class );
-		$meta_helper->shouldReceive( 'set_value', 'delete' )->andReturnUsing(
-			static function () use ( &$meta_writes ) {
-				++$meta_writes;
-
-				return true;
-			},
-		);
-		$postmeta_helper = new Indexable_To_Postmeta_Helper( $meta_helper );
-
-		foreach ( \array_unique( \array_merge( ...$changed_columns ) ) as $column ) {
-			$writes_before = $meta_writes;
-			$postmeta_helper->map_column_to_postmeta( $indexable, $column, true );
-
-			$this->assertGreaterThan(
-				$writes_before,
-				$meta_writes,
-				"Indexable column `{$column}` has no Indexable_To_Postmeta_Helper mapping, so writes to it are silently discarded and reverted by the indexable rebuild.",
-			);
-		}
-	}
-
-	/**
-	 * Tests that the SEO data array built by the field map exposes exactly the
-	 * properties documented in the output schema.
-	 *
-	 * The field contract is spread over hand-maintained structures (the output schema
-	 * and Post_SEO_Field_Map) which fail silently when they drift: a field missing from
-	 * either side is simply never surfaced to the ability's consumers. This test turns
-	 * that drift into a failure.
-	 *
-	 * @covers ::register_abilities
-	 * @covers ::register_get_post_seo_data_ability
-	 * @covers ::get_post_seo_data_output_schema
-	 *
-	 * @return void
-	 */
-	public function test_output_schema_matches_field_map_output() {
-		$output_schema = $this->get_registered_ability_args( 'yoast-seo/get-post-seo-data' )['output_schema']['items'];
-
-		$meta_surface = Mockery::mock( Meta_Surface::class );
-		$meta_surface->expects( 'for_indexable' )->andReturnFalse();
-		$field_map = new Post_SEO_Field_Map( $meta_surface );
-
-		$schema_properties = \array_keys( $output_schema['properties'] );
-		$output_fields     = \array_keys( $field_map->to_seo_array( Mockery::mock( Indexable_Mock::class ) ) );
-		\sort( $schema_properties );
-		\sort( $output_fields );
-
-		$this->assertSame(
-			$schema_properties,
-			$output_fields,
-			'The output schema and Post_SEO_Field_Map::to_seo_array() must describe the same set of fields.',
-		);
-	}
-
-	/**
-	 * Registers the abilities against a capturing stub and returns the arguments the
-	 * given ability was registered with.
-	 *
-	 * @param string $slug The ability slug to return the registration arguments for.
-	 *
-	 * @return array<string, mixed> The ability registration arguments.
-	 */
-	private function get_registered_ability_args( string $slug ): array {
-		$this->mock_enabled_features(
-			[
-				Keyphrase_Analysis::NAME          => false,
-				Readability_Analysis::NAME        => false,
-				Inclusive_Language_Analysis::NAME => false,
-			],
-		);
-
-		$captured = [];
-		Monkey\Functions\when( 'wp_register_ability' )->alias(
-			static function ( $name, $args ) use ( &$captured ) {
-				$captured[ $name ] = $args;
-			},
-		);
-
-		$this->instance->register_abilities();
-
-		return $captured[ $slug ];
-	}
-
-	/**
-	 * Registers a loose expectation for a score ability registration.
-	 *
-	 * @param string $slug The ability slug.
-	 *
-	 * @return void
-	 */
-	private function expect_score_ability( string $slug ): void {
-		Monkey\Functions\expect( 'wp_register_ability' )
-			->once()
-			->with( $slug, Mockery::type( 'array' ) );
-	}
-
-	/**
-	 * Registers loose expectations for the post SEO data ability registrations.
-	 *
-	 * @return void
-	 */
-	private function expect_post_seo_data_abilities(): void {
-		Monkey\Functions\expect( 'wp_register_ability' )
-			->once()
-			->with( 'yoast-seo/get-post-seo-data', Mockery::type( 'array' ) );
-
-		Monkey\Functions\expect( 'wp_register_ability' )
-			->once()
-			->with( 'yoast-seo/update-post-seo-data', Mockery::type( 'array' ) );
-	}
-
-	/**
-	 * Returns the read meta (read-only annotations).
-	 *
-	 * @return array<string, mixed> The meta.
-	 */
-	private function get_read_meta(): array {
-		return [
-			'show_in_rest' => true,
-			'annotations'  => [
-				'readonly'    => true,
-				'destructive' => false,
-				'idempotent'  => true,
-			],
-			'mcp'          => [
-				'public' => true,
-			],
-		];
-	}
-
-	/**
-	 * Returns the write meta (non-read-only annotations).
-	 *
-	 * @return array<string, mixed> The meta.
-	 */
-	private function get_write_meta(): array {
-		return [
-			'show_in_rest' => true,
-			'annotations'  => [
-				'readonly'    => false,
-				'destructive' => false,
-				'idempotent'  => true,
-			],
-			'mcp'          => [
-				'public' => true,
-			],
-		];
-	}
-
-	/**
-	 * Returns the expected identifier input schema for the read ability.
-	 *
-	 * @return array<string, mixed> The schema.
-	 */
-	private function get_expected_identifier_input_schema(): array {
-		return [
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => [
-				'post_id'   => [
-					'type'        => 'integer',
-					'description' => 'The ID of the post to retrieve.',
-					'minimum'     => 1,
-				],
-				'permalink' => [
-					'type'        => 'string',
-					'description' => 'The permalink (URL) of the post to retrieve.',
-				],
-				'title'     => [
-					'type'        => 'string',
-					'description' => 'Keywords to search for in post titles. Provide a comma-separated list to search for several titles at once; each value is matched as a whole phrase against the post title, and a post matching any value is returned. At most 10 phrases are used per request; any beyond the first 10 are ignored. Results are paginated to 10 entities per page; see the page parameter.',
-				],
-				'page'      => [
-					'type'        => 'integer',
-					'description' => 'The page of title-search results to return, 1-based and defaulting to 1. Matches are ordered most recently modified first, so request a later page to reach older matches. An empty result means there are no further pages. Only applies to a title search.',
-					'minimum'     => 1,
-					'default'     => 1,
-				],
-			],
-		];
-	}
-
-	/**
-	 * Returns the expected update input schema.
-	 *
-	 * @return array<string, mixed> The schema.
-	 */
-	private function get_expected_update_input_schema(): array {
-		return [
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => [
-				'post_id'             => [
-					'type'        => 'integer',
-					'description' => 'The ID of the post to update.',
-					'minimum'     => 1,
-				],
-				'permalink'           => [
-					'type'        => 'string',
-					'description' => 'The permalink (URL) of the post to update.',
-				],
-				'canonical'           => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The custom canonical URL for the post. Use null or an empty string to remove it and fall back to the default canonical.',
-				],
-				'is_cornerstone'      => [
-					'type'        => 'boolean',
-					'description' => 'Whether the post is marked as cornerstone content.',
-				],
-				'noindex'             => [
-					'type'        => [ 'boolean', 'null' ],
-					'description' => 'Whether search engines should be told not to index this post. true sets noindex (the post is excluded from search results); false forces the post to be indexed; null clears the setting and falls back to the post-type default.',
-				],
-				'nofollow'            => [
-					'type'        => 'boolean',
-					'description' => 'Whether search engines should be told not to follow the links on this post.',
-				],
-				'noimageindex'        => [
-					'type'        => 'boolean',
-					'description' => 'Whether search engines should be told not to index the images on this post.',
-				],
-				'noarchive'           => [
-					'type'        => 'boolean',
-					'description' => 'Whether search engines should be told not to show a cached copy of this post.',
-				],
-				'nosnippet'           => [
-					'type'        => 'boolean',
-					'description' => 'Whether search engines should be told not to show a snippet of this post in the search results.',
-				],
-				'schema_page_type'    => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The Schema.org page type for the post. Must be one of the supported page types. Use null to clear it and fall back to the default.',
-					'enum'        => \array_merge( \array_keys( Schema_Types::PAGE_TYPES ), [ '', null ] ),
-				],
-				'schema_article_type' => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The Schema.org article type for the post. Must be one of the supported article types. Use null to clear it and fall back to the default.',
-					'enum'        => \array_merge( \array_keys( Schema_Types::ARTICLE_TYPES ), [ '', null ] ),
-				],
-			],
-		];
-	}
-
-	/**
-	 * Returns the expected post SEO data output schema.
-	 *
-	 * @return array<string, mixed> The schema.
-	 */
-	private function get_expected_output_schema(): array {
-		$nullable_string = [ 'type' => [ 'string', 'null' ] ];
-		$score           = static function ( $analysis ) {
-			return [
-				'type'        => 'string',
-				'enum'        => [ 'na', 'bad', 'ok', 'good' ],
-				'description' => \sprintf(
-					'The result of the %s that ran on the post when it was last saved.',
-					$analysis,
-				),
-			];
-		};
-		$rendered        = static function ( $field ) {
-			return [
-				'type'        => [ 'string', 'null' ],
-				'description' => \sprintf(
-					'The %s as output on the front end: the global default template applied when no custom value is set, with replacement variables expanded. Null when nothing is output.',
-					$field,
-				),
-			];
-		};
-		$raw             = static function ( $field ) {
-			return [
-				'type'        => [ 'string', 'null' ],
-				'description' => \sprintf(
-					'The custom %s as stored for the post, which may contain unexpanded replacement variables. Null when no custom value is set; the rendered companion field carries what is actually output.',
-					$field,
-				),
-			];
-		};
-
-		return [
-			'type'       => 'object',
-			'properties' => [
-				'post_id'                         => [ 'type' => 'integer' ],
-				'post_title'                      => $nullable_string,
-				'permalink'                       => $nullable_string,
-				'post_type'                       => [ 'type' => 'string' ],
-				'post_status'                     => $nullable_string,
-				'seo_title'                       => $raw( 'SEO title' ),
-				'seo_title_rendered'              => $rendered( 'SEO title' ),
-				'meta_description'                => $raw( 'meta description' ),
-				'meta_description_rendered'       => $rendered( 'meta description' ),
-				'focus_keyphrase'                 => $nullable_string,
-				'canonical'                       => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The custom canonical URL as stored for the post. Null when no custom value is set; the rendered companion field carries what is actually output.',
-				],
-				'canonical_rendered'              => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The canonical URL as output on the front end: the custom value when set, otherwise the permalink of the post. Null when nothing is output.',
-				],
-				'is_cornerstone'                  => [ 'type' => 'boolean' ],
-				'noindex'                         => [
-					'type'        => [ 'boolean', 'null' ],
-					'description' => 'Whether search engines are told not to index this post. true means noindex (the post is excluded from search results); false means the post is forced to be indexed; null means no setting is stored and the post-type default applies.',
-				],
-				'nofollow'                        => [ 'type' => 'boolean' ],
-				'noimageindex'                    => [ 'type' => 'boolean' ],
-				'noarchive'                       => [ 'type' => 'boolean' ],
-				'nosnippet'                       => [ 'type' => 'boolean' ],
-				'open_graph_title'                => $raw( 'Open Graph title' ),
-				'open_graph_title_rendered'       => $rendered( 'Open Graph title' ),
-				'open_graph_description'          => $raw( 'Open Graph description' ),
-				'open_graph_description_rendered' => $rendered( 'Open Graph description' ),
-				'twitter_title'                   => $raw( 'X title' ),
-				'twitter_title_rendered'          => $rendered( 'X title' ),
-				'twitter_description'             => $raw( 'X description' ),
-				'twitter_description_rendered'    => $rendered( 'X description' ),
-				'schema_page_type'                => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The Schema.org page type stored for the post. Null means no override is set and the default for the post type applies.',
-				],
-				'schema_article_type'             => [
-					'type'        => [ 'string', 'null' ],
-					'description' => 'The Schema.org article type stored for the post. Null means no override is set and the default for the post type applies.',
-				],
-				'seo_score'                       => $score( 'SEO analysis' ),
-				'readability_score'               => $score( 'readability analysis' ),
-				'inclusive_language_score'        => $score( 'inclusive language analysis' ),
-			],
-		];
-	}
-
-	/**
-	 * Mocks the enabled features repository to return the given features array.
-	 *
-	 * @param array<string, bool> $features The features array.
-	 *
-	 * @return void
-	 */
-	private function mock_enabled_features( array $features ): void {
-		$features_list = Mockery::mock( Analysis_Features_List::class );
-
-		$features_list
-			->expects( 'to_array' )
-			->once()
-			->andReturn( $features );
-
-		$this->enabled_analysis_features_repository
-			->expects( 'get_features_by_keys' )
-			->once()
-			->with(
-				[
-					Keyphrase_Analysis::NAME,
-					Readability_Analysis::NAME,
-					Inclusive_Language_Analysis::NAME,
-				],
-			)
-			->andReturn( $features_list );
+		( new Abilities_Integration() )->register_abilities();
 	}
 }


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* In order to prevent the abilities integration from becoming too big with every new ability, we had to refactor it to use separate classes for each registered ability.

## Summary

<!--
Keep each bullet to one short sentence — put extra context in *Context* or *Relevant technical choices*, not here.
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, describe the incorrect behaviour that occurred, followed by the condition that triggered it. Use clear, past tense language and avoid hypothetical or nested conditionals. Example structure: “Fixes a bug where... happened when/was caused by ...”
If the changelog item is meant for the changelog of another add-on, start your changelog item with the name of that add-on's repo between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the changelog item is meant for the changelog of a JavaScript package, specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/add-ons, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* Refactors the abilities integration to make adding abilities easier and tidier in the future.

## Relevant technical choices:

* **Backwards compatibility.** Ability names, schemas, permission and execute callbacks are unchanged and locked by the per-ability tests. The former permission-callback methods on the integration (`can_manage_seo()`, `can_edit_advanced_metadata()`) are kept and deprecated in 28.6 per `DEPRECATING.md`, delegating to the capability helper via the surface. Only the integration's constructor signature changed, and it is built solely by the DI container.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions on how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Run a GET request to `/wp-json/wp-abilities/v1/abilities` with this PR and without and confirm the results are the same
  * Actually, there's a re-ordering of abilities because they are now in alphabetical order, but other than that the results are the same
* Disable the SEO or Readability or Inclusive Language analysis and re-run the above GET request
  * The `yoast-seo/get-seo-scores` (or `yoast-seo/get-readability-scores`, or ` yoast-seo/get-inclusive-language-scores` respectively) is removed from the results
* Disable the indexables via the `add_filter( 'Yoast\WP\SEO\should_index_indexables', '__return_false' );` snippet, re-run the above GET request and confirm that all 5 yoast abilities have been removed from the results.
* Quickly regression test all 5 abilities and confirm that they work like before this PR. This can mean run the following requests and confirm that you get the same results with before this PR:
  * A GET request to: `wp-json/wp-abilities/v1/abilities/yoast-seo/get-seo-scores/run?input[number_of_posts]=20`
  * A GET request to: `wp-json/wp-abilities/v1/abilities/yoast-seo/get-readability-scores/run?input[number_of_posts]=20`
  * A GET request to: `wp-json/wp-abilities/v1/abilities/yoast-seo/get-inclusive-language-scores/run?input[number_of_posts]=20`
  * A GET request to `/wp-json/wp-abilities/v1/abilities/yoast-seo/get-post-seo-data/run?input[post_id]=<POST_ID>`
  * A POST request to `/wp-json/wp-abilities/v1/abilities/yoast-seo/update-post-seo-data/run` with a body of `{ "input": { "post_id": <POST_ID>, "noindex": true } }`
    * Then you confirm that the post with the ID you gave, became noindex

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite
<!--
If you have checked any of the above cases, please add some context about the reason, what to check in the console,
which type/editor/browser should be tested in particular, multisite with subfolders or subdomains, etc.
-->

### Test instructions for QA when the code is in the RC
<!--
Sometimes some steps from the test instructions for the acceptance test aren't relevant anymore once the code has been merged or the feature is complete. If that is the case, do not check the checkbox below.
QA is our Quality Assurance team. The RC is the release candidate zip that is tested before a release.
For non-user-facing PRs (documentation, pure refactors, internal tooling), write "Not applicable" in the steps below and leave the checkbox unticked — QA verifies user-visible behaviour at RC time, not internal changes.
-->

* [x] QA should use the same steps as above.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing, please outline which parts of the plugin have been impacted by this PR.
-->
This PR affects the following parts of the plugin, which may require extra testing:

* Capabilities check for abilities: https://github.com/Yoast/wordpress-seo/pull/23508#issue-4987211998

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes #
