### PR TITLE
Bump @yoast/ai-frontend to 0.26.0 and drop the superseded AI suggestion styles

### DIFF
--- a/css/src/bulk-editor-page.css
+++ b/css/src/bulk-editor-page.css
@@ -62,17 +62,6 @@
 	}
 }
 
-/* Override the default textarea background color for AI suggestions. */
-/* Should be removed once .yst-root is removed from the bulk editor page. */
-.yst-root .yst-bulk-editor-ai-suggestion {
-	padding: 1px;
-	background-image: linear-gradient(to bottom right, #cd82ab, #a3b3ff);
-}
-
-.yst-root .yst-bulk-editor-ai-suggestion textarea.yst-textarea {
-	@apply !yst-bg-primary-50;
-}
-
 /* The AI error alerts in Premium */
 .yst-root .yst-bulk-editor-error-dismiss {
 	font-size: 10px;

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -33,7 +33,7 @@
     "@wordpress/rich-text": "^7.8.4",
     "@wordpress/server-side-render": "^5.8.12",
     "@wordpress/url": "^4.8.1",
-    "@yoast/ai-frontend": "^0.25.0",
+    "@yoast/ai-frontend": "^0.26.0",
     "@yoast/analysis-report": "^2.0.0-alpha.1",
     "@yoast/components": "^3.0.0-alpha.3",
     "@yoast/dashboard-frontend": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11167,10 +11167,10 @@
     js-yaml "^3.10.0"
     tslib "^2.4.0"
 
-"@yoast/ai-frontend@^0.25.0":
-  version "0.25.0"
-  resolved "https://registry.yarnpkg.com/@yoast/ai-frontend/-/ai-frontend-0.25.0.tgz#974b410edf85cf7b349a94bed4300d33a5c66633"
-  integrity sha512-KFPBkQxJhprVipa18A5GfFSEtJpwAwIXub3yJKhlEeEuUadx5gVa5VYkLwA1c1zZBxHLKoWebwtgIam6pjK5ig==
+"@yoast/ai-frontend@^0.26.0":
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/@yoast/ai-frontend/-/ai-frontend-0.26.0.tgz#a32f60bb026238a6e7ab2e686606fb51ad7918fb"
+  integrity sha512-elgu9kOKSTPimEznMBRgOR5dvCzpwWmaPQeFDauMByimWvHfjD3qxD31CgmWUfUzv/GWo/TgXVD3eQGluvI2DA==
   dependencies:
     "@draft-js-plugins/mention" "^5.3.0"
     "@heroicons/react" "^2.1.5"


### PR DESCRIPTION
## Context

The bulk editor's AI suggestion field has been moved into `@yoast/ai-frontend` as a platform-agnostic `SuggestionField` component (Yoast/ai-frontend#164, Yoast/ai-frontend#165), so consumers other than WordPress — starting with `wpseo-woocommerce` for alt-text generation — can reuse it. That component shipped in `@yoast/ai-frontend@0.26.0`.

Free owns the build of the `yoast-seo-ai-frontend-package` asset, so `SuggestionField` only reaches `window.yoast.aiFrontend` once Free bumps the dependency. This PR does that bump, and drops the bulk editor CSS that the package now carries itself.

Related: Yoast/reserved-tasks#1427, Yoast/wordpress-seo-premium#5066.

## Summary

This PR can be summarized in the following changelog entry:

* Non-user-facing: updates `@yoast/ai-frontend` to 0.26.0 and removes the bulk editor AI suggestion styles that now ship with the package.

## Relevant technical choices:

* The dependency lives in `packages/js/package.json`, not the root manifest. `@yoast/ai-frontend` is on a `0.x` version, where `^0.25.0` resolves to `>=0.25.0 <0.26.0` — so the caret bump is required, not cosmetic, and `yarn.lock` travels in the same commit because CI installs with `--frozen-lockfile`.
* The two `.yst-bulk-editor-ai-suggestion` rules are removed rather than kept as a safety net. The gradient frame and the `primary-50` textarea background are now part of the component itself (`.frame` and `textarea.field` in the package's `styles.module.scss`), so keeping them here would mean two sources of truth for the same look. After this PR, `yst-bulk-editor-ai-suggestion` appears nowhere in this repository.
* **This PR is paired with Yoast/wordpress-seo-premium#5066 and the two should merge together.** Premium `trunk` still applies `yst-bulk-editor-ai-suggestion` in `generated-field-cell.js`; #5066 is what replaces that markup with the package component. In the window between this PR merging and #5066 merging, anyone running Free `trunk` + Premium `trunk` sees the AI suggestion field without its gradient border. Nothing breaks — it is purely cosmetic, and only on `trunk`.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* [ ] Check out this branch and run `yarn install`, then `grunt build:js` and `grunt build:css`.
* [ ] Confirm the package resolved to 0.26.0: `grep version node_modules/@yoast/ai-frontend/package.json`.
* [ ] Activate Yoast SEO Premium on the branch of Yoast/wordpress-seo-premium#5066, so the bulk editor renders the package component.
* [ ] Go to **Yoast SEO → Bulk editor** and generate an AI suggestion for an SEO title or meta description.
* [ ] Confirm the Skeleton appears while the suggestion is being requested. 
* [ ] Resize the screen while the skeleton is shown and confirm the second line is shorter for larger text areas. 
* [ ] Confirm the suggestion appears in a field with the gradient border and a light purple background — the same look as before this change, now coming from the package instead of this stylesheet.
* [ ] Confirm **Apply** and **Discard** both still work.
* [ ] Confirm the browser console shows no errors, in particular no "Element type is invalid" from a missing export.
* [ ] Smoke test that the rest of the bulk-editor styles and the `UsageCounter` (sparks usage) in the AI generator or  the AI content planner feature modal still look good/ aren't broken. 

#### Relevant test scenarios
* [x] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [x] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

A missing or misnamed export from the bumped package surfaces as a console error rather than a visibly broken page, which is why the console should be open.

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* The `yoast-seo-ai-frontend-package` script asset, which is built here and consumed by Premium. Other Free consumers of this package — `UsageCounter` in the AI generator (`packages/js/src/ai-generator/components/app.js`) and in the AI content planner feature modal (`packages/js/src/ai-content-planner/components/feature-modal.js`) — come along with the version bump and are worth a smoke test.
* The bulk editor page stylesheet (`css/src/bulk-editor-page.css`). Only the AI suggestion rules were touched; the surrounding error-alert and cell-value rules are unchanged.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [x] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and committed the results, if my PR introduces or edits images or SVGs.

The component's own unit tests live in `@yoast/ai-frontend`; this PR carries no logic of its own.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Fixes [#1427](https://github.com/Yoast/reserved-tasks/issues/1427)
