### PR TITLE
Add a Yoast WooCommerce SEO upsell card to the product editor metabox

### DIFF
--- a/packages/js/src/components/WooSeoProductUpsellAd.js
+++ b/packages/js/src/components/WooSeoProductUpsellAd.js
@@ -14,23 +14,23 @@ const STORE_NAME_EDITOR = "yoast-seo/editor";
 const WOO_SEO_CTB_ID = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
 
 /**
- * Renders an upsell ad for Yoast WooCommerce SEO at the top of the product editor metabox.
+ * Renders an upsell ad for Yoast WooCommerce SEO at the top of the metabox for products and product terms.
  *
- * Only renders for product posts when WooCommerce is active and Yoast WooCommerce SEO is not.
+ * Only renders when WooCommerce is active and Yoast WooCommerce SEO is not.
  *
  * @returns {JSX.Element|null} The upsell ad, or null when it should not be shown.
  */
 export const WooSeoProductUpsellAd = () => {
 	const svgAriaProps = useSvgAria();
-	const { isWooSeoProductUpsell, upsellLink } = useSelect( ( select ) => {
+	const { isWooSeoUpsell, upsellLink } = useSelect( ( select ) => {
 		const editorSelect = select( STORE_NAME_EDITOR );
 		return {
-			isWooSeoProductUpsell: editorSelect.getIsWooSeoUpsell() && editorSelect.getIsProduct(),
+			isWooSeoUpsell: editorSelect.getIsWooSeoUpsell(),
 			upsellLink: editorSelect.selectLink( "https://yoa.st/woo-seo-product-editor-upsell" ),
 		};
 	}, [] );
 
-	if ( ! isWooSeoProductUpsell ) {
+	if ( ! isWooSeoUpsell ) {
 		return null;
 	}
 
@@ -47,7 +47,7 @@ export const WooSeoProductUpsellAd = () => {
 				id="woo-seo-product-upsell-ad"
 				className="yst-bg-white yst-border yst-border-woo-light yst-border-opacity-30 yst-rounded-lg yst-shadow-md yst-p-4"
 			>
-				<Title as="h4" className="yst-text-woo-light yst-text-base yst-font-medium yst-mb-2 yst-flex yst-gap-2">
+				<Title as="h3" size="4" className="yst-text-woo-light yst-text-base yst-font-medium yst-mb-2 yst-flex yst-gap-2">
 					Yoast WooCommerce SEO
 					<ShoppingCartIcon className="yst-w-4 yst-scale-x-[-1]" { ...svgAriaProps } />
 				</Title>

--- a/packages/js/src/components/WooSeoProductUpsellAd.js
+++ b/packages/js/src/components/WooSeoProductUpsellAd.js
@@ -45,16 +45,16 @@ export const WooSeoProductUpsellAd = () => {
 		<div className="yst-root">
 			<div
 				id="woo-seo-product-upsell-ad"
-				className="yst-border yst-border-woo-light yst-border-opacity-30 yst-rounded-lg yst-shadow-md yst-p-4"
+				className="yst-bg-white yst-border yst-border-woo-light yst-border-opacity-30 yst-rounded-lg yst-shadow-md yst-p-4"
 			>
 				<Title as="h4" className="yst-text-woo-light yst-text-base yst-font-medium yst-mb-2 yst-flex yst-gap-2">
 					Yoast WooCommerce SEO
-					<ShoppingCartIcon className="yst-w-5 yst-scale-x-[-1]" { ...svgAriaProps } />
+					<ShoppingCartIcon className="yst-w-4 yst-scale-x-[-1]" { ...svgAriaProps } />
 				</Title>
 				<p>
 					{ __( "Get ecommerce schema, product-specific assessments, and AI-generated image alt text, all in one plan.", "wordpress-seo" ) }
 				</p>
-				<ul className="yst-mt-2 yst-mb-1 yst-flex yst-flex-col yst-gap-1">
+				<ul className="yst-mt-2 yst-flex yst-flex-col yst-gap-1">
 					{ benefits.map( ( benefit ) => (
 						<li key={ benefit } className="yst-flex yst-items-start yst-gap-2">
 							<CheckCircleIcon className="yst-w-[18px] yst-h-[18px] yst-mt-px yst-shrink-0 yst-text-green-500" { ...svgAriaProps } />
@@ -64,11 +64,12 @@ export const WooSeoProductUpsellAd = () => {
 				</ul>
 				<Button
 					variant="upsell"
+					size="small"
 					as="a"
 					href={ upsellLink }
 					target="_blank"
 					rel="noopener noreferrer"
-					className="yst-mt-2"
+					className="yst-mt-4"
 					data-action="load-nfd-ctb"
 					data-ctb-id={ WOO_SEO_CTB_ID }
 				>

--- a/packages/js/src/components/WooSeoProductUpsellAd.js
+++ b/packages/js/src/components/WooSeoProductUpsellAd.js
@@ -1,0 +1,86 @@
+import LockOpenIcon from "@heroicons/react/outline/LockOpenIcon";
+import CheckCircleIcon from "@heroicons/react/solid/CheckCircleIcon";
+import ShoppingCartIcon from "@heroicons/react/solid/ShoppingCartIcon";
+import { useSelect } from "@wordpress/data";
+import { __, sprintf } from "@wordpress/i18n";
+import { Button, Title, useSvgAria } from "@yoast/ui-library";
+
+const STORE_NAME_EDITOR = "yoast-seo/editor";
+
+/**
+ * The ID for the Yoast WooCommerce SEO upsell ad.
+ * @type {string}
+ */
+const WOO_SEO_CTB_ID = "5b32250e-e6f0-44ae-ad74-3cefc8e427f9";
+
+/**
+ * Renders an upsell ad for Yoast WooCommerce SEO at the top of the product editor metabox.
+ *
+ * Only renders for product posts when WooCommerce is active and Yoast WooCommerce SEO is not.
+ *
+ * @returns {JSX.Element|null} The upsell ad, or null when it should not be shown.
+ */
+export const WooSeoProductUpsellAd = () => {
+	const svgAriaProps = useSvgAria();
+	const { isWooSeoProductUpsell, upsellLink } = useSelect( ( select ) => {
+		const editorSelect = select( STORE_NAME_EDITOR );
+		return {
+			isWooSeoProductUpsell: editorSelect.getIsWooSeoUpsell() && editorSelect.getIsProduct(),
+			upsellLink: editorSelect.selectLink( "https://yoa.st/woo-seo-product-editor-upsell" ),
+		};
+	}, [] );
+
+	if ( ! isWooSeoProductUpsell ) {
+		return null;
+	}
+
+	const benefits = [
+		__( "Product schema for price, reviews, and availability", "wordpress-seo" ),
+		__( "GTIN and SKU assessments", "wordpress-seo" ),
+		__( "Image alt text assessments", "wordpress-seo" ),
+		__( "Bulk AI-generated alt text for product images", "wordpress-seo" ),
+	];
+
+	return (
+		<div className="yst-root">
+			<div
+				id="woo-seo-product-upsell-ad"
+				className="yst-border yst-border-woo-light yst-border-opacity-30 yst-rounded-lg yst-shadow-md yst-p-4"
+			>
+				<Title as="h4" className="yst-text-woo-light yst-text-base yst-font-medium yst-mb-2 yst-flex yst-gap-2">
+					Yoast WooCommerce SEO
+					<ShoppingCartIcon className="yst-w-5 yst-scale-x-[-1]" { ...svgAriaProps } />
+				</Title>
+				<p>
+					{ __( "Get ecommerce schema, product-specific assessments, and AI-generated image alt text, all in one plan.", "wordpress-seo" ) }
+				</p>
+				<ul className="yst-mt-2 yst-mb-1 yst-flex yst-flex-col yst-gap-1">
+					{ benefits.map( ( benefit ) => (
+						<li key={ benefit } className="yst-flex yst-items-start yst-gap-2">
+							<CheckCircleIcon className="yst-w-[18px] yst-h-[18px] yst-mt-px yst-shrink-0 yst-text-green-500" { ...svgAriaProps } />
+							{ benefit }
+						</li>
+					) ) }
+				</ul>
+				<Button
+					variant="upsell"
+					as="a"
+					href={ upsellLink }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="yst-mt-2"
+					data-action="load-nfd-ctb"
+					data-ctb-id={ WOO_SEO_CTB_ID }
+				>
+					<LockOpenIcon className="yst-w-4 yst-me-1.5" { ...svgAriaProps } />
+					{ sprintf(
+						/* translators: %s expands to Yoast WooCommerce SEO. */
+						__( "Get %s", "wordpress-seo" ),
+						"Yoast WooCommerce SEO"
+					) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+

--- a/packages/js/src/components/WooSeoProductUpsellAd.js
+++ b/packages/js/src/components/WooSeoProductUpsellAd.js
@@ -47,7 +47,7 @@ export const WooSeoProductUpsellAd = () => {
 				id="woo-seo-product-upsell-ad"
 				className="yst-bg-white yst-border yst-border-woo-light yst-border-opacity-30 yst-rounded-lg yst-shadow-md yst-p-4"
 			>
-				<Title as="h3" size="4" className="yst-text-woo-light yst-text-base yst-font-medium yst-mb-2 yst-flex yst-gap-2">
+				<Title as="h3" size="4" className="yst-text-woo-light yst-text-base yst-leading-6 yst-font-medium yst-mb-2 yst-flex yst-gap-2">
 					Yoast WooCommerce SEO
 					<ShoppingCartIcon className="yst-w-4 yst-scale-x-[-1]" { ...svgAriaProps } />
 				</Title>

--- a/packages/js/src/components/fills/MetaboxFill.js
+++ b/packages/js/src/components/fills/MetaboxFill.js
@@ -26,6 +26,7 @@ import isBlockEditor from "../../helpers/isBlockEditor";
 import useToggleMarkerStatus from "./hooks/useToggleMarkerStatus";
 import ContentPlannerEditorItem from "../../ai-content-planner/containers/content-planner-editor-item";
 import { EditorIntro, EditorIntroText } from "../EditorIntro";
+import { WooSeoProductUpsellAd } from "../WooSeoProductUpsellAd";
 
 const BlackFridayPromotionWithMetaboxWarningsCheck = withMetaboxWarningsCheck( BlackFridayPromotion );
 
@@ -69,6 +70,7 @@ export default function MetaboxFill( { settings } ) {
 							withPromptForContentSuggestions={ isAiFeatureActive && isBlockEditorActive && isPost }
 						/>
 						{ isPost && isBlockEditorActive && isAiFeatureActive && <ContentPlannerEditorItem location="metabox" /> }
+						<WooSeoProductUpsellAd />
 					</EditorIntro>
 				</SidebarItem>
 				{ settings.isKeywordAnalysisActive && <SidebarItem key="keyword-input" renderPriority={ 8 }>

--- a/packages/js/src/containers/SnippetEditor.js
+++ b/packages/js/src/containers/SnippetEditor.js
@@ -1,12 +1,11 @@
 import { compose } from "@wordpress/compose";
-import { withDispatch, withSelect, useSelect } from "@wordpress/data";
+import { withDispatch, withSelect } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { SnippetEditor } from "@yoast/search-metadata-previews";
 import { LocationConsumer } from "@yoast/externals/contexts";
 import SnippetPreviewSection from "../components/SnippetPreviewSection";
 import { applyReplaceUsingPlugin } from "../helpers/replacementVariableHelpers";
 import getMemoizedFindCustomFields from "../helpers/getMemoizedFindCustomFields";
-import WooCommerceUpsell from "../components/WooCommerceUpsell";
 
 /**
  * Process the snippet editor form data before it's being displayed in the snippet preview.
@@ -49,10 +48,6 @@ export const mapEditorDataToPreview = function( data, context ) {
  * @returns {wp.Element} The component.
  */
 const SnippetEditorWrapper = ( props ) => {
-	const woocommerceUpsellLink = useSelect( select => select( "yoast-seo/editor" ).selectLink( "https://yoa.st/product-google-preview-metabox" ), [] );
-	const woocommerceUpsell = useSelect( ( select ) => select( "yoast-seo/editor" ).getIsWooSeoUpsell(), [] );
-	const woocommerceUpsellText = __( "Want an enhanced Google preview of how your WooCommerce products look in the search results?", "wordpress-seo" );
-
 	return <LocationConsumer>
 		{ location =>
 			<SnippetPreviewSection
@@ -60,7 +55,6 @@ const SnippetEditorWrapper = ( props ) => {
 				hasPaperStyle={ props.hasPaperStyle }
 			>
 				<>
-					{ woocommerceUpsell && <WooCommerceUpsell link={ woocommerceUpsellLink } text={ woocommerceUpsellText } /> }
 					<SnippetEditor
 						{ ...props }
 						descriptionPlaceholder={ __( "Please provide a meta description by editing the snippet below.", "wordpress-seo" ) }

--- a/packages/js/tests/components/WooSeoProductUpsellAd.test.js
+++ b/packages/js/tests/components/WooSeoProductUpsellAd.test.js
@@ -11,14 +11,12 @@ jest.mock( "@wordpress/data", () => ( {
  *
  * @param {Object} [overrides] Selector return values to override.
  * @param {boolean} [overrides.isWooSeoUpsell=true] Whether WooCommerce is active without Yoast WooCommerce SEO on a product entity.
- * @param {boolean} [overrides.isProduct=true] Whether the post type is a product.
  *
  * @returns {void}
  */
-const mockEditorStore = ( { isWooSeoUpsell = true, isProduct = true } = {} ) => {
+const mockEditorStore = ( { isWooSeoUpsell = true } = {} ) => {
 	const editorSelect = {
 		getIsWooSeoUpsell: () => isWooSeoUpsell,
-		getIsProduct: () => isProduct,
 		selectLink: ( link ) => `${ link }?shortlink=1`,
 	};
 	useSelect.mockImplementation( ( mapSelect ) => mapSelect( () => editorSelect ) );
@@ -29,11 +27,11 @@ describe( "WooSeoProductUpsellAd", () => {
 		useSelect.mockReset();
 	} );
 
-	it( "renders the Yoast WooCommerce SEO card for a product without the add-on", () => {
+	it( "renders the Yoast WooCommerce SEO card for a product entity without the add-on", () => {
 		mockEditorStore();
 		render( <WooSeoProductUpsellAd /> );
 
-		expect( screen.getByRole( "heading", { name: "Yoast WooCommerce SEO" } ) ).toBeInTheDocument();
+		expect( screen.getByRole( "heading", { level: 3, name: "Yoast WooCommerce SEO" } ) ).toBeInTheDocument();
 		expect( screen.getByText(
 			"Get ecommerce schema, product-specific assessments, and AI-generated image alt text, all in one plan."
 		) ).toBeInTheDocument();
@@ -58,15 +56,8 @@ describe( "WooSeoProductUpsellAd", () => {
 		expect( button ).toHaveAttribute( "data-ctb-id", "5b32250e-e6f0-44ae-ad74-3cefc8e427f9" );
 	} );
 
-	it( "renders nothing when Yoast WooCommerce SEO is active or WooCommerce is not", () => {
+	it( "renders nothing when Yoast WooCommerce SEO is active, WooCommerce is not, or this is not a product entity", () => {
 		mockEditorStore( { isWooSeoUpsell: false } );
-		const { container } = render( <WooSeoProductUpsellAd /> );
-
-		expect( container ).toBeEmptyDOMElement();
-	} );
-
-	it( "renders nothing on product terms, only on the product editor itself", () => {
-		mockEditorStore( { isProduct: false } );
 		const { container } = render( <WooSeoProductUpsellAd /> );
 
 		expect( container ).toBeEmptyDOMElement();

--- a/packages/js/tests/components/WooSeoProductUpsellAd.test.js
+++ b/packages/js/tests/components/WooSeoProductUpsellAd.test.js
@@ -1,0 +1,74 @@
+import { useSelect } from "@wordpress/data";
+import { WooSeoProductUpsellAd } from "../../src/components/WooSeoProductUpsellAd";
+import { render, screen } from "../test-utils";
+
+jest.mock( "@wordpress/data", () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+/**
+ * Points useSelect at a fake editor store.
+ *
+ * @param {Object} [overrides] Selector return values to override.
+ * @param {boolean} [overrides.isWooSeoUpsell=true] Whether WooCommerce is active without Yoast WooCommerce SEO on a product entity.
+ * @param {boolean} [overrides.isProduct=true] Whether the post type is a product.
+ *
+ * @returns {void}
+ */
+const mockEditorStore = ( { isWooSeoUpsell = true, isProduct = true } = {} ) => {
+	const editorSelect = {
+		getIsWooSeoUpsell: () => isWooSeoUpsell,
+		getIsProduct: () => isProduct,
+		selectLink: ( link ) => `${ link }?shortlink=1`,
+	};
+	useSelect.mockImplementation( ( mapSelect ) => mapSelect( () => editorSelect ) );
+};
+
+describe( "WooSeoProductUpsellAd", () => {
+	afterEach( () => {
+		useSelect.mockReset();
+	} );
+
+	it( "renders the Yoast WooCommerce SEO card for a product without the add-on", () => {
+		mockEditorStore();
+		render( <WooSeoProductUpsellAd /> );
+
+		expect( screen.getByRole( "heading", { name: "Yoast WooCommerce SEO" } ) ).toBeInTheDocument();
+		expect( screen.getByText(
+			"Get ecommerce schema, product-specific assessments, and AI-generated image alt text, all in one plan."
+		) ).toBeInTheDocument();
+
+		const benefits = screen.getAllByRole( "listitem" ).map( ( item ) => item.textContent );
+		expect( benefits ).toEqual( [
+			"Product schema for price, reviews, and availability",
+			"GTIN and SKU assessments",
+			"Image alt text assessments",
+			"Bulk AI-generated alt text for product images",
+		] );
+	} );
+
+	it( "links the button to the shortlink with the Yoast WooCommerce SEO click-to-buy", () => {
+		mockEditorStore();
+		render( <WooSeoProductUpsellAd /> );
+
+		const button = screen.getByRole( "link", { name: "Get Yoast WooCommerce SEO" } );
+		expect( button ).toHaveAttribute( "href", "https://yoa.st/woo-seo-product-editor-upsell?shortlink=1" );
+		expect( button ).toHaveAttribute( "target", "_blank" );
+		expect( button ).toHaveAttribute( "data-action", "load-nfd-ctb" );
+		expect( button ).toHaveAttribute( "data-ctb-id", "5b32250e-e6f0-44ae-ad74-3cefc8e427f9" );
+	} );
+
+	it( "renders nothing when Yoast WooCommerce SEO is active or WooCommerce is not", () => {
+		mockEditorStore( { isWooSeoUpsell: false } );
+		const { container } = render( <WooSeoProductUpsellAd /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( "renders nothing on product terms, only on the product editor itself", () => {
+		mockEditorStore( { isProduct: false } );
+		const { container } = render( <WooSeoProductUpsellAd /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );


### PR DESCRIPTION
## Context

In the product editor, Yoast SEO Free currently upsells Yoast WooCommerce SEO with a small text-and-button block inside the *Search appearance* section. As part of the AI product image alt text project, the design moves this to a dedicated card at the top of the Yoast SEO meta box that lists what the add-on brings: product schema, GTIN and SKU assessments, image alt text assessments, and bulk AI-generated alt text. The card shows for products, product categories and product tags when WooCommerce is active and Yoast WooCommerce SEO is not. Since the new card supersedes it, the *Search appearance* upsell is removed.

## Summary

This PR can be summarized in the following changelog entry:

* Adds a Yoast WooCommerce SEO upsell card to the top of the Yoast SEO meta box for products, product categories and product tags, when WooCommerce is active without Yoast WooCommerce SEO.
* Removes the Yoast WooCommerce SEO upsell from the *Search appearance* section for products, product categories and product tags.

## Relevant technical choices

* **Meta box only.** The WooCommerce product editor has no Yoast sidebar, so the card is rendered only from `MetaboxFill`, inside the editor intro.
* **Gated on the existing `getIsWooSeoUpsell` selector.** The card follows the same rule as the removed *Search appearance* upsell, so products, product categories and product tags all get it.
* **Heading is an `h3` with the Heading 4 style.** The card sits directly under the meta box's `h2`, so an `h4` would skip a level; `size="4"` keeps the 16px look from the design.

## Test instructions

### Test instructions for the acceptance test before the PR gets merged

1. [ ] Activate WooCommerce and make sure Yoast WooCommerce SEO is deactivated.
2. [ ] Edit a product, or add a new one.
3. [ ] In the *Yoast SEO* meta box, confirm a card titled *Yoast WooCommerce SEO* with a cart icon sits directly below *Optimize your content for discovery.*, matching the [design](https://www.figma.com/design/DxCMTut7yLqPYJMUCba14d/AI-Image-Alt-Text-Generator?node-id=77-5525).
4. [ ] Confirm the card lists four benefits with green check icons: *Product schema for price, reviews, and availability*, *GTIN and SKU assessments*, *Image alt text assessments* and *Bulk AI-generated alt text for product images*.
5. [ ] Click the yellow *Get Yoast WooCommerce SEO* button; confirm it opens `yoa.st/woo-seo-product-editor-upsell` in a new tab.
6. [ ] Expand *Search appearance* and confirm the *Want an enhanced Google preview of how your WooCommerce products look in the search results?* text and its 
7. [ ] *Unlock with Yoast WooCommerce SEO* button **are gone**. This 👇 sentence and the upsell button have been removed.
<img width="670" height="294" alt="image" src="https://github.com/user-attachments/assets/d3e9205b-9023-4736-8298-f0ef4ab36abb" />

8. [ ] Go to *Products > Categories*, edit/open a category and confirm the same card appears at the top of its Yoast SEO meta box; expand *Search appearance* and confirm the old Yoast WooCommerce SEO upsell **is gone** there too.
7a. [ ] Go to *Products > Tags*, edit/open a tag and confirm the card appears at the top of its Yoast SEO meta box as well.
9. [ ] Edit/open a regular post and confirm the card does not appear.
10. [ ] Activate Yoast WooCommerce SEO, check the **product editor** and a **product category and terms** and confirm the card is gone from both.
11. [ ] Run `cd packages/js && yarn jest tests/components/WooSeoProductUpsellAd.test.js`; expect 3 passing tests.

#### Style checks

Compare against the [design](https://www.figma.com/design/DxCMTut7yLqPYJMUCba14d/AI-Image-Alt-Text-Generator?node-id=780-4290) with the browser inspector open on the card (`#woo-seo-product-upsell-ad`).

12. [ ] Confirm the card has a white background, a `1px` solid border in `rgba(0, 117, 179, 0.3)` (Woo blue at 30%), an `8px` corner radius, `16px` padding on all sides and a soft drop shadow; confirm it spans the full width of the meta box content, the same width as the *Optimize your content for discovery.* line above it.
13. [ ] Confirm the *Yoast WooCommerce SEO* heading is an `h3` element (the design's *Heading 4* text style, rendered with the UI library `Title` at `size="4"`, see Technical choices above) in `#0075B3` (`rgb(0, 117, 179)`) at `16px`, font weight `500`, line height `24px`, with `8px` of space below it; confirm the heading outline reads `h2` *Yoast SEO* <img width="1675" height="89" alt="image" src="https://github.com/user-attachments/assets/941b7a08-2e6c-4738-a334-1cc159d83b2d" />

 → `h3` *Yoast WooCommerce SEO* → `h2` *Focus keyphrase* with no skipped level.

14. [ ] Confirm the cart icon next to it is `16px` wide, faces left and has the same blue.
15. [ ] Confirm the description and the four benefit lines are `13px` text in `#475569` (`rgb(71, 85, 105)`), with `8px` between the description and the list and `4px` between the benefit lines.
16. [ ] Confirm each check icon is `18px` × `18px` in `#22C55E` (`rgb(34, 197, 94)`) with an `8px` gap to its text, and that long benefit lines wrap under the text, not under the icon.
17. [ ] Confirm the *Get Yoast WooCommerce SEO* button is the small upsell button: `28px` tall, background `#FCD34D` (`rgb(252, 211, 77)`), text `#78350F` (`rgb(120, 53, 15)`) at `12px` font weight `500`, `6px` corner radius, `6px` vertical and `10px` horizontal padding, a `16px` lock icon with `6px` to the label, and `16px` of space between the benefit list and the button.
18. [ ] Hover the button and confirm the background darkens to `#FBBF24` (`rgb(251, 191, 36)`); Tab to it and confirm a visible focus ring; resize the window to about `1024px` wide and confirm the text wraps inside the card without overflowing.

### Relevant test scenarios

* [x] Changes should be tested with the browser console open — confirm no errors while the meta box loads.
* [x] Changes should be tested on different posts/pages/taxonomies/custom post types/custom taxonomies — the card must appear on products, product categories and product tags, and not on posts, pages or other taxonomies.
* [ ] Changes should be tested on different editors (Default Block/Gutenberg/Classic/Elementor/other)
* [ ] Changes should be tested on different browsers
* [ ] Changes should be tested on multisite

### Test instructions for QA when the code is in the RC

* [x] QA should use the same steps as above.

## Impact check

This PR affects the following parts of the plugin, which may require extra testing:

* The Yoast SEO meta box for WooCommerce products, product categories and product tags (editor intro and *Search appearance* section).
* The Yoast WooCommerce SEO upsells shown to Free and Premium users without the add-on.

## Other environments

* [ ] This PR also affects Shopify. I have added a changelog entry starting with [shopify-seo], added test instructions for Shopify and attached the Shopify label to this PR.
* [ ] This PR also affects Yoast SEO for Google Docs. I have added a changelog entry starting with [yoast-doc-extension], added test instructions for Yoast SEO for Google Docs and attached the Google Docs Add-on label to this PR.

## Documentation

* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] During testing, I had activated all plugins that Yoast SEO provides integrations for.
* [x] I have added unit tests to verify the code works as intended.
* [ ] If any part of the code is behind a feature flag, my test instructions also cover cases where the feature flag is switched off.
* [x] I have written this PR in accordance with my team's definition of done.
* [x] I have checked that the base branch is correctly set.
* [ ] I have run grunt build:images and commited the results, if my PR introduces new images or SVGs.

## Innovation

* [ ] No innovation project is applicable for this PR.
* [x] This PR falls under an innovation project. I have attached the innovation label.
* [ ] I have added my hours to the WBSO document.

Fixes https://github.com/Yoast/reserved-tasks/issues/1402




