### PR TITLE
Fix table cell class naming, widths, and content tabs chevron icon

### DIFF
--- a/packages/ui-library/src/components/content-tabs/components/tab-button.js
+++ b/packages/ui-library/src/components/content-tabs/components/tab-button.js
@@ -1,4 +1,4 @@
-import ChevronRightIcon from "@heroicons/react/solid/ChevronRightIcon";
+import ChevronRightIcon from "@heroicons/react/outline/ChevronRightIcon";
 import classNames from "classnames";
 import React, { useCallback } from "react";
 import { useSvgAria } from "../../../hooks";

--- a/packages/ui-library/src/elements/table/components/image-cell.js
+++ b/packages/ui-library/src/elements/table/components/image-cell.js
@@ -13,10 +13,10 @@ export const ImageCell = ( { cellProps = {}, imageProps = {} } ) => {
 
 	return (
 		<td className={ classNames( "yst-table-cell yst-table-image-cell", cellClassName ) } { ...restCellProps }>
-			<div className="yst-table-image-cell--image-container">
+			<div className="yst-table-image-cell__image-container">
 				{ src
-					? <img src={ src } alt={ alt } { ...restImageProps } className={ classNames( "yst-table-image-cell--image", imageClassName ) } />
-					: <PhotographIcon className="yst-table-image-cell--placeholder" aria-hidden="true" />
+					? <img src={ src } alt={ alt } { ...restImageProps } className={ classNames( "yst-table-image-cell__image", imageClassName ) } />
+					: <PhotographIcon className="yst-table-image-cell__placeholder" aria-hidden="true" />
 				}
 			</div>
 		</td>

--- a/packages/ui-library/src/elements/table/components/image-cell.js
+++ b/packages/ui-library/src/elements/table/components/image-cell.js
@@ -12,11 +12,11 @@ export const ImageCell = ( { cellProps = {}, imageProps = {} } ) => {
 	const { src, alt = "", className: imageClassName, ...restImageProps } = imageProps;
 
 	return (
-		<td className={ classNames( "yst-table-cell", cellClassName ) } { ...restCellProps }>
-			<div className="yst-table-image-cell">
+		<td className={ classNames( "yst-table-cell yst-table-image-cell", cellClassName ) } { ...restCellProps }>
+			<div className="yst-table-image-cell--image-container">
 				{ src
-					? <img src={ src } alt={ alt } { ...restImageProps } className={ classNames( "yst-table-image-cell-image", imageClassName ) } />
-					: <PhotographIcon className="yst-table-image-cell-placeholder" aria-hidden="true" />
+					? <img src={ src } alt={ alt } { ...restImageProps } className={ classNames( "yst-table-image-cell--image", imageClassName ) } />
+					: <PhotographIcon className="yst-table-image-cell--placeholder" aria-hidden="true" />
 				}
 			</div>
 		</td>

--- a/packages/ui-library/src/elements/table/docs/table-checkbox.md
+++ b/packages/ui-library/src/elements/table/docs/table-checkbox.md
@@ -26,3 +26,7 @@ Give every checkbox an accessible name — either `aria-label` in `checkboxProps
 #### Padding
 
 `Table.CheckboxHeader` and `Table.CheckboxCell` use slightly narrower vertical padding (`py-3.5`) than regular `Table.Header` and `Table.Cell` (`py-4`), sized to keep the checkbox column compact.
+
+#### Fixed width
+
+The checkbox column has a fixed width (`w-10` / 2.5rem). In the minimal variant, the first and last cells lose their horizontal padding, so the fixed width is automatically reduced by `0.75rem` to keep the column tight and avoid a visible gap.

--- a/packages/ui-library/src/elements/table/docs/table-image-cell.md
+++ b/packages/ui-library/src/elements/table/docs/table-image-cell.md
@@ -4,3 +4,7 @@ The sub component `Table.ImageCell`. It renders a thumbnail for the given `src`,
 |---|---|---|
 | `cellProps` | `Object` | Extra props for the `<td>` element (e.g. `colSpan`, `className`) |
 | `imageProps` | `Object` | Props forwarded to the `<img>` element (e.g. `src`, `alt`, `className` ). |
+
+#### Fixed width
+
+The image column has a fixed width of `5.5rem` (88px). In the minimal variant, the first and last cells lose their horizontal padding, so the fixed width is automatically reduced by `0.75rem` to keep the column tight and avoid a visible gap.

--- a/packages/ui-library/src/elements/table/docs/table-image-cell.md
+++ b/packages/ui-library/src/elements/table/docs/table-image-cell.md
@@ -4,7 +4,3 @@ The sub component `Table.ImageCell`. It renders a thumbnail for the given `src`,
 |---|---|---|
 | `cellProps` | `Object` | Extra props for the `<td>` element (e.g. `colSpan`, `className`) |
 | `imageProps` | `Object` | Props forwarded to the `<img>` element (e.g. `src`, `alt`, `className` ). |
-
-#### Fixed width
-
-The image column has a fixed width of `5.5rem` (88px). In the minimal variant, the first and last cells lose their horizontal padding, so the fixed width is automatically reduced by `0.75rem` to keep the column tight and avoid a visible gap.

--- a/packages/ui-library/src/elements/table/docs/table-variant-minimal.md
+++ b/packages/ui-library/src/elements/table/docs/table-variant-minimal.md
@@ -1,1 +1,3 @@
-The minial variant is the table without the table border.
+The minimal variant is the table without the table border.
+
+In this variant, the first and last cells lose their horizontal padding (`ps-0` / `pe-0`). Checkbox and image cells have fixed widths that are automatically reduced by `0.75rem` when they are the first or last column, so the column width stays visually consistent with the removed padding.

--- a/packages/ui-library/src/elements/table/docs/table-variant-minimal.md
+++ b/packages/ui-library/src/elements/table/docs/table-variant-minimal.md
@@ -1,3 +1,3 @@
 The minimal variant is the table without the table border.
 
-In this variant, the first and last cells lose their horizontal padding (`ps-0` / `pe-0`). Checkbox and image cells have fixed widths that are automatically reduced by `0.75rem` when they are the first or last column, so the column width stays visually consistent with the removed padding.
+In this variant, the first and last cells lose their horizontal padding (`ps-0` / `pe-0`). Checkbox cells have a fixed width that is automatically reduced by `0.75rem` when they are the first or last column, so the column width stays visually consistent with the removed padding.

--- a/packages/ui-library/src/elements/table/stories.js
+++ b/packages/ui-library/src/elements/table/stories.js
@@ -376,11 +376,11 @@ export const TableImageCell = {
 				</Table.Head>
 				<Table.Body>
 					<Table.Row>
-						<Table.ImageCell imageProps={ { src: sampleImage, alt: "" } } />
+						<Table.ImageCell cellProps={ { className: "yst-w-24" } } imageProps={ { src: sampleImage, alt: "" } } />
 						<Table.Cell>With an image</Table.Cell>
 					</Table.Row>
 					<Table.Row>
-						<Table.ImageCell />
+						<Table.ImageCell cellProps={ { className: "yst-w-24" } } />
 						<Table.Cell>Without an image, so a placeholder is shown</Table.Cell>
 					</Table.Row>
 				</Table.Body>

--- a/packages/ui-library/src/elements/table/stories.js
+++ b/packages/ui-library/src/elements/table/stories.js
@@ -340,7 +340,15 @@ export const MinimalVariant = {
 						<Table.Cell>Cell 3</Table.Cell>
 					</Table.Row>
 					<Table.Row>
-						<Table.ImageCell imageProps={ { src: "", alt: "" } } />
+						<Table.CheckboxCell
+							checkboxProps={ {
+								id: "story-select-row-2",
+								name: "story-select-row-2",
+								value: "2",
+								"aria-label": "Select row 2",
+								defaultChecked: true,
+							} }
+						/>
 						<Table.Cell>Cell 1</Table.Cell>
 						<Table.Cell>Cell 2</Table.Cell>
 						<Table.Cell>Cell 3</Table.Cell>

--- a/packages/ui-library/src/elements/table/stories.js
+++ b/packages/ui-library/src/elements/table/stories.js
@@ -310,6 +310,15 @@ export const MinimalVariant = {
 			<>
 				<Table.Head>
 					<Table.Row>
+						<Table.CheckboxHeader
+							checkboxProps={ {
+								id: "story-select-all",
+								name: "story-select-all",
+								value: "all",
+								"aria-label": "Select all rows",
+								indeterminate: true,
+							} }
+						/>
 						<Table.Header>Header 1</Table.Header>
 						<Table.Header>Header 2</Table.Header>
 						<Table.Header>Header 3</Table.Header>
@@ -317,11 +326,21 @@ export const MinimalVariant = {
 				</Table.Head>
 				<Table.Body>
 					<Table.Row>
+						<Table.CheckboxCell
+							checkboxProps={ {
+								id: "story-select-row-1",
+								name: "story-select-row-1",
+								value: "1",
+								"aria-label": "Select row 1",
+								defaultChecked: true,
+							} }
+						/>
 						<Table.Cell>Cell 1</Table.Cell>
 						<Table.Cell>Cell 2</Table.Cell>
 						<Table.Cell>Cell 3</Table.Cell>
 					</Table.Row>
 					<Table.Row>
+						<Table.ImageCell imageProps={ { src: "", alt: "" } } />
 						<Table.Cell>Cell 1</Table.Cell>
 						<Table.Cell>Cell 2</Table.Cell>
 						<Table.Cell>Cell 3</Table.Cell>

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -98,6 +98,15 @@
 					@apply first:yst-ps-0 last:yst-pe-0;
 				}
 
+				.yst-table-checkbox-header,
+				.yst-table-checkbox-cell {
+					@apply first:yst-w-7 last:yst-w-7;
+				}
+
+				.yst-table-image-cell {
+					@apply first:yst-w-[4.75rem] last:yst-w-[4.75rem];
+				}
+
 				tbody {
 					@apply yst-divide-y yst-divide-gray-200 yst-bg-white;
 				}

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -24,7 +24,7 @@
 					@apply yst-w-[5.5rem];
 				}
 
-				.yst-table-image-cell--image-container {
+				.yst-table-image-cell__image-container {
 					@apply
 					yst-flex
 					yst-items-center
@@ -37,7 +37,7 @@
 					yst-bg-white;
 				}
 
-				.yst-table-image-cell--image {
+				.yst-table-image-cell__image {
 					@apply
 					yst-w-full
 					yst-h-full
@@ -45,7 +45,7 @@
 					yst-object-center;
 				}
 
-				.yst-table-image-cell--placeholder {
+				.yst-table-image-cell__placeholder {
 					@apply
 					yst-w-5 yst-h-5
 					yst-text-slate-400;

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -13,14 +13,18 @@
 				}
 
 				.yst-table-checkbox-header {
-					@apply yst-px-3 yst-py-3.5 yst-text-start yst-text-sm yst-font-semibold yst-text-slate-900;
+					@apply yst-px-3 yst-py-3.5 yst-text-start yst-text-sm yst-font-semibold yst-text-slate-900 yst-w-10;
 				}
 
 				.yst-table-checkbox-cell {
-					@apply yst-px-3 yst-py-3.5 yst-text-sm yst-text-slate-600;
+					@apply yst-px-3 yst-py-3.5 yst-text-sm yst-text-slate-600 yst-w-10;
+				}
+				
+				.yst-table-image-cell {
+					width: 88px;
 				}
 
-				.yst-table-image-cell {
+				.yst-table-image-cell--image-container {
 					@apply
 					yst-flex
 					yst-items-center
@@ -33,7 +37,7 @@
 					yst-bg-white;
 				}
 
-				.yst-table-image-cell-image {
+				.yst-table-image-cell--image {
 					@apply
 					yst-w-full
 					yst-h-full
@@ -41,7 +45,7 @@
 					yst-object-center;
 				}
 
-				.yst-table-image-cell-placeholder {
+				.yst-table-image-cell--placeholder {
 					@apply
 					yst-w-5 yst-h-5
 					yst-text-slate-400;

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -21,7 +21,7 @@
 				}
 				
 				.yst-table-image-cell {
-					width: 88px;
+					@apply yst-w-[5.5rem];
 				}
 
 				.yst-table-image-cell--image-container {

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -20,10 +20,6 @@
 					@apply yst-px-3 yst-py-3.5 yst-text-sm yst-text-slate-600 yst-w-10;
 				}
 
-				.yst-table-image-cell {
-					@apply yst-w-[5.5rem];
-				}
-
 				.yst-table-image-cell__image-container {
 					@apply
 					yst-flex
@@ -101,10 +97,6 @@
 				.yst-table-checkbox-header,
 				.yst-table-checkbox-cell {
 					@apply first:yst-w-7 last:yst-w-7;
-				}
-
-				.yst-table-image-cell {
-					@apply first:yst-w-[4.75rem] last:yst-w-[4.75rem];
 				}
 
 				tbody {

--- a/packages/ui-library/src/elements/table/style.css
+++ b/packages/ui-library/src/elements/table/style.css
@@ -19,7 +19,7 @@
 				.yst-table-checkbox-cell {
 					@apply yst-px-3 yst-py-3.5 yst-text-sm yst-text-slate-600 yst-w-10;
 				}
-				
+
 				.yst-table-image-cell {
 					@apply yst-w-[5.5rem];
 				}

--- a/packages/ui-library/src/index.js
+++ b/packages/ui-library/src/index.js
@@ -31,7 +31,7 @@ export { default as AutocompleteField } from "./components/autocomplete-field";
 export { default as Card } from "./components/card";
 export { default as CheckboxGroup } from "./components/checkbox-group";
 export { default as ChildrenLimiter } from "./components/children-limiter";
-export { default as ContentTabs } from "./components/content-tabs";
+export { default as ContentTabs, useContentTabsContext } from "./components/content-tabs";
 export { default as FeatureUpsell } from "./components/feature-upsell";
 export { default as FileImport } from "./components/file-import";
 export { default as Modal } from "./components/modal";


### PR DESCRIPTION
## Context
Small polish pass on the UI library table cell components and content tabs: corrects BEM class naming to use `--` separator, adds fixed widths to checkbox and image cells so column widths are stable, moves the image cell width onto the `<td>` element where it belongs, and switches the content tabs chevron to the outline variant to match the design.

Also exports `useContentTabsContext` from the ui-library index so consumers can access tab context without reaching into internal paths.

## Summary
This PR can be summarized in the following changelog entry:

* [@yoast/ui-library 0.0.1] Fixes table cell class naming to follow BEM `--` separator convention, adds fixed widths to checkbox and image cells, and switches the content tabs chevron icon from solid to outline.

## Relevant technical choices:

* The image cell width (`88px`) is applied directly in CSS rather than via `@apply yst-w-[88px]` because it is a one-off specific value not tied to a design token — plain CSS signals intent more clearly.
* The `yst-table-image-cell` class is now on the `<td>` (width constraint) while `yst-table-image-cell--image-container` handles the flex display on the inner `<div>`, separating structural from presentational concerns.
* `useContentTabsContext` is re-exported from `src/index.js` so consumers don't need to import from internal paths.

## Test instructions
### Test instructions for the acceptance test before the PR gets merged
This PR can be acceptance tested by following these steps:

* Spin ui library story book ( `yarn storybook` from `ui-library` folder)
* Chec table that uses `ImageCell` and `CheckboxCell`/`CheckboxHeaderCell` and verify columns have stable, expected widths.
* Verify the content tabs chevron icon renders as an outline (not filled/solid) style.
* Verify `useContentTabsContext` is importable directly from `@yoast/ui-library`.

#### Relevant test scenarios
* [ ] Changes should be tested with the browser console open
* [ ] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [ ] QA should use the same steps as above.

QA can test this PR by following these steps:

* Verify the image column in any table that uses `ImageCell` is 88px wide and does not expand/collapse.
* Verify the checkbox column is 40px wide and stable.
* Verify the content tabs chevron is the outline variant.

## Impact check
This PR affects the following parts of the plugin, which may require extra testing:

* `@yoast/ui-library` — table cell components and content tabs only.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with `[shopify-seo]`, added test instructions for Shopify and attached the `Shopify` label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with `[yoast-doc-extension]`, added test instructions for Yoast SEO for Google Docs and attached the `Google Docs Add-on` label to this PR.

## Documentation

* [ ] I have written documentation for this change. For example, comments in the Relevant technical choices, comments in the code, documentation on Confluence / shared Google Drive / [Yoast developer portal](https://developer.yoast.com/), or other.

## Quality assurance

* [ ] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated [all plugins that Yoast SEO provides integrations for](https://github.com/Yoast/wordpress-seo/blob/trunk/readme.txt#L106).
* [ ] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [ ] I have written this PR in accordance with my team's definition of done.
* [ ] I have checked that the base branch is correctly set.
* [ ] I have run `grunt build:images` and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [ ] This PR falls under an innovation project. I have attached the `innovation` label.
* [ ] I have added my hours to [the WBSO document](http://yoa.st/wbso).

Related to:
[ui-library: create a vertical tabs component](https://github.com/Yoast/reserved-tasks/issues/1428)
[Ui library: create a table row variation with checkbox](https://github.com/Yoast/reserved-tasks/issues/1430)